### PR TITLE
gazelle: add support for vendored external packages

### DIFF
--- a/go/tools/gazelle/gazelle/BUILD
+++ b/go/tools/gazelle/gazelle/BUILD
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//go/tools/gazelle/generator:go_default_library",
         "//go/tools/gazelle/merger:go_default_library",
+        "//go/tools/gazelle/rules:go_default_library",
         "//go/tools/gazelle/wspace:go_default_library",
         "@io_bazel_buildifier//core:go_default_library",
         "@io_bazel_buildifier//differ:go_default_library",

--- a/go/tools/gazelle/generator/BUILD
+++ b/go/tools/gazelle/generator/BUILD
@@ -17,6 +17,7 @@ go_test(
     srcs = ["generator_test.go"],
     library = ":go_default_library",
     deps = [
+        "//go/tools/gazelle/rules:go_default_library",
         "//go/tools/gazelle/testdata:go_default_library",
     ],
 )

--- a/go/tools/gazelle/generator/generator.go
+++ b/go/tools/gazelle/generator/generator.go
@@ -50,10 +50,11 @@ type Generator struct {
 //
 // "repoRoot" is a path to the root directory of the repository.
 // "goPrefix" is the go_prefix corresponding to the repository root directory.
+// See also https://github.com/bazelbuild/rules_go#go_prefix.
 // "buildFileName" is the name of the BUILD file (BUILD or BUILD.bazel).
 // "buildTags" is a comma-delimited set of build tags to set in the build context.
-// See also https://github.com/bazelbuild/rules_go#go_prefix.
-func New(repoRoot, goPrefix, buildFileName, buildTags string) (*Generator, error) {
+// "external" is how external packages should be resolved.
+func New(repoRoot, goPrefix, buildFileName, buildTags string, external rules.ExternalResolver) (*Generator, error) {
 	bctx := build.Default
 	// Ignore source files in $GOROOT and $GOPATH
 	bctx.GOROOT = ""
@@ -81,7 +82,7 @@ func New(repoRoot, goPrefix, buildFileName, buildTags string) (*Generator, error
 		goPrefix:      goPrefix,
 		buildFileName: buildFileName,
 		bctx:          bctx,
-		g:             rules.NewGenerator(goPrefix),
+		g:             rules.NewGenerator(goPrefix, external),
 	}, nil
 }
 

--- a/go/tools/gazelle/generator/generator_test.go
+++ b/go/tools/gazelle/generator/generator_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	bzl "github.com/bazelbuild/buildifier/core"
+	"github.com/bazelbuild/rules_go/go/tools/gazelle/rules"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/testdata"
 )
 
@@ -34,7 +35,7 @@ var (
 
 func TestBuildTagOverride(t *testing.T) {
 	repo := filepath.Join(testdata.Dir(), "repo")
-	g, err := New(repo, "example.com/repo", "BUILD", "a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z")
+	g, err := New(repo, "example.com/repo", "BUILD", "a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z", rules.External)
 	if err != nil {
 		t.Errorf(`New(%q, "example.com/repo") failed with %v; want success`, repo, err)
 		return
@@ -174,9 +175,9 @@ func testGenerator(t *testing.T, buildFileName string) {
 	}
 
 	repo := filepath.Join(testdata.Dir(), "repo")
-	g, err := New(repo, "example.com/repo", buildFileName, "")
+	g, err := New(repo, "example.com/repo", buildFileName, "", rules.External)
 	if err != nil {
-		t.Errorf(`New(%q, "example.com/repo", %q, "") failed with %v; want success`, repo, err, buildFileName)
+		t.Errorf(`New(%q, "example.com/repo", %q, "", rules.External) failed with %v; want success`, repo, err, buildFileName)
 		return
 	}
 

--- a/go/tools/gazelle/rules/BUILD
+++ b/go/tools/gazelle/rules/BUILD
@@ -9,6 +9,7 @@ go_library(
         "resolve.go",
         "resolve_external.go",
         "resolve_structured.go",
+        "resolve_vendored.go",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/go/tools/gazelle/rules/generator_test.go
+++ b/go/tools/gazelle/rules/generator_test.go
@@ -51,7 +51,7 @@ func packageFromDir(t *testing.T, dir string) *build.Package {
 }
 
 func TestGenerator(t *testing.T) {
-	g := rules.NewGenerator("example.com/repo")
+	g := rules.NewGenerator("example.com/repo", rules.External)
 	for _, spec := range []struct {
 		dir  string
 		want string
@@ -221,7 +221,7 @@ func TestGenerator(t *testing.T) {
 }
 
 func TestGeneratorGoPrefix(t *testing.T) {
-	g := rules.NewGenerator("example.com/repo/lib")
+	g := rules.NewGenerator("example.com/repo/lib", rules.External)
 	pkg := packageFromDir(t, filepath.FromSlash("lib"))
 	rules, err := g.Generate("", pkg)
 	if err != nil {

--- a/go/tools/gazelle/rules/resolve_vendored.go
+++ b/go/tools/gazelle/rules/resolve_vendored.go
@@ -1,0 +1,11 @@
+package rules
+
+// vendoredResolver resolves external packages as packages in vendor/.
+type vendoredResolver struct{}
+
+func (v vendoredResolver) resolve(importpath, dir string) (label, error) {
+	return label{
+		pkg:  "vendor/" + importpath,
+		name: defaultLibName,
+	}, nil
+}


### PR DESCRIPTION
This PR adds support for external packages in `vendor/` in addition to `new_go_repository`.

When passed the `-external=vendored` flag, Gazelle will generate dependencies of the form (for example):

    deps = ["//vendor/golang.org/x/text/language:go_default_library"],

instead of

    deps = ["@org_golang_x_text//language:go_default_library"],