### PR TITLE
Fixes a test failure on darwin

### DIFF
--- a/go/tools/gazelle/wspace/finder_test.go
+++ b/go/tools/gazelle/wspace/finder_test.go
@@ -24,7 +24,7 @@ type testCase struct {
 }
 
 func TestFind(t *testing.T) {
-	tmp, err := ioutil.TempDir(os.Getenv("TEST_TMPDIR"), "")
+	tmp, err := ioutil.TempDir("", "")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fixes #125 

`$TEST_TMPDIR` looks to be under `execroot` and `wspace.Find` finds out a `WORKSPACE` in `execroot`

```
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
-----------------------------------------------------------------------------
--- FAIL: TestFind (0.00s)
	finder_test.go:54: Find("/private/var/tmp/_bazel_ci/34fe1368fbe38faf999248c2d68f258a/execroot/darwin-x86_64/_tmp/go_default_test_1/195401717") got "/private/var/tmp/_bazel_ci/34fe1368fbe38faf999248c2d68f258a/execroot/darwin-x86_64", want ""
FAIL
```