### PR TITLE
Fix go_prefix to resolve to the right repository

### DIFF
--- a/go/def.bzl
+++ b/go/def.bzl
@@ -334,7 +334,10 @@ go_library_attrs = {
     ),
     "go_prefix": attr.label(
         providers = ["go_prefix"],
-        default = Label("//:go_prefix"),
+        default = Label(
+            "//:go_prefix",
+            relative_to_caller_repository = True,
+        ),
         allow_files = False,
         cfg = HOST_CFG,
     ),


### PR DESCRIPTION
RELNOTES: go_prefix references the //:go_prefix rule in the repository
the BUILD file using go_* is in, not the repository where def.bzl lives
(probably @io_bazel_rules_go).