### PR TITLE
Remove an alias of the main workspace

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,11 +13,6 @@ new_go_repository(
 
 go_internal_tools_deps()
 
-local_repository(
-    name = "io_bazel_rules_go",
-    path = ".",
-)
-
 # Protocol buffers
 
 load("//proto:go_proto_library.bzl", "go_proto_repositories")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,12 +3,17 @@ workspace(name = "io_bazel_rules_go")
 load("//go:def.bzl", "go_repositories", "new_go_repository")
 load("//go/private:go_repositories.bzl", "go_internal_tools_deps")
 
-go_repositories()
+go_repositories(
+    # DO NOT specify this internal attribute outside of rules_go project itself.
+    rules_go_repo_only_for_internal_use = "@",
+)
 
 new_go_repository(
     name = "com_github_golang_glog",
     commit = "23def4e6c14b4da8ac2ed8007337bc5eb5007998",
     importpath = "github.com/golang/glog",
+    # DO NOT specify this internal attribute outside of rules_go project itself.
+    rules_go_repo_only_for_internal_use = "@",
 )
 
 go_internal_tools_deps()
@@ -17,4 +22,7 @@ go_internal_tools_deps()
 
 load("//proto:go_proto_library.bzl", "go_proto_repositories")
 
-go_proto_repositories()
+go_proto_repositories(
+    # DO NOT specify this internal attribute outside of rules_go project itself.
+    rules_go_repo_only_for_internal_use = "@",
+)

--- a/examples/proto/BUILD
+++ b/examples/proto/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",

--- a/go/private/go_repositories.bzl
+++ b/go/private/go_repositories.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//go/private:go_repository.bzl", "go_repository", "new_go_repository")
+load("//go/private:go_repository.bzl", "buildifier_repository_only_for_internal_use", "new_go_repository")
 
 repository_tool_deps = {
     'buildifier': struct(
@@ -29,7 +29,9 @@ repository_tool_deps = {
 
 def go_internal_tools_deps():
   """only for internal use in rules_go"""
-  go_repository(
+  # c.f. #135
+  # TODO(yugui) Simply use go_repository when we drop support of Bazel 0.3.2.
+  buildifier_repository_only_for_internal_use(
       name = "io_bazel_buildifier",
       commit = repository_tool_deps['buildifier'].commit,
       importpath = repository_tool_deps['buildifier'].importpath,
@@ -39,6 +41,9 @@ def go_internal_tools_deps():
       name = "org_golang_x_tools",
       commit = repository_tool_deps['tools'].commit,
       importpath = repository_tool_deps['tools'].importpath,
+      # c.f. #135
+      # TODO(yugui) Remove this attribute when we drop support of Bazel 0.3.2.
+      rules_go_repo_only_for_internal_use = "@",
   )
 
 def _fetch_repository_tools_deps(ctx, goroot, gopath):
@@ -117,7 +122,7 @@ _go_repository_tools = repository_rule(
 )
 
 GO_TOOLCHAIN_BUILD_FILE = """
-load("@io_bazel_rules_go//go/private:go_root.bzl", "go_root")
+load("{rules_go_repo}//go/private:go_root.bzl", "go_root")
 
 package(
   default_visibility = [ "//visibility:public" ])
@@ -164,12 +169,17 @@ def _go_repository_select_impl(ctx):
 
   ctx.file("BUILD", GO_TOOLCHAIN_BUILD_FILE.format(
     goroot = goroot,
+    rules_go_repo = ctx.attr.rules_go_repo_only_for_internal_use,
   ))
 
 
 _go_repository_select = repository_rule(
     _go_repository_select_impl,
     attrs = {
+        "rules_go_repo_only_for_internal_use": attr.string(
+            default = "@io_bazel_rules_go",
+        ),
+
         "_linux": attr.label(
             default = Label("@golang_linux_amd64//:BUILD"),
             allow_files = True,
@@ -184,7 +194,10 @@ _go_repository_select = repository_rule(
 )
 
 
-def go_repositories():
+# c.f. #135
+# TODO(yugui) remove the attribute rules_go_repo_only_for_internal_use when we
+# drop support of Bazel 0.3.2
+def go_repositories(rules_go_repo_only_for_internal_use):
   native.new_http_archive(
       name =  "golang_linux_amd64",
       url = "https://storage.googleapis.com/golang/go1.7.1.linux-amd64.tar.gz",
@@ -203,6 +216,7 @@ def go_repositories():
 
   _go_repository_select(
       name = "io_bazel_rules_go_toolchain",
+      rules_go_repo_only_for_internal_use = rules_go_repo_only_for_internal_use,
   )
   _go_repository_tools(
       name = "io_bazel_rules_go_repository_tools",

--- a/go/private/go_repository.bzl
+++ b/go/private/go_repository.bzl
@@ -40,10 +40,13 @@ def _new_go_repository_impl(ctx):
   _go_repository_impl(ctx)
   gazelle = ctx.path(ctx.attr._gazelle)
 
-  result = ctx.execute([
-      gazelle,
-      '--go_prefix', ctx.attr.importpath, '--mode', 'fix',
-      ctx.path('')])
+  cmds = [gazelle, '--go_prefix', ctx.attr.importpath, '--mode', 'fix']
+  if ctx.attr.rules_go_repo_only_for_internal_use:
+    cmds += ["--go_rules_bzl_only_for_internal_use",
+             "%s//go:def.bzl" % ctx.attr.rules_go_repo_only_for_internal_use]
+  cmds += [ctx.path('')]
+
+  result = ctx.execute(cmds)
   if result.return_code:
     fail("failed to generate BUILD files for %s: %s" % (
         ctx.attr.importpath, result.stderr))
@@ -80,5 +83,25 @@ new_go_repository = repository_rule(
             executable = True,
             cfg = "host",
         ),
+        # See also #135.
+        # TODO(yugui) Remove this attribute when we drop support of Bazel 0.3.2.
+        "rules_go_repo_only_for_internal_use": attr.string(),
     },
+)
+
+# See also #135.
+# TODO(yugui) Remove this rule when we drop support of Bazel 0.3.2.
+def _buildifier_repository_impl(ctx):
+  _go_repository_impl(ctx)
+  result = ctx.execute([
+      "find", ctx.path(''), '(', '-name', 'BUILD', '-or', '-name', '*.bzl', ')',
+      '-exec',
+      'sed', '-i', '', '-e', 's!@io_bazel_rules_go//!@//!', '{}',
+      ';'])
+  if result.return_code:
+    fail("Failed to postprocess BUILD files in buildifier: %s" % result.stderr)
+
+buildifier_repository_only_for_internal_use = repository_rule(
+    implementation = _buildifier_repository_impl,
+    attrs = _go_repository_attrs,
 )

--- a/go/tools/gazelle/gazelle/BUILD
+++ b/go/tools/gazelle/gazelle/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_binary", "go_test")
+load("//go:def.bzl", "go_library", "go_binary", "go_test")
 
 go_library(
     name = "go_default_library",

--- a/go/tools/gazelle/gazelle/main.go
+++ b/go/tools/gazelle/gazelle/main.go
@@ -38,6 +38,12 @@ var (
 	mode     = flag.String("mode", "fix", "print: prints all of the updated BUILD files\n\tfix: rewrites all of the BUILD files in place\n\tdiff: computes the rewrite but then just does a diff")
 )
 
+func init() {
+	// See also #135.
+	// TODO(yugui): Remove this flag when we drop support of Bazel 0.3.2
+	flag.StringVar(&generator.GoRulesBzl, "go_rules_bzl_only_for_internal_use", "@io_bazel_rules_go//go:def.bzl", "hacky flag to build rules_go repository itself")
+}
+
 var modeFromName = map[string]func(*bzl.File) error{
 	"print": printFile,
 	"fix":   fixFile,

--- a/go/tools/gazelle/generator/BUILD
+++ b/go/tools/gazelle/generator/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",

--- a/go/tools/gazelle/generator/generator.go
+++ b/go/tools/gazelle/generator/generator.go
@@ -28,9 +28,13 @@ import (
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/rules"
 )
 
-const (
-	// goRulesBzl is the label of the Skylark file which provides Go rules
-	goRulesBzl = "@io_bazel_rules_go//go:def.bzl"
+var (
+	// GoRulesBzl is the label of the Skylark file which provides Go rules
+	// You usually don't need to overwrite this variable.
+	//
+	// See also #135.
+	// TODO(yugui): Make it a constant when we drop support of Bazel 0.3.2.
+	GoRulesBzl = "@io_bazel_rules_go//go:def.bzl"
 )
 
 // Generator generates BUILD files for a Go repository.
@@ -159,7 +163,7 @@ func (g *Generator) generateLoad(f *bzl.File) bzl.Expr {
 
 func loadExpr(rules ...string) bzl.Expr {
 	list := []bzl.Expr{
-		&bzl.StringExpr{Value: goRulesBzl},
+		&bzl.StringExpr{Value: GoRulesBzl},
 	}
 	for _, r := range rules {
 		list = append(list, &bzl.StringExpr{Value: r})

--- a/go/tools/gazelle/merger/BUILD
+++ b/go/tools/gazelle/merger/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",

--- a/go/tools/gazelle/wspace/BUILD
+++ b/go/tools/gazelle/wspace/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",

--- a/proto/go_proto_library.bzl
+++ b/proto/go_proto_library.bzl
@@ -39,7 +39,7 @@ go_proto_library(
 )
 """
 
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "new_go_repository")
+load("//go:def.bzl", "go_library", "new_go_repository")
 
 _DEFAULT_LIB = "go_default_library"  # matching go_library
 
@@ -213,12 +213,16 @@ def go_proto_library(name, srcs = None, deps = None,
       **kwargs
   )
 
-def go_proto_repositories(shared = 1):
+# c.f. #135
+# TODO(yugui) Remove rules_go_repo_only_for_internal_use argument when we drop
+# support of Bazel 0.3.2.
+def go_proto_repositories(shared=1, rules_go_repo_only_for_internal_use=None):
   """Add this to your WORKSPACE to pull in all of the needed dependencies."""
   new_go_repository(
       name = "com_github_golang_protobuf",
       importpath = "github.com/golang/protobuf",
       commit = "1f49d83d9aa00e6ce4fc8258c71cc7786aec968a",
+      rules_go_repo_only_for_internal_use = rules_go_repo_only_for_internal_use,
   )
   if shared:
     # if using multiple *_proto_library, allows caller to skip this.
@@ -233,9 +237,11 @@ def go_proto_repositories(shared = 1):
       name = "org_golang_x_net",
       commit = "de35ec43e7a9aabd6a9c54d2898220ea7e44de7d",
       importpath = "golang.org/x/net",
+      rules_go_repo_only_for_internal_use = rules_go_repo_only_for_internal_use,
   )
   new_go_repository(
       name = "org_golang_google_grpc",
       tag = "v1.0.1-GA",
       importpath = "google.golang.org/grpc",
+      rules_go_repo_only_for_internal_use = rules_go_repo_only_for_internal_use,
   )


### PR DESCRIPTION
* Removes a `local_repository` which points the main workspace itself. Fixes #135.
* Add another workaround of recursive workspace reference issue in buildifier.
  We can remove this workaround when we drop support of Bazel 0.3.2.