### PR TITLE
Bump version to 0.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ They currently do not support (in order of importance):
     git_repository(
         name = "io_bazel_rules_go",
         remote = "https://github.com/bazelbuild/rules_go.git",
-        tag = "0.0.3",
+        tag = "0.0.4",
     )
     load("@io_bazel_rules_go//go:def.bzl", "go_repositories")
 


### PR DESCRIPTION
@pmbethe09 I'm going to release 0.0.4 to ship two important changes described in https://github.com/bazelbuild/rules_go/releases/tag/untagged-f7b118df27e01fcc5046.
Could you take a look?

This branch should be merged just before releasing 0.0.4.
