### PR TITLE
Revert "Revert "perform the main sandwich for go_binary""

### DIFF
--- a/go/tools/gazelle/generator/generator_test.go
+++ b/go/tools/gazelle/generator/generator_test.go
@@ -65,7 +65,29 @@ func TestGenerator(t *testing.T) {
 			"bin": {
 				{
 					Call: &bzl.CallExpr{
+						X: &bzl.LiteralExpr{Token: "go_library"},
+					},
+				},
+				{
+					Call: &bzl.CallExpr{
 						X: &bzl.LiteralExpr{Token: "go_binary"},
+					},
+				},
+			},
+			"bin_with_tests": {
+				{
+					Call: &bzl.CallExpr{
+						X: &bzl.LiteralExpr{Token: "go_library"},
+					},
+				},
+				{
+					Call: &bzl.CallExpr{
+						X: &bzl.LiteralExpr{Token: "go_binary"},
+					},
+				},
+				{
+					Call: &bzl.CallExpr{
+						X: &bzl.LiteralExpr{Token: "go_test"},
 					},
 				},
 			},
@@ -125,8 +147,18 @@ func TestGenerator(t *testing.T) {
 		{
 			Path: "bin/BUILD",
 			Stmt: []bzl.Expr{
-				loadExpr("go_binary"),
+				loadExpr("go_library", "go_binary"),
 				stub.fixtures["bin"][0].Call,
+				stub.fixtures["bin"][1].Call,
+			},
+		},
+		{
+			Path: "bin_with_tests/BUILD",
+			Stmt: []bzl.Expr{
+				loadExpr("go_library", "go_binary", "go_test"),
+				stub.fixtures["bin_with_tests"][0].Call,
+				stub.fixtures["bin_with_tests"][1].Call,
+				stub.fixtures["bin_with_tests"][2].Call,
 			},
 		},
 	}

--- a/go/tools/gazelle/rules/generator.go
+++ b/go/tools/gazelle/rules/generator.go
@@ -91,11 +91,20 @@ func (g *generator) Generate(rel string, pkg *build.Package) ([]*bzl.Rule, error
 		rules = append(rules, p)
 	}
 
-	r, err := g.generate(rel, pkg)
+	libName := defaultLibName
+	r, err := g.generateLib(rel, libName, pkg)
 	if err != nil {
 		return nil, err
 	}
 	rules = append(rules, r)
+
+	if pkg.IsCommand() {
+		r, err := g.generateBin(rel, libName, pkg)
+		if err != nil {
+			return nil, err
+		}
+		rules = append(rules, r)
+	}
 
 	p, err := g.filegroup(rel, pkg)
 	if err != nil {
@@ -123,20 +132,31 @@ func (g *generator) Generate(rel string, pkg *build.Package) ([]*bzl.Rule, error
 	return rules, nil
 }
 
-func (g *generator) generate(rel string, pkg *build.Package) (*bzl.Rule, error) {
-	kind := "go_library"
-	name := defaultLibName
-	if pkg.IsCommand() {
-		kind = "go_binary"
-		name = path.Base(pkg.Dir)
+func (g *generator) generateBin(rel, library string, pkg *build.Package) (*bzl.Rule, error) {
+	kind := "go_binary"
+	name := path.Base(pkg.Dir)
+
+	visibility := checkInternalVisibility(rel, "//visibility:public")
+	attrs := []keyvalue{
+		{key: "name", value: name},
+		{key: "library", value: ":" + library},
+		{key: "visibility", value: []string{visibility}},
+		{key: "deps", value: []string{library}},
 	}
 
+	return newRule(kind, nil, attrs)
+
+}
+
+func (g *generator) generateLib(rel, name string, pkg *build.Package) (*bzl.Rule, error) {
+	kind := "go_library"
+
 	visibility := "//visibility:public"
-	if i := strings.LastIndex(rel, "/internal/"); i >= 0 {
-		visibility = fmt.Sprintf("//%s:__subpackages__", rel[:i])
-	} else if strings.HasPrefix(rel, "internal/") {
-		visibility = "//:__subpackages__"
+	// Libraries made for a go_binary should not be exposed to the public.
+	if pkg.IsCommand() {
+		visibility = "//visibility:private"
 	}
+	visibility = checkInternalVisibility(rel, visibility)
 
 	attrs := []keyvalue{
 		{key: "name", value: name},
@@ -153,6 +173,17 @@ func (g *generator) generate(rel string, pkg *build.Package) (*bzl.Rule, error) 
 	}
 
 	return newRule(kind, nil, attrs)
+}
+
+// checkInternalVisibility overrides the given visibility if the package is
+// internal.
+func checkInternalVisibility(rel, visibility string) string {
+	if i := strings.LastIndex(rel, "/internal/"); i >= 0 {
+		visibility = fmt.Sprintf("//%s:__subpackages__", rel[:i])
+	} else if strings.HasPrefix(rel, "internal/") {
+		visibility = "//:__subpackages__"
+	}
+	return visibility
 }
 
 // filegroup is a small hack for directories with pre-generated .pb.go files

--- a/go/tools/gazelle/rules/generator_test.go
+++ b/go/tools/gazelle/rules/generator_test.go
@@ -107,11 +107,42 @@ func TestGenerator(t *testing.T) {
 		{
 			dir: "bin",
 			want: `
+				go_library(
+					name = "go_default_library",
+					srcs = ["main.go"],
+					visibility = ["//visibility:private"],
+					deps = ["//lib:go_default_library"],
+				)
+
 				go_binary(
 					name = "bin",
-					srcs = ["main.go"],
+					library = ":go_default_library",
 					visibility = ["//visibility:public"],
+					deps = ["go_default_library"],
+				)
+			`,
+		},
+		{
+			dir: "bin_with_tests",
+			want: `
+				go_library(
+					name = "go_default_library",
+					srcs = ["main.go"],
+					visibility = ["//visibility:private"],
 					deps = ["//lib:go_default_library"],
+				)
+
+				go_binary(
+					name = "bin_with_tests",
+					library = ":go_default_library",
+					visibility = ["//visibility:public"],
+					deps = ["go_default_library"],
+				)
+
+				go_test(
+					name = "go_default_test",
+					srcs = ["bin_test.go"],
+					library = ":go_default_library",
 				)
 			`,
 		},

--- a/go/tools/gazelle/testdata/repo/bin_with_tests/bin_test.go
+++ b/go/tools/gazelle/testdata/repo/bin_with_tests/bin_test.go
@@ -1,0 +1,26 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+)
+
+func TestCall(t *testing.T) {
+	if got, want := call(), 42; got != want {
+		t.Errorf("call() = %d; want %d", got, want)
+	}
+}

--- a/go/tools/gazelle/testdata/repo/bin_with_tests/main.go
+++ b/go/tools/gazelle/testdata/repo/bin_with_tests/main.go
@@ -1,0 +1,30 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+
+	"example.com/repo/lib"
+)
+
+func main() {
+	fmt.Println(call())
+}
+
+func call() string {
+	return lib.Answer()
+}


### PR DESCRIPTION
Reverts bazelbuild/rules_go#169

Will send fix for merging shortly after.