### PR TITLE
Add a framework for testing things that can't be checked through bazel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ script:
       --genrule_strategy=standalone \
       --local_resources=400,1,1.0 \
       //...
+  - tests/run_non_bazel_tests.bash
 
 notifications:
   email: false

--- a/tests/run_non_bazel_tests.bash
+++ b/tests/run_non_bazel_tests.bash
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# This script executes tests that can't be executed through Bazel. For example,
+# we may need to test the behavior of the rules when certain flags are passed
+# to Bazel on the command line.
+#
+# This is executed by Travis CI. It will always be executed after the main
+# bazel tests. Tests may assume bazel is installed, and dependencies in
+# WORKSPACE have been set up.
+
+cd $(dirname "$0")
+
+tests=(
+  test_filter_test/test_filter_test.bash
+)
+
+result=0
+for test in "${tests[@]}"; do
+  echo "Running $test" >&2
+  $test
+  if [ $? -ne 0 ]; then
+    echo "Finished $test: FAIL" >&2
+    result=1
+  else
+    echo "Finished $test: PASS" >&2
+  fi
+done
+
+exit $result

--- a/tests/test_filter_test/BUILD
+++ b/tests/test_filter_test/BUILD
@@ -1,0 +1,8 @@
+load("//go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = ["test_filter_test.go"],
+    tags = ["manual"],
+)

--- a/tests/test_filter_test/test_filter_test.bash
+++ b/tests/test_filter_test/test_filter_test.bash
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Check that --test_filter can be used to avoid a failing test case.
+cd $(dirname "$0")
+exec bazel test --test_filter=Pass :go_default_test

--- a/tests/test_filter_test/test_filter_test.go
+++ b/tests/test_filter_test/test_filter_test.go
@@ -1,0 +1,10 @@
+package test_filter
+
+import "testing"
+
+func TestShouldPass(t *testing.T) {
+}
+
+func TestShouldFail(t *testing.T) {
+	t.Fail()
+}


### PR DESCRIPTION
- Included an initial test case to check that --test_filter is
  observed by go_tests.
- The test framework is run through Travis CI.

Fixes #287