### PR TITLE
Set GOOS and GOARCH as BuildTags in Gazelle's generator

### DIFF
--- a/go/tools/gazelle/generator/generator.go
+++ b/go/tools/gazelle/generator/generator.go
@@ -56,6 +56,11 @@ func New(repoRoot, goPrefix string) (*Generator, error) {
 	bctx.GOROOT = ""
 	bctx.GOPATH = ""
 
+	// Do not import all files, use platform tags if any.
+	bctx.UseAllFiles = false
+	// Many open-source Go projects depend on these tags being used to filter.
+	bctx.BuildTags = []string{bctx.GOARCH, bctx.GOOS}
+
 	repoRoot, err := filepath.Abs(repoRoot)
 	if err != nil {
 		return nil, err

--- a/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/asm_linux.S
+++ b/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/asm_linux.S
@@ -1,0 +1,3 @@
+// +build linux
+
+// Test ASM file

--- a/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/asm_other.S
+++ b/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/asm_other.S
@@ -1,0 +1,3 @@
+// +build !linux
+
+// Test ASM file

--- a/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/foo.go
+++ b/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/foo.go
@@ -1,0 +1,31 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cgolibwithtags
+
+/**
+#cgo CFLAGS: -I/weird/path
+#cgo LDFLAGS: -lweird
+**/
+import "C"
+import "fmt"
+
+import "example.com/repo/lib"
+
+func CCall() int64 {
+	// Just for the lib import
+	fmt.Println(lib.Answer())
+	return C.callC()
+}

--- a/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/foo.h
+++ b/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/foo.h
@@ -1,0 +1,16 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+int64_t callC();

--- a/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/foo_linux.c
+++ b/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/foo_linux.c
@@ -1,0 +1,22 @@
+// +build linux
+
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <stdint.h>
+
+int64_t callC() {
+  return 42;
+}

--- a/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/foo_other.c
+++ b/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/foo_other.c
@@ -1,0 +1,22 @@
+// +build !linux
+
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <stdint.h>
+
+int64_t callC() {
+  return 42;
+}

--- a/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/foo_test.go
+++ b/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/foo_test.go
@@ -1,0 +1,24 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cgolibwithtags
+
+import "testing"
+
+func TestPure(t *testing.T) {
+	if PureCall() != 42 {
+		t.Fatalf("c'mon")
+	}
+}

--- a/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/pure_linux.go
+++ b/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/pure_linux.go
@@ -1,0 +1,32 @@
+// +build linux
+
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cgolibwithtags
+
+import (
+	"fmt"
+
+	"example.com/repo/lib"
+	"example.com/repo/lib/deep"
+)
+
+func PureCall() int64 {
+	// just for the extra import that's not in the CgoFiles
+	var d deep.Thought
+	fmt.Println(d.Compute())
+	return lib.Answer()
+}

--- a/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/pure_other.go
+++ b/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/pure_other.go
@@ -1,0 +1,32 @@
+// +build !linux
+
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cgolibwithtags
+
+import (
+	"fmt"
+
+	"example.com/repo/lib"
+	"example.com/repo/lib/deep"
+)
+
+func PureCall() int64 {
+	// just for the extra import that's not in the CgoFiles
+	var d deep.Thought
+	fmt.Println(d.Compute())
+	return lib.Answer()
+}


### PR DESCRIPTION
This solves issues where new_go_repository() fails for some open-source go repositories. After setting these, new_go_repository() appropriately filters source files by OS and architecture.