### PR TITLE
[WIP] Resolves a warning about the workspace name:

### DIFF
--- a/go/def.bzl
+++ b/go/def.bzl
@@ -1001,7 +1001,11 @@ def _go_repository_select_impl(ctx):
   else:
     fail("unsupported operating system: " + os)
 
-  ctx.symlink(goroot, ctx.path(''))
+  gobin = goroot.get_child("bin")
+  gopkg = goroot.get_child("pkg")
+  ctx.symlink(gobin, "bin")
+  ctx.symlink(gopkg, "pkg")
+  ctx.file("BUILD", GO_TOOLCHAIN_BUILD_FILE, False)
 
 _go_repository_select = repository_rule(
     _go_repository_select_impl,


### PR DESCRIPTION
"Workspace name in .../external/io_bazel_rules_go_toolchain/WORKSPACE
(@golang_darwin_amd64) does not match the name given in the
repository's definition (@io_bazel_rules_go_toolchain); this will
cause a build error in future versions."

The change was extracted from #91 by Paul Cody Johnston.