### PR TITLE
 Respect go_prefix attr of dependencies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,3 +2,25 @@ workspace(name = "io_bazel_rules_go")
 
 load("//go:def.bzl", "go_repositories")
 go_repositories()
+
+GLOG_BUILD = """
+load("@//go:def.bzl", "go_prefix", "go_library")
+
+go_prefix("github.com/golang/glog")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "glog.go",
+        "glog_file.go",
+    ],
+    visibility = ["//visibility:public"],
+)
+"""
+
+new_git_repository(
+    name = "com_github_golang_glog",
+    remote = "https://github.com/golang/glog.git",
+    commit = "23def4e6c14b4da8ac2ed8007337bc5eb5007998",
+    build_file_content = GLOG_BUILD,
+)

--- a/examples/external/BUILD
+++ b/examples/external/BUILD
@@ -1,0 +1,11 @@
+load("//go:def.bzl", "go_binary")
+
+go_binary(
+    name = "record_log",
+    srcs = [
+        "main.go",
+    ],
+    deps = [
+        "@com_github_golang_glog//:go_default_library",
+    ],
+)

--- a/examples/external/main.go
+++ b/examples/external/main.go
@@ -1,0 +1,31 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Command record_log just records a log with glog to
+// show an example of linking with a external dependency.
+package main
+
+import (
+	"flag"
+
+	"github.com/golang/glog"
+)
+
+func main() {
+	flag.Parse()
+	defer glog.Flush()
+
+	glog.Info("Hello")
+}


### PR DESCRIPTION
Uses go_prefix attr of individual dependencies to calculate their
importpaths.  This allows users to use Bazel's external dependency
resolution -- {,new_}git_repository rules -- to manage Go libraries.

c.f. https://github.com/bazelbuild/rules_go/issues/16#issuecomment-216010843

Supports case 1 and 3 in #16.