### PR TITLE
Allow .h files in srcs

### DIFF
--- a/go/tools/gazelle/rules/generator.go
+++ b/go/tools/gazelle/rules/generator.go
@@ -202,18 +202,19 @@ func (g *generator) generateLib(rel, name string, pkg *build.Package, cgoName st
 		{key: "name", value: name},
 	}
 
+	srcs := append([]string{}, pkg.GoFiles...)
 	if cgoName == "" {
-		srcs := append([]string{}, pkg.GoFiles...)
 		srcs = append(srcs, pkg.SFiles...)
-		attrs = append(attrs, keyvalue{key: "srcs", value: srcs})
 		if len(srcs) == 0 {
 			return nil, nil
 		}
+		srcs = append(srcs, pkg.HFiles...)
+		attrs = append(attrs, keyvalue{key: "srcs", value: srcs})
 	} else {
 		// go_library gets mad when an empty slice is passed in, but handles not
 		// being set at all just fine when "library" is set.
-		if len(pkg.GoFiles) != 0 {
-			attrs = append(attrs, keyvalue{key: "srcs", value: pkg.GoFiles})
+		if len(srcs) > 0 {
+			attrs = append(attrs, keyvalue{key: "srcs", value: srcs})
 		}
 		attrs = append(attrs, keyvalue{key: "library", value: ":" + cgoName})
 	}

--- a/go/tools/gazelle/rules/generator_test.go
+++ b/go/tools/gazelle/rules/generator_test.go
@@ -66,6 +66,7 @@ func TestGenerator(t *testing.T) {
 						"doc.go",
 						"lib.go",
 						"asm.s",
+            "asm.h",
 					],
 					visibility = ["//visibility:public"],
 					deps = ["//lib/internal/deep:go_default_library"],

--- a/go/tools/gazelle/testdata/repo/lib/asm.h
+++ b/go/tools/gazelle/testdata/repo/lib/asm.h
@@ -1,0 +1,1 @@
+// Test ASM header file

--- a/tests/asm_include/BUILD
+++ b/tests/asm_include/BUILD
@@ -1,0 +1,34 @@
+load("//go:def.bzl", "go_library", "go_test")
+
+config_setting(
+    name = "linux_amd64",
+    values = {"cpu": "k8"},
+)
+
+config_setting(
+    name = "darwin_amd64",
+    values = {"cpu": "darwin"},
+)
+
+LIB_AMD64_SRCS = [
+    "foo_amd64.go",
+    "foo_amd64.s",
+    "foo_amd64.h",
+]
+
+LIB_OTHER_SRCS = ["foo_other.go"]
+
+go_library(
+    name = "go_default_library",
+    srcs = select({
+        ":linux_amd64": LIB_AMD64_SRCS,
+        ":darwin_amd64": LIB_AMD64_SRCS,
+        "//conditions:default": LIB_OTHER_SRCS,
+    }),
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["foo_test.go"],
+    library = ":go_default_library",
+)

--- a/tests/asm_include/foo_amd64.go
+++ b/tests/asm_include/foo_amd64.go
@@ -1,0 +1,3 @@
+package foo
+
+func foo() int32

--- a/tests/asm_include/foo_amd64.h
+++ b/tests/asm_include/foo_amd64.h
@@ -1,0 +1,1 @@
+#define FOOVAL 42

--- a/tests/asm_include/foo_amd64.s
+++ b/tests/asm_include/foo_amd64.s
@@ -1,0 +1,5 @@
+#include "foo_amd64.h"
+
+TEXT ·foo(SB),$0-0
+  MOVQ $FOOVAL,RET(FP)
+  RET

--- a/tests/asm_include/foo_other.go
+++ b/tests/asm_include/foo_other.go
@@ -1,0 +1,7 @@
+package foo
+
+// Other architectures are not supported for this test. This function just
+// returns what the assembly function was supposed to return.
+func foo() int32 {
+	return 42
+}

--- a/tests/asm_include/foo_test.go
+++ b/tests/asm_include/foo_test.go
@@ -1,0 +1,10 @@
+package foo
+
+import "testing"
+
+func TestFoo(t *testing.T) {
+	x := foo()
+	if x != 42 {
+		t.Errorf("got %d; want %d", x, 42)
+	}
+}


### PR DESCRIPTION
- .h files are now allowed in srcs for go_library, go_binary, and
  go_test. _emit_go_asm_action will include directories containing
  .h files.
- Gazelle now adds .h files to srcs of go_library if no cgo_library
  is present.

Fixes #303