### PR TITLE
Fix dependencies on buildifier

### DIFF
--- a/go/private/go_repositories.bzl
+++ b/go/private/go_repositories.bzl
@@ -57,7 +57,7 @@ def _fetch_repository_tools_deps(ctx, goroot, gopath):
 
   result = ctx.execute([
       'env', 'GOROOT=%s' % goroot, 'GOPATH=%s' % gopath, 'PATH=%s/bin' % goroot,
-      'go', 'generate', 'github.com/bazelbuild/buildifier/core'])
+      'go', 'generate', 'github.com/bazelbuild/buildifier/build'])
   if result.return_code:
     fail("failed to go generate: %s" % result.stderr)
 

--- a/go/tools/gazelle/gazelle/diff.go
+++ b/go/tools/gazelle/gazelle/diff.go
@@ -19,7 +19,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	bzl "github.com/bazelbuild/buildifier/core"
+	bzl "github.com/bazelbuild/buildifier/build"
 	"github.com/bazelbuild/buildifier/differ"
 )
 

--- a/go/tools/gazelle/gazelle/fix.go
+++ b/go/tools/gazelle/gazelle/fix.go
@@ -20,7 +20,7 @@ import (
 	"os"
 	"path"
 
-	bzl "github.com/bazelbuild/buildifier/core"
+	bzl "github.com/bazelbuild/buildifier/build"
 )
 
 func fixFile(file *bzl.File) error {

--- a/go/tools/gazelle/gazelle/fix_test.go
+++ b/go/tools/gazelle/gazelle/fix_test.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	bzl "github.com/bazelbuild/buildifier/core"
+	bzl "github.com/bazelbuild/buildifier/build"
 )
 
 func TestFixFile(t *testing.T) {

--- a/go/tools/gazelle/gazelle/main.go
+++ b/go/tools/gazelle/gazelle/main.go
@@ -28,7 +28,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	bzl "github.com/bazelbuild/buildifier/core"
+	bzl "github.com/bazelbuild/buildifier/build"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/generator"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/merger"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/rules"

--- a/go/tools/gazelle/gazelle/print.go
+++ b/go/tools/gazelle/gazelle/print.go
@@ -18,7 +18,7 @@ package main
 import (
 	"os"
 
-	bzl "github.com/bazelbuild/buildifier/core"
+	bzl "github.com/bazelbuild/buildifier/build"
 )
 
 func printFile(f *bzl.File) error {

--- a/go/tools/gazelle/generator/generator.go
+++ b/go/tools/gazelle/generator/generator.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	bzl "github.com/bazelbuild/buildifier/core"
+	bzl "github.com/bazelbuild/buildifier/build"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/packages"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/rules"
 )

--- a/go/tools/gazelle/generator/generator_test.go
+++ b/go/tools/gazelle/generator/generator_test.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"testing"
 
-	bzl "github.com/bazelbuild/buildifier/core"
+	bzl "github.com/bazelbuild/buildifier/build"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/rules"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/testdata"
 )

--- a/go/tools/gazelle/merger/merger.go
+++ b/go/tools/gazelle/merger/merger.go
@@ -22,7 +22,7 @@ import (
 	"sort"
 	"strings"
 
-	bzl "github.com/bazelbuild/buildifier/core"
+	bzl "github.com/bazelbuild/buildifier/build"
 )
 
 const (

--- a/go/tools/gazelle/merger/merger_test.go
+++ b/go/tools/gazelle/merger/merger_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	bzl "github.com/bazelbuild/buildifier/core"
+	bzl "github.com/bazelbuild/buildifier/build"
 )
 
 const oldData = `

--- a/go/tools/gazelle/rules/construct.go
+++ b/go/tools/gazelle/rules/construct.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"reflect"
 
-	bzl "github.com/bazelbuild/buildifier/core"
+	bzl "github.com/bazelbuild/buildifier/build"
 )
 
 type keyvalue struct {

--- a/go/tools/gazelle/rules/generator.go
+++ b/go/tools/gazelle/rules/generator.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	bzl "github.com/bazelbuild/buildifier/core"
+	bzl "github.com/bazelbuild/buildifier/build"
 )
 
 const (

--- a/go/tools/gazelle/rules/generator_test.go
+++ b/go/tools/gazelle/rules/generator_test.go
@@ -20,7 +20,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	bzl "github.com/bazelbuild/buildifier/core"
+	bzl "github.com/bazelbuild/buildifier/build"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/rules"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/testdata"
 )

--- a/go/tools/wtool/main.go
+++ b/go/tools/wtool/main.go
@@ -26,7 +26,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	bzl "github.com/bazelbuild/buildifier/core"
+	bzl "github.com/bazelbuild/buildifier/build"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/rules"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/wspace"
 	"golang.org/x/tools/go/vcs"


### PR DESCRIPTION
Buildifier changed one of their packages from "core" to "build," thereby breaking Gazelle. This change makes Gazelle compile again, passes all tests and works correctly in my project.