### PR TITLE
Remove hard-coded depdence on BUILD.

### DIFF
--- a/go/private/go_repositories.bzl
+++ b/go/private/go_repositories.bzl
@@ -176,12 +176,12 @@ _go_repository_select = repository_rule(
         ),
 
         "_linux": attr.label(
-            default = Label("@golang_linux_amd64//:BUILD"),
+            default = Label("@golang_linux_amd64//:VERSION"),
             allow_files = True,
             single_file = True,
         ),
         "_darwin": attr.label(
-            default = Label("@golang_darwin_amd64//:BUILD"),
+            default = Label("@golang_darwin_amd64//:VERSION"),
             allow_files = True,
             single_file = True,
         ),


### PR DESCRIPTION
Changes the repositories.bzl script to use a file that is part of the
actual archive, instead of a file generated by Bazel.

This is the root cause of the breakage in
https://github.com/bazelbuild/bazel/issues/2252