### PR TITLE
Allow rule go_library to accept ASM source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ go_library(name, srcs, deps, data)
       <td><code>srcs</code></td>
       <td>
         <code>List of labels, required</code>
-        <p>List of Go <code>.go</code> source files used to build the
-        library</p>
+        <p>List of Go <code>.go</code> (at least one) or ASM <code>.s/.S</code>
+        source files used to build the library</p>
       </td>
     </tr>
     <tr>

--- a/examples/bin/bin.go
+++ b/examples/bin/bin.go
@@ -26,4 +26,7 @@ import (
 func main() {
 	fmt.Println("meaning: ", lib.Meaning())
 	fmt.Println("vendored: ", vendored.Vendored())
+
+	lib.AddTwoNumbers()
+	lib.SubTwoNumbers()
 }

--- a/examples/lib/BUILD
+++ b/examples/lib/BUILD
@@ -7,7 +7,10 @@ load("//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "add.s",
+        "asm.go",
         "lib.go",
+        "sub.s",
     ],
 )
 

--- a/examples/lib/add.s
+++ b/examples/lib/add.s
@@ -1,0 +1,8 @@
+#include "textflag.h"
+
+TEXT ·add(SB),NOSPLIT,$0
+	MOVQ x+0(FP), BX
+	MOVQ y+8(FP), BP
+	ADDQ BP, BX
+	MOVQ BX, ret+16(FP)
+	RET

--- a/examples/lib/asm.go
+++ b/examples/lib/asm.go
@@ -1,0 +1,14 @@
+package lib
+
+import "fmt"
+
+func add(x, y int64) int64
+func sub(x, y int64) int64
+
+func AddTwoNumbers() {
+	fmt.Println("2 + 3 =", add(2, 3))
+}
+
+func SubTwoNumbers() {
+	fmt.Println("2 - 3 =", sub(2, 3))
+}

--- a/examples/lib/lib_test.go
+++ b/examples/lib/lib_test.go
@@ -24,3 +24,7 @@ func TestMeaning(t *testing.T) {
 		t.Errorf("got %d, want 42", m)
 	}
 }
+
+// func TestAddTwoNumbers(t *testing.T) {
+// 	AddTwoNumbers()
+// }

--- a/examples/lib/lib_test.go
+++ b/examples/lib/lib_test.go
@@ -25,6 +25,6 @@ func TestMeaning(t *testing.T) {
 	}
 }
 
-// func TestAddTwoNumbers(t *testing.T) {
-// 	AddTwoNumbers()
-// }
+func TestAddTwoNumbers(t *testing.T) {
+	AddTwoNumbers()
+}

--- a/examples/lib/sub.s
+++ b/examples/lib/sub.s
@@ -1,0 +1,8 @@
+#include "textflag.h"
+
+TEXT ·sub(SB),NOSPLIT,$0
+	MOVQ x+0(FP), BX
+	MOVQ y+8(FP), BP
+	SUBQ BP, BX
+	MOVQ BX, ret+16(FP)
+	RET

--- a/go/toolchain/BUILD
+++ b/go/toolchain/BUILD
@@ -29,3 +29,12 @@ filegroup(
     }),
     visibility = ["//visibility:public"],
 )
+
+filegroup(
+    name = "go_include",
+    srcs = select({
+        ":darwin": ["@golang_darwin_amd64//:go_include"],
+        ":k8": ["@golang_linux_amd64//:go_include"],
+    }),
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
…in Go; add examples for go_asm_library; change go_library to take multiple cgo_objects; update README for go_asm_library and go_library.

This replaces the pull request #22 with a new implementation since I messed it up. The new impl followed Yugui's suggestions.