### PR TITLE
Support setting build tags explicitly in Gazelle and new_go_repository

### DIFF
--- a/go/private/go_repository.bzl
+++ b/go/private/go_repository.bzl
@@ -41,7 +41,8 @@ def _new_go_repository_impl(ctx):
   _go_repository_impl(ctx)
   gazelle = ctx.path(ctx.attr._gazelle)
 
-  cmds = [gazelle, '--go_prefix', ctx.attr.importpath, '--mode', 'fix']
+  cmds = [gazelle, '--go_prefix', ctx.attr.importpath, '--mode', 'fix',
+          "--build_tags", ",".join(ctx.attr.build_tags)]
   if ctx.attr.rules_go_repo_only_for_internal_use:
     cmds += ["--go_rules_bzl_only_for_internal_use",
              "%s//go:def.bzl" % ctx.attr.rules_go_repo_only_for_internal_use]
@@ -58,7 +59,7 @@ _go_repository_attrs = {
     "remote": attr.string(),
     "commit": attr.string(),
     "tag": attr.string(),
-
+    "build_tags": attr.string_list(),
     "_fetch_repo": attr.label(
         default = Label("@io_bazel_rules_go_repository_tools//:bin/fetch_repo"),
         allow_files = True,

--- a/go/tools/gazelle/gazelle/BUILD
+++ b/go/tools/gazelle/gazelle/BUILD
@@ -24,6 +24,7 @@ go_binary(
 
 go_test(
     name = "gazelle_test",
+    size = "small",
     srcs = ["fix_test.go"],
     library = ":go_default_library",
 )

--- a/go/tools/gazelle/gazelle/main.go
+++ b/go/tools/gazelle/gazelle/main.go
@@ -33,11 +33,11 @@ import (
 )
 
 var (
-	goPrefix  = flag.String("go_prefix", "", "go_prefix of the target workspace")
-	repoRoot  = flag.String("repo_root", "", "path to a directory which corresponds to go_prefix, otherwise gazelle searches for it.")
-	mode      = flag.String("mode", "fix", "print: prints all of the updated BUILD files\n\tfix: rewrites all of the BUILD files in place\n\tdiff: computes the rewrite but then just does a diff")
-	buildName = flag.String("build_name", "BUILD", "name of output build files to generate, defaults to 'BUILD'")
-
+	buildName       = flag.String("build_name", "BUILD", "name of output build files to generate, defaults to 'BUILD'")
+	buildTags       = flag.String("build_tags", "", "comma-separated list of build tags. If not specified, GOOS and GOARCH are used.")
+	goPrefix        = flag.String("go_prefix", "", "go_prefix of the target workspace")
+	repoRoot        = flag.String("repo_root", "", "path to a directory which corresponds to go_prefix, otherwise gazelle searches for it.")
+	mode            = flag.String("mode", "fix", "print: prints all of the updated BUILD files\n\tfix: rewrites all of the BUILD files in place\n\tdiff: computes the rewrite but then just does a diff")
 	validBuildNames = map[string]bool{
 		"BUILD":       true,
 		"BUILD.bazel": true,
@@ -57,7 +57,7 @@ var modeFromName = map[string]func(*bzl.File) error{
 }
 
 func run(dirs []string, emit func(*bzl.File) error) error {
-	g, err := generator.New(*repoRoot, *goPrefix, *buildName)
+	g, err := generator.New(*repoRoot, *goPrefix, *buildName, *buildTags)
 	if err != nil {
 		return err
 	}

--- a/go/tools/gazelle/generator/BUILD
+++ b/go/tools/gazelle/generator/BUILD
@@ -5,14 +5,15 @@ go_library(
     srcs = ["generator.go"],
     visibility = ["//visibility:public"],
     deps = [
-        "@io_bazel_buildifier//core:go_default_library",
         "//go/tools/gazelle/packages:go_default_library",
         "//go/tools/gazelle/rules:go_default_library",
+        "@io_bazel_buildifier//core:go_default_library",
     ],
 )
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["generator_test.go"],
     library = ":go_default_library",
     deps = [

--- a/go/tools/gazelle/generator/generator_test.go
+++ b/go/tools/gazelle/generator/generator_test.go
@@ -32,6 +32,19 @@ var (
 	buildTagRepoPath = "cgolib_with_build_tags"
 )
 
+func TestBuildTagOverride(t *testing.T) {
+	repo := filepath.Join(testdata.Dir(), "repo")
+	g, err := New(repo, "example.com/repo", "BUILD", "a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z")
+	if err != nil {
+		t.Errorf(`New(%q, "example.com/repo") failed with %v; want success`, repo, err)
+		return
+	}
+
+	if len(g.bctx.BuildTags) != 26 {
+		t.Errorf("Got %d build tags; want 26", len(g.bctx.BuildTags))
+	}
+}
+
 func TestGenerator(t *testing.T) {
 	testGenerator(t, "BUILD")
 }
@@ -161,7 +174,7 @@ func testGenerator(t *testing.T, buildName string) {
 	}
 
 	repo := filepath.Join(testdata.Dir(), "repo")
-	g, err := New(repo, "example.com/repo", buildName)
+	g, err := New(repo, "example.com/repo", buildName, "")
 	if err != nil {
 		t.Errorf(`New(%q, "example.com/repo") failed with %v; want success`, repo, err)
 		return


### PR DESCRIPTION
Add flag for explicitly specifying build tag directives in Gazelle.
The parameters are a comma-delimited list of build tags.
If no build_tags are specified, GOOS and GOARCH are the default build tags.
If build_tags are specified, they are used explicitly.

Add attribute to new_go_repository definition to allow using explicit build tags.