### PR TITLE
go_proto_library: attempt to make the well known protos Just Work

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,7 +1,10 @@
 load("//go:def.bzl", "go_prefix")
 load("//go/private:lines_sorted_test.bzl", "lines_sorted_test")
+load("//proto:go_proto_library.bzl", "go_google_protobuf")
 
 go_prefix("github.com/bazelbuild/rules_go")
+
+go_google_protobuf()
 
 lines_sorted_test(
     name = "contributors_sorted_test",

--- a/examples/proto/dep/BUILD
+++ b/examples/proto/dep/BUILD
@@ -3,6 +3,7 @@ load("//proto:go_proto_library.bzl", "go_proto_library")
 go_proto_library(
     name = "useful_proto",
     srcs = ["useful.proto"],
+    rules_go_repo_only_for_internal_use = "@",
     visibility = ["//visibility:public"],
     deps = ["@com_github_golang_protobuf//ptypes/duration:go_default_library"],
 )

--- a/examples/proto/gostyle/BUILD
+++ b/examples/proto/gostyle/BUILD
@@ -3,6 +3,7 @@ load("//proto:go_proto_library.bzl", "go_proto_library")
 go_proto_library(
     name = "go_default_library",
     srcs = ["gostyle.proto"],
+    rules_go_repo_only_for_internal_use = "@",
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_golang_protobuf//ptypes/any:go_default_library",

--- a/examples/proto/gostyle/gostyle.proto
+++ b/examples/proto/gostyle/gostyle.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package gostyle;
 
-import "ptypes/any/any.proto";
+import "google/protobuf/any.proto";
 
 message GoStyleObject {
   int32 go_not_bazel = 2;

--- a/examples/proto/grpc/BUILD
+++ b/examples/proto/grpc/BUILD
@@ -5,6 +5,7 @@ go_proto_library(
     name = "my_svc_proto",
     srcs = ["my_svc.proto"],
     has_services = 1,
+    rules_go_repo_only_for_internal_use = "@",
     deps = [
         "//examples/proto/lib:lib_proto",
         "@com_github_golang_protobuf//ptypes/any:go_default_library",

--- a/examples/proto/grpc/my_svc.proto
+++ b/examples/proto/grpc/my_svc.proto
@@ -3,8 +3,8 @@ syntax = "proto3";
 package examples.svc;
 
 import "examples/proto/lib/lib.proto";
-import "ptypes/any/any.proto";
-import "ptypes/empty/empty.proto";
+import "google/protobuf/any.proto";
+import "google/protobuf/empty.proto";
 
 message GetRequest {
   examples.lib.LibObject obj = 1;

--- a/examples/proto/lib/BUILD
+++ b/examples/proto/lib/BUILD
@@ -6,6 +6,7 @@ go_proto_library(
         "lib.proto",
         "lib2.proto",
     ],
+    rules_go_repo_only_for_internal_use = "@",
     visibility = ["//visibility:public"],
     deps = ["//examples/proto/dep:useful_proto"],
 )

--- a/proto/go_proto_library.bzl
+++ b/proto/go_proto_library.bzl
@@ -54,10 +54,17 @@ def _go_prefix(ctx):
 
 def _external_dirs(files):
   """Compute any needed -I options to protoc from external filegroups."""
-  return set(["/".join(f.dirname.split("/")[:2])
-              for f in files if f.dirname[:9] == "external/"] +
-             ["/".join(f.dirname.split("/")[:3])
-              for f in files if f.dirname[:10] == "bazel-out/"])
+  res = []
+  for f in files:
+    toks = f.dirname.split("/")
+    if toks[0] == "external":
+      res.append("/".join(toks[:2]))
+    elif len(toks) > 4 and toks[3] == "external":
+      res.append("/".join(toks[:5]))
+    elif toks[1] == "external" or toks[0][:6] == "bazel-":
+      res.append("/".join(toks[:3]))
+    
+  return set(res)
 
 def _go_proto_library_gen_impl(ctx):
   """Rule implementation that generates Go using protoc."""

--- a/proto/go_proto_library.bzl
+++ b/proto/go_proto_library.bzl
@@ -44,6 +44,7 @@ load("//go:def.bzl", "go_library", "new_go_repository")
 _DEFAULT_LIB = "go_default_library"  # matching go_library
 _PROTOS_SUFFIX = "_protos"
 _GO_GOOGLE_PROTOBUF = "go_google_protobuf"
+_WELL_KNOWN_REPO = "@com_github_golang_protobuf//ptypes/"
 
 def _go_prefix(ctx):
   """slash terminated go-prefix."""
@@ -185,11 +186,9 @@ def _add_target_suffix(target, suffix):
   toks = target.split("/")
   return target + ":" + toks[-1] + suffix
 
-_well_known_repo = "@com_github_golang_protobuf//ptypes/"
-
 def _well_known_proto_deps(deps, repo):
   for d in deps:
-    if d[:len(_well_known_repo)] == _well_known_repo:
+    if d.startswith(_WELL_KNOWN_REPO):
       return [repo + "//:" + _GO_GOOGLE_PROTOBUF]
   return []
 
@@ -211,6 +210,8 @@ def go_proto_library(name, srcs = None, deps = None,
     has_services: indicates the proto has gRPC services and deps
     testonly: mark as testonly
     visibility: visibility to use on underlying go_library
+    rules_go_repo_only_for_internal_use: don't use this, only to allow
+                                         internal tests to work.
     well_known_repo: repo for special-case protos
                      which should be copied to google/protobuf
     **kwargs: any other args which are passed through to the underlying go_library
@@ -255,7 +256,7 @@ def go_proto_library(name, srcs = None, deps = None,
   )
 
 def _well_known_import_key(name):
-  return "%s%s:go_default_library" % (_well_known_repo, name)
+  return "%s%s:go_default_library" % (_WELL_KNOWN_REPO, name)
 
 _well_known_imports = ["any", "duration", "empty", "struct", "timestamp", "wrappers"]
 

--- a/proto/go_proto_library.bzl
+++ b/proto/go_proto_library.bzl
@@ -87,13 +87,13 @@ def _go_proto_library_gen_impl(ctx):
   """Rule implementation that generates Go using protoc."""
   bazel_style = ctx.label.name != _DEFAULT_LIB + _PROTOS_SUFFIX
   protos = list(ctx.files.srcs)
-  well_known = list(ctx.files.well_known_protos)
   go_package_name = ""
   if bazel_style:
     go_package_name = "/" + ctx.label.name[:-len(_PROTOS_SUFFIX)]
   m_import_path = ",".join(["M%s=%s%s%s" % (f.path, _go_prefix(ctx),
                                             ctx.label.package, go_package_name)
                             for f in ctx.files.srcs])
+  well_known = []
   for d in ctx.attr.deps:
     if not hasattr(d, "_protos"):
       # should be a raw filegroup then
@@ -101,6 +101,8 @@ def _go_proto_library_gen_impl(ctx):
       continue
     protos += d._protos
     m_import_path += "," + d._m_import_path
+  for wk in ctx.files.well_known_protos:
+    well_known = 
   use_grpc = ""
   if ctx.attr.grpc:
     use_grpc = "plugins=grpc,"


### PR DESCRIPTION
This method requires a one-time "go_google_protobuf()" in your root BUILD file, but after that, engineers don't have to worry about setting their import paths/maps.