### PR TITLE
Avoid involving a toolchain for the other build platform

### DIFF
--- a/go/toolchain/BUILD
+++ b/go/toolchain/BUILD
@@ -1,40 +1,18 @@
 package(
-    default_visibility = ["//src:__subpackages__"],
+    default_visibility = ["//visibility:public"],
 )
 
-config_setting(
-    name = "darwin",
-    values = {"host_cpu": "darwin"},
-)
-
-config_setting(
-    name = "k8",
-    values = {"host_cpu": "k8"},
-)
-
-filegroup(
+alias(
     name = "toolchain",
-    srcs = select({
-        ":darwin": ["@golang_darwin_amd64//:toolchain"],
-        ":k8": ["@golang_linux_amd64//:toolchain"],
-    }),
-    visibility = ["//visibility:public"],
+    actual = "@io_bazel_rules_go_toolchain//:toolchain",
 )
 
-filegroup(
+alias(
     name = "go_tool",
-    srcs = select({
-        ":darwin": ["@golang_darwin_amd64//:go_tool"],
-        ":k8": ["@golang_linux_amd64//:go_tool"],
-    }),
-    visibility = ["//visibility:public"],
+    actual = "@io_bazel_rules_go_toolchain//:go_tool",
 )
 
-filegroup(
+alias(
     name = "go_include",
-    srcs = select({
-        ":darwin": ["@golang_darwin_amd64//:go_include"],
-        ":k8": ["@golang_linux_amd64//:go_include"],
-    }),
-    visibility = ["//visibility:public"],
+    actual = "@io_bazel_rules_go_toolchain//:go_include",
 )


### PR DESCRIPTION
Resolve a go toolchain for the build platform earlier because it does not make sense to download toolchains for other build platforms.

* this makes it easier to support even more platform
* this makes it easier to support locally installed toolchain, c.f. #46
* this prevents "bazel query" from forcing users to download a toolchain for the other platform