### PR TITLE
Adds go_root rule.

### DIFF
--- a/go/def.bzl
+++ b/go/def.bzl
@@ -499,6 +499,14 @@ go_env_attrs = {
         allow_files = True,
         cfg = "host",
     ),
+    "go_root": attr.label(
+        providers = ["go_root"],
+        default = Label(
+            "//go/toolchain:go_root",
+        ),
+        allow_files = False,
+        cfg = "host",
+    ),
 }
 
 go_library_attrs = go_env_attrs + {

--- a/go/private/go_repositories.bzl
+++ b/go/private/go_repositories.bzl
@@ -144,13 +144,10 @@ go_root(
 """
 
 def _go_repository_select_impl(ctx):
-  rules_goroot = ctx.os.environ.get("RULES_GOROOT", None)
   os_name = ctx.os.name
 
   # 1. Configure the goroot path
-  if rules_goroot:
-    goroot = ctx.path(rules_goroot)
-  elif os_name == 'linux':
+  if os_name == 'linux':
     goroot = ctx.path(ctx.attr._linux).dirname
   elif os_name == 'mac os x':
     goroot = ctx.path(ctx.attr._darwin).dirname
@@ -168,14 +165,6 @@ def _go_repository_select_impl(ctx):
   ctx.file("BUILD", GO_TOOLCHAIN_BUILD_FILE.format(
     goroot = goroot,
   ))
-
-  # 3. If the user has specified the goroot explicitly, confirm a
-  # functional installation.
-  if rules_goroot:
-    go = gobin.get_child("go")
-    result = ctx.execute([go, "env"])
-    if result.return_code:
-      fail("$RULES_GOROOT/bin/go not found: %s" % (goroot, result.stderr))
 
 
 _go_repository_select = repository_rule(

--- a/go/private/go_repositories.bzl
+++ b/go/private/go_repositories.bzl
@@ -145,18 +145,17 @@ go_root(
 
 def _go_repository_select_impl(ctx):
   rules_goroot = ctx.os.environ.get("RULES_GOROOT", None)
+  os_name = ctx.os.name
 
   # 1. Configure the goroot path
   if rules_goroot:
     goroot = ctx.path(rules_goroot)
+  elif os_name == 'linux':
+    goroot = ctx.path(ctx.attr._linux).dirname
+  elif os_name == 'mac os x':
+    goroot = ctx.path(ctx.attr._darwin).dirname
   else:
-    os_name = ctx.os.name
-    if os_name == 'linux':
-      goroot = ctx.path(ctx.attr._linux).dirname
-    elif os_name == 'mac os x':
-      goroot = ctx.path(ctx.attr._darwin).dirname
-    else:
-      fail("Unsupported operating system: " + os_name)
+    fail("Unsupported operating system: " + os_name)
 
   # 2. Create the symlinks and write the BUILD file.
   gobin = goroot.get_child("bin")
@@ -176,10 +175,7 @@ def _go_repository_select_impl(ctx):
     go = gobin.get_child("go")
     result = ctx.execute([go, "env"])
     if result.return_code:
-      fail("""
-Something's not right.  Are you sure '%s' points to a functional GOROOT?
---> %s
-""" % (goroot, result.stderr))
+      fail("$RULES_GOROOT/bin/go not found: %s" % (goroot, result.stderr))
 
 
 _go_repository_select = repository_rule(

--- a/go/private/go_repositories.bzl
+++ b/go/private/go_repositories.bzl
@@ -117,6 +117,8 @@ _go_repository_tools = repository_rule(
 )
 
 GO_TOOLCHAIN_BUILD_FILE = """
+load("@io_bazel_rules_go//go/private:go_root.bzl", "go_root")
+
 package(
   default_visibility = [ "//visibility:public" ])
 
@@ -134,22 +136,51 @@ filegroup(
   name = "go_include",
   srcs = [ "pkg/include" ],
 )
+
+go_root(
+  name = "go_root",
+  path = "{goroot}",
+)
 """
 
-
 def _go_repository_select_impl(ctx):
-  os = ctx.os.name
-  # NOTE: This mapping cannot be table-driven to prevent
-  # Bazel from downloading the other archive.
-  if os == 'linux':
-    goroot = ctx.path(ctx.attr._linux).dirname
-  elif os == 'mac os x':
-    goroot = ctx.path(ctx.attr._darwin).dirname
-  else:
-    fail("unsupported operating system: " + os)
+  rules_goroot = ctx.os.environ.get("RULES_GOROOT", None)
 
-  ctx.symlink(goroot, ctx.path(''))
-  ctx.file("WORKSPACE", "workspace(name = '%s')" % ctx.name)
+  # 1. Configure the goroot path
+  if rules_goroot:
+    goroot = ctx.path(rules_goroot)
+  else:
+    os_name = ctx.os.name
+    if os_name == 'linux':
+      goroot = ctx.path(ctx.attr._linux).dirname
+    elif os_name == 'mac os x':
+      goroot = ctx.path(ctx.attr._darwin).dirname
+    else:
+      fail("Unsupported operating system: " + os_name)
+
+  # 2. Create the symlinks and write the BUILD file.
+  gobin = goroot.get_child("bin")
+  gopkg = goroot.get_child("pkg")
+  gosrc = goroot.get_child("src")
+  ctx.symlink(gobin, "bin")
+  ctx.symlink(gopkg, "pkg")
+  ctx.symlink(gosrc, "src")
+
+  ctx.file("BUILD", GO_TOOLCHAIN_BUILD_FILE.format(
+    goroot = goroot,
+  ))
+
+  # 3. If the user has specified the goroot explicitly, confirm a
+  # functional installation.
+  if rules_goroot:
+    go = gobin.get_child("go")
+    result = ctx.execute([go, "env"])
+    if result.return_code:
+      fail("""
+Something's not right.  Are you sure '%s' points to a functional GOROOT?
+--> %s
+""" % (goroot, result.stderr))
+
 
 _go_repository_select = repository_rule(
     _go_repository_select_impl,
@@ -172,7 +203,7 @@ def go_repositories():
   native.new_http_archive(
       name =  "golang_linux_amd64",
       url = "https://storage.googleapis.com/golang/go1.7.1.linux-amd64.tar.gz",
-      build_file_content = GO_TOOLCHAIN_BUILD_FILE,
+      build_file_content = "",
       sha256 = "43ad621c9b014cde8db17393dc108378d37bc853aa351a6c74bf6432c1bbd182",
       strip_prefix = "go",
   )
@@ -180,7 +211,7 @@ def go_repositories():
   native.new_http_archive(
       name = "golang_darwin_amd64",
       url = "https://storage.googleapis.com/golang/go1.7.1.darwin-amd64.tar.gz",
-      build_file_content = GO_TOOLCHAIN_BUILD_FILE,
+      build_file_content = "",
       sha256 = "9fd80f19cc0097f35eaa3a52ee28795c5371bb6fac69d2acf70c22c02791f912",
       strip_prefix = "go",
   )

--- a/go/private/go_root.bzl
+++ b/go/private/go_root.bzl
@@ -1,0 +1,33 @@
+# Copyright 2016 The Bazel Go Rules Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def _go_root_impl(ctx):
+  """go_root_impl propogates a GOROOT path string."""
+  return struct(go_root = ctx.attr.path)
+
+go_root = rule(
+  _go_root_impl,
+  attrs = {
+    "path": attr.string(),
+  },
+)
+"""Captures the goroot value for use as a label dependency.
+
+Args:
+  path (string): the absolute path to GOROOT.
+
+Returns:
+  (struct): .go_root (string): the GOROOT value provider.
+
+"""

--- a/go/toolchain/BUILD
+++ b/go/toolchain/BUILD
@@ -16,3 +16,8 @@ alias(
     name = "go_include",
     actual = "@io_bazel_rules_go_toolchain//:go_include",
 )
+
+alias(
+    name = "go_root",
+    actual = "@io_bazel_rules_go_toolchain//:go_root",
+)


### PR DESCRIPTION
- Captures the absolute path of GOROOT at the time of toolchain
  configuration.  This becomes necessary for cross-compile support
  (#70).

- Symlinks @io_bazel_rules_go_toolchain{src, bin, pkg} to platform
  toolchain paths to avoid workspace name mismatch warnings (closes
  #104).

- Introduces the RULES_GOROOT environment variable to allow use of a
  pre-existing go toolchain.