### PR TITLE
Import Gazel, BUILD file generator

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,3 +25,14 @@ new_git_repository(
     commit = "23def4e6c14b4da8ac2ed8007337bc5eb5007998",
     remote = "https://github.com/golang/glog.git",
 )
+
+git_repository(
+    name = "io_bazel_buildifier",
+    commit = "0ca1d7991357ae7a7555589af88930d82cf07c0a",
+    remote = "https://github.com/bazelbuild/buildifier.git",
+)
+
+local_repository(
+    name = "io_bazel_rules_go",
+    path = ".",
+)

--- a/go/tools/gazel/gazel/BUILD
+++ b/go/tools/gazel/gazel/BUILD
@@ -1,0 +1,10 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+
+go_binary(
+    name = "gazel",
+    srcs = ["main.go"],
+    deps = [
+        "@io_bazel_buildifier//core:go_default_library",
+        "//go/tools/gazel/generator:go_default_library",
+    ],
+)

--- a/go/tools/gazel/gazel/BUILD
+++ b/go/tools/gazel/gazel/BUILD
@@ -1,10 +1,27 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_binary", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "diff.go",
+        "fix.go",
+        "main.go",
+        "print.go",
+    ],
+    deps = [
+        "@io_bazel_buildifier//core:go_default_library",
+        "@io_bazel_buildifier//differ:go_default_library",
+        "//go/tools/gazel/generator:go_default_library",
+    ],
+)
 
 go_binary(
     name = "gazel",
-    srcs = ["main.go"],
-    deps = [
-        "@io_bazel_buildifier//core:go_default_library",
-        "//go/tools/gazel/generator:go_default_library",
-    ],
+    library = ":go_default_library",
+)
+
+go_test(
+    name = "gazel_test",
+    srcs = ["fix_test.go"],
+    library = ":go_default_library",
 )

--- a/go/tools/gazel/gazel/diff.go
+++ b/go/tools/gazel/gazel/diff.go
@@ -1,0 +1,58 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+
+	bzl "github.com/bazelbuild/buildifier/core"
+	"github.com/bazelbuild/buildifier/differ"
+)
+
+func diffFile(file *bzl.File) (err error) {
+	f, err := ioutil.TempFile("", "BUILD")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		merr := os.Remove(f.Name())
+		if err == nil {
+			err = merr
+		}
+	}()
+	err = func() (err error) {
+		defer func() {
+			cerr := f.Close()
+			if err == nil {
+				err = cerr
+			}
+		}()
+		_, err = f.Write(bzl.Format(file))
+		return err
+	}()
+	if err != nil {
+		return err
+	}
+
+	diff := differ.Find()
+	if _, err := os.Stat(file.Path); os.IsNotExist(err) {
+		diff.Show(os.DevNull, f.Name())
+		return nil
+	}
+	diff.Show(file.Path, f.Name())
+	return nil
+}

--- a/go/tools/gazel/gazel/fix.go
+++ b/go/tools/gazel/gazel/fix.go
@@ -1,0 +1,27 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"io/ioutil"
+
+	bzl "github.com/bazelbuild/buildifier/core"
+)
+
+func fixFile(file *bzl.File) error {
+	// TODO(yugui) Respect exisiting manual configurations as well as possible
+	return ioutil.WriteFile(file.Path, bzl.Format(file), 0644)
+}

--- a/go/tools/gazel/gazel/fix_test.go
+++ b/go/tools/gazel/gazel/fix_test.go
@@ -1,0 +1,64 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	bzl "github.com/bazelbuild/buildifier/core"
+)
+
+func TestFixFile(t *testing.T) {
+	tmpdir := os.Getenv("TEST_TMPDIR")
+	dir, err := ioutil.TempDir(tmpdir, "")
+	if err != nil {
+		t.Fatalf("ioutil.TempDir(%q, %q) failed with %v; want success", tmpdir, "", err)
+	}
+	defer os.RemoveAll(dir)
+
+	stubFile := &bzl.File{
+		Path: filepath.Join(dir, "BUILD"),
+		Stmt: []bzl.Expr{
+			&bzl.CallExpr{
+				X: &bzl.LiteralExpr{Token: "foo_rule"},
+				List: []bzl.Expr{
+					&bzl.BinaryExpr{
+						X:  &bzl.LiteralExpr{Token: "name"},
+						Op: "=",
+						Y:  &bzl.StringExpr{Value: "bar"},
+					},
+				},
+			},
+		},
+	}
+
+	if err := fixFile(stubFile); err != nil {
+		t.Errorf("fixFile(%#v) failed with %v; want success", stubFile, err)
+		return
+	}
+
+	buf, err := ioutil.ReadFile(stubFile.Path)
+	if err != nil {
+		t.Errorf("ioutil.ReadFile(%q) failed with %v; want success", stubFile.Path, err)
+		return
+	}
+	if got, want := string(buf), bzl.FormatString(stubFile); got != want {
+		t.Errorf("buf = %q; want %q", got, want)
+	}
+}

--- a/go/tools/gazel/gazel/main.go
+++ b/go/tools/gazel/gazel/main.go
@@ -28,11 +28,12 @@ import (
 )
 
 var (
-	repoRoot = flag.String("repo_root", "", "path to a root directory of a repository")
+	goPrefix = flag.String("go_prefix", "", "go_prefix of the target workspace")
+	repoRoot = flag.String("repo_root", "", "path to a directory which corresponds to go_prefix")
 )
 
 func run(dirs []string) error {
-	g, err := generator.New(*repoRoot)
+	g, err := generator.New(*repoRoot, *goPrefix)
 	if err != nil {
 		return err
 	}
@@ -72,10 +73,15 @@ func main() {
 	flag.Usage = usage
 	flag.Parse()
 
+	if *goPrefix == "" {
+		// TODO(yugui) Extract go_prefix from the top level BUILD file if exists
+		log.Fatal("-go_prefix is required")
+	}
 	if *repoRoot == "" {
 		if flag.NArg() != 1 {
 			log.Fatal("-repo_root is required")
 		}
+		// TODO(yugui) Guess repoRoot at the same time as goPrefix
 		*repoRoot = flag.Arg(0)
 	}
 	if err := run(flag.Args()); err != nil {

--- a/go/tools/gazel/gazel/main.go
+++ b/go/tools/gazel/gazel/main.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 
 	bzl "github.com/bazelbuild/buildifier/core"
 	"github.com/bazelbuild/rules_go/go/tools/gazel/generator"
@@ -31,9 +32,16 @@ var (
 	rulesGoRepo = flag.String("rules_go_repo", generator.DefaultRulesGoRepo, "repository name of rules_go")
 	goPrefix    = flag.String("go_prefix", "", "go_prefix of the target workspace")
 	repoRoot    = flag.String("repo_root", "", "path to a directory which corresponds to go_prefix")
+	mode        = flag.String("mode", "print", "print, fix or diff")
 )
 
-func run(dirs []string) error {
+var modeFromName = map[string]func(*bzl.File) error{
+	"print": printFile,
+	"fix":   fixFile,
+	"diff":  diffFile,
+}
+
+func run(dirs []string, emit func(*bzl.File) error) error {
 	g, err := generator.New(*repoRoot, *goPrefix)
 	if err != nil {
 		return err
@@ -46,7 +54,8 @@ func run(dirs []string) error {
 			return err
 		}
 		for _, f := range files {
-			if _, err := os.Stdout.Write(bzl.Format(f)); err != nil {
+			f.Path = filepath.Join(*repoRoot, f.Path)
+			if err := emit(f); err != nil {
 				return err
 			}
 		}
@@ -67,6 +76,13 @@ notice.
 It takes a list of paths to Go package directories.
 It recursively traverses its subpackages.
 All the directories must be under the directory specified in -base_dir.
+
+There are several modes of gazel.
+In print mode, gazel prints reconciled BUILD files to stdout.
+In fix mode, gazel creates BUILD files or updates existing ones.
+In diff mode, gazel shows diff.
+
+FLAGS:
 `)
 	flag.PrintDefaults()
 }
@@ -86,7 +102,13 @@ func main() {
 		// TODO(yugui) Guess repoRoot at the same time as goPrefix
 		*repoRoot = flag.Arg(0)
 	}
-	if err := run(flag.Args()); err != nil {
+
+	emit := modeFromName[*mode]
+	if emit == nil {
+		log.Fatalf("unrecognized mode %s", *mode)
+	}
+
+	if err := run(flag.Args(), emit); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/go/tools/gazel/gazel/main.go
+++ b/go/tools/gazel/gazel/main.go
@@ -1,0 +1,84 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Command gazel is a BUILD file generator for Go projects.
+// See "gazel --help" for more details.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	bzl "github.com/bazelbuild/buildifier/core"
+	"github.com/bazelbuild/rules_go/go/tools/gazel/generator"
+)
+
+var (
+	repoRoot = flag.String("repo_root", "", "path to a root directory of a repository")
+)
+
+func run(dirs []string) error {
+	g, err := generator.New(*repoRoot)
+	if err != nil {
+		return err
+	}
+
+	for _, d := range dirs {
+		files, err := g.Generate(d)
+		if err != nil {
+			return err
+		}
+		for _, f := range files {
+			if _, err := os.Stdout.Write(bzl.Format(f)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func usage() {
+	fmt.Fprintln(os.Stderr, `usage: gazel [flags...] [package-dirs...]
+
+Gazel is a BUILD file generator for Go projects.
+
+Currently its primary usage is to generate BUILD files for external dependencies
+in a go_vendor repository rule.
+You can still use Gazel for other purposes, but its interface can change without
+notice.
+
+It takes a list of paths to Go package directories.
+It recursively traverses its subpackages.
+All the directories must be under the directory specified in -base_dir.
+`)
+	flag.PrintDefaults()
+}
+
+func main() {
+	flag.Usage = usage
+	flag.Parse()
+
+	if *repoRoot == "" {
+		if flag.NArg() != 1 {
+			log.Fatal("-repo_root is required")
+		}
+		*repoRoot = flag.Arg(0)
+	}
+	if err := run(flag.Args()); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/go/tools/gazel/gazel/main.go
+++ b/go/tools/gazel/gazel/main.go
@@ -28,8 +28,9 @@ import (
 )
 
 var (
-	goPrefix = flag.String("go_prefix", "", "go_prefix of the target workspace")
-	repoRoot = flag.String("repo_root", "", "path to a directory which corresponds to go_prefix")
+	rulesGoRepo = flag.String("rules_go_repo", generator.DefaultRulesGoRepo, "repository name of rules_go")
+	goPrefix    = flag.String("go_prefix", "", "go_prefix of the target workspace")
+	repoRoot    = flag.String("repo_root", "", "path to a directory which corresponds to go_prefix")
 )
 
 func run(dirs []string) error {
@@ -37,6 +38,7 @@ func run(dirs []string) error {
 	if err != nil {
 		return err
 	}
+	g.RulesGoRepo = *rulesGoRepo
 
 	for _, d := range dirs {
 		files, err := g.Generate(d)

--- a/go/tools/gazel/gazel/print.go
+++ b/go/tools/gazel/gazel/print.go
@@ -1,0 +1,27 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	bzl "github.com/bazelbuild/buildifier/core"
+)
+
+func printFile(f *bzl.File) (err error) {
+	_, err = os.Stdout.Write(bzl.Format(f))
+	return err
+}

--- a/go/tools/gazel/generator/BUILD
+++ b/go/tools/gazel/generator/BUILD
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["generator.go"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@io_bazel_buildifier//core:go_default_library",
+        "//go/tools/gazel/packages:go_default_library",
+        "//go/tools/gazel/rules:go_default_library",
+        "//go/tools/gazel/testdata:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["generator_test.go"],
+    library = ":go_default_library",
+    deps = [
+        "//go/tools/gazel/testdata:go_default_library",
+    ],
+)

--- a/go/tools/gazel/generator/generator.go
+++ b/go/tools/gazel/generator/generator.go
@@ -38,7 +38,9 @@ type Generator struct {
 // New returns a new Generator which is responsible for a Go repository.
 //
 // "repoRoot" is a path to the root directory of the repository.
-func New(repoRoot string) (*Generator, error) {
+// "goPrefix" is the go_prefix corresponding to the repository root directory.
+// See also https://github.com/bazelbuild/rules_go#go_prefix.
+func New(repoRoot, goPrefix string) (*Generator, error) {
 	bctx := build.Default
 	// Ignore source files in $GOROOT and $GOPATH
 	bctx.GOROOT = ""
@@ -51,7 +53,7 @@ func New(repoRoot string) (*Generator, error) {
 	return &Generator{
 		repoRoot: filepath.Clean(repoRoot),
 		bctx:     bctx,
-		g:        rules.NewGenerator(),
+		g:        rules.NewGenerator(goPrefix),
 	}, nil
 }
 

--- a/go/tools/gazel/generator/generator.go
+++ b/go/tools/gazel/generator/generator.go
@@ -1,0 +1,104 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package generator provides core functionality of
+// BUILD file generation in gazel.
+package generator
+
+import (
+	"fmt"
+	"go/build"
+	"path/filepath"
+	"strings"
+
+	bzl "github.com/bazelbuild/buildifier/core"
+	"github.com/bazelbuild/rules_go/go/tools/gazel/packages"
+	"github.com/bazelbuild/rules_go/go/tools/gazel/rules"
+)
+
+// Generator generates BUILD files for a Go repository.
+type Generator struct {
+	repoRoot string
+	bctx     build.Context
+	g        rules.Generator
+}
+
+// New returns a new Generator which is responsible for a Go repository.
+//
+// "repoRoot" is a path to the root directory of the repository.
+func New(repoRoot string) (*Generator, error) {
+	bctx := build.Default
+	// Ignore source files in $GOROOT and $GOPATH
+	bctx.GOROOT = ""
+	bctx.GOPATH = ""
+
+	repoRoot, err := filepath.Abs(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	return &Generator{
+		repoRoot: filepath.Clean(repoRoot),
+		bctx:     bctx,
+		g:        rules.NewGenerator(),
+	}, nil
+}
+
+// Generate generates a BUILD file for each Go package found under
+// the given directory.
+// The directory must be the repository root directory the caller
+// passed to New, or its subdirectory.
+func (g *Generator) Generate(dir string) ([]*bzl.File, error) {
+	dir, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, err
+	}
+	dir = filepath.Clean(dir)
+	if !isDescendingDir(dir, g.repoRoot) {
+		return nil, fmt.Errorf("dir %s is not under the repository root %s", dir, g.repoRoot)
+	}
+
+	var files []*bzl.File
+	err = packages.Walk(g.bctx, dir, func(pkg *build.Package) error {
+		rel, err := filepath.Rel(g.repoRoot, pkg.Dir)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			rel = ""
+		}
+
+		rs, err := g.g.Generate(filepath.ToSlash(rel), pkg)
+		if err != nil {
+			return err
+		}
+		file := &bzl.File{Path: filepath.Join(rel, "BUILD")}
+		for _, r := range rs {
+			file.Stmt = append(file.Stmt, r.Call)
+		}
+		files = append(files, file)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return files, nil
+}
+
+func isDescendingDir(dir, root string) bool {
+	if dir == root {
+		return true
+	}
+	return strings.HasPrefix(dir, fmt.Sprintf("%s%c", root, filepath.Separator))
+}

--- a/go/tools/gazel/generator/generator.go
+++ b/go/tools/gazel/generator/generator.go
@@ -28,11 +28,21 @@ import (
 	"github.com/bazelbuild/rules_go/go/tools/gazel/rules"
 )
 
+const (
+	// DefaultRulesGoRepo is the canonical workspace name of rules_go
+	DefaultRulesGoRepo = "@io_bazel_rules_go"
+)
+
 // Generator generates BUILD files for a Go repository.
 type Generator struct {
 	repoRoot string
 	bctx     build.Context
 	g        rules.Generator
+
+	// RulesGoRepo overrides Bazel repository name of rules_go.
+	// It is configurable only for importing external repositories into
+	// rules_go itself. So you usually don't have to specifiy this value.
+	RulesGoRepo string
 }
 
 // New returns a new Generator which is responsible for a Go repository.
@@ -51,9 +61,10 @@ func New(repoRoot, goPrefix string) (*Generator, error) {
 		return nil, err
 	}
 	return &Generator{
-		repoRoot: filepath.Clean(repoRoot),
-		bctx:     bctx,
-		g:        rules.NewGenerator(goPrefix),
+		repoRoot:    filepath.Clean(repoRoot),
+		bctx:        bctx,
+		g:           rules.NewGenerator(goPrefix),
+		RulesGoRepo: DefaultRulesGoRepo,
 	}, nil
 }
 
@@ -81,14 +92,11 @@ func (g *Generator) Generate(dir string) ([]*bzl.File, error) {
 			rel = ""
 		}
 
-		rs, err := g.g.Generate(filepath.ToSlash(rel), pkg)
+		file, err := g.generateOne(rel, pkg)
 		if err != nil {
 			return err
 		}
-		file := &bzl.File{Path: filepath.Join(rel, "BUILD")}
-		for _, r := range rs {
-			file.Stmt = append(file.Stmt, r.Call)
-		}
+
 		files = append(files, file)
 		return nil
 	})
@@ -96,6 +104,54 @@ func (g *Generator) Generate(dir string) ([]*bzl.File, error) {
 		return nil, err
 	}
 	return files, nil
+}
+
+func (g *Generator) generateOne(rel string, pkg *build.Package) (*bzl.File, error) {
+	rs, err := g.g.Generate(filepath.ToSlash(rel), pkg)
+	if err != nil {
+		return nil, err
+	}
+
+	file := &bzl.File{Path: filepath.Join(rel, "BUILD")}
+	for _, r := range rs {
+		file.Stmt = append(file.Stmt, r.Call)
+	}
+	if load := g.generateLoad(file); load != nil {
+		file.Stmt = append([]bzl.Expr{load}, file.Stmt...)
+	}
+	return file, nil
+}
+
+func (g *Generator) generateLoad(f *bzl.File) bzl.Expr {
+	var list []string
+	for _, kind := range []string{
+		"go_prefix",
+		"go_library",
+		"go_binary",
+		"go_test",
+		// TODO(yugui) Support cgo_library
+	} {
+		if len(f.Rules(kind)) > 0 {
+			list = append(list, kind)
+		}
+	}
+	if len(list) == 0 {
+		return nil
+	}
+	return loadExpr(fmt.Sprintf("%s//go:def.bzl", g.RulesGoRepo), list...)
+}
+
+func loadExpr(ruleFile string, rules ...string) bzl.Expr {
+	var list []bzl.Expr
+	for _, r := range append([]string{ruleFile}, rules...) {
+		list = append(list, &bzl.StringExpr{Value: r})
+	}
+
+	return &bzl.CallExpr{
+		X:            &bzl.LiteralExpr{Token: "load"},
+		List:         list,
+		ForceCompact: true,
+	}
 }
 
 func isDescendingDir(dir, root string) bool {

--- a/go/tools/gazel/generator/generator_test.go
+++ b/go/tools/gazel/generator/generator_test.go
@@ -38,6 +38,13 @@ func TestGenerator(t *testing.T) {
 					},
 				},
 			},
+			"lib/deep": {
+				{
+					Call: &bzl.CallExpr{
+						X: &bzl.LiteralExpr{Token: "go_library"},
+					},
+				},
+			},
 			"bin": {
 				{
 					Call: &bzl.CallExpr{
@@ -49,9 +56,9 @@ func TestGenerator(t *testing.T) {
 	}
 
 	repo := filepath.Join(testdata.Dir(), "repo")
-	g, err := New(repo)
+	g, err := New(repo, "example.com/repo")
 	if err != nil {
-		t.Errorf("New(%q) failed with %v; want success", repo, err)
+		t.Errorf(`New(%q, "example.com/repo") failed with %v; want success`, repo, err)
 		return
 	}
 	g.g = stub
@@ -66,6 +73,10 @@ func TestGenerator(t *testing.T) {
 		{
 			Path: "lib/BUILD",
 			Stmt: []bzl.Expr{stub.fixtures["lib"][0].Call},
+		},
+		{
+			Path: "lib/deep/BUILD",
+			Stmt: []bzl.Expr{stub.fixtures["lib/deep"][0].Call},
 		},
 		{
 			Path: "bin/BUILD",

--- a/go/tools/gazel/generator/generator_test.go
+++ b/go/tools/gazel/generator/generator_test.go
@@ -34,6 +34,11 @@ func TestGenerator(t *testing.T) {
 			"lib": {
 				{
 					Call: &bzl.CallExpr{
+						X: &bzl.LiteralExpr{Token: "go_prefix"},
+					},
+				},
+				{
+					Call: &bzl.CallExpr{
 						X: &bzl.LiteralExpr{Token: "go_library"},
 					},
 				},
@@ -42,6 +47,11 @@ func TestGenerator(t *testing.T) {
 				{
 					Call: &bzl.CallExpr{
 						X: &bzl.LiteralExpr{Token: "go_library"},
+					},
+				},
+				{
+					Call: &bzl.CallExpr{
+						X: &bzl.LiteralExpr{Token: "go_test"},
 					},
 				},
 			},
@@ -72,15 +82,26 @@ func TestGenerator(t *testing.T) {
 	want := []*bzl.File{
 		{
 			Path: "lib/BUILD",
-			Stmt: []bzl.Expr{stub.fixtures["lib"][0].Call},
+			Stmt: []bzl.Expr{
+				loadExpr("@io_bazel_rules_go//go:def.bzl", "go_prefix", "go_library"),
+				stub.fixtures["lib"][0].Call,
+				stub.fixtures["lib"][1].Call,
+			},
 		},
 		{
 			Path: "lib/deep/BUILD",
-			Stmt: []bzl.Expr{stub.fixtures["lib/deep"][0].Call},
+			Stmt: []bzl.Expr{
+				loadExpr("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test"),
+				stub.fixtures["lib/deep"][0].Call,
+				stub.fixtures["lib/deep"][1].Call,
+			},
 		},
 		{
 			Path: "bin/BUILD",
-			Stmt: []bzl.Expr{stub.fixtures["bin"][0].Call},
+			Stmt: []bzl.Expr{
+				loadExpr("@io_bazel_rules_go//go:def.bzl", "go_binary"),
+				stub.fixtures["bin"][0].Call,
+			},
 		},
 	}
 	sort.Sort(fileSlice(want))

--- a/go/tools/gazel/generator/generator_test.go
+++ b/go/tools/gazel/generator/generator_test.go
@@ -1,0 +1,105 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generator
+
+import (
+	"fmt"
+	"go/build"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	bzl "github.com/bazelbuild/buildifier/core"
+	"github.com/bazelbuild/rules_go/go/tools/gazel/testdata"
+)
+
+func TestGenerator(t *testing.T) {
+	stub := stubRuleGen{
+		fixtures: map[string][]*bzl.Rule{
+			"lib": {
+				{
+					Call: &bzl.CallExpr{
+						X: &bzl.LiteralExpr{Token: "go_library"},
+					},
+				},
+			},
+			"bin": {
+				{
+					Call: &bzl.CallExpr{
+						X: &bzl.LiteralExpr{Token: "go_binary"},
+					},
+				},
+			},
+		},
+	}
+
+	repo := filepath.Join(testdata.Dir(), "repo")
+	g, err := New(repo)
+	if err != nil {
+		t.Errorf("New(%q) failed with %v; want success", repo, err)
+		return
+	}
+	g.g = stub
+
+	got, err := g.Generate(repo)
+	if err != nil {
+		t.Errorf("g.Generate(%q) failed with %v; want success", repo, err)
+	}
+	sort.Sort(fileSlice(got))
+
+	want := []*bzl.File{
+		{
+			Path: "lib/BUILD",
+			Stmt: []bzl.Expr{stub.fixtures["lib"][0].Call},
+		},
+		{
+			Path: "bin/BUILD",
+			Stmt: []bzl.Expr{stub.fixtures["bin"][0].Call},
+		},
+	}
+	sort.Sort(fileSlice(want))
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("g.Generate(%q) = %v; want %v", repo, prettyFiles(got), prettyFiles(want))
+	}
+}
+
+type prettyFiles []*bzl.File
+
+func (p prettyFiles) String() string {
+	var items []string
+	for _, f := range p {
+		items = append(items, fmt.Sprintf("{Path: %q, Stmt: %q", f.Path, string(bzl.Format(f))))
+	}
+	return fmt.Sprintf("[%s]", strings.Join(items, ","))
+}
+
+type fileSlice []*bzl.File
+
+func (p fileSlice) Less(i, j int) bool { return strings.Compare(p[i].Path, p[j].Path) < 0 }
+func (p fileSlice) Len() int           { return len(p) }
+func (p fileSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+// stubRuleGen is a test stub implementation of rules.Generator
+type stubRuleGen struct {
+	fixtures map[string][]*bzl.Rule
+}
+
+func (s stubRuleGen) Generate(rel string, pkg *build.Package) ([]*bzl.Rule, error) {
+	return s.fixtures[rel], nil
+}

--- a/go/tools/gazel/packages/BUILD
+++ b/go/tools/gazel/packages/BUILD
@@ -1,0 +1,16 @@
+load("//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "walk.go",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_xtest",
+    srcs = ["walk_test.go"],
+    deps = [":go_default_library"],
+)

--- a/go/tools/gazel/packages/doc.go
+++ b/go/tools/gazel/packages/doc.go
@@ -1,0 +1,17 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package packages provides Go package traversal in a Bazel repository.
+package packages

--- a/go/tools/gazel/packages/walk.go
+++ b/go/tools/gazel/packages/walk.go
@@ -1,0 +1,54 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package packages
+
+import (
+	"go/build"
+	"os"
+	"path/filepath"
+)
+
+// A WalkFunc is a callback called by Walk for each package.
+type WalkFunc func(pkg *build.Package) error
+
+// Walk walks through Go packages under the given dir.
+// It calls back "f" for each package.
+//
+// It is similar to "golang.org/x/tools/go/buildutil".ForEachPackage, but
+// it does not assume the standard Go tree because Bazel rules_go uses go_prefix.
+// instead of the standard tree.
+func Walk(bctx build.Context, root string, f WalkFunc) error {
+	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			return nil
+		}
+		if base := info.Name(); base == "" || base[0] == '.' || base[0] == '_' || base == "testdata" {
+			return filepath.SkipDir
+		}
+
+		pkg, err := bctx.ImportDir(path, build.ImportComment)
+		if _, ok := err.(*build.NoGoError); ok {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		return f(pkg)
+	})
+}

--- a/go/tools/gazel/packages/walk_test.go
+++ b/go/tools/gazel/packages/walk_test.go
@@ -1,0 +1,108 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package packages_test
+
+import (
+	"go/build"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/gazel/packages"
+)
+
+func tempDir() (string, error) {
+	return ioutil.TempDir(os.Getenv("TEST_TMPDIR"), "walk_test")
+}
+
+func TestWalkSimple(t *testing.T) {
+	dir, err := tempDir()
+	if err != nil {
+		t.Fatalf("tempDir() failed with %v; want success", err)
+	}
+	defer os.RemoveAll(dir)
+
+	fname := filepath.Join(dir, "lib.go")
+	if err := ioutil.WriteFile(fname, []byte("package lib"), 0600); err != nil {
+		t.Fatalf(`ioutil.WriteFile(%q, "package lib", 0600) failed with %v; want success`, fname, err)
+	}
+
+	var n int
+	err = packages.Walk(build.Default, dir, func(pkg *build.Package) error {
+		if got, want := pkg.Name, "lib"; got != want {
+			t.Errorf("pkg.Name = %q; want %q", got, want)
+		}
+		n++
+		return nil
+	})
+	if err != nil {
+		t.Errorf("packages.Walk(build.Default, %q, func) failed with %v; want success", dir, err)
+	}
+	if got, want := n, 1; got != want {
+		t.Errorf("n = %d; want %d", got, want)
+	}
+}
+
+func TestWalkNested(t *testing.T) {
+	dir, err := tempDir()
+	if err != nil {
+		t.Fatalf("tempDir() failed with %v; want success", err)
+	}
+	defer os.RemoveAll(dir)
+
+	for _, p := range []struct {
+		path, content string
+	}{
+		{path: "a/foo.go", content: "package a"},
+		{path: "b/c/bar.go", content: "package c"},
+		{path: "b/d/baz.go", content: "package main"},
+	} {
+		path := filepath.Join(dir, p.path)
+		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+			t.Fatalf("os.MkdirAll(%q, 0700) failed with %v; want success", filepath.Dir(path), err)
+		}
+		if err := ioutil.WriteFile(path, []byte(p.content), 0600); err != nil {
+			t.Fatalf("ioutil.WriteFile(%q, %q, 0600) failed with %v; want success", path, p.content, err)
+		}
+	}
+
+	var dirs, pkgs []string
+	err = packages.Walk(build.Default, dir, func(pkg *build.Package) error {
+		rel, err := filepath.Rel(dir, pkg.Dir)
+		if err != nil {
+			t.Errorf("filepath.Rel(%q, %q) failed with %v; want success", dir, pkg.Dir, err)
+			return err
+		}
+		dirs = append(dirs, filepath.ToSlash(rel))
+		pkgs = append(pkgs, pkg.Name)
+		return nil
+	})
+	if err != nil {
+		t.Errorf("packages.Walk(build.Default, %q, func) failed with %v; want success", dir, err)
+	}
+
+	sort.Strings(dirs)
+	if got, want := dirs, []string{"a", "b/c", "b/d"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("pkgs = %q; want %q", got, want)
+	}
+	sort.Strings(pkgs)
+	if got, want := pkgs, []string{"a", "c", "main"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("pkgs = %q; want %q", got, want)
+	}
+}

--- a/go/tools/gazel/rules/BUILD
+++ b/go/tools/gazel/rules/BUILD
@@ -6,11 +6,22 @@ go_library(
         "construct.go",
         "doc.go",
         "generator.go",
+        "resolve.go",
+        "resolve_structured.go",
     ],
     visibility = ["//visibility:public"],
     deps = [
         "@io_bazel_buildifier//core:go_default_library",
     ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "resolve_structured_test.go",
+        "resolve_test.go",
+    ],
+    library = ":go_default_library",
 )
 
 go_test(

--- a/go/tools/gazel/rules/BUILD
+++ b/go/tools/gazel/rules/BUILD
@@ -1,0 +1,25 @@
+load("//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "construct.go",
+        "doc.go",
+        "generator.go",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@io_bazel_buildifier//core:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_xtest",
+    srcs = ["generator_test.go"],
+    data = glob(["testdata/**/*"]),
+    deps = [
+        "@io_bazel_buildifier//core:go_default_library",
+        ":go_default_library",
+        "//go/tools/gazel/testdata:go_default_library",
+    ],
+)

--- a/go/tools/gazel/rules/construct.go
+++ b/go/tools/gazel/rules/construct.go
@@ -1,0 +1,83 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rules
+
+import (
+	"fmt"
+	"reflect"
+
+	bzl "github.com/bazelbuild/buildifier/core"
+)
+
+type keyvalue struct {
+	key   string
+	value interface{}
+}
+
+func newRule(kind string, args []interface{}, kwargs []keyvalue) (*bzl.Rule, error) {
+	var list []bzl.Expr
+	for i, arg := range args {
+		expr, err := newValue(arg)
+		if err != nil {
+			return nil, fmt.Errorf("wrong arg %v at args[%d]: %v", arg, i, err)
+		}
+		list = append(list, expr)
+	}
+	for _, arg := range kwargs {
+		expr, err := newValue(arg.value)
+		if err != nil {
+			return nil, fmt.Errorf("wrong value %v at kwargs[%q]: %v", arg.value, arg.key, err)
+		}
+		list = append(list, &bzl.BinaryExpr{
+			X:  &bzl.LiteralExpr{Token: arg.key},
+			Op: "=",
+			Y:  expr,
+		})
+	}
+
+	return &bzl.Rule{
+		Call: &bzl.CallExpr{
+			X:    &bzl.LiteralExpr{Token: kind},
+			List: list,
+		},
+	}, nil
+}
+
+// newValue converts a Go value into the corresponding expression in Bazel BUILD file.
+func newValue(val interface{}) (bzl.Expr, error) {
+	rv := reflect.ValueOf(val)
+	switch rv.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return &bzl.LiteralExpr{Token: fmt.Sprintf("%d", val)}, nil
+	case reflect.Float32, reflect.Float64:
+		return &bzl.LiteralExpr{Token: fmt.Sprintf("%f", val)}, nil
+	case reflect.String:
+		return &bzl.StringExpr{Value: val.(string)}, nil
+	case reflect.Slice, reflect.Array:
+		var list []bzl.Expr
+		for i := 0; i < rv.Len(); i++ {
+			elem, err := newValue(rv.Index(i).Interface())
+			if err != nil {
+				return nil, err
+			}
+			list = append(list, elem)
+		}
+		return &bzl.ListExpr{List: list}, nil
+	default:
+		return nil, fmt.Errorf("not implemented %T", val)
+	}
+}

--- a/go/tools/gazel/rules/doc.go
+++ b/go/tools/gazel/rules/doc.go
@@ -1,0 +1,17 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rules provides Bazel rule generation for Go build targets.
+package rules

--- a/go/tools/gazel/rules/generator.go
+++ b/go/tools/gazel/rules/generator.go
@@ -1,0 +1,62 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rules
+
+import (
+	"go/build"
+	"path"
+
+	bzl "github.com/bazelbuild/buildifier/core"
+)
+
+// Generator generates Bazel build rules for Go build targets
+type Generator interface {
+	// Generate generates build rules for build targets in a Go package in a
+	// repository.
+	//
+	// "rel" is a relative slash-separated path from the repostiry root
+	// directory to the Go package directory. It is empty if the package
+	// directory is the repository root itself.
+	// "pkg" is a description about the package.
+	Generate(rel string, pkg *build.Package) ([]*bzl.Rule, error)
+}
+
+// NewGenerator returns an implementation of Generator.
+func NewGenerator() Generator {
+	return new(generator)
+}
+
+type generator struct{}
+
+func (g *generator) Generate(rel string, pkg *build.Package) ([]*bzl.Rule, error) {
+	kind := "go_library"
+	name := "go_default_library"
+	if pkg.IsCommand() {
+		kind = "go_binary"
+		name = path.Base(pkg.Dir)
+	}
+
+	var rules []*bzl.Rule
+	r, err := newRule(kind, nil, []keyvalue{
+		{key: "name", value: name},
+		{key: "srcs", value: pkg.GoFiles},
+	})
+	if err != nil {
+		return nil, err
+	}
+	rules = append(rules, r)
+	return rules, nil
+}

--- a/go/tools/gazel/rules/generator.go
+++ b/go/tools/gazel/rules/generator.go
@@ -65,6 +65,14 @@ func (g *generator) Generate(rel string, pkg *build.Package) ([]*bzl.Rule, error
 		}
 		rules = append(rules, t)
 	}
+
+	if len(pkg.XTestGoFiles) > 0 {
+		t, err := g.generateXTest(rel, pkg, r.AttrString("name"))
+		if err != nil {
+			return nil, err
+		}
+		rules = append(rules, t)
+	}
 	return rules, nil
 }
 
@@ -110,6 +118,24 @@ func (g *generator) generateTest(rel string, pkg *build.Package, library string)
 	if len(deps) > 0 {
 		attrs = append(attrs, keyvalue{key: "deps", value: deps})
 	}
+	return newRule("go_test", nil, attrs)
+}
+
+func (g *generator) generateXTest(rel string, pkg *build.Package, library string) (*bzl.Rule, error) {
+	name := library + "_xtest"
+	if library == "go_default_library" {
+		name = "go_default_xtest"
+	}
+	attrs := []keyvalue{
+		{key: "name", value: name},
+		{key: "srcs", value: pkg.XTestGoFiles},
+	}
+
+	deps, err := g.dependencies(pkg.XTestImports, rel)
+	if err != nil {
+		return nil, err
+	}
+	attrs = append(attrs, keyvalue{key: "deps", value: deps})
 	return newRule("go_test", nil, attrs)
 }
 

--- a/go/tools/gazel/rules/generator.go
+++ b/go/tools/gazel/rules/generator.go
@@ -18,6 +18,7 @@ package rules
 import (
 	"go/build"
 	"path"
+	"strings"
 
 	bzl "github.com/bazelbuild/buildifier/core"
 )
@@ -35,13 +36,30 @@ type Generator interface {
 }
 
 // NewGenerator returns an implementation of Generator.
-func NewGenerator() Generator {
-	return new(generator)
+//
+// "goPrefix" is the go_prefix corresponding to the repository root.
+// See also https://github.com/bazelbuild/rules_go#go_prefix.
+func NewGenerator(goPrefix string) Generator {
+	return &generator{
+		// TODO(yugui) Support another resolver to cover the pattern 2 in
+		// https://github.com/bazelbuild/rules_go/issues/16#issuecomment-216010843
+		r: structuredResolver{goPrefix: goPrefix},
+	}
 }
 
-type generator struct{}
+type generator struct {
+	r labelResolver
+}
 
 func (g *generator) Generate(rel string, pkg *build.Package) ([]*bzl.Rule, error) {
+	r, err := g.generate(rel, pkg)
+	if err != nil {
+		return nil, err
+	}
+	return []*bzl.Rule{r}, nil
+}
+
+func (g *generator) generate(rel string, pkg *build.Package) (*bzl.Rule, error) {
 	kind := "go_library"
 	name := "go_default_library"
 	if pkg.IsCommand() {
@@ -49,14 +67,39 @@ func (g *generator) Generate(rel string, pkg *build.Package) ([]*bzl.Rule, error
 		name = path.Base(pkg.Dir)
 	}
 
-	var rules []*bzl.Rule
-	r, err := newRule(kind, nil, []keyvalue{
+	attrs := []keyvalue{
 		{key: "name", value: name},
 		{key: "srcs", value: pkg.GoFiles},
-	})
+	}
+
+	deps, err := g.dependencies(pkg.Imports, rel)
 	if err != nil {
 		return nil, err
 	}
-	rules = append(rules, r)
-	return rules, nil
+	if len(deps) > 0 {
+		attrs = append(attrs, keyvalue{key: "deps", value: deps})
+	}
+
+	return newRule(kind, nil, attrs)
+}
+
+func (g *generator) dependencies(imports []string, dir string) ([]string, error) {
+	var deps []string
+	for _, p := range imports {
+		if isStandard(p) {
+			continue
+		}
+		l, err := g.r.resolve(p, dir)
+		if err != nil {
+			return nil, err
+		}
+		deps = append(deps, l.String())
+	}
+	return deps, nil
+}
+
+// isStandard determines if importpath points a Go standard package.
+func isStandard(importpath string) bool {
+	seg := strings.SplitN(importpath, "/", 2)[0]
+	return !strings.Contains(seg, ".")
 }

--- a/go/tools/gazel/rules/generator_test.go
+++ b/go/tools/gazel/rules/generator_test.go
@@ -51,7 +51,7 @@ func packageFromDir(t *testing.T, dir string) *build.Package {
 }
 
 func TestGenerator(t *testing.T) {
-	g := rules.NewGenerator()
+	g := rules.NewGenerator("example.com/repo")
 	for _, spec := range []struct {
 		dir  string
 		want string
@@ -65,6 +65,7 @@ func TestGenerator(t *testing.T) {
 						"doc.go",
 						"lib.go",
 					],
+					deps = ["//lib/deep:go_default_library"],
 				)
 			`,
 		},
@@ -74,6 +75,7 @@ func TestGenerator(t *testing.T) {
 				go_binary(
 					name = "bin",
 					srcs = ["main.go"],
+					deps = ["//lib:go_default_library"],
 				)
 			`,
 		},

--- a/go/tools/gazel/rules/generator_test.go
+++ b/go/tools/gazel/rules/generator_test.go
@@ -1,0 +1,91 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rules_test
+
+import (
+	"go/build"
+	"path/filepath"
+	"testing"
+
+	bzl "github.com/bazelbuild/buildifier/core"
+	"github.com/bazelbuild/rules_go/go/tools/gazel/rules"
+	"github.com/bazelbuild/rules_go/go/tools/gazel/testdata"
+)
+
+func canonicalize(t *testing.T, filename, content string) string {
+	f, err := bzl.Parse(filename, []byte(content))
+	if err != nil {
+		t.Fatalf("bzl.Parse(%q, %q) failed with %v; want success", filename, content, err)
+	}
+	return string(bzl.Format(f))
+}
+
+func format(rules []*bzl.Rule) string {
+	var f bzl.File
+	for _, r := range rules {
+		f.Stmt = append(f.Stmt, r.Call)
+	}
+	return string(bzl.Format(&f))
+}
+
+func packageFromDir(t *testing.T, dir string) *build.Package {
+	dir = filepath.Join(testdata.Dir(), "repo", dir)
+	pkg, err := build.ImportDir(dir, build.ImportComment)
+	if err != nil {
+		t.Fatalf("build.ImportDir(%q, build.ImportComment) failed with %v; want success", dir, err)
+	}
+	return pkg
+}
+
+func TestGenerator(t *testing.T) {
+	g := rules.NewGenerator()
+	for _, spec := range []struct {
+		dir  string
+		want string
+	}{
+		{
+			dir: "lib",
+			want: `
+				go_library(
+					name = "go_default_library",
+					srcs = [
+						"doc.go",
+						"lib.go",
+					],
+				)
+			`,
+		},
+		{
+			dir: "bin",
+			want: `
+				go_binary(
+					name = "bin",
+					srcs = ["main.go"],
+				)
+			`,
+		},
+	} {
+		pkg := packageFromDir(t, filepath.FromSlash(spec.dir))
+		rules, err := g.Generate(spec.dir, pkg)
+		if err != nil {
+			t.Errorf("g.Generate(%q, %#v) failed with %v; want success", spec.dir, pkg, err)
+		}
+
+		if got, want := format(rules), canonicalize(t, spec.dir+"/BUILD", spec.want); got != want {
+			t.Errorf("g.Generate(%q, %#v) = %s; want %s", spec.dir, pkg, got, want)
+		}
+	}
+}

--- a/go/tools/gazel/rules/generator_test.go
+++ b/go/tools/gazel/rules/generator_test.go
@@ -67,6 +67,12 @@ func TestGenerator(t *testing.T) {
 					],
 					deps = ["//lib/deep:go_default_library"],
 				)
+
+				go_test(
+					name = "go_default_test",
+					srcs = ["lib_test.go"],
+					library = ":go_default_library",
+				)
 			`,
 		},
 		{

--- a/go/tools/gazel/rules/generator_test.go
+++ b/go/tools/gazel/rules/generator_test.go
@@ -103,3 +103,24 @@ func TestGenerator(t *testing.T) {
 		}
 	}
 }
+
+func TestGeneratorGoPrefix(t *testing.T) {
+	g := rules.NewGenerator("example.com/repo/lib/deep")
+	want := `
+		go_prefix("example.com/repo/lib/deep")
+
+		go_library(
+			name = "go_default_library",
+			srcs = ["thought.go"],
+		)
+	`
+	pkg := packageFromDir(t, filepath.FromSlash("lib/deep"))
+	rules, err := g.Generate("", pkg)
+	if err != nil {
+		t.Errorf("g.Generate(%q, %#v) failed with %v; want success", "", pkg, err)
+	}
+
+	if got, want := format(rules), canonicalize(t, "BUILD", want); got != want {
+		t.Errorf("g.Generate(%q, %#v) = %s; want %s", "", pkg, got, want)
+	}
+}

--- a/go/tools/gazel/rules/generator_test.go
+++ b/go/tools/gazel/rules/generator_test.go
@@ -73,6 +73,12 @@ func TestGenerator(t *testing.T) {
 					srcs = ["lib_test.go"],
 					library = ":go_default_library",
 				)
+
+				go_test(
+					name = "go_default_xtest",
+					srcs = ["lib_external_test.go"],
+					deps = [":go_default_library"],
+				)
 			`,
 		},
 		{

--- a/go/tools/gazel/rules/resolve.go
+++ b/go/tools/gazel/rules/resolve.go
@@ -1,0 +1,51 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rules
+
+import (
+	"fmt"
+)
+
+// A labelResolver resolves a Go importpath into a label in Bazel.
+type labelResolver interface {
+	// resolve resolves a Go importpath "importpath", which is referenced from
+	// a Go package directory "dir" in the current repository.
+	// "dir" is a relative slash-delimited path from the top level of the
+	// current repository.
+	resolve(importpath, dir string) (label, error)
+}
+
+type resolverFunc func(importpath, dir string) (label, error)
+
+func (f resolverFunc) resolve(importpath, dir string) (label, error) {
+	return f(importpath, dir)
+}
+
+// A label represents a label of a build target in Bazel.
+type label struct {
+	repo, pkg, name string
+	relative        bool
+}
+
+func (l label) String() string {
+	if l.relative {
+		return fmt.Sprintf(":%s", l.name)
+	}
+	if l.repo != "" {
+		return fmt.Sprintf("@%s//%s:%s", l.repo, l.pkg, l.name)
+	}
+	return fmt.Sprintf("//%s:%s", l.pkg, l.name)
+}

--- a/go/tools/gazel/rules/resolve_structured.go
+++ b/go/tools/gazel/rules/resolve_structured.go
@@ -1,0 +1,50 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rules
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+// structuredResolver resolves go_library labels within the same repository as
+// the one of goPrefix.
+type structuredResolver struct {
+	goPrefix string
+}
+
+// resolve takes a Go importpath within the same respository as r.goPrefix
+// and resolves it into a label in Bazel.
+func (r structuredResolver) resolve(importpath, dir string) (label, error) {
+	if strings.HasPrefix(importpath, "./") {
+		importpath = path.Join(r.goPrefix, dir, importpath[2:])
+	}
+
+	if importpath == r.goPrefix {
+		return label{name: "go_default_library"}, nil
+	}
+
+	if prefix := r.goPrefix + "/"; strings.HasPrefix(importpath, prefix) {
+		pkg := strings.TrimPrefix(importpath, prefix)
+		if pkg == dir {
+			return label{name: "go_default_library", relative: true}, nil
+		}
+		return label{pkg: pkg, name: "go_default_library"}, nil
+	}
+
+	return label{}, fmt.Errorf("importpath %q does not start with goPrefix %q", importpath, r.goPrefix)
+}

--- a/go/tools/gazel/rules/resolve_structured_test.go
+++ b/go/tools/gazel/rules/resolve_structured_test.go
@@ -1,0 +1,92 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rules
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestStructuredResolver(t *testing.T) {
+	r := structuredResolver{goPrefix: "example.com/repo"}
+	for _, spec := range []struct {
+		importpath string
+		curPkg     string
+		want       label
+	}{
+		{
+			importpath: "example.com/repo",
+			curPkg:     "",
+			want:       label{name: "go_default_library"},
+		},
+		{
+			importpath: "example.com/repo/lib",
+			curPkg:     "",
+			want:       label{pkg: "lib", name: "go_default_library"},
+		},
+		{
+			importpath: "example.com/repo/another",
+			curPkg:     "",
+			want:       label{pkg: "another", name: "go_default_library"},
+		},
+
+		{
+			importpath: "example.com/repo",
+			curPkg:     "lib",
+			want:       label{name: "go_default_library"},
+		},
+		{
+			importpath: "example.com/repo/lib",
+			curPkg:     "lib",
+			want:       label{name: "go_default_library", relative: true},
+		},
+		{
+			importpath: "example.com/repo/lib/sub",
+			curPkg:     "lib",
+			want:       label{pkg: "lib/sub", name: "go_default_library"},
+		},
+		{
+			importpath: "example.com/repo/another",
+			curPkg:     "lib",
+			want:       label{pkg: "another", name: "go_default_library"},
+		},
+	} {
+
+		l, err := r.resolve(spec.importpath, spec.curPkg)
+		if err != nil {
+			t.Errorf("r.resolve(%q) failed with %v; want success", spec.importpath, err)
+			continue
+		}
+		if got, want := l, spec.want; !reflect.DeepEqual(got, want) {
+			t.Errorf("r.resolve(%q) = %s; want %s", spec.importpath, got, want)
+		}
+	}
+}
+
+func TestStructuredResolverError(t *testing.T) {
+	r := structuredResolver{goPrefix: "example.com/repo"}
+
+	for _, importpath := range []string{
+		"example.com/another",
+		"example.com/another/sub",
+		"example.com/repo_suffix",
+	} {
+		l, err := r.resolve(importpath, "")
+		if err == nil {
+			t.Errorf("r.resolve(%q) = %s; want error", importpath, l)
+		}
+	}
+}

--- a/go/tools/gazel/rules/resolve_test.go
+++ b/go/tools/gazel/rules/resolve_test.go
@@ -13,14 +13,36 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package lib
+package rules
 
 import (
-	"example.com/repo/lib/deep"
+	"testing"
 )
 
-// Answer returns the ultimate answer to life, the universe and everything.
-func Answer() int {
-	var d deep.Thought
-	return d.Compute()
+func TestLabelString(t *testing.T) {
+	for _, spec := range []struct {
+		l    label
+		want string
+	}{
+		{
+			l:    label{name: "foo"},
+			want: "//:foo",
+		},
+		{
+			l:    label{pkg: "foo/bar", name: "baz"},
+			want: "//foo/bar:baz",
+		},
+		{
+			l:    label{repo: "com_example_repo", pkg: "foo/bar", name: "baz"},
+			want: "@com_example_repo//foo/bar:baz",
+		},
+		{
+			l:    label{relative: true, name: "foo"},
+			want: ":foo",
+		},
+	} {
+		if got, want := spec.l.String(), spec.want; got != want {
+			t.Errorf("%#v.String() = %q; want %q", spec.l, got, want)
+		}
+	}
 }

--- a/go/tools/gazel/testdata/BUILD
+++ b/go/tools/gazel/testdata/BUILD
@@ -1,0 +1,12 @@
+package(
+    default_testonly = 1,
+    default_visibility = ["//go/tools/gazel:__subpackages__"],
+)
+
+load("//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["testdata.go"],
+    data = glob(["repo/**/*.go"]),
+)

--- a/go/tools/gazel/testdata/repo/bin/main.go
+++ b/go/tools/gazel/testdata/repo/bin/main.go
@@ -1,0 +1,26 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+
+	"example.com/repo/lib"
+)
+
+func main() {
+	fmt.Println(lib.Answer())
+}

--- a/go/tools/gazel/testdata/repo/lib/deep/thought.go
+++ b/go/tools/gazel/testdata/repo/lib/deep/thought.go
@@ -13,14 +13,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package lib
+package deep
 
-import (
-	"example.com/repo/lib/deep"
-)
+// Thought is an emulator of the Deep Thought computer.
+type Thought struct{}
 
-// Answer returns the ultimate answer to life, the universe and everything.
-func Answer() int {
-	var d deep.Thought
-	return d.Compute()
-}
+func (t Thought) Compute() int { return 42 }

--- a/go/tools/gazel/testdata/repo/lib/doc.go
+++ b/go/tools/gazel/testdata/repo/lib/doc.go
@@ -1,0 +1,17 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package lib is an example go library package to be used as a test data of Gazel.
+package lib

--- a/go/tools/gazel/testdata/repo/lib/lib.go
+++ b/go/tools/gazel/testdata/repo/lib/lib.go
@@ -1,0 +1,21 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lib
+
+// Answer returns the ultimate answer to life, the universe and everything.
+func Answer() int {
+	return 42
+}

--- a/go/tools/gazel/testdata/repo/lib/lib_external_test.go
+++ b/go/tools/gazel/testdata/repo/lib/lib_external_test.go
@@ -1,0 +1,28 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lib_test
+
+import (
+	"testing"
+
+	"example.com/repo/lib"
+)
+
+func TestAnswerExternal(t *testing.T) {
+	if got, want := lib.Answer(), 42; got != want {
+		t.Errorf("lib.Answer() = %d; want %d", got, want)
+	}
+}

--- a/go/tools/gazel/testdata/repo/lib/lib_test.go
+++ b/go/tools/gazel/testdata/repo/lib/lib_test.go
@@ -1,0 +1,26 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lib
+
+import (
+	"testing"
+)
+
+func TestAnswer(t *testing.T) {
+	if got, want := Answer(), 42; got != want {
+		t.Errorf("Answer() = %d; want %d", got, want)
+	}
+}

--- a/go/tools/gazel/testdata/testdata.go
+++ b/go/tools/gazel/testdata/testdata.go
@@ -1,0 +1,31 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package testdata provides convenient access to testdata files
+package testdata
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Dir returns a path to the testdata directory.
+func Dir() string {
+	srcdir := os.Getenv("TEST_SRCDIR")
+	return filepath.Join(
+		srcdir, os.Getenv("TEST_WORKSPACE"),
+		"go", "tools", "gazel", "testdata",
+	)
+}


### PR DESCRIPTION
Supported:
* `load` golang build rules
* Generate `go_prefix` if necessary
* Generate `go_library`, `go_binary`, `go_test` rules
* Refer dependencies between rules within a repository
* Write `BUILD` files, show diff or just prints the result into stdout

To be supported later:
* cgo
* Refer dependencies to external repository
* The pattern 2 in https://github.com/bazelbuild/rules_go/issues/16#issuecomment-216010843
* `visibility`
* respect manual modifications on fixing existing `BUILD` files
* `go_vendor` rule which automatically applies Gazel to external repositories, as discussed in https://github.com/bazelbuild/rules_go/issues/16#issuecomment-216218578

Gazel should be considered experimental. It is possible that this is replaced with glaze when Google opensources it.

c.f. #15 