### PR TITLE
Gazelle finds "gazelle:ignore" before and after top-level statements

### DIFF
--- a/go/tools/gazelle/README.md
+++ b/go/tools/gazelle/README.md
@@ -21,7 +21,7 @@ If you don't even have a WORKSPACE file yet, you also need to set -repo_root
 
 * `# keep` on an entry to a `deps` or `srcs` attribute will instruct gazelle to keep that element
 even if it thinks otherwise
-* `# gazelle:ignore` in a BUILD file will instruct gazelle to leave the file alone.
+* `# gazelle:ignore` at the top level of a BUILD file will instruct gazelle to leave the file alone.
 
 ## Known Shortcomings
 

--- a/go/tools/gazelle/merger/merger_test.go
+++ b/go/tools/gazelle/merger/merger_test.go
@@ -77,7 +77,7 @@ go_test(
 )
 `
 
-const ignore = `# gazelle:ignore
+const ignoreTop = `# gazelle:ignore
 
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
@@ -89,6 +89,14 @@ go_library(
     ],
 )
 `
+
+const ignoreBefore = `# gazelle:ignore
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+`
+
+const ignoreAfterLast = `
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+# gazelle:ignore`
 
 type testCase struct {
 	previous, current, expected string
@@ -106,7 +114,9 @@ func TestMergeWithExisting(t *testing.T) {
 	defer os.Remove(tmp.Name())
 	for _, tc := range []testCase{
 		{oldData, newData, expected, false},
-		{ignore, newData, "", true},
+		{ignoreTop, newData, "", true},
+		{ignoreBefore, newData, "", true},
+		{ignoreAfterLast, newData, "", true},
 	} {
 		if err := ioutil.WriteFile(tmp.Name(), []byte(tc.previous), 0755); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Previously, Gazelle only searched comments after top-level statements
for the "gazelle:ignore" comment. This caught comments at the top of
the file (since the buildifier parser adds an implicit top-level
statement to hold comments), but only if there was a blank line before
the first real statement.

With this change, comments before top-level statements are now
recognized.

Fixes #302