### PR TITLE
allow Go 1.8 by updating to latest buildifier

### DIFF
--- a/go/private/go_repositories.bzl
+++ b/go/private/go_repositories.bzl
@@ -18,12 +18,12 @@ repository_tool_deps = {
     'buildifier': struct(
         importpath = 'github.com/bazelbuild/buildifier',
         repo = 'https://github.com/bazelbuild/buildifier',
-        commit = '0ca1d7991357ae7a7555589af88930d82cf07c0a',
+        commit = '0e32ea36fbdf03af102705d5e0f144231e673953',
     ),
     'tools': struct(
         importpath = 'golang.org/x/tools',
         repo = 'https://github.com/golang/tools',
-        commit = '2bbdb4568e161d12394da43e88b384c6be63928b',
+        commit = '3d92dd60033c312e3ae7cac319c792271cf67e37',
     )
 }
 

--- a/go/private/go_repositories.bzl
+++ b/go/private/go_repositories.bzl
@@ -59,7 +59,7 @@ def _fetch_repository_tools_deps(ctx, goroot, gopath):
       'env', 'GOROOT=%s' % goroot, 'GOPATH=%s' % gopath, 'PATH=%s/bin' % goroot,
       'go', 'generate', 'github.com/bazelbuild/buildifier/core'])
   if result.return_code:
-    fail("failed to go genrate: %s" % result.stderr)
+    fail("failed to go generate: %s" % result.stderr)
 
 _GO_REPOSITORY_TOOLS_BUILD_FILE = """
 package(default_visibility = ["//visibility:public"])


### PR DESCRIPTION
This is the change I made to try out Go 1.8beta1 in my bazel repo. However, I'm still getting errors from my bazel repository about `go tool: no such tool "yacc"` (even after a `bazel clean --expunge`). See the pasted error below. I don't have a `io_bazel_rules_go_repository_tools` repository defined in my own repo's WORKSPACE, so that seems like this must be coming from the `rules_go` stack.

With

    git_repository(
       name = "io_bazel_rules_go",
      remote = "https://github.com/jmhodges/rules_go.git",
      commit = "6f57106f725ce225c5d697c373c5073f38befd13",
    )

I get this error from my go builds:

    ERROR: /Users/jmhodges/founding/src/founding/go/svc/convolabeler/BUILD:5:1: no such package '@com_github_lib_pq//': no such package '@io_bazel_rules_go_repository_tools//': Traceback (most recent call last):
        File "/private/var/tmp/_bazel_jmhodges/ee957dabdee1b1a9e1f2fe90369cf80f/external/io_bazel_rules_go/go/private/go_repositories.bzl", line 85
            _fetch_repository_tools_deps(ctx, goroot, gopath)
        File "/private/var/tmp/_bazel_jmhodges/ee957dabdee1b1a9e1f2fe90369cf80f/external/io_bazel_rules_go/go/private/go_repositories.bzl", line 62, in _fetch_repository_tools_deps
            fail("failed to go generate: %s" % re...)
    failed to go generate: go tool: no such tool "yacc"
    src/github.com/bazelbuild/buildifier/core/lex.go:20: running "go": exit status 2
     and referenced by '//go/svc/convolabeler:go_default_library'.
    ERROR: Analysis of target '//go/svc/convolabeler:convolabeler' failed; build aborted.