### PR TITLE
Add well-known special case paths to externalResolver

### DIFF
--- a/go/tools/gazelle/packages/walk.go
+++ b/go/tools/gazelle/packages/walk.go
@@ -43,10 +43,10 @@ func Walk(bctx build.Context, root string, f WalkFunc) error {
 		}
 
 		pkg, err := bctx.ImportDir(path, build.ImportComment)
-		if _, ok := err.(*build.NoGoError); ok {
-			return nil
-		}
 		if err != nil {
+			if _, ok := err.(*build.NoGoError); ok {
+				return nil
+			}
 			return err
 		}
 		return f(pkg)

--- a/go/tools/gazelle/rules/resolve_external_test.go
+++ b/go/tools/gazelle/rules/resolve_external_test.go
@@ -23,6 +23,24 @@ import (
 	"golang.org/x/tools/go/vcs"
 )
 
+type special struct {
+	in, want string
+}
+
+func TestSpecialCases(t *testing.T) {
+	for _, c := range []special{
+		{"golang.org/x/net/context", "golang.org/x/net"},
+		{"golang.org/x/tools/go/vcs", "golang.org/x/tools"},
+		{"golang.org/x/goimports", "golang.org/x/goimports"},
+		{"cloud.google.com/fashion/industry", "cloud.google.com/fashion"},
+		{"unsupported.org/x/net/context", ""},
+	} {
+		if got := specialCases(c.in); got != c.want {
+			t.Errorf("specialCases(%q) = %q; want %q", c.in, got, c.want)
+		}
+	}
+}
+
 func TestExternalResolver(t *testing.T) {
 	repoRootForImportPath = stubRepoRootForImportPath
 


### PR DESCRIPTION
This avoids a lot of network calls in vcs.RepoRootForImportPath.

Testing in repos like google.golang.org/genproto took
runtime from ~9s on average to ~0.01s