### PR TITLE
add go_srcs to toolchain

### DIFF
--- a/go/def.bzl
+++ b/go/def.bzl
@@ -493,6 +493,11 @@ go_env_attrs = {
         allow_files = False,
         cfg = "host",
     ),
+    "go_src": attr.label(
+        default = Label("//go/toolchain:go_src"),
+        allow_files = True,
+        cfg = "host",
+    ),
     "go_include": attr.label(
         default = Label("//go/toolchain:go_include"),
         single_file = True,

--- a/go/private/go_repositories.bzl
+++ b/go/private/go_repositories.bzl
@@ -128,6 +128,11 @@ filegroup(
 )
 
 filegroup(
+  name = "go_src",
+  srcs = glob(["src/**"]),
+)
+
+filegroup(
   name = "go_include",
   srcs = [ "pkg/include" ],
 )

--- a/go/toolchain/BUILD
+++ b/go/toolchain/BUILD
@@ -21,3 +21,8 @@ alias(
     name = "go_root",
     actual = "@io_bazel_rules_go_toolchain//:go_root",
 )
+
+alias(
+    name = "go_src",
+    actual = "@io_bazel_rules_go_toolchain//:go_src",
+)


### PR DESCRIPTION
Tools that generate go code an use [go/build](http://godoc.org/go/build) often require all source to be present. This allows rules that use go_env_attrs to declare GOROOT/src as input.
