### PR TITLE
compile stdlib for the (GOOS, GOARCH)'s of --cpus we support

### DIFF
--- a/go/private/go_repositories.bzl
+++ b/go/private/go_repositories.bzl
@@ -157,6 +157,22 @@ def _go_repository_select_impl(ctx):
   ctx.symlink(gopkg, "pkg")
   ctx.symlink(gosrc, "src")
 
+  cross_targets = (
+      ('linux', 'amd64'),
+      ('linux', 'arm'),
+      ('linux', '386'),
+      ('darwin', 'amd64'),
+      ('freebsd', 'amd64'),
+  )
+
+  for goos, goarch in cross_targets:
+    result = ctx.execute([
+        'env', 'GOROOT=%s' % goroot, 'PATH=%s/bin' % goroot,
+        'GOOS=%s' % goos, 'GOARCH=%s' % goarch,
+        'go', 'install', 'std'])
+    if result.return_code:
+      fail("failed to install cross compiled stdlib: %s" % result.stderr)
+
   ctx.file("BUILD", GO_TOOLCHAIN_BUILD_FILE.format(
     goroot = goroot,
     rules_go_repo = ctx.attr.rules_go_repo_only_for_internal_use,


### PR DESCRIPTION
Without this, the build complains about stdlib packages missing when using --cpu.

```console
$ bazel build --cpu armeabi-v7a //cmd/kubectl                   
INFO: Found 1 target...
ERROR: /usr/local/google/home/mikedanese/go/src/k8s.io/kubernetes/vendor/BUILD:180:1: null failed: linux-sandbox failed: error executing command /usr/local/google/home/mikedanese/.cache/bazel/_bazel_mikedanese/6c65a147ac17188f348dcacc7c554ab3/execroot/kubernetes/_bin/linux-sandbox ... (remaining 3 argument(s) skipped).
k8s.io/kubernetes/vendor/github.com/MakeNowJust/heredoc/heredoc.go:26: can't find import: "fmt"
```

This works especially well when not depending on cgo libraries.