### PR TITLE
Update Jenkins build artifact name change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ before_install:
   - CI_BASE="http://ci.bazel.io/job/Bazel/JAVA_VERSION=1.8,PLATFORM_NAME=$OS-$ARCH/lastSuccessfulBuild/artifact/output/ci"
   - CI_ARTIFACT="bazel--installer.sh"
   - URL="$GH_BASE/$GH_ARTIFACT"
+  - if [[ "$V" == "HEAD" && "$OS" == "linux" ]]; then CI_ARTIFACT="`wget -qO- $CI_BASE | grep -oP 'bazel-.*?-installer.sh' | uniq`"; fi
+  - if [[ "$V" == "HEAD" && "$OS" == "osx" ]];   then CI_ARTIFACT="`wget -qO- $CI_BASE | pcregrep -o 'bazel-.*?-installer.sh' | uniq`"; fi
   - if [[ "$V" == "HEAD" ]]; then URL="$CI_BASE/$CI_ARTIFACT"; fi
   - echo $URL
   - wget -O install.sh $URL


### PR DESCRIPTION
The bazel installer shell script build output from jenkins seems to have changed from `bazel--installer.sh` to `bazel-0.4.0rc1-installer.sh`.  This update tests for a version string matching a release candidate and uses ci.bazel.io as the base url for that artifact.