### PR TITLE
cgo libraries are now built with -pthread

### DIFF
--- a/tests/cgo_pthread_flag/BUILD
+++ b/tests/cgo_pthread_flag/BUILD
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "cgo_library", "go_library", "go_test")
+
+cgo_library(
+    name = "cgo_default_library",
+    srcs = ["cgo_pthread_flag.go"],
+)
+
+go_library(
+    name = "go_default_library",
+    library = ":cgo_default_library",
+)
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = ["cgo_pthread_flag_test.go"],
+    library = ":go_default_library",
+)

--- a/tests/cgo_pthread_flag/cgo_pthread_flag.go
+++ b/tests/cgo_pthread_flag/cgo_pthread_flag.go
@@ -1,0 +1,25 @@
+package cgo_pthread_flag
+
+/*
+#include <pthread.h>
+
+void* f(void* p) {
+	*(int*) p = 42;
+	return NULL;
+}
+
+int callFInBackground() {
+	int x;
+	pthread_t thread;
+	pthread_create(&thread, NULL, f, &x);
+	pthread_join(thread, NULL);
+	return x;
+}
+*/
+import "C"
+
+// Wrapper for callFInBackground. We don't support using Cgo directly from
+// tests yet.
+func callFFromGo() int {
+	return int(C.callFInBackground())
+}

--- a/tests/cgo_pthread_flag/cgo_pthread_flag_test.go
+++ b/tests/cgo_pthread_flag/cgo_pthread_flag_test.go
@@ -1,0 +1,12 @@
+package cgo_pthread_flag
+
+import "testing"
+
+// Checks that we can build and run pthread code without explicitly giving
+// any flags to cgo. -pthread should be passed to the C compiler by default.
+func TestCgoPthread(t *testing.T) {
+	x := int(callFFromGo())
+	if x != 42 {
+		t.Errorf("got %d; want 42", x)
+	}
+}


### PR DESCRIPTION
This matches behavior of "go build", which compiles and links C code
with -pthread (or -mthreads on Windows).