### PR TITLE
Test that AUTHORS and CONTRIBUTORS are sorted

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,14 +6,9 @@
 # Name or Organization <email address>
 # The email address is not required for organizations.
 
-Google Inc.
 Benjamin Staffin <benley@gmail.com>
 Brian Silverman <bsilver16384@gmail.com>
-Damien Martin-Guillerez <dmarting@google.com>
-David Chen <dzc@google.com>
 David Santiago <david.santiago@gmail.com>
-Han-Wen Nienhuys <hanwen@google.com>
+Google Inc.
 Jake Voytko <jake@reviewninja.com>
-Kristina Chodorow <kchodorow@google.com>
-Lukacs Berki <lberki@google.com>
 Yuki Yugui Sonoda <yugui@yugui.jp>

--- a/BUILD
+++ b/BUILD
@@ -1,3 +1,18 @@
 load("//go:def.bzl", "go_prefix")
+load("//go/private:lines_sorted_test.bzl", "lines_sorted_test")
 
 go_prefix("github.com/bazelbuild/rules_go")
+
+lines_sorted_test(
+    name = "contributors_sorted_test",
+    cmd = "grep -v '^#' $< | grep -v '^$$' >$@",
+    error_message = "Contributors must be sorted by first name",
+    file = "CONTRIBUTORS",
+)
+
+lines_sorted_test(
+    name = "authors_sorted_test",
+    cmd = "grep -v '^#' $< | grep -v '^$$' >$@",
+    error_message = "Authors must be sorted by first name",
+    file = "AUTHORS",
+)

--- a/go/private/files_equal_test.bzl
+++ b/go/private/files_equal_test.bzl
@@ -1,0 +1,71 @@
+# Copyright 2016 The Bazel Go Rules Authors. All rights reserved.
+# Copyright 2016 The Closure Rules Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests that two files contain the same data."""
+
+def _impl(ctx):
+  if ctx.file.golden == ctx.file.actual:
+    fail("GOLDEN and ACTUAL should be different files")
+  ctx.file_action(
+      output=ctx.outputs.executable,
+      content="\n".join([
+          "#!/bin/bash",
+          "function checksum() {",
+          "  if command -v openssl >/dev/null; then",
+          "    openssl sha1 $1 | cut -f 2 -d ' '",
+          "  elif command -v sha256sum >/dev/null; then",
+          "    sha256sum $1 | cut -f 1 -d ' '",
+          "  elif command -v shasum >/dev/null; then",
+          "    cat $1 | shasum -a 256 | cut -f 1 -d ' '",
+          "  else",
+          "    echo please install openssl >&2",
+          "    exit 1",
+          "  fi",
+          "}",
+          "SUM1=$(checksum %s)" % _runpath(ctx.file.golden),
+          "SUM2=$(checksum %s)" % _runpath(ctx.file.actual),
+          "if [[ ${SUM1} != ${SUM2} ]]; then",
+          "  echo ERROR: %s >&2" % ctx.attr.error_message,
+          "  echo %s ${SUM1} >&2" % _runpath(ctx.file.golden),
+          "  echo %s ${SUM2} >&2" % _runpath(ctx.file.actual),
+          "  exit 1",
+          "fi",
+      ]),
+      executable=True)
+  return struct(runfiles=ctx.runfiles([ctx.file.golden,
+                                       ctx.file.actual]))
+
+def _runpath(f):
+  """Figures out the proper runfiles path for a file, using voodoo"""
+  if f.path.startswith('bazel-out/'):
+    return f.short_path
+  else:
+    return f.path
+
+files_equal_test = rule(
+    attrs = {
+        "golden": attr.label(
+            mandatory = True,
+            allow_files = True,
+            single_file = True),
+        "actual": attr.label(
+            mandatory = True,
+            allow_files = True,
+            single_file = True),
+        "error_message": attr.string(
+            default="FILES DO NOT HAVE EQUAL CONTENTS"),
+    },
+    implementation = _impl,
+    test = True)

--- a/go/private/lines_sorted_test.bzl
+++ b/go/private/lines_sorted_test.bzl
@@ -1,0 +1,45 @@
+# Copyright 2016 The Bazel Go Rules Authors. All rights reserved.
+# Copyright 2016 The Closure Rules Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//go/private:files_equal_test.bzl", "files_equal_test")
+
+def lines_sorted_test(name, file, cmd="cat $< >$@", visibility=None, **kwargs):
+  """Tests that lines within a file are sorted."""
+
+  native.genrule(
+      name = name + "_lines",
+      testonly = True,
+      srcs = [file],
+      outs = [name + "_lines.txt"],
+      cmd = cmd,
+      visibility = visibility,
+   )
+
+  native.genrule(
+      name = name + "_lines_sorted",
+      testonly = True,
+      srcs = [name + "_lines.txt"],
+      outs = [name + "_lines_sorted.txt"],
+      cmd = "sort $< >$@",
+      visibility = visibility,
+   )
+
+  files_equal_test(
+      name = name,
+      actual = name + "_lines.txt",
+      golden = name + "_lines_sorted.txt",
+      visibility = visibility,
+      **kwargs
+   )


### PR DESCRIPTION
@pmbethe09 said in #47 that these files are to be sorted. So I've added a regression test to help contributors know that.

I've also removed Googlers from the AUTHORS file, as this file is intended for copyright holders. Google Inc. owns the code. See the comments in the AUTHORS and CONTRIBUTORS files to learn more about this policy.

**Recommended TODOs**

1. Consider auditing other AUTHORS to find out if their employer is actually the copyright holder. For instance, I noticed one contributor is employed by Fitbit Inc. Perhaps that's what should go in the AUTHORS file.

2. Consider changing copyright headers on source files to read "The Bazel Go Rules Authors" rather than the Bazel Authors, since this project has an independent AUTHORS file.