### PR TITLE
Propagates transitive dependencies from direct deps in library

### DIFF
--- a/examples/lib/BUILD
+++ b/examples/lib/BUILD
@@ -12,6 +12,7 @@ go_library(
         "lib.go",
         "sub.s",
     ],
+    deps = ["//examples/lib/deep:go_default_library"],
 )
 
 go_test(

--- a/examples/lib/deep/BUILD
+++ b/examples/lib/deep/BUILD
@@ -1,0 +1,11 @@
+package(default_visibility = ["//examples/lib:__pkg__"])
+
+load("//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "thought.go",
+    ],
+)

--- a/examples/lib/deep/doc.go
+++ b/examples/lib/deep/doc.go
@@ -1,0 +1,3 @@
+// Package deep provides an emulator of a computer which calculates
+// answer to the ultimate question of Life, the Universe, and Everything.
+package deep

--- a/examples/lib/deep/thought.go
+++ b/examples/lib/deep/thought.go
@@ -1,0 +1,6 @@
+package deep
+
+// Thought emulates Deep Thought.
+func Thought() int {
+	return 42
+}

--- a/examples/lib/lib.go
+++ b/examples/lib/lib.go
@@ -17,13 +17,15 @@ package lib
 
 import (
 	"reflect"
+
+	"github.com/bazelbuild/rules_go/examples/lib/deep"
 )
 
 var buildTime string
 
-// Meaning calculates the meaning of Life, the Universe and Everything.
+// Meaning returns the meaning of Life, the Universe and Everything.
 func Meaning() int {
-	return 42
+	return deep.Thought()
 }
 
 type dummy struct{}

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -271,7 +271,7 @@ def go_library_impl(ctx):
 
   transitive_libs = set([out_lib])
   transitive_importmap = {out_lib.path: _go_importpath(ctx)}
-  for dep in ctx.attr.deps:
+  for dep in deps:
      transitive_libs += dep.transitive_go_library_object
      transitive_cgo_deps += dep.transitive_cgo_deps
      transitive_importmap += dep.transitive_go_importmap


### PR DESCRIPTION
`go_library_impl` used to ignore dependencies in `ctx.attr.library` when it calculates transitive dependencies.  This PR makes it correctly propagate such transitive dependencies in `ctx.attr.library`.

Fixes #6.  Replaces #32.