### PR TITLE
Bump version to 0.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ They currently do not support (in order of importance):
     git_repository(
         name = "io_bazel_rules_go",
         remote = "https://github.com/bazelbuild/rules_go.git",
-        tag = "0.0.2",
+        tag = "0.0.3",
     )
     load("@io_bazel_rules_go//go:def.bzl", "go_repositories")
 


### PR DESCRIPTION
Here's a draft of release note

https://github.com/bazelbuild/rules_go/releases/tag/untagged-e20c0eb0db5c557ee2d4