### PR TITLE
add support for '# keep', on srcs/deps 

### DIFF
--- a/go/tools/gazelle/merger/merger_test.go
+++ b/go/tools/gazelle/merger/merger_test.go
@@ -21,6 +21,7 @@ go_test(
     name = "go_default_test",
     size = "small",
     srcs = [
+        "gen_test.go",  # keep
         "parse_test.go",
     ],
     data = glob(["testdata/*"]),
@@ -69,6 +70,7 @@ go_test(
     srcs = [
         "parse_test.go",
         "print_test.go",
+        "gen_test.go",  # keep
     ],
     data = glob(["testdata/*"]),
     library = ":go_default_library",


### PR DESCRIPTION
e.g. same-package generated sources like in buildifier