### PR TITLE
Add optional attribute 'remote' to go_repository and new_go_repository

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -16,6 +16,7 @@ David Chen <dzc@google.com>
 David Santiago <david.santiago@gmail.com>
 Han-Wen Nienhuys <hanwen@google.com>
 Jake Voytko <jake@reviewninja.com>
+Josh Powell <powelljo@us.ibm.com>
 Justine Alexandra Roberts Tunney <jart@google.com>
 Kristina Chodorow <kchodorow@google.com>
 Lukacs Berki <lberki@google.com>

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ placed in the WORKSPACE.
 ## go\_repository
 
 ```bzl
-go_repository(name, importpath, commit, tag)
+go_repository(name, importpath, remote, commit, tag)
 ```
 
 Fetches a remote repository of a Go project, expecting it contains `BUILD`
@@ -175,8 +175,16 @@ redirection of Go.
       <td><code>importpath</code></td>
       <td>
         <code>String, required</code>
-        <p>An import path in Go, which corresponds to the root of the target
-        remote repository</p>
+        <p>An import path in Go, which also provides a default value for the
+	root of the target remote repository</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>remote</code></td>
+      <td>
+        <code>String, optional</code>
+        <p>The root of the target remote repository, if this differs from the
+	value of <code>importpath</code></p>
       </td>
     </tr>
     <tr>
@@ -203,7 +211,7 @@ redirection of Go.
 ## new\_go\_repository
 
 ```bzl
-new_go_repository(name, importpath, commit, tag)
+new_go_repository(name, importpath, remote, commit, tag)
 ```
 
 Fetches a remote repository of a Go project and automatically generates
@@ -232,8 +240,16 @@ importpath redirection of Go.
       <td><code>importpath</code></td>
       <td>
         <code>String, required</code>
-        <p>An import path in Go, which corresponds to the root of the target
-        remote repository</p>
+        <p>An import path in Go, which also provides a default value for the
+	root of the target remote repository</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>remote</code></td>
+      <td>
+        <code>String, optional</code>
+        <p>The root of the target remote repository, if this differs from the
+	value of <code>importpath</code></p>
       </td>
     </tr>
     <tr>

--- a/go/private/go_repository.bzl
+++ b/go/private/go_repository.bzl
@@ -27,13 +27,14 @@ def _go_repository_impl(ctx):
 
   # TODO(yugui): support submodule?
   # c.f. https://www.bazel.io/versions/master/docs/be/workspace.html#git_repository.init_submodules
+  remote = ctx.attr.remote if ctx.attr.remote else ctx.attr.importpath
   result = ctx.execute([
       fetch_repo,
       '--dest', ctx.path(''),
-      '--remote', ctx.attr.importpath,
+      '--remote', remote,
       '--rev', rev])
   if result.return_code:
-    fail("failed to fetch %s: %s" % (ctx.attr.importpath, result.stderr))
+    fail("failed to fetch %s: %s" % (remote, result.stderr))
 
 
 def _new_go_repository_impl(ctx):
@@ -54,6 +55,7 @@ def _new_go_repository_impl(ctx):
 
 _go_repository_attrs = {
     "importpath": attr.string(mandatory = True),
+    "remote": attr.string(),
     "commit": attr.string(),
     "tag": attr.string(),
 


### PR DESCRIPTION
1. Allows optional attribute 'remote' in go_repository and new_go_repository rules, which will override importpath if provided.  Note: importpath is still required, still provides the go_prefix and is still the default value for the remote repository.

2. Auxiliary updates to documentation and CONTRIBUTORS file as needed.