### PR TITLE
[Incompatible Change] Prefixes C/C++ related attributes with "c".

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ go_library(name, srcs, deps, data)
 ## cgo\_library
 
 ```bzl
-cgo_library(name, srcs, copts, linkopts, deps, data)
+cgo_library(name, srcs, copts, clinkopts, cdeps, deps, data)
 ```
 <table class="table table-condensed table-bordered table-params">
   <colgroup>
@@ -243,18 +243,25 @@ cgo_library(name, srcs, copts, linkopts, deps, data)
       </td>
     </tr>
     <tr>
-      <td><code>linkopts</code></td>
+      <td><code>clinkopts</code></td>
       <td>
         <code>List of strings, optional</code>
         <p>Add these flags to the C++ linker</p>
       </td>
     </tr>
     <tr>
-      <td><code>deps</code></td>
+      <td><code>cdeps</code></td>
       <td>
         <code>List of labels, optional</code>
         <p>List of C/C++ libraries to be linked into the binary target.
         They must be <code>cc_library</code> rules.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>deps</code></td>
+      <td>
+        <code>List of labels, optional</code>
+        <p>List of other libraries to be linked to this library</p>
       </td>
     </tr>
     <tr>

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ cgo_library(name, srcs, copts, clinkopts, cdeps, deps, data)
       <td><code>deps</code></td>
       <td>
         <code>List of labels, optional</code>
-        <p>List of other libraries to be linked to this library</p>
+        <p>List of other Go libraries to be linked to this library</p>
       </td>
     </tr>
     <tr>
@@ -329,7 +329,7 @@ go_binary(name, srcs, deps, data)
       <td><code>deps</code></td>
       <td>
         <code>List of labels, optional</code>
-        <p>List of other libraries to linked to this binary target</p>
+        <p>List of other Go libraries to linked to this binary target</p>
       </td>
     </tr>
     <tr>
@@ -378,7 +378,7 @@ go_test(name, srcs, deps, data)
       <td><code>deps</code></td>
       <td>
         <code>List of labels, optional</code>
-        <p>List of other libraries to linked to this test target</p>
+        <p>List of other Go libraries to linked to this test target</p>
       </td>
     </tr>
     <tr>

--- a/examples/cgo/BUILD
+++ b/examples/cgo/BUILD
@@ -13,9 +13,9 @@ cgo_library(
         "use_exported.c",
         "use_exported.h",
     ],
-    deps = ["//examples/cgo/cc_dependency:version"],
-    linkopts = ["-lm"],
-    go_deps = [":sub"],
+    deps = [":sub"],
+    cdeps = ["//examples/cgo/cc_dependency:version"],
+    clinkopts = ["-lm"],
     visibility = ["//visibility:private"],
 )
 
@@ -30,7 +30,7 @@ go_library(
 cgo_library(
     name = "sub",
     srcs = ["sub/floor.go"],
-    linkopts = ["-lm"],
+    clinkopts = ["-lm"],
     visibility = ["//visibility:private"],
 )
 


### PR DESCRIPTION
`cgo_library` has both Go-related attributes `srcs` and `library`, and
C-related attributes `deps`, `copts`, `linkopts`.  And their naming was not
strategic nor consistent.
Actually `deps` attribute had a different meaning from `go_library`.
And even worse, there was no way to add `go_library` dependency to
`cgo_library`.

This change make attributes of `cgo_library` a superset of the ones of
`go_library`. And it consistently prefixes C/C++ related attributes with
"c".

NOTE: This breaks backward-compatibility of `cgo_library`.