### PR TITLE
Support for build constraints (tags)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ The rules should be considered experimental. They support:
 
 They currently do not support (in order of importance):
 
-* build constraints/tags (`//+build` comments - see <a
-  href="https://golang.org/pkg/go/build/">here</a>)
 * bazel-style auto generating BUILD (where the library name is other than
   go_default_library)
 * C/C++ interoperation except cgo (swig etc.)

--- a/go/private/go_tool_binary.bzl
+++ b/go/private/go_tool_binary.bzl
@@ -1,0 +1,45 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def go_tool_binary(name, srcs):
+  """Builds a Go program using `go build`.
+
+  This is used instead of `go_binary` for tools that are executed inside
+  actions emitted by the go rules. This avoids a bootstrapping problem. This
+  is very limited and only supports sources in the main package with no
+  dependencies outside the standard library.
+
+  Args:
+    name: A unique name for this rule.
+    srcs: list of pure Go source files. No cgo allowed.
+  """
+  native.genrule(
+      name = name,
+      srcs = srcs + ["//go/toolchain:go_src"],
+      outs = [name + "_bin"],
+      cmd = " ".join([
+          "GOROOT=$$(cd $$(dirname $(location //go/toolchain:go_tool))/..; pwd)",
+          "$(location //go/toolchain:go_tool)",
+          "build",
+          "-o",
+          "$@",
+          "$(locations %s)" % " ".join(srcs),
+      ]),
+      executable = True,
+      tools = [
+        "//go/toolchain",
+        "//go/toolchain:go_tool",
+      ],
+      visibility = ["//visibility:public"],
+  )

--- a/go/tools/extract_package/BUILD
+++ b/go/tools/extract_package/BUILD
@@ -1,20 +1,15 @@
-package(default_visibility = ["//visibility:public"])
+load("//go/private:go_tool_binary.bzl", "go_tool_binary")
+load("//go:def.bzl", "go_test")
 
-load("//go:def.bzl", "go_library", "go_binary", "go_test")
-
-go_library(
-    name = "extract_package_lib",
-    srcs = ["extract.go"],
-    visibility = ["//visibility:private"],
-)
-
-go_binary(
+go_tool_binary(
     name = "extract_package",
-    library = ":extract_package_lib",
+    srcs = ["extract.go"],
 )
 
 go_test(
     name = "extract_package_test",
-    srcs = ["extract_test.go"],
-    library = ":extract_package_lib",
+    srcs = [
+        "extract.go",
+        "extract_test.go",
+    ],
 )

--- a/go/tools/filter_tags/BUILD
+++ b/go/tools/filter_tags/BUILD
@@ -1,19 +1,15 @@
-package(default_visibility = ["//visibility:public"])
+load("//go/private:go_tool_binary.bzl", "go_tool_binary")
+load("//go:def.bzl", "go_test")
 
-load("//go:def.bzl", "go_prefix", "go_library", "go_binary", "go_test")
-
-go_library(
-    name = "filter_tags_lib",
+go_tool_binary(
+    name = "filter_tags",
     srcs = ["filter_tags.go"],
 )
 
-go_binary(
-    name = "filter_tags",
-    library = ":filter_tags_lib",
-)
-
 go_test(
-    name = "filter_tags_test",
-    srcs = ["filter_tags_test.go"],
-    library = ":filter_tags_lib",
+    name = "filter_tags_tags",
+    srcs = [
+        "filter_tags.go",
+        "filter_tags_test.go",
+    ],
 )

--- a/go/tools/filter_tags/filter_tags.go
+++ b/go/tools/filter_tags/filter_tags.go
@@ -55,12 +55,14 @@ func main() {
 
 	bctx := build.Default
 	bctx.BuildTags = strings.Split(*tags, ",")
-	bctx.CgoEnabled = *cgo // Worth setting? build.MatchFile ignores this.
+	bctx.CgoEnabled = *cgo
 
-	outputs, err := filterFilenames(bctx, flag.Args())
+	filenames, err := filterFilenames(bctx, flag.Args())
 	if err != nil {
 		log.Fatalf("build_tags error: %v\n", err)
 	}
 
-	fmt.Println(strings.Join(outputs, " "))
+	for _, filename := range filenames {
+		fmt.Println(filename)
+	}
 }

--- a/tests/tags_os/BUILD
+++ b/tests/tags_os/BUILD
@@ -1,0 +1,22 @@
+load("//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        # Filtered by filename suffix
+        "foo_darwin.go",
+        "foo_linux.go",
+        # Filtered by tag
+        "foo_unknown.go",
+        "bar_d.go",
+        "bar_l.go",
+        "bar_unknown.go",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = ["tags_os_test.go"],
+    library = ":go_default_library",
+)

--- a/tests/tags_os/bar_d.go
+++ b/tests/tags_os/bar_d.go
@@ -1,0 +1,5 @@
+// +build darwin
+
+package tags_os
+
+const bar = "bar_darwin"

--- a/tests/tags_os/bar_l.go
+++ b/tests/tags_os/bar_l.go
@@ -1,0 +1,5 @@
+// +build linux
+
+package tags_os
+
+const bar = "bar_linux"

--- a/tests/tags_os/bar_unknown.go
+++ b/tests/tags_os/bar_unknown.go
@@ -1,0 +1,5 @@
+// +build !linux,!darwin
+
+package tags_os
+
+const bar = "bar_unknown"

--- a/tests/tags_os/foo_darwin.go
+++ b/tests/tags_os/foo_darwin.go
@@ -1,0 +1,3 @@
+package tags_os
+
+const foo = "foo_darwin"

--- a/tests/tags_os/foo_linux.go
+++ b/tests/tags_os/foo_linux.go
@@ -1,0 +1,3 @@
+package tags_os
+
+const foo = "foo_linux"

--- a/tests/tags_os/foo_unknown.go
+++ b/tests/tags_os/foo_unknown.go
@@ -1,0 +1,5 @@
+// +build !linux,!darwin
+
+package tags_os
+
+const foo = "foo_unknown"

--- a/tests/tags_os/tags_os_test.go
+++ b/tests/tags_os/tags_os_test.go
@@ -1,0 +1,26 @@
+package tags_os
+
+import (
+	"runtime"
+	"testing"
+)
+
+func check(name, value string, t *testing.T) {
+	var expected string
+	if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
+		expected = name + "_" + runtime.GOOS
+	} else {
+		expected = name + "_unknown"
+	}
+	if value != expected {
+		t.Errorf("got %s; want %s", value, expected)
+	}
+}
+
+func TestFoo(t *testing.T) {
+	check("foo", foo, t)
+}
+
+func TestBar(t *testing.T) {
+	check("bar", bar, t)
+}


### PR DESCRIPTION
- _emit_go_compile_action now executes filter_tags (which is a thin
  wrapper over go/build.Context.MatchFile) before invoking the
  compiler with the filtered source files. The cgo flag is set based
  on whether the package has any cgo code.
- filter_tags now prints one filtered filename per line to avoid
  problems with filenames containing spaces.
- filter_tags and extract_package are built with a new macro,
  go_tool_binary, which invokes "go build" through a genrule.

Credit to @robotoer for the initial implementation in #267.

Fixes #310