### PR TITLE
Integrates filter_tags into emit_go_compile_action.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ The rules should be considered experimental. They support:
 
 They currently do not support (in order of importance):
 
-* build constraints/tags (`//+build` comments - see <a
-  href="https://golang.org/pkg/go/build/">here</a>))
 * bazel-style auto generating BUILD (where the library name is other than go_default_library)
 * C/C++ interoperation except cgo (swig etc.)
 * race detector

--- a/go/tools/filter_tags/BUILD
+++ b/go/tools/filter_tags/BUILD
@@ -1,18 +1,18 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//go:def.bzl", "go_prefix", "go_library", "go_binary", "go_test")
+load("//go:def.bzl", "go_tool_library", "go_tool_binary", "go_tool_test")
 
-go_library(
+go_tool_library(
     name = "filter_tags_lib",
     srcs = ["filter_tags.go"],
 )
 
-go_binary(
+go_tool_binary(
     name = "filter_tags",
     library = ":filter_tags_lib",
 )
 
-go_test(
+go_tool_test(
     name = "filter_tags_test",
     srcs = ["filter_tags_test.go"],
     library = ":filter_tags_lib",


### PR DESCRIPTION
This change adds basic golang build constraint support to rules_go by integrating the already existing `filter_tags` binary.

The meat of the change is in the `emit_go_compile_action` func where filter_tags is run against the list of go sources producing a filtered list of go sources that are passed to the go compile tool.

I also had to create a new set of go_library, go_binary, and go_test rules for building filter_tags without requiring itself (preventing a circular dependency). This means that tools built with these rules will not support build constraints, but generic builds will.

The overall effect of this change is making go_library and friends only compile sources that meet their build constraints.

Potential future work:
* Add support for defining custom tags in the BUILD file that should be considered "satisfied":
  
      go_library(
          tags=['release'],
          ...
      )