### PR TITLE
add support for injecting build stamps with link options

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ go_library(
 ## go\_binary
 
 ```bzl
-go_binary(name, srcs, deps, data)
+go_binary(name, srcs, deps, data, linkstamp)
 ```
 <table class="table table-condensed table-bordered table-params">
   <colgroup>
@@ -497,6 +497,23 @@ go_binary(name, srcs, deps, data)
       <td>
         <code>List of labels, optional</code>
         <p>List of files needed by this rule at runtime.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>linkstamp</code></td>
+      <td>
+        <code>String; optional; default is ""</code>
+        <p>The name of a package containing global variables set by the linker
+        as part of a link stamp. This may be used to embed version information
+        in the generated binary. The -X flags will be of the form
+        <code>-X <i>linkstamp</i>.KEY=VALUE</code>. The keys and values are
+        read from <code>bazel-bin/volatile-status.txt</code> and
+        <code>bazel-bin/stable-status.txt</code>. If you build with
+        <code>--workspace_status_command=<i>./status.sh</i></code>, the output
+        of <code>status.sh</code> will be written to these files.
+        <a href="https://github.com/bazelbuild/bazel/blob/master/tools/buildstamp/get_workspace_status">
+        Bazel <code>tools/buildstamp/get_workspace_status</code></a> is
+        a good template which prints Git workspace status.</p>
       </td>
     </tr>
   </tbody>

--- a/examples/stamped_bin/BUILD
+++ b/examples/stamped_bin/BUILD
@@ -1,0 +1,19 @@
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+load("//go:def.bzl", "go_binary", "go_library")
+
+go_binary(
+    name = "stamped_bin",
+    srcs = ["main.go"],
+    linkstamp = "github.com/bazelbuild/rules_go/examples/stamped_bin/stamp",
+    deps = [
+        ":stamp",
+    ],
+)
+
+go_library(
+    name = "stamp",
+    srcs = ["stamp.go"],
+)

--- a/examples/stamped_bin/main.go
+++ b/examples/stamped_bin/main.go
@@ -1,0 +1,30 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/bazelbuild/rules_go/examples/stamped_bin/stamp"
+)
+
+func main() {
+	fmt.Println(stamp.BUILD_TIMESTAMP)
+	if stamp.BUILD_TIMESTAMP == "fail" {
+		os.Exit(1)
+	}
+}

--- a/examples/stamped_bin/stamp.go
+++ b/examples/stamped_bin/stamp.go
@@ -1,0 +1,18 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stamp
+
+var BUILD_TIMESTAMP = "fail"


### PR DESCRIPTION
for a workspace with BUILD_SCM_VERSION=10 defined as a volatile status and a go binary rule:
```
go_binary(
    ....
    stamp = True,
    linkstamp = "my/pkg/version",
)
```

The go binary will be linked with the option `-X my/pkg/version.BUILD_SCM_VERSION`