### PR TITLE
gazelle: don't rewrite files with gazelle:ignore

### DIFF
--- a/go/tools/gazelle/gazelle/main.go
+++ b/go/tools/gazelle/gazelle/main.go
@@ -99,6 +99,10 @@ func run(dirs []string, emit func(*bzl.File) error, external rules.ExternalResol
 			}
 			// Existing file, so merge and maybe remove the old one
 			if f, err = merger.MergeWithExisting(f, existingFilePath); err != nil {
+				if _, ok := err.(merger.GazelleIgnoreError); ok {
+					// found gazelle:ignore comment. Do not rewrite.
+					continue
+				}
 				return err
 			}
 			bzl.Rewrite(f, nil) // have buildifier 'format' our rules.

--- a/go/tools/gazelle/merger/merger.go
+++ b/go/tools/gazelle/merger/merger.go
@@ -30,6 +30,14 @@ const (
 	keep          = "# keep"           // marker in srcs or deps to tell gazelle to preserve.
 )
 
+type GazelleIgnoreError struct {
+	posn bzl.Position
+}
+
+func (e GazelleIgnoreError) Error() string {
+	return fmt.Sprintf("%s found on line %d", gazelleIgnore, e.posn)
+}
+
 var (
 	mergeableFields = map[string]bool{
 		"srcs":    true,
@@ -52,7 +60,7 @@ func MergeWithExisting(newfile *bzl.File, existingFilePath string) (*bzl.File, e
 	for _, s := range f.Stmt {
 		for _, c := range s.Comment().After {
 			if strings.HasPrefix(c.Token, gazelleIgnore) {
-				return f, nil
+				return nil, GazelleIgnoreError{c.Start}
 			}
 		}
 	}


### PR DESCRIPTION
Previously, Gazelle would avoid merging files with a "#
gazelle:ignore" comment, but it would still rewrite them. This could
result in small changes, e.g., whitespace.

Gazelle will no longer rewrite these files at all.

Fixes #266.