### PR TITLE
Support more edge cases in CGoCodeGen action

### DIFF
--- a/examples/cgo/BUILD
+++ b/examples/cgo/BUILD
@@ -9,11 +9,13 @@ cgo_library(
     srcs = [
         "import_example.go",
         "export_example.go",
-        "use_exported.h",
+        "generated.go",
         "use_exported.c",
+        "use_exported.h",
     ],
     deps = ["//examples/cgo/cc_dependency:version"],
     linkopts = ["-lm"],
+    go_deps = [":sub"],
     visibility = ["//visibility:private"],
 )
 
@@ -25,8 +27,23 @@ go_library(
     library = ":cgo_lib",
 )
 
+cgo_library(
+    name = "sub",
+    srcs = ["sub/floor.go"],
+    linkopts = ["-lm"],
+    visibility = ["//visibility:private"],
+)
+
 go_test(
     name = "cgo_lib_test",
     srcs = ["cgo_lib_test.go"],
     library = ":cgo_lib",
+)
+
+genrule(
+    name = "generate_go_src",
+    srcs = ["generated.go.tpl"],
+    outs = ["generated.go"],
+    cmd = "cp -f $< $@",
+    visibility = ["//visibility:private"],
 )

--- a/examples/cgo/generated.go.tpl
+++ b/examples/cgo/generated.go.tpl
@@ -1,0 +1,13 @@
+package cgo
+
+import (
+	//#cgo LDFLAGS: -lm
+	//#include <math.h>
+	"C"
+	"math"
+)
+
+// Ncbrt returns the cube root of n.
+func Ncbrt(n int) int {
+	return int(math.Floor(float64(C.cbrt(C.double(n)))))
+}

--- a/examples/cgo/import_example.go
+++ b/examples/cgo/import_example.go
@@ -7,12 +7,13 @@ import (
 	//#include "use_exported.h"
 	//#include "cc_dependency/version.h"
 	"C"
-	"math"
+
+	"github.com/bazelbuild/rules_go/examples/cgo/sub"
 )
 
 // Nsqrt returns the square root of n.
 func Nsqrt(n int) int {
-	return int(math.Floor(float64(C.sqrt(C.double(n)))))
+	return int(sub.Floor(float64(C.sqrt(C.double(n)))))
 }
 
 func PrintGoVersion() {

--- a/examples/cgo/sub/floor.go
+++ b/examples/cgo/sub/floor.go
@@ -1,0 +1,13 @@
+package sub
+
+import (
+	//#cgo LDFLAGS: -lm
+	//#include <math.h>
+	"C"
+)
+
+// Floor calculates floor of the given number
+// with the implementation in the standard C library.
+func Floor(f float64) float64 {
+	return float64(C.floor(C.double(f)))
+}


### PR DESCRIPTION
* The current package name might be empty.
* The current package might be in a non-root workspace.
   * fixes #35
* cgo source files might be generated files and they might be in `$(GENDIR)` or in `$(BINDIR)`.
* cgo source files might be in a subdirectory of the bazel package directory.