### PR TITLE
Don't add tests and benchmarks twice.

### DIFF
--- a/go/tools/generate_test_main.go
+++ b/go/tools/generate_test_main.go
@@ -80,12 +80,6 @@ func main() {
 				cases.HasTestMain = true
 				continue
 			}
-			if strings.HasPrefix(fn.Name.Name, "Test") {
-				cases.TestNames = append(cases.TestNames, fn.Name.Name)
-			}
-			if strings.HasPrefix(fn.Name.Name, "Benchmark") {
-				cases.BenchmarkNames = append(cases.BenchmarkNames, fn.Name.Name)
-			}
 
 			// Here we check the signature of the Test* function. To
 			// be considered a test:


### PR DESCRIPTION
Tests and benchmarks are added to the end of this method.