### PR TITLE
fix go_test when a TestMain function is defined

### DIFF
--- a/examples/lib/lib_x_test.go
+++ b/examples/lib/lib_x_test.go
@@ -17,13 +17,15 @@ package lib_test
 
 import (
 	"flag"
+	"os"
 	"testing"
 
 	"github.com/bazelbuild/rules_go/examples/lib"
 )
 
 var (
-	buildTimeWant = flag.String("lib_test.buildtime", "", "expected value in TestBuildTime")
+	buildTimeWant     = flag.String("lib_test.buildtime", "", "expected value in TestBuildTime")
+	wasTestMainCalled = false
 )
 
 func TestLibraryPkgPath(t *testing.T) {
@@ -36,4 +38,15 @@ func TestBuildTime(t *testing.T) {
 	if got, want := lib.BuildTime(), *buildTimeWant; got != want {
 		t.Errorf("buildTime = %q; want %q", got, want)
 	}
+}
+
+func TestMainCalled(t *testing.T) {
+	if !wasTestMainCalled {
+		t.Errorf("TestMain was not called")
+  }
+}
+
+func TestMain(m *testing.M) {
+	wasTestMainCalled = true
+	os.Exit(m.Run())
 }

--- a/go/tools/generate_test_main.go
+++ b/go/tools/generate_test_main.go
@@ -130,38 +130,35 @@ package main
 import (
 	"os"
 	"testing"
+	"testing/internal/testdeps"
 
 {{ if .TestNames }}
-        undertest "{{.Package}}"
+	undertest "{{.Package}}"
 {{else if .BenchmarkNames }}
-        undertest "{{.Package}}"
+	undertest "{{.Package}}"
 {{ end }}
 )
 
-func everything(pat, str string) (bool, error) {
-	return true, nil
-}
-
 var tests = []testing.InternalTest{
 {{range .TestNames}}
-   {"{{.}}", undertest.{{.}} },
+	{"{{.}}", undertest.{{.}} },
 {{end}}
 }
 
 var benchmarks = []testing.InternalBenchmark{
 {{range .BenchmarkNames}}
-   {"{{.}}", undertest.{{.}} },
+	{"{{.}}", undertest.{{.}} },
 {{end}}
 }
 
 func main() {
-  os.Chdir("{{.RunDir}}")
-  {{if not .HasTestMain}}
-  testing.Main(everything, tests, benchmarks, nil)
-  {{else}}
-  m := testing.MainStart(everything, tests, benchmarks, nil)
-  undertest.TestMain(m)
-  {{end}}
+	os.Chdir("{{.RunDir}}")
+	m := testing.MainStart(testdeps.TestDeps{}, tests, benchmarks, nil)
+{{if not .HasTestMain}}
+	os.Exit(m.Run())
+{{else}}
+	undertest.TestMain(m)
+{{end}}
 }
 `))
 	if err := tpl.Execute(outFile, &cases); err != nil {


### PR DESCRIPTION
This broke in Go 1.8. testing.MainStart now expects a testing.testDeps
interface as its first argument. testing.internal.testdeps.TestDeps is
a public implementation of this, used by "go test".

This may not be stable, but examples/lib:lib_external_test will break
if this changes when we update our Go dependency in the future, so
we'll catch problems like this.

Fixes #273