### PR TITLE
Support more rules in Gazel

### DIFF
--- a/go/tools/gazelle/generator/generator_test.go
+++ b/go/tools/gazelle/generator/generator_test.go
@@ -34,6 +34,11 @@ func TestGenerator(t *testing.T) {
 			"lib": {
 				{
 					Call: &bzl.CallExpr{
+						X: &bzl.LiteralExpr{Token: "go_prefix"},
+					},
+				},
+				{
+					Call: &bzl.CallExpr{
 						X: &bzl.LiteralExpr{Token: "go_library"},
 					},
 				},
@@ -42,6 +47,11 @@ func TestGenerator(t *testing.T) {
 				{
 					Call: &bzl.CallExpr{
 						X: &bzl.LiteralExpr{Token: "go_library"},
+					},
+				},
+				{
+					Call: &bzl.CallExpr{
+						X: &bzl.LiteralExpr{Token: "go_test"},
 					},
 				},
 			},
@@ -72,15 +82,26 @@ func TestGenerator(t *testing.T) {
 	want := []*bzl.File{
 		{
 			Path: "lib/BUILD",
-			Stmt: []bzl.Expr{stub.fixtures["lib"][0].Call},
+			Stmt: []bzl.Expr{
+				loadExpr("@io_bazel_rules_go//go:def.bzl", "go_prefix", "go_library"),
+				stub.fixtures["lib"][0].Call,
+				stub.fixtures["lib"][1].Call,
+			},
 		},
 		{
 			Path: "lib/deep/BUILD",
-			Stmt: []bzl.Expr{stub.fixtures["lib/deep"][0].Call},
+			Stmt: []bzl.Expr{
+				loadExpr("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test"),
+				stub.fixtures["lib/deep"][0].Call,
+				stub.fixtures["lib/deep"][1].Call,
+			},
 		},
 		{
 			Path: "bin/BUILD",
-			Stmt: []bzl.Expr{stub.fixtures["bin"][0].Call},
+			Stmt: []bzl.Expr{
+				loadExpr("@io_bazel_rules_go//go:def.bzl", "go_binary"),
+				stub.fixtures["bin"][0].Call,
+			},
 		},
 	}
 	sort.Sort(fileSlice(want))

--- a/go/tools/gazelle/rules/generator.go
+++ b/go/tools/gazelle/rules/generator.go
@@ -27,6 +27,10 @@ const (
 	// defaultLibName is the name of the default go_library rule in a Go
 	// package directory. It must be consistent to _DEFAULT_LIB in go/def.bzl.
 	defaultLibName = "go_default_library"
+	// defaultTestName is a name of an internal test corresponding to
+	// defaultLibName. It does not need to be consistent to something but it
+	// just needs to be unique in the Bazel package
+	defaultTestName = "go_default_test"
 )
 
 // Generator generates Bazel build rules for Go build targets
@@ -62,7 +66,16 @@ func (g *generator) Generate(rel string, pkg *build.Package) ([]*bzl.Rule, error
 	if err != nil {
 		return nil, err
 	}
-	return []*bzl.Rule{r}, nil
+	rules := []*bzl.Rule{r}
+
+	if len(pkg.TestGoFiles) > 0 {
+		t, err := g.generateTest(rel, pkg, r.AttrString("name"))
+		if err != nil {
+			return nil, err
+		}
+		rules = append(rules, t)
+	}
+	return rules, nil
 }
 
 func (g *generator) generate(rel string, pkg *build.Package) (*bzl.Rule, error) {
@@ -87,6 +100,27 @@ func (g *generator) generate(rel string, pkg *build.Package) (*bzl.Rule, error) 
 	}
 
 	return newRule(kind, nil, attrs)
+}
+
+func (g *generator) generateTest(rel string, pkg *build.Package, library string) (*bzl.Rule, error) {
+	name := library + "_test"
+	if library == defaultLibName {
+		name = defaultTestName
+	}
+	attrs := []keyvalue{
+		{key: "name", value: name},
+		{key: "srcs", value: pkg.TestGoFiles},
+		{key: "library", value: ":" + library},
+	}
+
+	deps, err := g.dependencies(pkg.TestImports, rel)
+	if err != nil {
+		return nil, err
+	}
+	if len(deps) > 0 {
+		attrs = append(attrs, keyvalue{key: "deps", value: deps})
+	}
+	return newRule("go_test", nil, attrs)
 }
 
 func (g *generator) dependencies(imports []string, dir string) ([]string, error) {

--- a/go/tools/gazelle/rules/generator.go
+++ b/go/tools/gazelle/rules/generator.go
@@ -54,6 +54,7 @@ type Generator interface {
 // See also https://github.com/bazelbuild/rules_go#go_prefix.
 func NewGenerator(goPrefix string) Generator {
 	return &generator{
+		goPrefix: goPrefix,
 		// TODO(yugui): Support another resolver to cover the pattern 2 in
 		// https://github.com/bazelbuild/rules_go/issues/16#issuecomment-216010843
 		r: structuredResolver{goPrefix: goPrefix},
@@ -61,15 +62,25 @@ func NewGenerator(goPrefix string) Generator {
 }
 
 type generator struct {
-	r labelResolver
+	goPrefix string
+	r        labelResolver
 }
 
 func (g *generator) Generate(rel string, pkg *build.Package) ([]*bzl.Rule, error) {
+	var rules []*bzl.Rule
+	if rel == "" {
+		p, err := newRule("go_prefix", []interface{}{g.goPrefix}, nil)
+		if err != nil {
+			return nil, err
+		}
+		rules = append(rules, p)
+	}
+
 	r, err := g.generate(rel, pkg)
 	if err != nil {
 		return nil, err
 	}
-	rules := []*bzl.Rule{r}
+	rules = append(rules, r)
 
 	if len(pkg.TestGoFiles) > 0 {
 		t, err := g.generateTest(rel, pkg, r.AttrString("name"))

--- a/go/tools/gazelle/rules/generator_test.go
+++ b/go/tools/gazelle/rules/generator_test.go
@@ -67,6 +67,12 @@ func TestGenerator(t *testing.T) {
 					],
 					deps = ["//lib/deep:go_default_library"],
 				)
+
+				go_test(
+					name = "go_default_test",
+					srcs = ["lib_test.go"],
+					library = ":go_default_library",
+				)
 			`,
 		},
 		{

--- a/go/tools/gazelle/rules/generator_test.go
+++ b/go/tools/gazelle/rules/generator_test.go
@@ -103,3 +103,24 @@ func TestGenerator(t *testing.T) {
 		}
 	}
 }
+
+func TestGeneratorGoPrefix(t *testing.T) {
+	g := rules.NewGenerator("example.com/repo/lib/deep")
+	want := `
+		go_prefix("example.com/repo/lib/deep")
+
+		go_library(
+			name = "go_default_library",
+			srcs = ["thought.go"],
+		)
+	`
+	pkg := packageFromDir(t, filepath.FromSlash("lib/deep"))
+	rules, err := g.Generate("", pkg)
+	if err != nil {
+		t.Errorf("g.Generate(%q, %#v) failed with %v; want success", "", pkg, err)
+	}
+
+	if got, want := format(rules), canonicalize(t, "BUILD", want); got != want {
+		t.Errorf("g.Generate(%q, %#v) = %s; want %s", "", pkg, got, want)
+	}
+}

--- a/go/tools/gazelle/rules/generator_test.go
+++ b/go/tools/gazelle/rules/generator_test.go
@@ -73,6 +73,12 @@ func TestGenerator(t *testing.T) {
 					srcs = ["lib_test.go"],
 					library = ":go_default_library",
 				)
+
+				go_test(
+					name = "go_default_xtest",
+					srcs = ["lib_external_test.go"],
+					deps = [":go_default_library"],
+				)
 			`,
 		},
 		{

--- a/go/tools/gazelle/testdata/repo/lib/lib_external_test.go
+++ b/go/tools/gazelle/testdata/repo/lib/lib_external_test.go
@@ -1,0 +1,28 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lib_test
+
+import (
+	"testing"
+
+	"example.com/repo/lib"
+)
+
+func TestAnswerExternal(t *testing.T) {
+	if got, want := lib.Answer(), 42; got != want {
+		t.Errorf("lib.Answer() = %d; want %d", got, want)
+	}
+}

--- a/go/tools/gazelle/testdata/repo/lib/lib_test.go
+++ b/go/tools/gazelle/testdata/repo/lib/lib_test.go
@@ -1,0 +1,26 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lib
+
+import (
+	"testing"
+)
+
+func TestAnswer(t *testing.T) {
+	if got, want := Answer(), 42; got != want {
+		t.Errorf("Answer() = %d; want %d", got, want)
+	}
+}


### PR DESCRIPTION
* Extracted from #51 
* Depends on #57 and #58 

* Supports generation of `go_test` rules for internal and external tests
* Supports generation of `go_prefix` rules
* Supports generation of `load` of the rules.
* Not yet support generation of `cgo_library`.