### PR TITLE
Fix support for BUILD.bazel files

### DIFF
--- a/go/private/go_repository.bzl
+++ b/go/private/go_repository.bzl
@@ -43,6 +43,8 @@ def _new_go_repository_impl(ctx):
 
   cmds = [gazelle, '--go_prefix', ctx.attr.importpath, '--mode', 'fix',
           "--build_tags", ",".join(ctx.attr.build_tags)]
+  if ctx.attr.build_file_name:
+      cmds += ["--build_file_name", ctx.attr.build_file_name]
   if ctx.attr.rules_go_repo_only_for_internal_use:
     cmds += ["--go_rules_bzl_only_for_internal_use",
              "%s//go:def.bzl" % ctx.attr.rules_go_repo_only_for_internal_use]
@@ -55,6 +57,7 @@ def _new_go_repository_impl(ctx):
 
 
 _go_repository_attrs = {
+    "build_file_name": attr.string(),
     "importpath": attr.string(mandatory = True),
     "remote": attr.string(),
     "commit": attr.string(),

--- a/go/tools/gazelle/gazelle/diff.go
+++ b/go/tools/gazelle/gazelle/diff.go
@@ -24,7 +24,7 @@ import (
 )
 
 func diffFile(file *bzl.File) error {
-	f, err := ioutil.TempFile("", *buildName)
+	f, err := ioutil.TempFile("", *buildFileName)
 	if err != nil {
 		return err
 	}

--- a/go/tools/gazelle/gazelle/fix.go
+++ b/go/tools/gazelle/gazelle/fix.go
@@ -17,10 +17,18 @@ package main
 
 import (
 	"io/ioutil"
+	"os"
+	"path"
 
 	bzl "github.com/bazelbuild/buildifier/core"
 )
 
 func fixFile(file *bzl.File) error {
-	return ioutil.WriteFile(file.Path, bzl.Format(file), 0644)
+	if err := ioutil.WriteFile(file.Path, bzl.Format(file), 0644); err != nil {
+		return err
+	}
+	if path.Base(file.Path) != *buildFileName {
+		return os.Rename(file.Path, path.Join(path.Dir(file.Path), *buildFileName))
+	}
+	return nil
 }

--- a/go/tools/gazelle/gazelle/main.go
+++ b/go/tools/gazelle/gazelle/main.go
@@ -180,7 +180,9 @@ func findBuildFile(repo string) (string, error) {
 			if fi.Mode().IsRegular() {
 				return p, nil
 			}
-		} else if !os.IsNotExist(err) {
+			continue
+		}
+		if !os.IsNotExist(err) {
 			return "", err
 		}
 	}

--- a/go/tools/gazelle/gazelle/main.go
+++ b/go/tools/gazelle/gazelle/main.go
@@ -24,7 +24,9 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
 
 	bzl "github.com/bazelbuild/buildifier/core"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/generator"
@@ -33,15 +35,12 @@ import (
 )
 
 var (
-	buildName       = flag.String("build_name", "BUILD", "name of output build files to generate, defaults to 'BUILD'")
-	buildTags       = flag.String("build_tags", "", "comma-separated list of build tags. If not specified, GOOS and GOARCH are used.")
-	goPrefix        = flag.String("go_prefix", "", "go_prefix of the target workspace")
-	repoRoot        = flag.String("repo_root", "", "path to a directory which corresponds to go_prefix, otherwise gazelle searches for it.")
-	mode            = flag.String("mode", "fix", "print: prints all of the updated BUILD files\n\tfix: rewrites all of the BUILD files in place\n\tdiff: computes the rewrite but then just does a diff")
-	validBuildNames = map[string]bool{
-		"BUILD":       true,
-		"BUILD.bazel": true,
-	}
+	buildFileName  = flag.String("build_file_name", "BUILD", "name of output build files to generate.")
+	buildTags      = flag.String("build_tags", "", "comma-separated list of build tags. If not specified, GOOS and GOARCH are used.")
+	goPrefix       = flag.String("go_prefix", "", "go_prefix of the target workspace")
+	repoRoot       = flag.String("repo_root", "", "path to a directory which corresponds to go_prefix, otherwise gazelle searches for it.")
+	mode           = flag.String("mode", "fix", "print: prints all of the updated BUILD files\n\tfix: rewrites all of the BUILD files in place\n\tdiff: computes the rewrite but then just does a diff")
+	buildFileNames = []string{"BUILD.bazel", "BUILD"}
 )
 
 func init() {
@@ -56,8 +55,17 @@ var modeFromName = map[string]func(*bzl.File) error{
 	"diff":  diffFile,
 }
 
+func isValidBuildFileName(buildFileName string) bool {
+	for _, bfn := range buildFileNames {
+		if buildFileName == bfn {
+			return true
+		}
+	}
+	return false
+}
+
 func run(dirs []string, emit func(*bzl.File) error) error {
-	g, err := generator.New(*repoRoot, *goPrefix, *buildName, *buildTags)
+	g, err := generator.New(*repoRoot, *goPrefix, *buildFileName, *buildTags)
 	if err != nil {
 		return err
 	}
@@ -69,12 +77,31 @@ func run(dirs []string, emit func(*bzl.File) error) error {
 		}
 		for _, f := range files {
 			f.Path = filepath.Join(*repoRoot, f.Path)
-			if f, err = merger.MergeWithExisting(f); err != nil {
+			existingFilePath, err := findBuildFile(path.Dir(f.Path))
+			if os.IsNotExist(err) {
+				// No existing file, so write a new one
+				bzl.Rewrite(f, nil) // have buildifier 'format' our rules.
+				if err := emit(f); err != nil {
+					return err
+				}
+				continue
+			}
+			if err != nil {
+				// An unexpected error
+				return err
+			}
+			// Existing file, so merge and maybe remove the old one
+			if f, err = merger.MergeWithExisting(f, existingFilePath); err != nil {
 				return err
 			}
 			bzl.Rewrite(f, nil) // have buildifier 'format' our rules.
 			if err := emit(f); err != nil {
 				return err
+			}
+			if f.Path != existingFilePath {
+				if err := os.Remove(existingFilePath); err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -126,8 +153,8 @@ func main() {
 		}
 	}
 
-	if !validBuildNames[*buildName] {
-		log.Fatalf("-build_name %q must be in: %v", *buildName, validBuildNames)
+	if !isValidBuildFileName(*buildFileName) {
+		log.Fatalf("invalid build file name %q, valid names are %s", *buildFileName, strings.Join(buildFileNames, ", "))
 	}
 
 	emit := modeFromName[*mode]
@@ -145,23 +172,27 @@ func main() {
 	}
 }
 
-func readBuild(root string) (data []byte, location string, _ error) {
-	for n := range validBuildNames {
-		p := filepath.Join(root, n)
-		b, err := ioutil.ReadFile(p)
-		if err != nil {
-			if os.IsNotExist(err) {
-				continue
+func findBuildFile(repo string) (string, error) {
+	for _, base := range buildFileNames {
+		p := filepath.Join(repo, base)
+		fi, err := os.Stat(p)
+		if err == nil {
+			if fi.Mode().IsRegular() {
+				return p, nil
 			}
-			return nil, "", err
+		} else if !os.IsNotExist(err) {
+			return "", err
 		}
-		return b, p, nil
 	}
-	return nil, "", fmt.Errorf("no build files found at %q", root)
+	return "", os.ErrNotExist
 }
 
 func loadGoPrefix(repo string) (string, error) {
-	b, p, err := readBuild(repo)
+	p, err := findBuildFile(repo)
+	if err != nil {
+		return "", err
+	}
+	b, err := ioutil.ReadFile(p)
 	if err != nil {
 		return "", err
 	}

--- a/go/tools/gazelle/generator/generator.go
+++ b/go/tools/gazelle/generator/generator.go
@@ -39,20 +39,21 @@ var (
 
 // Generator generates BUILD files for a Go repository.
 type Generator struct {
-	repoRoot  string
-	goPrefix  string
-	buildName string
-	bctx      build.Context
-	g         rules.Generator
+	repoRoot      string
+	goPrefix      string
+	buildFileName string
+	bctx          build.Context
+	g             rules.Generator
 }
 
 // New returns a new Generator which is responsible for a Go repository.
 //
 // "repoRoot" is a path to the root directory of the repository.
 // "goPrefix" is the go_prefix corresponding to the repository root directory.
+// "buildFileName" is the name of the BUILD file (BUILD or BUILD.bazel).
 // "buildTags" is a comma-delimited set of build tags to set in the build context.
 // See also https://github.com/bazelbuild/rules_go#go_prefix.
-func New(repoRoot, goPrefix, buildName, buildTags string) (*Generator, error) {
+func New(repoRoot, goPrefix, buildFileName, buildTags string) (*Generator, error) {
 	bctx := build.Default
 	// Ignore source files in $GOROOT and $GOPATH
 	bctx.GOROOT = ""
@@ -76,11 +77,11 @@ func New(repoRoot, goPrefix, buildName, buildTags string) (*Generator, error) {
 	}
 
 	return &Generator{
-		repoRoot:  filepath.Clean(repoRoot),
-		goPrefix:  goPrefix,
-		buildName: buildName,
-		bctx:      bctx,
-		g:         rules.NewGenerator(goPrefix),
+		repoRoot:      filepath.Clean(repoRoot),
+		goPrefix:      goPrefix,
+		buildFileName: buildFileName,
+		bctx:          bctx,
+		g:             rules.NewGenerator(goPrefix),
 	}, nil
 }
 
@@ -110,7 +111,7 @@ func (g *Generator) Generate(dir string) ([]*bzl.File, error) {
 		if len(files) == 0 && rel != "" {
 			// "dir" was not a buildable Go package but still need a BUILD file
 			// for go_prefix.
-			files = append(files, emptyToplevel(g.goPrefix, g.buildName))
+			files = append(files, g.emptyToplevel())
 		}
 
 		file, err := g.generateOne(rel, pkg)
@@ -127,15 +128,15 @@ func (g *Generator) Generate(dir string) ([]*bzl.File, error) {
 	return files, nil
 }
 
-func emptyToplevel(goPrefix, buildName string) *bzl.File {
+func (g *Generator) emptyToplevel() *bzl.File {
 	return &bzl.File{
-		Path: buildName,
+		Path: g.buildFileName,
 		Stmt: []bzl.Expr{
 			loadExpr("go_prefix"),
 			&bzl.CallExpr{
 				X: &bzl.LiteralExpr{Token: "go_prefix"},
 				List: []bzl.Expr{
-					&bzl.StringExpr{Value: goPrefix},
+					&bzl.StringExpr{Value: g.goPrefix},
 				},
 			},
 		},
@@ -148,7 +149,7 @@ func (g *Generator) generateOne(rel string, pkg *build.Package) (*bzl.File, erro
 		return nil, err
 	}
 
-	file := &bzl.File{Path: filepath.Join(rel, g.buildName)}
+	file := &bzl.File{Path: filepath.Join(rel, g.buildFileName)}
 	for _, r := range rs {
 		file.Stmt = append(file.Stmt, r.Call)
 	}

--- a/go/tools/gazelle/generator/generator_test.go
+++ b/go/tools/gazelle/generator/generator_test.go
@@ -53,7 +53,7 @@ func TestGeneratorDotBazel(t *testing.T) {
 	testGenerator(t, "BUILD.bazel")
 }
 
-func testGenerator(t *testing.T, buildName string) {
+func testGenerator(t *testing.T, buildFileName string) {
 	stub := stubRuleGen{
 		goFiles: make(map[string][]string),
 		cFiles:  make(map[string][]string),
@@ -174,9 +174,9 @@ func testGenerator(t *testing.T, buildName string) {
 	}
 
 	repo := filepath.Join(testdata.Dir(), "repo")
-	g, err := New(repo, "example.com/repo", buildName, "")
+	g, err := New(repo, "example.com/repo", buildFileName, "")
 	if err != nil {
-		t.Errorf(`New(%q, "example.com/repo") failed with %v; want success`, repo, err)
+		t.Errorf(`New(%q, "example.com/repo", %q, "") failed with %v; want success`, repo, err, buildFileName)
 		return
 	}
 
@@ -193,7 +193,7 @@ func testGenerator(t *testing.T, buildName string) {
 
 	want := []*bzl.File{
 		{
-			Path: buildName,
+			Path: buildFileName,
 			Stmt: []bzl.Expr{
 				loadExpr("go_prefix"),
 				&bzl.CallExpr{
@@ -205,7 +205,7 @@ func testGenerator(t *testing.T, buildName string) {
 			},
 		},
 		{
-			Path: "lib/" + buildName,
+			Path: "lib/" + buildFileName,
 			Stmt: []bzl.Expr{
 				loadExpr("go_prefix", "go_library"),
 				stub.fixtures["lib"][0].Call,
@@ -213,7 +213,7 @@ func testGenerator(t *testing.T, buildName string) {
 			},
 		},
 		{
-			Path: "lib/internal/deep/" + buildName,
+			Path: "lib/internal/deep/" + buildFileName,
 			Stmt: []bzl.Expr{
 				loadExpr("go_library", "go_test"),
 				stub.fixtures["lib/internal/deep"][0].Call,
@@ -221,14 +221,14 @@ func testGenerator(t *testing.T, buildName string) {
 			},
 		},
 		{
-			Path: "lib/relativeimporter/" + buildName,
+			Path: "lib/relativeimporter/" + buildFileName,
 			Stmt: []bzl.Expr{
 				loadExpr("go_library"),
 				stub.fixtures["lib/relativeimporter"][0].Call,
 			},
 		},
 		{
-			Path: "bin/" + buildName,
+			Path: "bin/" + buildFileName,
 			Stmt: []bzl.Expr{
 				loadExpr("go_library", "go_binary"),
 				stub.fixtures["bin"][0].Call,
@@ -236,7 +236,7 @@ func testGenerator(t *testing.T, buildName string) {
 			},
 		},
 		{
-			Path: "bin_with_tests/" + buildName,
+			Path: "bin_with_tests/" + buildFileName,
 			Stmt: []bzl.Expr{
 				loadExpr("go_library", "go_binary", "go_test"),
 				stub.fixtures["bin_with_tests"][0].Call,
@@ -245,7 +245,7 @@ func testGenerator(t *testing.T, buildName string) {
 			},
 		},
 		{
-			Path: "cgolib/" + buildName,
+			Path: "cgolib/" + buildFileName,
 			Stmt: []bzl.Expr{
 				loadExpr("go_library", "go_test", "cgo_library"),
 				stub.fixtures["cgolib"][0].Call,
@@ -254,7 +254,7 @@ func testGenerator(t *testing.T, buildName string) {
 			},
 		},
 		{
-			Path: "cgolib_with_build_tags/" + buildName,
+			Path: "cgolib_with_build_tags/" + buildFileName,
 			Stmt: []bzl.Expr{
 				loadExpr("go_library", "go_test", "cgo_library"),
 				stub.fixtures["cgolib"][0].Call,
@@ -263,7 +263,7 @@ func testGenerator(t *testing.T, buildName string) {
 			},
 		},
 		{
-			Path: "allcgolib/" + buildName,
+			Path: "allcgolib/" + buildFileName,
 			Stmt: []bzl.Expr{
 				loadExpr("go_library", "go_test", "cgo_library"),
 				stub.fixtures["cgolib"][0].Call,

--- a/go/tools/gazelle/merger/merger.go
+++ b/go/tools/gazelle/merger/merger.go
@@ -19,7 +19,6 @@ package merger
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"sort"
 	"strings"
 
@@ -39,15 +38,11 @@ var (
 	}
 )
 
-// MergeWithExisting looks for an existing BUILD file at file.Path
-// loads it, and attempts to merge elements of newfile into it.
-// returns newfile, nil if FileNotExists
-func MergeWithExisting(newfile *bzl.File) (*bzl.File, error) {
-	b, err := ioutil.ReadFile(newfile.Path)
+// MergeWithExisting merges newfile with an existing build file at
+// existingFilePath and returns newfile.
+func MergeWithExisting(newfile *bzl.File, existingFilePath string) (*bzl.File, error) {
+	b, err := ioutil.ReadFile(existingFilePath)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return newfile, nil
-		}
 		return nil, err
 	}
 	f, err := bzl.Parse(newfile.Path, b)


### PR DESCRIPTION
This PR builds on the work in #219 and includes the ability to use `BUILD.bazel` files in `new_go_repository`, for example:

```
new_go_repository(
    name = "org_golang_x_text",
    build_file_name = "BUILD.bazel",
    commit = "a8b38433e35b65ba247bb267317037dee1b70cea",
    importpath = "golang.org/x/text",
)
```