### PR TITLE
Correct importpath of generated go_library archives

### DIFF
--- a/examples/lib/BUILD
+++ b/examples/lib/BUILD
@@ -21,3 +21,13 @@ go_test(
     ],
     library = ":go_default_library",
 )
+
+go_test(
+    name = "lib_external_test",
+    srcs = [
+        "lib_x_test.go",
+    ],
+    deps = [
+         ":go_default_library",
+    ],
+)

--- a/examples/lib/lib_x_test.go
+++ b/examples/lib/lib_x_test.go
@@ -13,20 +13,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package lib
+package lib_test
 
 import (
-	"reflect"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/examples/lib"
 )
 
-// Meaning calculates the meaning of Life, the Universe and Everything.
-func Meaning() int {
-	return 42
-}
-
-type dummy struct{}
-
-// PkgPath returns the package importpath of this package.
-func PkgPath() string {
-	return reflect.TypeOf(dummy{}).PkgPath()
+func TestLibraryPkgPath(t *testing.T) {
+	if got, want := lib.PkgPath(), "github.com/bazelbuild/rules_go/examples/lib"; got != want {
+		t.Errorf("lib.PkgPath() = %q; want %q", got, want)
+	}
 }


### PR DESCRIPTION
Put library archives into the right places in the standard layout of Go workspace by omitting  "go_default_library" from their paths. This lets linker symbols in the final binary output have right values.

It also allows us to specify -X linker flag with the importpath we expect.
c.f. https://github.com/bazelbuild/rules_go/pull/27#issuecomment-220780509