### PR TITLE
Support gc_goopts and gc_linkopts attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ go_prefix(prefix)
 ## go\_library
 
 ```bzl
-go_library(name, srcs, deps, data)
+go_library(name, srcs, deps, data, gc_goopts)
 ```
 <table class="table table-condensed table-bordered table-params">
   <colgroup>
@@ -357,6 +357,17 @@ go_library(name, srcs, deps, data)
         <p>List of files needed by this rule at runtime.</p>
       </td>
     </tr>
+    <tr>
+      <td><code>gc_goopts</code></td>
+      <td>
+        <code>List of strings, optional</code>
+        <p>List of flags to add to the Go compilation command. Subject to
+        <a href="https://bazel.build/versions/master/docs/be/make-variables.html#make-var-substitution">Make
+        variable substitution</a> and
+        <a href="https://bazel.build/versions/master/docs/be/common-definitions.html#sh-tokenization">Bourne
+        shell tokenization</a>.</p>
+      </td>
+    </tr>
   </tbody>
 </table>
 
@@ -364,7 +375,7 @@ go_library(name, srcs, deps, data)
 ## cgo\_library
 
 ```bzl
-cgo_library(name, srcs, copts, clinkopts, cdeps, deps, data)
+cgo_library(name, srcs, copts, clinkopts, cdeps, deps, data, gc_goopts)
 ```
 <table class="table table-condensed table-bordered table-params">
   <colgroup>
@@ -431,6 +442,17 @@ cgo_library(name, srcs, copts, clinkopts, cdeps, deps, data)
         <p>List of files needed by this rule at runtime.</p>
       </td>
     </tr>
+    <tr>
+      <td><code>gc_goopts</code></td>
+      <td>
+        <code>List of strings, optional</code>
+        <p>List of flags to add to the Go compilation command. Subject to
+        <a href="https://bazel.build/versions/master/docs/be/make-variables.html#make-var-substitution">Make
+        variable substitution</a> and
+        <a href="https://bazel.build/versions/master/docs/be/common-definitions.html#sh-tokenization">Bourne
+        shell tokenization</a>.</p>
+      </td>
+    </tr>
   </tbody>
 </table>
 
@@ -457,7 +479,7 @@ go_library(
 ## go\_binary
 
 ```bzl
-go_binary(name, srcs, deps, data, linkstamp)
+go_binary(name, srcs, deps, data, linkstamp, gc_goopts, gc_linkopts)
 ```
 <table class="table table-condensed table-bordered table-params">
   <colgroup>
@@ -516,6 +538,28 @@ go_binary(name, srcs, deps, data, linkstamp)
         a good template which prints Git workspace status.</p>
       </td>
     </tr>
+    <tr>
+      <td><code>gc_goopts</code></td>
+      <td>
+        <code>List of strings, optional</code>
+        <p>List of flags to add to the Go compilation command. Subject to
+        <a href="https://bazel.build/versions/master/docs/be/make-variables.html#make-var-substitution">Make
+        variable substitution</a> and
+        <a href="https://bazel.build/versions/master/docs/be/common-definitions.html#sh-tokenization">Bourne
+        shell tokenization</a>.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>gc_linkopts</code></td>
+      <td>
+        <code>List of strings, optional</code>
+        <p>List of flags to add to the Go link command. Subject to
+        <a href="https://bazel.build/versions/master/docs/be/make-variables.html#make-var-substitution">Make
+        variable substitution</a> and
+        <a href="https://bazel.build/versions/master/docs/be/common-definitions.html#sh-tokenization">Bourne
+        shell tokenization</a>.</p>
+      </td>
+    </tr>
   </tbody>
 </table>
 
@@ -523,7 +567,7 @@ go_binary(name, srcs, deps, data, linkstamp)
 ## go\_test
 
 ```bzl
-go_test(name, srcs, deps, data)
+go_test(name, srcs, deps, data, gc_goopts, gc_linkopts)
 ```
 <table class="table table-condensed table-bordered table-params">
   <colgroup>
@@ -563,6 +607,28 @@ go_test(name, srcs, deps, data)
       <td>
         <code>List of labels, optional</code>
         <p>List of files needed by this rule at runtime.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>gc_goopts</code></td>
+      <td>
+        <code>List of strings, optional</code>
+        <p>List of flags to add to the Go compilation command. Subject to
+        <a href="https://bazel.build/versions/master/docs/be/make-variables.html#make-var-substitution">Make
+        variable substitution</a> and
+        <a href="https://bazel.build/versions/master/docs/be/common-definitions.html#sh-tokenization">Bourne
+        shell tokenization</a>.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>gc_linkopts</code></td>
+      <td>
+        <code>List of strings, optional</code>
+        <p>List of flags to add to the Go link command. Subject to
+        <a href="https://bazel.build/versions/master/docs/be/make-variables.html#make-var-substitution">Make
+        variable substitution</a> and
+        <a href="https://bazel.build/versions/master/docs/be/common-definitions.html#sh-tokenization">Bourne
+        shell tokenization</a>.</p>
       </td>
     </tr>
   </tbody>

--- a/tests/gc_opts_unsafe/BUILD
+++ b/tests/gc_opts_unsafe/BUILD
@@ -1,0 +1,80 @@
+load("//go:def.bzl", "cgo_library", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "unsafe_srcs_lib",
+    srcs = ["unsafe.go"],
+    gc_goopts = ["-u"],
+    tags = ["manual"],
+)
+
+go_library(
+    name = "unsafe_library_lib",
+    library = ":unsafe_srcs_lib",
+    tags = ["manual"],
+)
+
+go_binary(
+    name = "unsafe_srcs_bin",
+    srcs = [
+        "empty_main.go",
+        "unsafe.go",
+    ],
+    gc_goopts = ["-u"],
+    tags = ["manual"],
+)
+
+go_binary(
+    name = "unsafe_library_bin",
+    srcs = ["empty_main.go"],
+    library = ":unsafe_srcs_lib",
+    tags = ["manual"],
+)
+
+go_test(
+    name = "unsafe_srcs_test",
+    srcs = [
+        "empty_test.go",
+        "unsafe.go",
+    ],
+    gc_goopts = ["-u"],
+    tags = ["manual"],
+)
+
+go_test(
+    name = "unsafe_library_test",
+    library = ":unsafe_srcs_lib",
+    tags = ["manual"],
+)
+
+cgo_library(
+    name = "unsafe_cgo_lib",
+    srcs = ["unsafe_cgo.go"],
+    gc_goopts = ["-u"],
+    tags = ["manual"],
+)
+
+go_library(
+    name = "unsafe_cgo_client_lib",
+    library = ":unsafe_cgo_lib",
+    tags = ["manual"],
+)
+
+go_binary(
+    name = "unsafe_link_bin",
+    srcs = [
+        "empty_main.go",
+        "unsafe.go",
+    ],
+    gc_linkopts = ["-u"],
+    tags = ["manual"],
+)
+
+go_test(
+    name = "unsafe_link_test",
+    srcs = [
+        "empty_test.go",
+        "unsafe.go",
+    ],
+    gc_linkopts = ["-u"],
+    tags = ["manual"],
+)

--- a/tests/gc_opts_unsafe/empty_main.go
+++ b/tests/gc_opts_unsafe/empty_main.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/tests/gc_opts_unsafe/empty_test.go
+++ b/tests/gc_opts_unsafe/empty_test.go
@@ -1,0 +1,1 @@
+package main

--- a/tests/gc_opts_unsafe/gc_opts_unsafe.bash
+++ b/tests/gc_opts_unsafe/gc_opts_unsafe.bash
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# This test verifies that flags passed through gc_goopts and gc_link_opts
+# attributes in go_library, go_binary, go_test, and cgo_library are actually
+# passed to the Go compiler.
+#
+# Each of the targets listed below is expected to fail, but only if the
+# "-u" flag is passed to the compiler or linker (reject unsafe code). This
+# test builds the targets manually and verifies Bazel fails with the expected
+# error message.
+
+cd $(dirname "$0")
+
+result=0
+
+function check_build_fails {
+  local target=$1
+  local message=$2
+  bazel build "$target" 2>&1 | tee output.txt
+  local target_result=${PIPESTATUS[0]}
+  if [ $target_result -eq 0 ]; then
+    echo "build of $target succeeded but should have failed" >&2
+    return 1
+  fi
+  if ! grep -q "$message" output.txt; then
+    echo "build of $target failed for a different reason" >&2
+    return 1
+  fi
+  return 0
+}
+
+compile_test_targets=(
+  :unsafe_srcs_lib
+  :unsafe_library_lib
+  :unsafe_srcs_bin
+  :unsafe_library_bin
+  :unsafe_srcs_test
+  :unsafe_library_test
+  :unsafe_cgo_lib
+  :unsafe_cgo_client_lib
+)
+
+for target in "${compile_test_targets[@]}"; do 
+  check_build_fails "$target" "cannot import package unsafe"
+  if [ $? -ne 0 ]; then
+    result=1
+  fi
+done
+
+link_test_targets=(
+  :unsafe_link_bin
+  :unsafe_link_test  
+)
+
+for target in "${link_test_targets[@]}"; do
+  check_build_fails "$target" "load of unsafe package"
+  if [ $? -ne 0 ]; then
+    result=1
+  fi
+done
+
+exit $result

--- a/tests/gc_opts_unsafe/unsafe.go
+++ b/tests/gc_opts_unsafe/unsafe.go
@@ -1,0 +1,5 @@
+package main
+
+import "unsafe"
+
+var null = unsafe.Pointer(uintptr(0))

--- a/tests/gc_opts_unsafe/unsafe_cgo.go
+++ b/tests/gc_opts_unsafe/unsafe_cgo.go
@@ -1,0 +1,6 @@
+package main
+
+import "C"
+import "unsafe"
+
+var null = unsafe.Pointer(uintptr(0))

--- a/tests/run_non_bazel_tests.bash
+++ b/tests/run_non_bazel_tests.bash
@@ -11,6 +11,7 @@
 cd $(dirname "$0")
 
 tests=(
+  gc_opts_unsafe/gc_opts_unsafe.bash
   test_filter_test/test_filter_test.bash
 )
 


### PR DESCRIPTION
go_library, cgo_library, go_binary, and go_test now support the
gc_goopts attribute. This is a list of flags to pass to the Go
compiler.

go_binary and go_test also support the gc_linkopts attribute. This is
a list of flags to be passed to the Go linker.

Note that _emit_go_compile_action and _emit_go_link_action have had
small interface changes and are now private. I didn't see any uses of
these functions on GitHub, and I'd like to avoid having people depend
on them in the future.

Fixes #217