### PR TITLE
Bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ They currently do not support (in order of importance):
     git_repository(
         name = "io_bazel_rules_go",
         remote = "https://github.com/bazelbuild/rules_go.git",
-        tag = "0.1.0",
+        tag = "0.2.0",
     )
     load("@io_bazel_rules_go//go:def.bzl", "go_repositories")
 


### PR DESCRIPTION
This PR should be merged just before releasing 0.2.0
* [draft](https://github.com/bazelbuild/rules_go/releases/edit/untagged-15f6d0704b27e8388a97)