### PR TITLE
remove extraneous go_binary dep on lib; fix merger to remove deleted …

### DIFF
--- a/go/tools/gazelle/rules/generator.go
+++ b/go/tools/gazelle/rules/generator.go
@@ -141,11 +141,9 @@ func (g *generator) generateBin(rel, library string, pkg *build.Package) (*bzl.R
 		{key: "name", value: name},
 		{key: "library", value: ":" + library},
 		{key: "visibility", value: []string{visibility}},
-		{key: "deps", value: []string{library}},
 	}
 
 	return newRule(kind, nil, attrs)
-
 }
 
 func (g *generator) generateLib(rel, name string, pkg *build.Package) (*bzl.Rule, error) {

--- a/go/tools/gazelle/rules/generator_test.go
+++ b/go/tools/gazelle/rules/generator_test.go
@@ -118,7 +118,6 @@ func TestGenerator(t *testing.T) {
 					name = "bin",
 					library = ":go_default_library",
 					visibility = ["//visibility:public"],
-					deps = ["go_default_library"],
 				)
 			`,
 		},
@@ -136,7 +135,6 @@ func TestGenerator(t *testing.T) {
 					name = "bin_with_tests",
 					library = ":go_default_library",
 					visibility = ["//visibility:public"],
-					deps = ["go_default_library"],
 				)
 
 				go_test(


### PR DESCRIPTION
…fields and make library mergeable.
Adds back 
https://github.com/bazelbuild/rules_go/commit/706e737885c14969b57255e551e72c7ccd5b5506
with needed fix for merge