### PR TITLE
support example only test packages

### DIFF
--- a/go/tools/generate_test_main.go
+++ b/go/tools/generate_test_main.go
@@ -92,7 +92,9 @@ import (
 	"os"
 	"testing"
 
+{{ if .Names }}
         undertest "{{.Package}}"
+{{ end }}
 )
 
 func everything(pat, str string) (bool, error) {


### PR DESCRIPTION
Without this change, you would get an unused import error. It's common to have empty test packages with only GoDoc Example functions.