### PR TITLE
gazelle adds a data dependency for tests on testdata files

### DIFF
--- a/go/tools/gazelle/generator/generator.go
+++ b/go/tools/gazelle/generator/generator.go
@@ -79,11 +79,11 @@ func New(repoRoot, goPrefix, buildFileName, buildTags string, external rules.Ext
 	}
 
 	return &Generator{
-		repoRoot:      filepath.Clean(repoRoot),
+		repoRoot:      repoRoot,
 		goPrefix:      goPrefix,
 		buildFileName: buildFileName,
 		bctx:          bctx,
-		g:             rules.NewGenerator(goPrefix, external),
+		g:             rules.NewGenerator(repoRoot, goPrefix, external),
 	}, nil
 }
 

--- a/go/tools/gazelle/generator/generator_test.go
+++ b/go/tools/gazelle/generator/generator_test.go
@@ -187,6 +187,18 @@ func testGenerator(t *testing.T, buildFileName string) {
 					},
 				},
 			},
+			"tests_with_testdata": {
+				{
+					Call: &bzl.CallExpr{
+						X: &bzl.LiteralExpr{Token: "go_test"},
+					},
+				},
+				{
+					Call: &bzl.CallExpr{
+						X: &bzl.LiteralExpr{Token: "go_test"},
+					},
+				},
+			},
 		},
 	}
 
@@ -286,6 +298,14 @@ func testGenerator(t *testing.T, buildFileName string) {
 				stub.fixtures["cgolib"][0].Call,
 				stub.fixtures["cgolib"][1].Call,
 				stub.fixtures["cgolib"][2].Call,
+			},
+		},
+		{
+			Path: "tests_with_testdata/" + buildFileName,
+			Stmt: []bzl.Expr{
+				loadExpr("go_test"),
+				stub.fixtures["tests_with_testdata"][0].Call,
+				stub.fixtures["tests_with_testdata"][1].Call,
 			},
 		},
 	}

--- a/go/tools/gazelle/rules/generator_test.go
+++ b/go/tools/gazelle/rules/generator_test.go
@@ -51,7 +51,8 @@ func packageFromDir(t *testing.T, dir string) *build.Package {
 }
 
 func TestGenerator(t *testing.T) {
-	g := rules.NewGenerator("example.com/repo", rules.External)
+	repoRoot := filepath.Join(testdata.Dir(), "repo")
+	g := rules.NewGenerator(repoRoot, "example.com/repo", rules.External)
 	for _, spec := range []struct {
 		dir  string
 		want string
@@ -207,6 +208,21 @@ func TestGenerator(t *testing.T) {
 					library = ":go_default_library",
 				)
 			`},
+		{
+			dir: "tests_with_testdata",
+			want: `
+				go_test(
+					name = "go_default_test",
+					srcs = ["internal_test.go"],
+					data = glob(["testdata/**"]),
+				)
+
+				go_test(
+					name = "go_default_xtest",
+					srcs = ["external_test.go"],
+					data = glob(["testdata/**"]),
+				)
+			`},
 	} {
 		pkg := packageFromDir(t, filepath.FromSlash(spec.dir))
 		rules, err := g.Generate(spec.dir, pkg)
@@ -221,7 +237,8 @@ func TestGenerator(t *testing.T) {
 }
 
 func TestGeneratorGoPrefix(t *testing.T) {
-	g := rules.NewGenerator("example.com/repo/lib", rules.External)
+	repoRoot := filepath.Join(testdata.Dir(), "repo")
+	g := rules.NewGenerator(repoRoot, "example.com/repo/lib", rules.External)
 	pkg := packageFromDir(t, filepath.FromSlash("lib"))
 	rules, err := g.Generate("", pkg)
 	if err != nil {

--- a/go/tools/gazelle/testdata/BUILD
+++ b/go/tools/gazelle/testdata/BUILD
@@ -20,5 +20,6 @@ go_library(
         "repo/**/*.hh",
         "repo/**/*.hxx",
         "repo/**/*.hpp",
+        "repo/**/testdata/**",
     ]),
 )

--- a/go/tools/gazelle/testdata/repo/tests_with_testdata/external_test.go
+++ b/go/tools/gazelle/testdata/repo/tests_with_testdata/external_test.go
@@ -1,0 +1,20 @@
+/* Copyright 2017 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests_with_testdata_test
+
+import "testing"
+
+func TestMoreStuff(t *testing.T) {}

--- a/go/tools/gazelle/testdata/repo/tests_with_testdata/internal_test.go
+++ b/go/tools/gazelle/testdata/repo/tests_with_testdata/internal_test.go
@@ -1,0 +1,20 @@
+/* Copyright 2017 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests_with_testdata
+
+import "testing"
+
+func TestStuff(t *testing.T) {}


### PR DESCRIPTION
If a directory named "testdata" is present in a Go package, now adds a
"data" attribute to newly generated rules that globs the contents of
the directory.

    go_test(
        name = "go_default_test",
        ...
        data = glob(["testdata/**"]),
    )

This attribute is included in newly generated internal and external
tests. It is not merged into existing test rules.

Related to #294