### PR TITLE
Adds cross-compilation support to rules_go.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -19,4 +19,5 @@ Jake Voytko <jake@reviewninja.com>
 Justine Alexandra Roberts Tunney <jart@google.com>
 Kristina Chodorow <kchodorow@google.com>
 Lukacs Berki <lberki@google.com>
+Paul Johnston <pcj@pubref.org>
 Yuki Yugui Sonoda <yugui@yugui.jp>

--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
 # Go rules
 
-<div class="toc">
-  <h2>Rules</h2>
-  <ul>
-    <li><a href="#go_prefix">go_prefix</a></li>
-    <li><a href="#go_library">go_library</a></li>
-    <li><a href="#cgo_library">cgo_library</a></li>
-    <li><a href="#go_binary">go_binary</a></li>
-    <li><a href="#go_test">go_test</a></li>
-  </ul>
-</div>
+| ---: | :--- |
+| [go_prefix](#go_prefix) | Declare an import prefix. |
+| [go_library](#go_library) | Compile a pure go library. |
+| [cgo_library](#cgo_library) | Build a cgo library. |
+| [go_binary](#go_binary) | Build an executable binary file. |
+| [xgo_binary](#xgo_binary) | Build a cross-compiled binary file. |
+| [go_test](#go_test) | Generate a test. |
+
 
 ## Overview
 
@@ -343,6 +341,48 @@ go_binary(name, srcs, deps, data)
       <td>
         <code>List of labels, optional</code>
         <p>List of files needed by this rule at runtime.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+
+<a name="xgo_binary"></a>
+## xgo\_binary
+
+```bzl
+xgo_binary(name, deps, os_arch)
+```
+<table class="table table-condensed table-bordered table-params">
+  <colgroup>
+    <col class="col-param" />
+    <col class="param-description" />
+  </colgroup>
+  <thead>
+    <tr>
+      <th colspan="2">Attributes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>name</code></td>
+      <td>
+        <code>Name, required</code>
+        <p>A unique name for this rule.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>deps</code></td>
+      <td>
+        <code>Label(s) naming go_binary rules, required</code>
+        <p>The go_binary target to cross-compile.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>os_arch</code></td>
+      <td>
+        <code>string, required</code>
+        <p>Designates the desired platform.  Allowed values are enumerated in [goos_goarch.bzl](https://github.com/bazelbuild/rules_go/blob/master/go/private/goos_goarch.bzl) and correspond to https://golang.org/doc/install/source#environment.</p>
       </td>
     </tr>
   </tbody>

--- a/examples/external/BUILD
+++ b/examples/external/BUILD
@@ -1,4 +1,4 @@
-load("//go:def.bzl", "go_binary")
+load("//go:def.bzl", "go_binary", "xgo_binary")
 
 go_binary(
     name = "record_log",
@@ -7,5 +7,13 @@ go_binary(
     ],
     deps = [
         "@com_github_golang_glog//:go_default_library",
+    ],
+)
+
+xgo_binary(
+    name = "linux_arm_record_log",
+    os_arch = "linux_arm",
+    deps = [
+        ":record_log",
     ],
 )

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -12,489 +12,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//go/private:goos_goarch.bzl",     "GOOS_GOARCH")
+load("//go/private:go_prefix.bzl",       "go_prefix")
+load("//go/private:go_repositories.bzl", "go_repositories")
+
 """These are bare-bones Go rules.
-
-In order of priority:
-
 - No support for build tags
-
 - BUILD file must be written by hand.
-
 - No support for SWIG
-
 - No test sharding or test XML.
-
 """
+
+# ****************************************************************
+# Constants
+# ****************************************************************
 
 _DEFAULT_LIB = "go_default_library"
 
 _VENDOR_PREFIX = "/vendor/"
 
 go_filetype = FileType([".go", ".s", ".S"])
+
 # be consistent to cc_library.
 hdr_exts = ['.h', '.hh', '.hpp', '.hxx', '.inc']
+
 cc_hdr_filetype = FileType(hdr_exts)
 
-################
-
-# In Go, imports are always fully qualified with a URL,
-# eg. github.com/user/project. Hence, a label //foo:bar from within a
-# Bazel workspace must be referred to as
-# "github.com/user/project/foo/bar". To make this work, each rule must
-# know the repository's URL. This is achieved, by having all go rules
-# depend on a globally unique target that has a "go_prefix" transitive
-# info provider.
-
-def _go_prefix_impl(ctx):
-  """go_prefix_impl provides the go prefix to use as a transitive info provider."""
-  return struct(go_prefix = ctx.attr.prefix)
-
-def _go_prefix(ctx):
-  """slash terminated go-prefix"""
-  prefix = ctx.attr.go_prefix.go_prefix
-  if prefix != "" and not prefix.endswith("/"):
-    prefix = prefix + "/"
-  return prefix
-
-_go_prefix_rule = rule(
-    _go_prefix_impl,
-    attrs = {
-        "prefix": attr.string(mandatory = True),
-    },
-)
-
-def go_prefix(prefix):
-  """go_prefix sets the Go import name to be used for this workspace."""
-  _go_prefix_rule(name = "go_prefix",
-    prefix = prefix,
-    visibility = ["//visibility:public" ]
-  )
-
-################
-
-# TODO(bazel-team): it would be nice if Bazel had this built-in.
-def symlink_tree_commands(dest_dir, artifact_dict):
-  """Symlink_tree_commands returns a list of commands to create the
-  dest_dir, and populate it according to the given dict.
-
-  Args:
-    dest_dir: The destination directory, a string.
-    artifact_dict: The mapping of exec-path => path in the dest_dir.
-
-  Returns:
-    A list of commands that will setup the symlink tree.
-  """
-  cmds = [
-    "rm -rf " + dest_dir,
-    "mkdir -p " + dest_dir,
-  ]
-
-  for old_path, new_path in artifact_dict.items():
-    pos = new_path.rfind('/')
-    if pos >= 0:
-      new_dir = new_path[:pos]
-      up = (new_dir.count('/') + 1 +
-            dest_dir.count('/') + 1)
-    else:
-      new_dir = ''
-      up = dest_dir.count('/') + 1
-    cmds += [
-      "mkdir -p %s/%s" % (dest_dir, new_dir),
-      "ln -s %s%s %s/%s" % ('../' * up, old_path, dest_dir, new_path),
-    ]
-  return cmds
-
-def go_environment_vars(ctx):
-  """Return a map of environment variables for use with actions, based on
-  the arguments. Uses the ctx.fragments.cpp.cpu attribute, if present,
-  and picks a default of target_os="linux" and target_arch="amd64"
-  otherwise.
-
-  Args:
-    The skylark Context.
-
-  Returns:
-    A dict of environment variables for running Go tool commands that build for
-    the target OS and architecture.
-  """
-  bazel_to_go_toolchain = {"k8": {"GOOS": "linux",
-                                  "GOARCH": "amd64"},
-                           "piii": {"GOOS": "linux",
-                                    "GOARCH": "386"},
-                           "darwin": {"GOOS": "darwin",
-                                      "GOARCH": "amd64"},
-                           "freebsd": {"GOOS": "freebsd",
-                                       "GOARCH": "amd64"},
-                           "armeabi-v7a": {"GOOS": "linux",
-                                           "GOARCH": "arm"},
-                           "arm": {"GOOS": "linux",
-                                   "GOARCH": "arm"}}
-  return bazel_to_go_toolchain.get(ctx.fragments.cpp.cpu,
-                                   {"GOOS": "linux",
-                                    "GOARCH": "amd64"})
-
-def _emit_generate_params_action(cmds, ctx, fn):
-  cmds_all = ["set -e"]
-  cmds_all += cmds
-  cmds_all_str = "\n".join(cmds_all)
-  f = ctx.new_file(ctx.configuration.bin_dir, fn)
-  ctx.file_action( output = f, content = cmds_all_str, executable = True)
-  return f
-
-def emit_go_asm_action(ctx, source, out_obj):
-  """Construct the command line for compiling Go Assembly code.
-  Constructs a symlink tree to accomodate for workspace name.
-  Args:
-    ctx: The skylark Context.
-    source: a source code artifact
-    out_obj: the artifact (configured target?) that should be produced
-  """
-  args = [
-      ctx.file.go_tool.path, "tool", "asm",
-      "-I", ctx.file.go_include.path,
-      "-o", out_obj.path,
-      source.path,
-  ]
-  cmds = [
-      "export GOROOT=$(pwd)/" + ctx.file.go_tool.dirname + "/..",
-      "mkdir -p " + out_obj.dirname,
-      " ".join(args),
-  ]
-
-  f = _emit_generate_params_action(cmds, ctx, out_obj.path + ".GoAsmCompileFile.params")
-
-  ctx.action(
-      inputs = [source] + ctx.files.toolchain,
-      outputs = [out_obj],
-      mnemonic = "GoAsmCompile",
-      executable = f,
-  )
-
-def _go_importpath(ctx):
-  """Returns the expected importpath of the go_library being built.
-
-  Args:
-    ctx: The skylark Context
-
-  Returns:
-    Go importpath of the library
-  """
-  path = _go_prefix(ctx)[:-1]
-  if ctx.label.package:
-    path += "/" + ctx.label.package
-  if ctx.label.name != _DEFAULT_LIB:
-    path += "/" + ctx.label.name
-  if path.rfind(_VENDOR_PREFIX) != -1:
-    path = path[len(_VENDOR_PREFIX) + path.rfind(_VENDOR_PREFIX):]
-  if path[0] == "/":
-    path = path[1:]
-  return path
-
-def emit_go_compile_action(ctx, sources, deps, out_lib, extra_objects=[]):
-  """Construct the command line for compiling Go code.
-  Constructs a symlink tree to accommodate for workspace name.
-
-  Args:
-    ctx: The skylark Context.
-    sources: an iterable of source code artifacts (or CTs? or labels?)
-    deps: an iterable of dependencies. Each dependency d should have an
-      artifact in d.go_library_object representing an imported library.
-    out_lib: the artifact (configured target?) that should be produced
-    extra_objects: an iterable of extra object files to be added to the
-      output archive file.
-  """
-  tree_layout = {}
-  inputs = []
-  for d in deps:
-    actual_path = d.go_library_object.path
-    importpath = d.transitive_go_importmap[actual_path]
-    tree_layout[actual_path] = importpath + ".a"
-    inputs += [d.go_library_object]
-
-  inputs += list(sources)
-  prefix = _go_prefix(ctx)
-  for s in sources:
-    tree_layout[s.path] = prefix + s.path
-
-  out_dir = out_lib.path + ".dir"
-  out_depth = out_dir.count('/') + 1
-  cmds = symlink_tree_commands(out_dir, tree_layout)
-  args = [
-      "cd ", out_dir, "&&",
-      ('../' * out_depth) + ctx.file.go_tool.path,
-      "tool", "compile",
-      "-o", ('../' * out_depth) + out_lib.path, "-pack",
-      "-I", "."
-  ]
-
-  # Set -p to the import path of the library, ie.
-  # (ctx.label.package + "/" ctx.label.name) for now.
-  cmds += [ "export GOROOT=$(pwd)/" + ctx.file.go_tool.dirname + "/..",
-    ' '.join(args + cmd_helper.template(set(sources), prefix + "%{path}"))]
-  extra_inputs = ctx.files.toolchain
-
-  if extra_objects:
-    extra_inputs += extra_objects
-    objs = ' '.join([c.path for c in extra_objects])
-    cmds += ["cd " + ('../' * out_depth),
-             ctx.file.go_tool.path + " tool pack r " + out_lib.path + " " + objs]
-
-  f = _emit_generate_params_action(cmds, ctx, out_lib.path + ".GoCompileFile.params")
-
-  ctx.action(
-      inputs = inputs + extra_inputs,
-      outputs = [out_lib],
-      mnemonic = "GoCompile",
-      executable = f,
-      env = go_environment_vars(ctx))
-
-def go_library_impl(ctx):
-  """Implements the go_library() rule."""
-
-  sources = set(ctx.files.srcs)
-  go_srcs = set([s for s in sources if s.basename.endswith('.go')])
-  asm_srcs = [s for s in sources if s.basename.endswith('.s') or s.basename.endswith('.S')]
-  deps = ctx.attr.deps
-
-  cgo_object = None
-  if hasattr(ctx.attr, "cgo_object"):
-    cgo_object = ctx.attr.cgo_object
-
-  if ctx.attr.library:
-    go_srcs += ctx.attr.library.go_sources
-    asm_srcs += ctx.attr.library.asm_sources
-    deps += ctx.attr.library.direct_deps
-    if ctx.attr.library.cgo_object:
-      if cgo_object:
-        fail("go_library %s cannot have cgo_object because the package " +
-             "already has cgo_object in %s" % (ctx.label.name,
-                                               ctx.attr.library.name))
-      cgo_object = ctx.attr.library.cgo_object
-
-  if not go_srcs:
-    fail("may not be empty", "srcs")
-
-  transitive_cgo_deps = set([], order="link")
-  if cgo_object:
-    transitive_cgo_deps += cgo_object.cgo_deps
-
-  extra_objects = [cgo_object.cgo_obj] if cgo_object else []
-  for src in asm_srcs:
-    obj = ctx.new_file(src, "%s.dir/%s.o" % (ctx.label.name, src.basename[:-2]))
-    emit_go_asm_action(ctx, src, obj)
-    extra_objects += [obj]
-
-  out_lib = ctx.outputs.lib
-  emit_go_compile_action(ctx, go_srcs, deps, out_lib,
-                         extra_objects=extra_objects)
-
-  transitive_libs = set([out_lib])
-  transitive_importmap = {out_lib.path: _go_importpath(ctx)}
-  for dep in deps:
-     transitive_libs += dep.transitive_go_library_object
-     transitive_cgo_deps += dep.transitive_cgo_deps
-     transitive_importmap += dep.transitive_go_importmap
-
-  dylibs = []
-  if cgo_object:
-    dylibs += [d for d in cgo_object.cgo_deps if d.path.endswith(".so")]
-
-  runfiles = ctx.runfiles(files = dylibs, collect_data = True)
-  return struct(
-    label = ctx.label,
-    files = set([out_lib]),
-    direct_deps = deps,
-    runfiles = runfiles,
-    go_sources = go_srcs,
-    asm_sources = asm_srcs,
-    go_library_object = out_lib,
-    transitive_go_library_object = transitive_libs,
-    cgo_object = cgo_object,
-    transitive_cgo_deps = transitive_cgo_deps,
-    transitive_go_importmap = transitive_importmap
-  )
-
-def _c_linker_options(ctx, blacklist=[]):
-  """Extracts flags to pass to $(CC) on link from the current context
-
-  Args:
-    ctx: the current context
-    blacklist: Any flags starts with any of these prefixes are filtered out from
-      the return value.
-
-  Returns:
-    A list of command line flags
-  """
-  cpp = ctx.fragments.cpp
-  features = ctx.features
-  options = cpp.compiler_options(features)
-  options += cpp.unfiltered_compiler_options(features)
-  options += cpp.link_options
-  options += cpp.mostly_static_link_options(ctx.features, False)
-  filtered = []
-  for opt in options:
-    if any([opt.startswith(prefix) for prefix in blacklist]):
-      continue
-    filtered.append(opt)
-  return filtered
-
-def _short_path(f):
-  """Returns a short path of the given file.
-
-  It returns a relative path to the file from its root.
-  This is a workaround of bazelbuild/bazel#1462
-  """
-  if not f.root.path:
-    return f.path
-  prefix = f.root.path
-  if prefix[-1] != '/':
-    prefix = prefix + '/'
-  if not f.path.startswith(prefix):
-    fail("file name %s is not prefixed with its root %s", f.path, prefix)
-  return f.path[len(prefix):]
-
-def emit_go_link_action(ctx, importmap, transitive_libs, cgo_deps, lib,
-                        executable, x_defs={}):
-  """Sets up a symlink tree to libraries to link together."""
-  out_dir = executable.path + ".dir"
-  out_depth = out_dir.count('/') + 1
-  tree_layout = {}
-
-  config_strip = len(ctx.configuration.bin_dir.path) + 1
-  pkg_depth = executable.dirname[config_strip:].count('/') + 1
-  prefix = _go_prefix(ctx)
-
-  for l in transitive_libs:
-    actual_path = l.path
-    importpath = importmap[actual_path]
-    tree_layout[l.path] = importpath + ".a"
-
-  for d in cgo_deps:
-    tree_layout[d.path] = _short_path(d)
-
-  main_archive = importmap[lib.path] + ".a"
-  tree_layout[lib.path] = main_archive
-
-  ld = "%s" % ctx.fragments.cpp.compiler_executable
-  if ld[0] != '/':
-    ld = ('../' * out_depth) + ld
-  ldflags = _c_linker_options(ctx) + [
-      "-Wl,-rpath,$ORIGIN/" + ("../" * pkg_depth),
-      "-L" + prefix,
-  ]
-  for d in cgo_deps:
-    if d.basename.endswith('.so'):
-      dirname = _short_path(d)[:-len(d.basename)]
-      ldflags += ["-Wl,-rpath,$ORIGIN/" + ("../" * pkg_depth) + dirname]
-
-  link_cmd = [
-      ('../' * out_depth) + ctx.file.go_tool.path,
-      "tool", "link", "-L", ".",
-      "-o", _go_importpath(ctx),
-  ]
-
-  if x_defs:
-    link_cmd += [" -X %s='%s' " % (k, v) for k,v in x_defs.items()]
-
-  # workaround for a bug in ld(1) on Mac OS X.
-  # http://lists.apple.com/archives/Darwin-dev/2006/Sep/msg00084.html
-  # TODO(yugui) Remove this workaround once rules_go stops supporting XCode 7.2
-  # or earlier.
-  if ctx.fragments.cpp.cpu != 'darwin':
-    link_cmd += ["-s"]
-
-  link_cmd += [
-      "-extld", ld,
-      "-extldflags", "'%s'" % " ".join(ldflags),
-      main_archive,
-  ]
-
-  cmds = symlink_tree_commands(out_dir, tree_layout)
-  # Avoided -s on OSX but but it requires dsymutil to be on $PATH.
-  # TODO(yugui) Remove this workaround once rules_go stops supporting XCode 7.2
-  # or earlier.
-  cmds += ["export PATH=$PATH:/usr/bin"]
-  cmds += [
-    "export GOROOT=$(pwd)/" + ctx.file.go_tool.dirname + "/..",
-    "cd " + out_dir,
-    ' '.join(link_cmd),
-    "mv -f " + _go_importpath(ctx) + " " + ("../" * out_depth) + executable.path,
-  ]
-
-  f = _emit_generate_params_action(cmds, ctx, lib.path + ".GoLinkFile.params")
-
-  ctx.action(
-      inputs = (list(transitive_libs) + [lib] + list(cgo_deps) +
-                ctx.files.toolchain + ctx.files._crosstool),
-      outputs = [executable],
-      executable = f,
-      mnemonic = "GoLink",
-      env = go_environment_vars(ctx))
-
-def go_binary_impl(ctx):
-  """go_binary_impl emits actions for compiling and linking a go executable."""
-  lib_result = go_library_impl(ctx)
-  executable = ctx.outputs.executable
-  lib_out = ctx.outputs.lib
-
-  emit_go_link_action(
-    ctx,
-    transitive_libs=lib_result.transitive_go_library_object,
-    importmap=lib_result.transitive_go_importmap,
-    cgo_deps=lib_result.transitive_cgo_deps,
-    lib=lib_out, executable=executable,
-    x_defs=ctx.attr.x_defs)
-
-  runfiles = ctx.runfiles(collect_data = True,
-                          files = ctx.files.data)
-  return struct(files = set([executable]) + lib_result.files,
-                runfiles = runfiles,
-                cgo_object = lib_result.cgo_object)
-
-def go_test_impl(ctx):
-  """go_test_impl implements go testing.
-
-  It emits an action to run the test generator, and then compiles the
-  test into a binary."""
-
-  lib_result = go_library_impl(ctx)
-  main_go = ctx.outputs.main_go
-  prefix = _go_prefix(ctx)
-
-  go_import = _go_importpath(ctx)
-
-  args = (["--package", go_import, "--output", ctx.outputs.main_go.path] +
-          cmd_helper.template(lib_result.go_sources, "%{path}"))
-
-  inputs = list(lib_result.go_sources) + list(ctx.files.toolchain)
-  ctx.action(
-      inputs = inputs,
-      executable = ctx.executable.test_generator,
-      outputs = [main_go],
-      mnemonic = "GoTestGenTest",
-      arguments = args,
-      env = dict(go_environment_vars(ctx), RUNDIR=ctx.label.package))
-
-  emit_go_compile_action(
-    ctx, set([main_go]), ctx.attr.deps + [lib_result], ctx.outputs.main_lib)
-
-  importmap = lib_result.transitive_go_importmap + {
-      ctx.outputs.main_lib.path: _go_importpath(ctx) + "_main_test"}
-  emit_go_link_action(
-    ctx,
-    importmap=importmap,
-    transitive_libs=lib_result.transitive_go_library_object,
-    cgo_deps=lib_result.transitive_cgo_deps,
-    lib=ctx.outputs.main_lib, executable=ctx.outputs.executable,
-    x_defs=ctx.attr.x_defs)
-
-  # TODO(bazel-team): the Go tests should do a chdir to the directory
-  # holding the data files, so open-source go tests continue to work
-  # without code changes.
-  runfiles = ctx.runfiles(collect_data = True,
-                          files = (ctx.files.data + [ctx.outputs.executable] +
-                                   list(lib_result.runfiles.files)))
-  return struct(runfiles=runfiles)
+_crosstool_attrs = {
+    "_crosstool": attr.label(
+        default = Label("//tools/defaults:crosstool"),
+    )
+}
 
 go_env_attrs = {
     "toolchain": attr.label(
@@ -523,6 +71,14 @@ go_env_attrs = {
         allow_files = True,
         cfg = HOST_CFG,
     ),
+    "go_root": attr.label(
+      providers = ["go_root"],
+      default = Label(
+        "//go/toolchain:go_root",
+      ),
+      allow_files = False,
+      cfg = HOST_CFG,
+    ),
 }
 
 go_library_attrs = go_env_attrs + {
@@ -532,28 +88,1107 @@ go_library_attrs = go_env_attrs + {
     ),
     "srcs": attr.label_list(allow_files = go_filetype),
     "deps": attr.label_list(
-        providers = [
-            "direct_deps",
-            "go_library_object",
-            "transitive_go_importmap",
-            "transitive_go_library_object",
-            "transitive_cgo_deps",
-        ],
+      providers = [
+        "direct_deps",
+        "go_library_object",
+        "transitive_go_importmap",
+        "transitive_go_library_object",
+        "transitive_cgo_deps",
+      ],
     ),
     "library": attr.label(
-        providers = ["go_sources", "asm_sources", "cgo_object"],
+      providers = ["go_sources", "asm_sources", "cgo_object"],
     ),
-}
-
-_crosstool_attrs = {
-    "_crosstool": attr.label(
-        default = Label("//tools/defaults:crosstool"),
-    )
 }
 
 go_library_outputs = {
     "lib": "%{name}.a",
 }
+
+# ****************************************************************
+# Helper Functions
+# ****************************************************************
+
+# TODO(bazel-team): it would be nice if Bazel had this built-in.
+def symlink_tree_commands(dest_dir, artifacts):
+  """Build a list of commands to prepare the dest_dir.
+
+  Args:
+    dest_dir (string): The destination directory
+    artifacts (dict<string,string>): The mapping of exec-path => path in the dest_dir.
+
+  Returns:
+    (list<string>): a list of commands that will setup the symlink tree.
+
+  """
+  cmds = [
+    "rm -rf " + dest_dir,
+    "mkdir -p " + dest_dir,
+  ]
+
+  for old_path, new_path in artifacts.items():
+    pos = new_path.rfind('/')
+    if pos >= 0:
+      new_dir = new_path[:pos]
+      up = (new_dir.count('/') + 1 +
+            dest_dir.count('/') + 1)
+    else:
+      new_dir = ''
+      up = dest_dir.count('/') + 1
+    cmds += [
+      "mkdir -p %s/%s" % (dest_dir, new_dir),
+      "ln -s %s%s %s/%s" % ('../' * up, old_path, dest_dir, new_path),
+    ]
+
+  return cmds
+
+
+def _short_path(f):
+  """Returns a short path of the given file.
+  NOTE: This is a workaround of bazelbuild/bazel#1462
+
+  Args:
+    f (File): the input file
+
+  Returns:
+    (string): a relative path to the file from its root.
+
+  """
+  if not f.root.path:
+    return f.path
+  prefix = f.root.path
+  if prefix[-1] != '/':
+    prefix = prefix + '/'
+  if not f.path.startswith(prefix):
+    fail("file name %s is not prefixed with its root %s", f.path, prefix)
+  return f.path[len(prefix):]
+
+
+def _pkg_dir(workspace_root, package_name):
+  """Get directory for the given workspace and package
+
+  Args:
+    workspace_root (string): the ctx.label.workspace_root value.
+    package_name (string): the ctx.label.package value.
+
+  Returns:
+    (string): the package directory.  Default is '.'
+
+  """
+  if workspace_root and package_name:
+    return workspace_root + "/" + package_name
+  if workspace_root:
+    return workspace_root
+  if package_name:
+    return package_name
+  return "."
+
+
+def _c_linker_opts(cpp_fragment, features, blacklist=[]):
+  """Build go tool link $CC flags.
+
+  Args:
+    cpp_fragment (struct): cxt.fragments.cpp
+    features (list<string>): ctx.features
+    blacklist (list<string>): Any flags starts with any of these
+               prefixes are filtered out from the return value.
+  Returns:
+    (list<string>): filtered options.
+
+  """
+  options = cpp_fragment.compiler_options(features)
+  options += cpp_fragment.unfiltered_compiler_options(features)
+  options += cpp_fragment.link_options
+  options += cpp_fragment.mostly_static_link_options(features, False)
+
+  filtered = []
+  for opt in options:
+    if any([opt.startswith(prefix) for prefix in blacklist]):
+      continue
+    filtered.append(opt)
+  return filtered
+
+
+def _go_importpath(prefix, label):
+  """Get the path to a library artifact as it should appear for the
+  import statement.
+
+  Args:
+    prefix (string): the go_prefix value.
+    label (Label): the rule label object.
+
+  Returns:
+    (string): the path.
+
+  """
+  path = prefix
+  if path.endswith("/"):
+    path = path[:-1]
+  if label.package:
+    path += "/" + label.package
+  if label.name != _DEFAULT_LIB:
+    path += "/" + label.name
+  if path.rfind(_VENDOR_PREFIX) != -1:
+    path = path[len(_VENDOR_PREFIX) + path.rfind(_VENDOR_PREFIX):]
+  return path
+
+
+def _go_outputdir(label, env):
+  """Get the directory path where a generated library artifact should be placed.
+
+  Args:
+    label (Label): the rule label object.
+    env (dict<string,string>): the go_env mappings.  GOOS and GOARCH
+    are required.
+
+  Returns:
+    (string): the path.
+
+  """
+  return "%s_%s/%s" % (env["GOOS"], env["GOARCH"], label.name)
+
+
+def _go_prefix_from_provider(attr):
+  """Get the go-prefix from an attribute.
+
+  Args:
+    attr (struct): attr having a 'go_prefix' provider.
+
+  Returns:
+    (string): the prefix, always terminated with a slash.
+
+  """
+  prefix = attr.go_prefix
+  if prefix != "" and not prefix.endswith("/"):
+    prefix = prefix + "/"
+  return prefix
+
+
+def _go_root_from_provider(attr):
+  """Get the abs path from a 'go_root'-provided attr.
+
+  Args:
+    attr (attr): struct having a 'go_root' provider.
+
+  Returns:
+    (string): the GOROOT, should be an absolute path.
+
+  NOTE: Cross-compilation requires an absolute path to GOROOT.
+        Retrieve the value from the go_root label that was embedded
+        into the toolchain BUILD file at the time of repository
+        creation.
+
+  """
+  return attr.go_root
+
+
+def _go_env_from_ctx(ctx):
+  """Return a map of environment variables for use with actions, based on
+  the arguments. Uses the ctx.fragments.cpp.cpu attribute, if present,
+  and picks a default of target_os="linux" and target_arch="amd64"
+  otherwise.  GOROOT is always included.
+
+  Args:
+    ctx (struct): The skylark Context.
+
+  Returns:
+    (dict<string,string>): A dict of environment variables for running
+    Go tool commands that build for the target OS and architecture.
+
+  """
+
+  bazel_to_go_toolchain = {
+    "k8": {
+      "GOOS": "linux",
+      "GOARCH": "amd64"
+    },
+    "piii": {
+      "GOOS": "linux",
+      "GOARCH": "386"
+    },
+    "darwin": {
+      "GOOS": "darwin",
+      "GOARCH": "amd64"
+    },
+    "freebsd": {
+      "GOOS": "freebsd",
+      "GOARCH": "amd64"
+    },
+    "armeabi-v7a": {
+      "GOOS": "linux",
+      "GOARCH": "arm"
+    },
+    "arm": {
+      "GOOS": "linux",
+      "GOARCH": "arm"
+    },
+  }
+
+  default = {
+    "GOOS": "linux",
+    "GOARCH": "amd64"
+  }
+
+  key = ctx.fragments.cpp.cpu
+  env =  bazel_to_go_toolchain.get(key, default)
+
+  return env
+
+
+# ****************************************************************
+# Action Emitting Functions
+# ****************************************************************
+
+def _emit_params_file_action(ctx, path, mnemonic, cmds):
+  """Helper function that writes a potentially long command list to a file.
+
+  Args:
+    ctx (struct): The ctx object.
+    path (string): the file path where the params file should be written.
+    mnemonic (string): the action mnemomic.
+    cmds (list<string>): the command list.
+
+  Returns:
+    (File): an executable file that runs the command set.
+
+  """
+  filename = "%s.%sFile.params" % (path, mnemonic)
+  f = ctx.new_file(ctx.configuration.bin_dir, filename)
+  ctx.file_action(output = f,
+                  content = "\n".join(["set -e"] + cmds),
+                  executable = True)
+  return f
+
+
+def _emit_go_asm_action(ctx,
+                        toolchain,
+                        go_env,
+                        go_root,
+                        go_include_path,
+                        asm_src,
+                        out_obj,
+                        install_std_library = False):
+  """Construct the command line for compiling Go Assembly code.
+  Constructs a symlink tree to accomodate for workspace name.
+
+  Args:
+    ctx (struct): The skylark Context.
+    toolchain (list<File>): from ctx.files.toolchain or equivalent.
+    go_env (dict<string,string>): environment for a go command.
+    go_root (string): absolute path to GOROOT.
+    go_include_path (string): usually $GOROOT/pkg/include.
+    asm_src (File): an assembly source file.
+    out_obj: the .o artifact that should be produced.
+    install_std_library (bool): if true, a 'go install std' will occur.
+
+  """
+
+  args = [
+      "$GOROOT/bin/go", "tool", "asm",
+      "-I", go_include_path,
+      "-o", out_obj.path,
+      asm_src.path,
+  ]
+
+  cmds = [
+      "mkdir -p " + out_obj.dirname,
+      " ".join(args),
+  ]
+
+  if install_std_library:
+    cmds.insert(0, "$GOROOT/bin/go install std") # add -x to see commands
+
+  mnemonic = "GoAsmCompile"
+  params = _emit_params_file_action(ctx, out_obj.path, mnemonic, cmds)
+  ctx.action(
+    mnemonic = mnemonic,
+    executable = params,
+    inputs = [asm_src] + toolchain,
+    outputs = [out_obj],
+    env = go_env + {
+      "GOROOT": go_root,
+    },
+  )
+
+
+def _emit_go_compile_action(ctx,
+                            toolchain,
+                            go_env,
+                            go_root,
+                            go_prefix,
+                            srcs,
+                            out_lib,
+                            deps = [],
+                            extra_objects = [],
+                            install_std_library = False):
+  """Construct the command line for compiling Go code.
+  Constructs a symlink tree to accomodate for workspace name.
+
+  Args:
+    ctx (struct): The skylark Context.
+    toolchain (list<File>): from ctx.files.toolchain or equivalent.
+    go_env (dict<string,string>): environment for a go command.
+    go_root (string): absolute path to GOROOT.
+    go_prefix (string): the go import prefix.
+    srcs (list<File>): *.go sourcefiles.
+    deps (list<struct>): providers:
+        .go_library_object<File>
+        .transitive_go_importmap<string,string>
+    out_lib (File): the .a archive that should be produced.
+    extra_objects (list<File>): extra objects to pack into the archive.
+    install_std_library (bool): if True, a 'go install std' will occur.
+
+  """
+
+  tree_layout = {}
+  inputs = []
+  for d in deps:
+    actual_path = d.go_library_object.path
+    importpath = d.transitive_go_importmap[actual_path]
+    tree_layout[actual_path] = importpath + ".a"
+    inputs += [d.go_library_object]
+
+  inputs += list(srcs)
+  for src in srcs:
+    tree_layout[src.path] = go_prefix + src.path
+
+  out_dir = out_lib.path + ".dir"
+  out_depth = out_dir.count('/') + 1
+  cmds = symlink_tree_commands(out_dir, tree_layout)
+
+  # go install std is smart enough not to redo work and return quickly
+  # if the stdlib has already been created.
+  if install_std_library:
+    cmds += ["$GOROOT/bin/go install std"]
+
+  args = [
+    "cd ", out_dir,
+    "&&",
+    "$GOROOT/bin/go", "tool", "compile",
+    "-o", ('../' * out_depth) + out_lib.path,
+    "-pack",
+    "-I", ".",
+  ]
+
+  cmds += [' '.join(args + cmd_helper.template(set(srcs), go_prefix + "%{path}"))]
+  extra_inputs = toolchain
+
+  if extra_objects:
+    extra_inputs += extra_objects
+    objs = ' '.join([c.path for c in extra_objects])
+    cmds += ["cd " + ('../' * out_depth),
+             "$GOROOT/bin/go tool pack r " + out_lib.path + " " + objs]
+
+  mnemonic = "GoCompile"
+  params = _emit_params_file_action(ctx, out_lib.path, mnemonic, cmds)
+  ctx.action(
+    mnemonic = mnemonic,
+    executable = params,
+    inputs = inputs + extra_inputs,
+    outputs = [out_lib],
+    env = go_env + {
+      "GOROOT": go_root,
+    }
+  )
+
+
+def _emit_go_link_action(ctx,
+                         toolchain,
+                         crosstool,
+                         go_env,
+                         go_root,
+                         go_prefix,
+                         label,
+                         importmap,
+                         transitive_libs,
+                         cgo_deps,
+                         configuration_bin_dir_path,
+                         cpp_fragment,
+                         features,
+                         lib,
+                         executable,
+                         x_defs = {}):
+  """Construct the command line for compiling Go code.
+  Constructs a symlink tree to accomodate for workspace name.
+
+  Args:
+    ctx (struct): The skylark Context.
+    toolchain (list<File>): from ctx.files.toolchain or equivalent.
+    crosstool (list<File>): from ctx.files._crosstool or equivalent.
+    go_env (dict<string,string>): environment for a go command.
+    go_root (string): absolute path to GOROOT.
+    go_prefix (string): the go import prefix.
+    label (Label): the label namespace.
+    importmap (dict<string,string>): filename to importpath mappings.
+    transitive_libs (iterable<File>): .a dependencies.
+    cgo_deps (iterable<File>): .o cgo dependencies.
+    configuration_bin_dir_path (string): usually ctx.configuration.bin_dir.path.
+    cpp_fragment (struct): usually ctx.fragment.cpp.
+    features (struct): usually ctx.features.
+    lib (File): the primary input .a library (output of go tool compile).
+    executable (File): the primary output of the go linker to generate.
+    x_defs (dict<string,string>): -X definitions.
+
+  """
+
+  out_dir = executable.path + ".dir"
+  out_depth = out_dir.count('/') + 1
+  config_strip = len(configuration_bin_dir_path) + 1
+  pkg_depth = executable.dirname[config_strip:].count('/') + 1
+
+  tree_layout = {}
+  for l in transitive_libs:
+    actual_path = l.path
+    importpath = importmap[actual_path]
+    tree_layout[l.path] = importpath + ".a"
+
+  for d in cgo_deps:
+    tree_layout[d.path] = _short_path(d)
+
+  go_importpath = _go_importpath(go_prefix, label)
+  main_archive = importmap[lib.path] + ".a"
+  tree_layout[lib.path] = main_archive
+
+  ld = "%s" % cpp_fragment.compiler_executable
+  if ld[0] != '/':
+    ld = ('../' * out_depth) + ld
+  ldflags = _c_linker_opts(cpp_fragment, features) + [
+      "-Wl,-rpath,$ORIGIN/" + ("../" * pkg_depth),
+      "-L" + go_prefix,
+  ]
+  for d in cgo_deps:
+    if d.basename.endswith('.so'):
+      dirname = _short_path(d)[:-len(d.basename)]
+      ldflags += ["-Wl,-rpath,$ORIGIN/" + ("../" * pkg_depth) + dirname]
+
+  link_cmd = [
+      "$GOROOT/bin/go", "tool", "link",
+       "-L", ".",
+      "-o", go_importpath,
+  ]
+
+  if x_defs:
+    link_cmd += [" -X %s='%s' " % (k, v) for k,v in x_defs.items()]
+
+  # workaround for a bug in ld(1) on Mac OS X.
+  # http://lists.apple.com/archives/Darwin-dev/2006/Sep/msg00084.html
+  # TODO(yugui) Remove this workaround once rules_go stops supporting XCode 7.2
+  # or earlier.
+  if go_env["GOOS"] != 'darwin':
+    link_cmd += ["-s"]
+
+  link_cmd += [
+      "-extld", ld,
+      "-extldflags", "'%s'" % " ".join(ldflags),
+      main_archive,
+  ]
+
+  cmds = symlink_tree_commands(out_dir, tree_layout)
+
+  # Avoided -s on OSX but but it requires dsymutil to be on $PATH.
+  # TODO(yugui) Remove this workaround once rules_go stops supporting XCode 7.2
+  # or earlier.
+  cmds += ["export PATH=$PATH:/usr/bin"]
+  cmds += [
+    "cd " + out_dir,
+    ' '.join(link_cmd),
+    "mv -f " + go_importpath + " " + ("../" * out_depth) + executable.path,
+  ]
+
+  inputs = list(transitive_libs) + [lib] + list(cgo_deps) + toolchain + crosstool
+
+  mnemonic = "GoLink"
+  params = _emit_params_file_action(ctx, lib.path, mnemonic, cmds)
+  ctx.action(
+    mnemonic = mnemonic,
+    executable = params,
+    inputs = inputs,
+    outputs = [executable],
+    env = go_env + {
+      "GOROOT": go_root,
+    }
+  )
+
+# ****************************************************************
+# common build implementations (used by rules and aspects)
+# ****************************************************************
+
+def _go_library_build(ctx,
+                      label,
+                      toolchain,
+                      go_prefix,
+                      go_env,
+                      go_root,
+                      go_include_path,
+                      srcs,
+                      out_lib,
+                      cgo_object = None,
+                      library = None,
+                      deps = [],
+                      extra_objects = [],
+                      install_std_library = False):
+  """Abstracts the context dependent parts of go_library_impl into a separate function.
+  Designed to be called from a rule or aspect agnostic to the ctx object.
+
+  Args:
+    ctx (struct): The skylark Context.
+    label (Label): the ctx.label namespace.
+    toolchain (list<File>): from ctx.files.toolchain or equivalent.
+    go_env (dict<string,string>): environment for a go command.
+    go_root (string): absolute path to GOROOT.
+    go_prefix (string): the go import prefix.
+    go_include_path (string): usually $GOROOT/pkg/include.
+    srcs (list<File>): .go, .s, or .S inputs.
+    out_lib (File): the .a archive that should be produced.
+    cgo_object (struct): dependent cgo_object.
+    deps (list<struct>): Providers:
+        .go_library_object<File>
+        .transitive_go_importmap<string,string>
+    library (struct): Usually from go_test.
+        .go_sources (list<File>): list of .go files.
+        .asm_sources (list<File>): list of .s or .S files.
+        .direct_deps (list<File>): list of .o files.
+        .cgo_object (struct): cgo object.
+    extra_objects (list<File>): extra objects to pack into the archive.
+    install_std_library (bool): if True, a 'go install std' will occur.
+
+  Returns:
+    (struct): .direct_deps (list<struct>): deps used by this rule,
+              .dylibs (list<File>): .so files needed for runfiles,
+              .go_srcs (list<File>): .go files used,
+              .asm_srcs (list<File>): .s files used,
+              .out_lib (File): generated .a file,
+              .transitive_libs (list<File>): transitive .a files,
+              .cgo_object (struct): cgo_object used,
+              .transitive_cgo_deps (list<File>): transitive .o files,
+              .transitive_importmap (dict<string,string>): transitive mappings.
+
+  """
+
+  # Collect and filter source files.
+  go_srcs = set([s for s in srcs if s.basename.endswith('.go')])
+  asm_srcs = [s for s in srcs if s.basename.endswith('.s') or s.basename.endswith('.S')]
+
+  # Merge in sources from a dependent 'library' target.
+  if library:
+    go_srcs += library.go_sources
+    asm_srcs += library.asm_sources
+    deps += library.direct_deps
+    if library.cgo_object:
+      if cgo_object:
+        fail("go_library %s cannot have cgo_object because the package " +
+             "already has cgo_object %s" % (label.name, library.cgo_object))
+      cgo_object = library.cgo_object
+
+  if not go_srcs:
+    fail("may not be empty", "srcs")
+
+  # Start building a transitive cgo_deps object
+  transitive_cgo_deps = set([], order="link")
+
+  if cgo_object:
+    transitive_cgo_deps += cgo_object.cgo_deps
+    extra_objects += [cgo_object.cgo_obj]
+
+  # Build the name of the directory to place the library in
+  dirname = _go_outputdir(label, go_env)
+
+  # All asm sources.  Each one gets a new {file}.o and an emit_asm
+  # action.  The object file goes into the list of 'extra objects'.
+  for asm_src in asm_srcs:
+    asm_filename = "%s.dir/%s.o" % (dirname, asm_src.basename[:-2])
+    asm_obj = ctx.new_file(asm_src, asm_filename)
+    extra_objects += [asm_obj]
+    _emit_go_asm_action(ctx = ctx,
+                        go_env = go_env,
+                        go_root = go_root,
+                        toolchain = toolchain,
+                        go_include_path = go_include_path,
+                        asm_src = asm_src,
+                        out_obj = asm_obj,
+                        install_std_library = install_std_library)
+
+  _emit_go_compile_action(ctx = ctx,
+                          go_env = go_env,
+                          go_root = go_root,
+                          go_prefix = go_prefix,
+                          srcs = go_srcs,
+                          deps = deps,
+                          toolchain = toolchain,
+                          out_lib = out_lib,
+                          extra_objects = extra_objects,
+                          install_std_library = install_std_library)
+
+  # Build transitive outputs
+  transitive_libs = set([out_lib])
+  transitive_importmap = {out_lib.path: _go_importpath(go_prefix, label)}
+  for dep in deps:
+     transitive_libs += dep.transitive_go_library_object
+     transitive_cgo_deps += dep.transitive_cgo_deps
+     transitive_importmap += dep.transitive_go_importmap
+
+  # Build list of shared object dylibs. these *.so files are needed
+  # for runtime.
+  dylibs = []
+  if cgo_object:
+    dylibs += [d for d in cgo_object.cgo_deps if d.path.endswith(".so")]
+
+  return struct(direct_deps = deps,
+                dylibs = dylibs,
+                go_srcs = go_srcs,
+                asm_srcs = asm_srcs,
+                out_lib = out_lib,
+                transitive_libs = transitive_libs,
+                cgo_object = cgo_object,
+                transitive_cgo_deps = transitive_cgo_deps,
+                transitive_importmap = transitive_importmap)
+
+
+def _go_binary_build(ctx,
+                     label,
+                     toolchain,
+                     crosstool,
+                     cpp_fragment,
+                     configuration_bin_dir_path,
+                     features,
+                     go_env,
+                     go_root,
+                     go_prefix,
+                     go_include_path,
+                     srcs,
+                     out_lib,
+                     executable,
+                     deps = [],
+                     cgo_object = None,
+                     library = None,
+                     extra_objects = [],
+                     x_defs = {},
+                     install_std_library = False):
+  """Abstracts the context dependent parts of go_binary_impl into a separate function.
+  Designed to be called from a rule or aspect agnostic to the ctx object.
+
+  Args:
+    ctx (struct): The skylark Context.
+    label (Label): the ctx.label namespace.
+    toolchain (list<File>): from ctx.files.toolchain or equivalent.
+    crosstool (list<File>): from ctx.files._crosstool or equivalent.
+    cpp_fragment (struct): usually ctx.fragment.cpp.
+    configuration_bin_dir_path (string): usually ctx.configuration.bin_dir.path.
+    features (struct): usually ctx.features.
+    go_env (dict<string,string>): environment for a go command.
+    go_root (string): absolute path to GOROOT.
+    go_prefix (string): the go import prefix.
+    go_include_path (string): usually ctx.file.go_include.path ($GOROOT/pkg/include).
+    srcs (list<File>): .go, .s, or .S inputs.
+    out_lib (File): the .a archive that should be produced.
+    executable (File): the binary that should be produced.
+    deps (list<struct>): Providers:
+        .go_library_object<File>
+        .transitive_go_importmap<string,string>
+    cgo_object (struct): dependent cgo_object.
+    library (struct): Usually from go_test.
+        .go_sources (list<File>): list of .go files.
+        .asm_sources (list<File>): list of .s or .S files.
+        .direct_deps (list<File>): list of .o files.
+        .cgo_object (struct): cgo object.
+    extra_objects (list<File>): extra objects to pack into the archive.
+    x_defs (dict<string,string>): -X definitions.
+    install_std_library (bool): if True, a 'go install std' will occur.
+
+  Returns:
+    (struct): .executable (File): the generated binary,
+              .go_library_result (<struct>): output of go_library_build,
+              .cgo_object (struct): cgo_object used.
+
+  """
+
+  result = _go_library_build(
+    cgo_object = cgo_object,
+    install_std_library = install_std_library,
+    ctx = ctx,
+    deps = deps,
+    go_env = go_env,
+    go_include_path = go_include_path,
+    go_prefix = go_prefix,
+    go_root = go_root,
+    label = label,
+    library = library,
+    out_lib = out_lib,
+    srcs = srcs,
+    toolchain = toolchain)
+
+  _emit_go_link_action(
+    cpp_fragment = cpp_fragment,
+    cgo_deps = result.transitive_cgo_deps,
+    crosstool = crosstool,
+    ctx = ctx,
+    executable = executable,
+    features = features,
+    go_env = go_env,
+    go_prefix = go_prefix,
+    go_root = go_root,
+    importmap = result.transitive_importmap,
+    configuration_bin_dir_path = configuration_bin_dir_path,
+    label = label,
+    lib = result.out_lib,
+    transitive_libs = result.transitive_libs,
+    x_defs = x_defs,
+    toolchain = toolchain,
+  )
+
+  return struct(
+    cgo_object = result.cgo_object,
+    executable = executable,
+    go_library_result = result,
+  )
+
+# ################################################################
+# ASPECTS
+# ################################################################
+
+def _xgo_collect_deps(deps):
+  """Generate a list of cross-compiled dependencies.
+
+  The values from go_library providers in rule.attr.deps are not
+  cross-compiled.  Instead, we need to build our own set of deps from
+  the xgo_aspect_result provider.
+
+  Args:
+    deps (list<struct>): ctx.rule.attr.deps or equiv.
+
+  Returns:
+    (list<struct>): list of cross-compiled deps having providers:
+        .go_library_object (File),
+        .transitive_go_importmap (dict<string,string>),
+        .transitive_go_library_object (list<File>),
+        .transitive_cgo_deps (list<File>).
+
+  """
+  xdeps = []
+
+  for d in deps:
+    results = d.xgo_aspect_result.results
+    for build in results:
+      if hasattr(build, "go_library_result"):
+        lib_result = build.go_library_result
+        xdeps.append(struct(
+          go_library_object = lib_result.out_lib,
+          transitive_go_importmap = lib_result.transitive_importmap,
+          transitive_go_library_object = lib_result.transitive_libs,
+          transitive_cgo_deps = lib_result.transitive_cgo_deps,
+        ))
+
+  return xdeps
+
+
+def _xgo_collect_runfiles(rule):
+  """Generate a list of runfiles from a rule.
+
+  Can't use a ctx.runfiles object (not allowed for aspects).
+
+  Args:
+    rule (struct): ctx.rule object.
+
+  Returns:
+    (list<File>): list of runfiles.
+
+  """
+  files = []
+
+  if hasattr(rule.files, "data"):
+    files += [file for file in rule.files.data]
+
+  return files
+
+
+def _xgo_cgo_object_impl(target, ctx):
+  fail("Cross-compilation with cgo-object dependencies is not currently supported.  Failed at %s" % target.label)
+
+
+def _xgo_cgo_codegen_rule_impl(target, ctx):
+  fail("Cross-compilation with cgo-codegen dependencies is not currently supported.  Failed at %s" % target.label)
+
+
+def _xgo_go_library_impl(target, ctx):
+  """go_library_impl aspect implementation.
+
+  Args:
+    target (struct): the target rule.
+    ctx (struct): the aspect context.
+
+  Returns:
+    (struct): with providers:
+            .go_library_result (struct): output of go_library_build
+            .xgo_lib (File): the cross-compiled library .a file.
+            .runfiles (list<File>): list of runfiles.
+  )
+
+  """
+  rule = ctx.rule
+  label = target.label
+
+  os_arch = ctx.attr.os_arch.split("_")
+  go_os = os_arch[0]
+  go_arch = os_arch[1]
+  go_env = {"GOOS": go_os, "GOARCH": go_arch}
+  go_prefix = _go_prefix_from_provider(rule.attr.go_prefix)
+  go_root = _go_root_from_provider(rule.attr.go_root)
+  go_include_path = rule.file.go_include.path
+
+  filename = "_xgo/" + ctx.attr.os_arch + "/" + label.name + ".a"
+  xgo_lib = ctx.new_file(filename)
+
+  srcs = rule.files.srcs
+  cgo_object = rule.attr.cgo_object if hasattr(rule.attr, "cgo_object") else None
+  install_std_library = True,
+  features = ctx.features
+  library = rule.attr.library if hasattr(rule.attr, "library") else None
+  out_lib = xgo_lib
+  toolchain = rule.files.toolchain # need x-toolchain?
+
+  deps = _xgo_collect_deps(rule.attr.deps)
+
+  result = _go_library_build(
+    ctx,
+    label = label,
+    srcs = srcs,
+    go_prefix = go_prefix,
+    go_root = go_root,
+    go_env = go_env,
+    go_include_path = go_include_path,
+    deps = deps,
+    cgo_object = cgo_object,
+    library = library,
+    out_lib = xgo_lib,
+    toolchain = toolchain,
+    install_std_library = install_std_library)
+
+  return struct(
+    go_library_result = result,
+    xgo_lib = xgo_lib,
+    runfiles = result.dylibs,
+  )
+
+
+def _xgo_go_binary_impl(target, ctx):
+  """go_binary_impl aspect implementation.
+
+  Args:
+    target (struct): the target rule.
+    ctx (struct): the aspect context.
+
+  Returns:
+    (struct):
+            .go_binary_result (struct): output of go_binary_build
+            .xgo_lib (File): the cross-compiled library .a file.
+            .xgo_out (File): the cross-compiled library .a file.
+            .runfiles (list<File>): list of runfiles.
+  )
+
+  """
+  rule = ctx.rule
+
+  os_arch = ctx.attr.os_arch.split("_")
+  go_os = os_arch[0]
+  go_arch = os_arch[1]
+  go_env = {"GOOS": go_os, "GOARCH": go_arch}
+  go_prefix = _go_prefix_from_provider(rule.attr.go_prefix)
+  go_root = _go_root_from_provider(rule.attr.go_root)
+  go_include_path = rule.file.go_include.path
+
+  filename = "_xgo/" + ctx.attr.os_arch + "/" + ctx.label.name
+  xgo_out = ctx.new_file(filename)
+  xgo_lib = ctx.new_file(filename + ".a")
+
+  cgo_object = rule.attr.cgo_object if hasattr(rule.attr, "cgo_object") else None
+  configuration_bin_dir_path = ctx.configuration.bin_dir.path
+  cpp_fragment = ctx.fragments.cpp
+  crosstool = rule.files._crosstool
+  install_std_library = True,
+  executable = xgo_out
+  features = ctx.features
+  label = ctx.label
+  library = rule.attr.library if hasattr(rule.attr, "library") else None
+  out_lib = xgo_lib
+  srcs = rule.files.srcs
+  toolchain = rule.files.toolchain # need x-toolchain
+  x_defs = rule.attr.x_defs # may need to replace these also
+
+  deps = _xgo_collect_deps(rule.attr.deps)
+
+  go_binary_result = _go_binary_build(
+    ctx = ctx,
+    cgo_object = cgo_object,
+    configuration_bin_dir_path = configuration_bin_dir_path,
+    cpp_fragment = cpp_fragment,
+    crosstool = crosstool,
+    install_std_library = install_std_library,
+    deps = deps,
+    executable = executable,
+    features = features,
+    go_env = go_env,
+    go_include_path = go_include_path,
+    go_prefix = go_prefix,
+    go_root = go_root,
+    label = label,
+    library = library,
+    out_lib = out_lib,
+    srcs = srcs,
+    toolchain = toolchain,
+    x_defs = x_defs)
+
+  # TODO(pcj): Is this necesssary to add in runfiles?
+  #dylibs = go_binary_result.go_library_result.dylibs
+
+  return struct(
+    go_binary_result = go_binary_result,
+    runfiles = _xgo_collect_runfiles(rule),
+    xgo_lib = xgo_lib,
+    xgo_out = xgo_out,
+  )
+
+
+def xgo_aspect_impl(target, ctx):
+  """xgo_aspect implementation.
+
+  This implementation interrogates the kind of rule in the shadow
+  graph being visited.  It then performs a cross-compilation task
+  based, either xgo binary or xgo library.  Cgo inputs are not
+  supported and will cause the build to fail.  The output of the
+  aspect is provided back to the originating rule via the
+  xgo_aspect_result provider.  Therefore, a normal rule implementation
+  can get all results via `[dep.xgo_aspect_result for dep in
+  ctx.attr.deps]`.
+
+  Args:
+    target (struct): the target rule.
+    ctx (struct): the aspect context.
+
+  Returns:
+    (struct):
+            .results (list<struct>): direct results
+            .files (set<File>): direct file outputs (the cross-compiled binaries)
+            .runfiles (set<File>): runfiles.
+            .transitive_files (list<File>): transitive outputs
+            .transitive_runfiles (list<File>): transitive runfiles.
+            .transitive_results (list<struct>)
+  )
+
+  """
+
+  # ctx.rule has["attr", "executable", "file", "files", "kind"]
+  kind = ctx.rule.kind
+
+  files = []
+  runfiles = []
+  results = []
+
+  # Switch on the kind of rule we are processing.
+  if kind == 'go_binary':
+    xgo_binary_result = _xgo_go_binary_impl(target, ctx)
+    results.append(xgo_binary_result)
+    files.append(xgo_binary_result.xgo_out)
+    runfiles += xgo_binary_result.runfiles
+  elif kind == 'go_library':
+    xgo_library_result = _xgo_go_library_impl(target, ctx)
+    results.append(xgo_library_result)
+    runfiles += xgo_library_result.runfiles
+  elif kind == '_cgo_codegen_rule':
+    _xgo_cgo_codegen_rule_impl(target, ctx)
+  elif kind == '_cgo_object':
+    _xgo_cgo_object_impl(target, ctx)
+  else:
+    fail("Unexpected aspect dependency kind %s" % kind)
+
+  transitive_files = files
+  transitive_runfiles = runfiles
+  transitive_results = results
+  for d in ctx.rule.attr.deps:
+    transitive_files += list(d.xgo_aspect_result.files)
+    transitive_runfiles += list(d.xgo_aspect_result.runfiles)
+    transitive_results += d.xgo_aspect_result.transitive_results
+
+  return struct(
+    xgo_aspect_result = struct(
+      files = set(files),
+      runfiles = set(runfiles),
+      results = results,
+      transitive_files = transitive_files,
+      transitive_runfiles = transitive_runfiles,
+      transitive_results = transitive_results,
+    )
+  )
+
+xgo_aspect = aspect(
+  implementation = xgo_aspect_impl,
+  # Propogate across all input deps even though we fail on cgo-related
+  # stuff (better to fail than be surprised later).
+  attr_aspects = ["deps", "cgo_object", "cgogen"],
+  attrs = {
+    # This is a skylark "parameterized aspect attribute" implemented
+    # in https://github.com/bazelbuild/bazel/commit/74558fcc.  It
+    # says: "if any rule attribute declares me in their aspect list,
+    # that rule must have a corresponding string attribute matching
+    # the name 'os_arch' and must take a value enumerated in these
+    # pre-declared values."  Note that it is not private.
+    # Parameterized aspect attributes are currently the only way an
+    # aspect implementation can get extra information not already
+    # provided by shadow nodes.  They also currently can only have
+    # type 'string' and must take a known enumeration of values.
+    # Fortunately GOOS_GOARCH fits this profile.
+    "os_arch": attr.string(values = GOOS_GOARCH),
+  },
+  fragments = ["cpp"],
+)
+
+# ################################################################
+# RULES
+# ################################################################
+
+# ****************************************************************
+# The go_library rule
+# ****************************************************************
+
+def go_library_impl(ctx):
+  """Implements the go_library() rule."""
+
+  go_env = _go_env_from_ctx(ctx)
+  go_prefix = _go_prefix_from_provider(ctx.attr.go_prefix)
+  go_root = _go_root_from_provider(ctx.attr.go_root)
+  go_include_path = ctx.file.go_include.path
+  cgo_object = ctx.attr.cgo_object if hasattr(ctx.attr, "cgo_object") else None
+
+  result = _go_library_build(ctx,
+                            label = ctx.label,
+                            srcs = ctx.files.srcs,
+                            go_prefix = go_prefix,
+                            go_root = go_root,
+                            go_env = go_env,
+                            go_include_path = go_include_path,
+                            deps = ctx.attr.deps,
+                            cgo_object = cgo_object,
+                            library = ctx.attr.library,
+                            out_lib = ctx.outputs.lib,
+                            toolchain = ctx.files.toolchain,
+                            install_std_library = False)
+
+  runfiles = ctx.runfiles(files = result.dylibs, collect_data = True)
+
+  return struct(
+    label = ctx.label,
+    files = set([result.out_lib]),
+    direct_deps = result.direct_deps,
+    runfiles = runfiles,
+    go_sources = result.go_srcs,
+    asm_sources = result.asm_srcs,
+    go_library_object = result.out_lib,
+    transitive_go_library_object = result.transitive_libs,
+    cgo_object = result.cgo_object,
+    transitive_cgo_deps = result.transitive_cgo_deps,
+    transitive_go_importmap = result.transitive_importmap,
+    go_library_result = result,
+  )
+
 
 go_library = rule(
     go_library_impl,
@@ -565,17 +1200,196 @@ go_library = rule(
     fragments = ["cpp"],
     outputs = go_library_outputs,
 )
+"""Build a go library.
+
+Args:
+  data (list<Label>): runfile data files.
+  srcs (list<Label>): go sources (.go, .s, .S,)
+  deps (list<Label>): list of go_library targets.
+  library (Label): singular label providing "go_sources", "asm_sources",
+                   and "cgo_object".  Typically used by go_test.
+  cgo_object (Label): dependent cgo_object rule.
+
+Results:
+  (struct): with providers:
+    .label (Label),
+    .files (set<File>): .a files
+    .direct_deps (list<File>): direct .a inputs.
+    .runfiles (runfiles): the ctx.runfiles output.
+    .go_sources (list<File>): .go files used in this library.
+    .asm_sources (list<File>): .sS files used in this library.
+    .go_library_object (File): primary .a output.
+    .transitive_go_library_object (set<File>): transitive .a files.
+    .cgo_object (struct): cgo_object for this library, or None.
+    .transitive_cgo_deps (list<struct>): transitive cgo dependencies.
+    .transitive_go_importmap (dict<string,string>): cumulative mappings.
+    .go_library_result (struct): output of go_library_build.
+
+Implicit Targets:
+  %{name}.a: the library file.
+
+"""
+
+# ****************************************************************
+# The go_binary rule
+# ****************************************************************
+
+
+def _go_binary_impl(ctx):
+
+  go_env = _go_env_from_ctx(ctx)
+  go_prefix = _go_prefix_from_provider(ctx.attr.go_prefix)
+  go_root = _go_root_from_provider(ctx.attr.go_root)
+  go_include_path = ctx.file.go_include.path
+
+  cgo_object = ctx.attr.cgo_object if hasattr(ctx.attr, "cgo_object") else None
+  library = ctx.attr.library if hasattr(ctx.attr, "library") else None
+  out_lib = ctx.outputs.lib
+  executable = ctx.outputs.executable
+  configuration_bin_dir_path = ctx.configuration.bin_dir.path
+
+  go_binary_result = _go_binary_build(
+    cgo_object = cgo_object,
+    configuration_bin_dir_path = configuration_bin_dir_path,
+    cpp_fragment = ctx.fragments.cpp,
+    crosstool = ctx.files._crosstool,
+    install_std_library = False,
+    ctx = ctx,
+    deps = ctx.attr.deps,
+    executable = executable,
+    features = ctx.features,
+    go_env = go_env,
+    go_include_path = go_include_path,
+    go_prefix = go_prefix,
+    go_root = go_root,
+    label = ctx.label,
+    library = library,
+    out_lib = out_lib,
+    srcs = ctx.files.srcs,
+    toolchain = ctx.files.toolchain,
+    x_defs = ctx.attr.x_defs)
+
+  runfiles = ctx.runfiles(collect_data = True,
+                          files = ctx.files.data)
+
+  go_library_result = go_binary_result.go_library_result
+
+  return struct(
+    files = set([executable, go_library_result.out_lib]),
+    runfiles = runfiles,
+    cgo_object = go_library_result.cgo_object,
+    go_binary_result = go_binary_result,
+    go_library_result = go_library_result,
+  )
+
 
 go_binary = rule(
-    go_binary_impl,
-    attrs = go_library_attrs + _crosstool_attrs + {
-        "stamp": attr.bool(default = False),
-        "x_defs": attr.string_dict(),
-    },
-    executable = True,
-    fragments = ["cpp"],
-    outputs = go_library_outputs,
+  _go_binary_impl,
+  attrs = go_library_attrs + _crosstool_attrs + {
+    "stamp": attr.bool(default = False),
+    "x_defs": attr.string_dict(),
+  },
+  executable = True,
+  fragments = ["cpp"],
+  outputs = go_library_outputs,
 )
+"""Build a go executable file.
+
+Args: all go_library attributes, plus:
+  stamp (bool): apply a timestamp?
+  x_defs (string_dict<string,string>): -X definitions.
+
+Results:
+  (struct): with:
+    .files (set<File>): the binary and .a library files.
+    runfiles (runfiles): ctx.runfiles
+    cgo_object (struct): same as go_library
+    go_binary_result (struct): same as go_library
+    .go_library_result (File): same as go_library
+
+Implicit Targets:
+  %{name}.a: the library file.
+
+"""
+
+
+# ****************************************************************
+# The go_test rule
+# ****************************************************************
+
+
+def go_test_impl(ctx):
+  """go_test_impl implements go testing.
+  It emits an action to run the test generator, and then compiles the
+  test into a binary.
+  """
+  go_env = _go_env_from_ctx(ctx)
+  go_prefix = _go_prefix_from_provider(ctx.attr.go_prefix)
+  go_root = _go_root_from_provider(ctx.attr.go_root)
+  go_importpath = _go_importpath(go_prefix, ctx.label)
+  main_go = ctx.outputs.main_go
+
+  lib_result = go_library_impl(ctx)
+  transitive_libs = lib_result.transitive_go_library_object
+  transitive_cgo_deps = lib_result.transitive_cgo_deps
+  go_sources = lib_result.go_sources
+
+  args = ["--package", go_importpath,
+          "--output", ctx.outputs.main_go.path]
+  args += cmd_helper.template(go_sources, "%{path}")
+
+  inputs = list(go_sources) + list(ctx.files.toolchain)
+  out_lib = ctx.outputs.main_lib
+
+  ctx.action(mnemonic = "GoTestGenTest",
+             inputs = inputs,
+             executable = ctx.executable.test_generator,
+             outputs = [main_go],
+             arguments = args,
+             env = go_env + {
+               "GOROOT": go_root,
+               "RUNDIR": ctx.label.package
+             })
+
+  _emit_go_compile_action(ctx = ctx,
+                          go_env = go_env,
+                          go_root = go_root,
+                          go_prefix = go_prefix,
+                          toolchain = ctx.files.toolchain,
+                          srcs = [main_go],
+                          deps = ctx.attr.deps + [lib_result],
+                          out_lib = out_lib)
+
+  importmap = lib_result.transitive_go_importmap + {
+    out_lib.path: go_importpath + "_main_test"
+  }
+
+  _emit_go_link_action(ctx = ctx,
+                       label = ctx.label,
+                       go_env = go_env,
+                       go_prefix = go_prefix,
+                       go_root = go_root,
+                       x_defs = ctx.attr.x_defs,
+                       importmap = importmap,
+                       transitive_libs = transitive_libs,
+                       cgo_deps = transitive_cgo_deps,
+                       configuration_bin_dir_path = ctx.configuration.bin_dir.path,
+                       lib = out_lib,
+                       executable = ctx.outputs.executable,
+                       crosstool = ctx.files._crosstool,
+                       toolchain = ctx.files.toolchain,
+                       cpp_fragment = ctx.fragments.cpp,
+                       features = ctx.features)
+
+  # TODO(bazel-team): the Go tests should do a chdir to the directory
+  # holding the data files, so open-source go tests continue to work
+  # without code changes.
+  runfiles = ctx.runfiles(collect_data = True,
+                          files = (ctx.files.data + [ctx.outputs.executable] +
+                                   list(lib_result.runfiles.files)))
+
+  return struct(runfiles = runfiles)
+
 
 go_test = rule(
     go_test_impl,
@@ -600,16 +1414,65 @@ go_test = rule(
 )
 
 
-def _pkg_dir(workspace_root, package_name):
-  if workspace_root and package_name:
-    return workspace_root + "/" + package_name
-  if workspace_root:
-    return workspace_root
-  if package_name:
-    return package_name
-  return "."
+# ****************************************************************
+# The xgo_binary rule
+# ****************************************************************
+
+
+def xgo_binary_impl(ctx):
+  files = set()
+  runfiles = set()
+
+  # By this time, all aspects finished processing and have stored
+  # their results in the 'xgo_aspect_result' provider slot of each
+  # dep.
+
+  for dep in ctx.attr.deps:
+    result = dep.xgo_aspect_result
+    files = files | result.transitive_files
+    runfiles = runfiles | result.transitive_runfiles
+
+  return struct(
+    files = files,
+    runfiles = ctx.runfiles(files = list(runfiles)),
+  )
+
+xgo_binary = rule(
+  xgo_binary_impl,
+  attrs = {
+    "deps": attr.label_list(
+      providers = [
+        "xgo_aspect_result",
+      ],
+      aspects = [xgo_aspect],
+    ),
+    "os_arch": attr.string(default = "linux_arm64"),
+  },
+  fragments = ["cpp"],
+)
+"""Generates a cross-compiled binary object(s).
+
+Depend on this rule like a filegroup to pull the list of generated
+files.
+
+Args:
+  deps (list<Label>): go_binary dependencies.
+  os_arch (string): The desired platform in the form "GOOS_GOARCH".
+                    Must be one of the values in goos_goarch.bzl file.
+
+"""
+
+
+# ****************************************************************
+# The cgo_codegen rule
+# ****************************************************************
+
 
 def _cgo_codegen_impl(ctx):
+
+  go_env = _go_env_from_ctx(ctx)
+  go_root = _go_root_from_provider(ctx.attr.go_root)
+
   srcs = ctx.files.srcs + ctx.files.c_hdrs
   linkopts = ctx.attr.linkopts
   deps = set([], order="link")
@@ -634,7 +1497,6 @@ def _cgo_codegen_impl(ctx):
   cc = ctx.fragments.cpp.compiler_executable
   copts = ctx.fragments.cpp.c_options + ctx.attr.copts
   cmds = symlink_tree_commands(out_dir + "/src", tree_layout) + [
-      "export GOROOT=$(pwd)/" + ctx.file.go_tool.dirname + "/..",
       # We cannot use env for CC because $(CC) on OSX is relative
       # and '../' does not work fine due to symlinks.
       "export CC=$(cd $(dirname {cc}); pwd)/$(basename {cc})".format(cc=cc),
@@ -649,25 +1511,26 @@ def _cgo_codegen_impl(ctx):
                copts + [f.basename for f in ctx.files.srcs]),
       "rm -f $objdir/_cgo_.o $objdir/_cgo_flags"]
 
-  f = _emit_generate_params_action(cmds, ctx, out_dir + ".CGoCodeGenFile.params")
-
+  mnemonic = "CGoCodeGen"
+  params = _emit_params_file_action(ctx, out_dir, mnemonic, cmds)
   ctx.action(
-      inputs = srcs + ctx.files.toolchain + ctx.files._crosstool,
-      outputs = ctx.outputs.outs,
-      mnemonic = "CGoCodeGen",
-      progress_message = "CGoCodeGen %s" % ctx.label,
-      executable = f,
-      env = go_environment_vars(ctx) + {
-          "CGO_LDFLAGS": " ".join(linkopts),
-      },
-  )
+    mnemonic = mnemonic,
+    executable = params,
+    inputs = srcs + ctx.files.toolchain + ctx.files._crosstool,
+    outputs = ctx.outputs.outs,
+    progress_message = "%s %s" % (mnemonic, ctx.label),
+    env = go_env + {
+      "GOROOT": go_root,
+      "CGO_LDFLAGS": " ".join(linkopts),
+    })
+
   return struct(
       label = ctx.label,
       files = set(ctx.outputs.outs),
       cgo_deps = deps,
   )
 
-_cgo_codegn_rule = rule(
+_cgo_codegen_rule = rule(
     _cgo_codegen_impl,
     attrs = go_env_attrs + _crosstool_attrs + {
         "srcs": attr.label_list(
@@ -725,82 +1588,94 @@ def _cgo_codegen(name, srcs, c_hdrs=[], deps=[], linkopts=[],
     c_thunks.append(outgen + "/" + basename + ".cgo2.c")
 
   outs = struct(
-      name = name,
-
-      outdir = outgen,
-      go_thunks = go_thunks,
-      c_thunks = c_thunks,
-      c_exports = [
-          outgen + "/_cgo_export.c",
-          outgen + "/_cgo_export.h",
-      ],
-      c_dummy = outgen + "/_cgo_main.c",
-      gotypes = outgen + "/_cgo_gotypes.go",
+    name = name,
+    outdir = outgen,
+    go_thunks = go_thunks,
+    c_thunks = c_thunks,
+    c_exports = [
+      outgen + "/_cgo_export.c",
+      outgen + "/_cgo_export.h",
+    ],
+    c_dummy = outgen + "/_cgo_main.c",
+    gotypes = outgen + "/_cgo_gotypes.go",
   )
 
-  _cgo_codegn_rule(
-      name = name,
-      srcs = srcs,
-      c_hdrs = c_hdrs,
-      deps = deps,
-      linkopts = linkopts,
+  _cgo_codegen_rule(
+    name = name,
+    srcs = srcs,
+    c_hdrs = c_hdrs,
+    deps = deps,
+    linkopts = linkopts,
 
-      go_tool = go_tool,
-      toolchain = toolchain,
+    go_tool = go_tool,
+    toolchain = toolchain,
 
-      outdir = outdir,
-      outs = outs.go_thunks + outs.c_thunks + outs.c_exports + [
-          outs.c_dummy, outs.gotypes,
-      ],
+    outdir = outdir,
+    outs = outs.go_thunks + outs.c_thunks + outs.c_exports + [
+      outs.c_dummy, outs.gotypes,
+    ],
 
-      visibility = ["//visibility:private"],
+    visibility = ["//visibility:private"],
   )
+
   return outs
 
+
+# ****************************************************************
+# The cgo_import rule
+# ****************************************************************
+
+
 def _cgo_import_impl(ctx):
+  go_env = _go_env_from_ctx(ctx)
+  go_root = _go_root_from_provider(ctx.attr.go_root)
+
   cmds = [
-      ("export GOROOT=$(pwd)/" + ctx.file.go_tool.dirname + "/.."),
-      (ctx.file.go_tool.path + " tool cgo" +
+      ("$GOROOT/bin/go tool cgo" +
        " -dynout " + ctx.outputs.out.path +
        " -dynimport " + ctx.file.cgo_o.path +
        " -dynpackage $(%s %s)"  % (ctx.executable._extract_package.path,
                                    ctx.file.sample_go_src.path)),
   ]
-  f = _emit_generate_params_action(cmds, ctx, ctx.outputs.out.path + ".CGoImportGenFile.params")
+
+  mnemonic = "CGoImportGen"
+  params = _emit_params_file_action(ctx, ctx.outputs.out.path, mnemonic, cmds)
   ctx.action(
-      inputs = (ctx.files.toolchain +
-                [ctx.file.go_tool, ctx.executable._extract_package,
-                 ctx.file.cgo_o, ctx.file.sample_go_src]),
-      outputs = [ctx.outputs.out],
-      executable = f,
-      mnemonic = "CGoImportGen",
+    mnemonic = mnemonic,
+    executable = params,
+    inputs = (ctx.files.toolchain +
+              [ctx.file.go_tool, ctx.executable._extract_package,
+               ctx.file.cgo_o, ctx.file.sample_go_src]),
+    outputs = [ctx.outputs.out],
+    env = go_env + {
+      "GOROOT": go_root,
+    }
   )
   return struct(
       files = set([ctx.outputs.out]),
   )
 
 _cgo_import = rule(
-    _cgo_import_impl,
-    attrs = go_env_attrs + {
-        "cgo_o": attr.label(
-            allow_files = True,
-            single_file = True,
-        ),
-        "sample_go_src": attr.label(
-            allow_files = True,
-            single_file = True,
-        ),
-
-        "out": attr.output(
-            mandatory = True,
-        ),
-
-        "_extract_package": attr.label(
-            default = Label("//go/tools/extract_package"),
-            executable = True,
-            cfg = HOST_CFG,
-        ),
-    },
+  _cgo_import_impl,
+  attrs = go_env_attrs + {
+    "cgo_o": attr.label(
+      allow_files = True,
+      single_file = True,
+    ),
+    "sample_go_src": attr.label(
+      allow_files = True,
+      single_file = True,
+    ),
+    "out": attr.output(
+      mandatory = True,
+    ),
+    "_extract_package": attr.label(
+      default = Label("//go/tools/extract_package"),
+    executable = True,
+      cfg = HOST_CFG,
+    ),
+  },
+  fragments = ["cpp"],
 )
 """Generates symbol-import directives for cgo
 
@@ -811,18 +1686,28 @@ Args:
   out: Destination of the generated codes.
 """
 
+
+# ****************************************************************
+# The cgo_object rule
+# ****************************************************************
+
+
 def _cgo_object_impl(ctx):
-  arguments = _c_linker_options(ctx, blacklist=[
-      # never link any dependency libraries
-      "-l", "-L",
-      # manage flags to ld(1) by ourselves
-      "-Wl,"])
+  cpp_fragment = ctx.fragments.cpp
+  linker_blacklist = [
+    # never link any dependency libraries
+    "-l", "-L",
+    # manage flags to ld(1) by ourselves
+    "-Wl,",
+  ]
+  arguments = _c_linker_opts(cpp_fragment, ctx.features, linker_blacklist)
   arguments += [
       "-o", ctx.outputs.out.path,
       "-nostdlib",
       "-Wl,-r",
   ]
-  if ctx.fragments.cpp.cpu == "darwin":
+
+  if cpp_fragment.cpu == "darwin":
     arguments += ["-shared", "-Wl,-all_load"]
   else:
     arguments += ["-Wl,-whole-archive"]
@@ -830,37 +1715,35 @@ def _cgo_object_impl(ctx):
   lo = ctx.files.src[-1]
   arguments += [lo.path]
 
-  ctx.action(
-      inputs = [lo] + ctx.files._crosstool,
-      outputs = [ctx.outputs.out],
-      mnemonic = "CGoObject",
-      progress_message = "Linking %s" % _short_path(ctx.outputs.out),
-      executable = ctx.fragments.cpp.compiler_executable,
-      arguments = arguments,
-  )
+  ctx.action(mnemonic = "CGoObject",
+             inputs = [lo] + ctx.files._crosstool,
+             outputs = [ctx.outputs.out],
+             executable = ctx.fragments.cpp.compiler_executable,
+             arguments = arguments,
+             progress_message = "Linking %s" % _short_path(ctx.outputs.out))
+
   return struct(
-      files = set([ctx.outputs.out]),
-      cgo_obj = ctx.outputs.out,
-      cgo_deps = ctx.attr.cgogen.cgo_deps,
+    files = set([ctx.outputs.out]),
+    cgo_obj = ctx.outputs.out,
+    cgo_deps = ctx.attr.cgogen.cgo_deps,
   )
 
 _cgo_object = rule(
-    _cgo_object_impl,
-    attrs = _crosstool_attrs + {
-        "src": attr.label(
-            mandatory = True,
-            providers = ["cc"],
-        ),
-        "cgogen": attr.label(
-            mandatory = True,
-            providers = ["cgo_deps"],
-        ),
-
-        "out": attr.output(
-            mandatory = True,
-         )
-    },
-    fragments = ["cpp"],
+  _cgo_object_impl,
+  attrs = _crosstool_attrs + {
+    "src": attr.label(
+      mandatory = True,
+      providers = ["cc"],
+    ),
+    "cgogen": attr.label(
+      mandatory = True,
+      providers = ["cgo_deps"],
+    ),
+    "out": attr.output(
+      mandatory = True,
+    ),
+  },
+  fragments = ["cpp"],
 )
 """Generates _all.o to be archived together with Go objects.
 
@@ -927,6 +1810,7 @@ def cgo_library(name, srcs,
   pkg_dir = _pkg_dir(
       "external/" + REPOSITORY_NAME[1:] if len(REPOSITORY_NAME) > 1 else "",
       PACKAGE_NAME)
+
   # Bundles objects into an archive so that _cgo_.o and _all.o can share them.
   native.cc_library(
       name = cgogen.outdir + "/_cgo_lib",
@@ -956,6 +1840,7 @@ def cgo_library(name, srcs,
       linkopts = clinkopts,
       visibility = ["//visibility:private"],
   )
+
   _cgo_import(
       name = "%s.cgo.importgen" % name,
       cgo_o = cgogen.outdir + "/_cgo_.o",
@@ -984,77 +1869,4 @@ def cgo_library(name, srcs,
       go_tool = go_tool,
       toolchain = toolchain,
       **kwargs
-  )
-
-
-################
-
-GO_TOOLCHAIN_BUILD_FILE = """
-package(
-  default_visibility = [ "//visibility:public" ])
-
-filegroup(
-  name = "toolchain",
-  srcs = glob(["bin/*", "pkg/**", ]),
-)
-
-filegroup(
-  name = "go_tool",
-  srcs = [ "bin/go" ],
-)
-
-filegroup(
-  name = "go_include",
-  srcs = [ "pkg/include" ],
-)
-"""
-
-def _go_repository_select_impl(ctx):
-  os = ctx.os.name
-  # NOTE: This mapping cannot be table-driven to prevent
-  # Bazel from downloading the other archive.
-  if os == 'linux':
-    goroot = ctx.path(ctx.attr._linux).dirname
-  elif os == 'mac os x':
-    goroot = ctx.path(ctx.attr._darwin).dirname
-  else:
-    fail("unsupported operating system: " + os)
-
-  ctx.symlink(goroot, ctx.path(''))
-
-_go_repository_select = repository_rule(
-    _go_repository_select_impl,
-    attrs = {
-        "_linux": attr.label(
-            default = Label("@golang_linux_amd64//:BUILD"),
-            allow_files = True,
-            single_file = True,
-        ),
-        "_darwin": attr.label(
-            default = Label("@golang_darwin_amd64//:BUILD"),
-            allow_files = True,
-            single_file = True,
-        ),
-    },
-)
-
-def go_repositories():
-  native.new_http_archive(
-      name =  "golang_linux_amd64",
-      url = "https://storage.googleapis.com/golang/go1.7.1.linux-amd64.tar.gz",
-      build_file_content = GO_TOOLCHAIN_BUILD_FILE,
-      sha256 = "43ad621c9b014cde8db17393dc108378d37bc853aa351a6c74bf6432c1bbd182",
-      strip_prefix = "go",
-  )
-
-  native.new_http_archive(
-      name = "golang_darwin_amd64",
-      url = "https://storage.googleapis.com/golang/go1.7.1.darwin-amd64.tar.gz",
-      build_file_content = GO_TOOLCHAIN_BUILD_FILE,
-      sha256 = "9fd80f19cc0097f35eaa3a52ee28795c5371bb6fac69d2acf70c22c02791f912",
-      strip_prefix = "go",
-  )
-
-  _go_repository_select(
-      name = "io_bazel_rules_go_toolchain",
   )

--- a/go/private/go_prefix.bzl
+++ b/go/private/go_prefix.bzl
@@ -1,0 +1,48 @@
+# Copyright 2016 The Bazel Go Rules Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def _go_prefix_impl(ctx):
+  """go_prefix_impl provides the go prefix to use as a transitive info provider."""
+  return struct(go_prefix = ctx.attr.prefix)
+
+_go_prefix_rule = rule(
+    _go_prefix_impl,
+    attrs = {
+        "prefix": attr.string(mandatory = True),
+    },
+)
+
+def go_prefix(prefix):
+  """go_prefix sets the Go import name to be used for this workspace."""
+  _go_prefix_rule(name = "go_prefix",
+    prefix = prefix,
+    visibility = ["//visibility:public" ]
+  )
+"""Capture the go_prefix for use as a label dependency.
+
+In Go, imports are always fully qualified with a URL,
+eg. github.com/user/project. Hence, a label //foo:bar from within a
+Bazel workspace must be referred to as
+"github.com/user/project/foo/bar". To make this work, each rule must
+know the repository's URL. This is achieved, by having all go rules
+depend on a globally unique target that has a "go_prefix" transitive
+info provider.
+
+Args:
+  prefix (string): the import prefix, typically similar to 'github.com/user/project'.
+
+Returns:
+  (struct): .go_prefix (string) provider.
+
+"""

--- a/go/private/go_repositories.bzl
+++ b/go/private/go_repositories.bzl
@@ -1,0 +1,132 @@
+# Copyright 2016 The Bazel Go Rules Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+GO_TOOLCHAIN_BUILD_FILE = """
+package(
+  default_visibility = [ "//visibility:public" ])
+
+filegroup(
+  name = "toolchain",
+  srcs = glob(["bin/*", "pkg/**", ]),
+)
+
+filegroup(
+  name = "go_tool",
+  srcs = [ "bin/go" ],
+)
+
+filegroup(
+  name = "go_include",
+  srcs = [ "pkg/include" ],
+)
+"""
+
+GO_ROOT_ADDENDUM = """
+load("@io_bazel_rules_go//go/private:go_root.bzl", "go_root")
+
+go_root(
+  name = "go_root",
+  path = "{goroot}",
+)
+"""
+
+def _go_toolchain_impl(ctx):
+  """Symlinks the correct go toolchain."""
+
+  bazel_goroot = ctx.os.environ.get("BAZEL_GOROOT", None)
+
+  # 1. Configure the goroot path
+  if bazel_goroot:
+    goroot = ctx.path(bazel_goroot)
+  else:
+    os_name = ctx.os.name
+    # NOTE: This mapping cannot be table-driven to prevent
+    # Bazel from downloading the other archive.
+    if os_name == 'linux':
+      goroot = ctx.path(ctx.attr._linux).dirname
+    elif os_name == 'mac os x':
+      goroot = ctx.path(ctx.attr._darwin).dirname
+    else:
+      fail("unsupported operating system: " + os_name)
+
+  # 2. Create the symlinks and write the BUILD file.
+  gobin = goroot.get_child("bin")
+  gopkg = goroot.get_child("pkg")
+  ctx.symlink(gobin, "bin")
+  ctx.symlink(gopkg, "pkg")
+  ctx.file("BUILD", GO_TOOLCHAIN_BUILD_FILE + GO_ROOT_ADDENDUM.format(
+    goroot = goroot,
+  ), False)
+
+  # 3. If the user has specified the goroot explicitly, confirm a
+  # working installation by checking the output of 'go version'.
+  if bazel_goroot:
+    go = gobin.get_child("go")
+    result = ctx.execute([go, "env"])
+    if result.return_code:
+      fail("""
+Something's not right.  Are you sure '%s' points to a functional GOROOT?
+--> %s
+""" % (go, result.stderr))
+
+
+_go_toolchain = repository_rule(
+      _go_toolchain_impl,
+      attrs = {
+        #"goroot": attr.string(),
+        "_linux": attr.label(
+            default = Label("@golang_linux_amd64//:BUILD"),
+            allow_files = True,
+            single_file = True,
+        ),
+        "_darwin": attr.label(
+            default = Label("@golang_darwin_amd64//:BUILD"),
+            allow_files = True,
+            single_file = True,
+        ),
+        # "go_root": attr.label(
+        #   providers = ["go_root"],
+        #   default = Label(
+        #     "//:go_root",
+        #     relative_to_caller_repository = False
+        #   ),
+        #   allow_files = False,
+        # ),
+    },
+)
+
+def go_repositories():
+  """Provide workspace dependencies including the go toolchain.  If the
+  environment variable "BAZEL_GOROOT" is set rules_go will use it
+  rather than downloading a toolchain.
+  """
+  native.new_http_archive(
+      name =  "golang_linux_amd64",
+      url = "https://storage.googleapis.com/golang/go1.7.1.linux-amd64.tar.gz",
+      build_file_content = GO_TOOLCHAIN_BUILD_FILE,
+      sha256 = "43ad621c9b014cde8db17393dc108378d37bc853aa351a6c74bf6432c1bbd182",
+      strip_prefix = "go",
+  )
+
+  native.new_http_archive(
+      name = "golang_darwin_amd64",
+      url = "https://storage.googleapis.com/golang/go1.7.1.darwin-amd64.tar.gz",
+      build_file_content = GO_TOOLCHAIN_BUILD_FILE,
+      sha256 = "9fd80f19cc0097f35eaa3a52ee28795c5371bb6fac69d2acf70c22c02791f912",
+      strip_prefix = "go",
+  )
+
+  _go_toolchain(
+      name = "io_bazel_rules_go_toolchain",
+  )

--- a/go/private/go_root.bzl
+++ b/go/private/go_root.bzl
@@ -1,0 +1,33 @@
+# Copyright 2016 The Bazel Go Rules Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def _go_root_impl(ctx):
+  """go_root_impl propogates a GOROOT path string."""
+  return struct(go_root = ctx.attr.path)
+
+go_root = rule(
+  _go_root_impl,
+  attrs = {
+    "path": attr.string(),
+  },
+)
+"""Captures the goroot value for use as a label dependency.
+
+Args:
+  path (string): the absolute path to GOROOT.
+
+Returns:
+  (struct): .go_root (string): the GOROOT value provider.
+
+"""

--- a/go/private/goos_goarch.bzl
+++ b/go/private/goos_goarch.bzl
@@ -1,0 +1,48 @@
+# Copyright 2016 The Bazel Go Rules Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Permitted combinations from
+https://golang.org/doc/install/source#environment.  Pronounced
+"goose-garch" (https://www.youtube.com/watch?v=KINIAgRpkDA).
+"""
+GOOS_GOARCH = [
+  "android_arm",
+  "darwin_386",
+  "darwin_amd64",
+  "darwin_arm",
+  "darwin_arm64",
+  "dragonfly_amd64",
+  "freebsd_386",
+  "freebsd_amd64",
+  "freebsd_arm",
+  "linux_386",
+  "linux_amd64",
+  "linux_arm",
+  "linux_arm64",
+  "linux_ppc64",
+  "linux_ppc64le",
+  "linux_mips64",
+  "linux_mips64le",
+  "netbsd_386",
+  "netbsd_amd64",
+  "netbsd_arm",
+  "openbsd_386",
+  "openbsd_amd64",
+  "openbsd_arm",
+  "plan9_386",
+  "plan9_amd64",
+  "solaris_amd64",
+  "windows_386",
+  "windows_amd64",
+]

--- a/go/toolchain/BUILD
+++ b/go/toolchain/BUILD
@@ -16,3 +16,8 @@ alias(
     name = "go_include",
     actual = "@io_bazel_rules_go_toolchain//:go_include",
 )
+
+alias(
+    name = "go_root",
+    actual = "@io_bazel_rules_go_toolchain//:go_root",
+)


### PR DESCRIPTION
- New rule 'xgo_binary' takes a list of go_binary dependencies and an
  'os_arch' string attribute.  Build output 'foo' is namespaced in
  bazel-bin/PACKAGE_NAME/_xgo/GOOS_GOARCH/foo.  Cross-compilation is
  achieved via a parameterized aspect implementation that propogates
  down the 'deps' attribute; platform target is informed by the
  'os_arch' attribute whose values are enumerated in
  //go/private/goos_goarch.bzl.
- New rule 'go_root' captures the absolute path of GOROOT at the time
  of toolchain installation.  This rule is only used internally.  For
  some reason cross-compilation requires an absolute path to GOROOT.
- Repository rule 'go_repositories' takes an optional environment
  variable BAZEL_GOROOT to use local go toolchain if desired.
- Partitions def.bzl file into individual bzl files in go/private
  where possible.  Each file implements a single rule.  These are
  loaded by def.bzl, so end-user is unaffected.
- Reorganization of def.bzl into sections: constants, utility
  functions, action functions, aspects, and rules.
- Reengineered go_library_impl and go_binary_impl into functions
  go_library_build and go_binary_build that act as common entrypoints
  for the reworked __impl functions as well the new aspect
  implementations _xgo___impl.  These functions are agnostic to the
  layout of the ctx argument (different for normal rules vs. aspect
  rules).  The parameter lists are longer but declare their
  requirements more explicitly.
- Expanded documentation of most functions with skydoc docstrings and
  type annotations.
- Cross-compilation of cgo targets is not supported.  Assembly files
  are permitted but must be consistent with the target architecture.
