### PR TITLE
Enable test filtering with --test_filter

### DIFF
--- a/go/tools/generate_test_main.go
+++ b/go/tools/generate_test_main.go
@@ -128,6 +128,7 @@ func main() {
 	tpl := template.Must(template.New("source").Parse(`
 package main
 import (
+	"flag"
 	"os"
 	"testing"
 	"testing/internal/testdeps"
@@ -153,6 +154,12 @@ var benchmarks = []testing.InternalBenchmark{
 
 func main() {
 	os.Chdir("{{.RunDir}}")
+	if filter := os.Getenv("TESTBRIDGE_TEST_ONLY"); filter != "" {
+		if f := flag.Lookup("test.run"); f != nil {
+			f.Value.Set(filter)
+		}
+	}
+
 	m := testing.MainStart(testdeps.TestDeps{}, tests, benchmarks, nil)
 {{if not .HasTestMain}}
 	os.Exit(m.Run())


### PR DESCRIPTION
Modified generate_test_main.go to map the TESTBRIDGE_TEST_ONLY
environment variable (set by Bazel for --test_filter) onto the
-test.run flag, which is defined and used by the testing package.

Fixes #272