### PR TITLE
Remove support for tags from gazelle

### DIFF
--- a/go/private/go_repository.bzl
+++ b/go/private/go_repository.bzl
@@ -41,8 +41,7 @@ def _new_go_repository_impl(ctx):
   _go_repository_impl(ctx)
   gazelle = ctx.path(ctx.attr._gazelle)
 
-  cmds = [gazelle, '--go_prefix', ctx.attr.importpath, '--mode', 'fix',
-          "--build_tags", ",".join(ctx.attr.build_tags)]
+  cmds = [gazelle, '--go_prefix', ctx.attr.importpath, '--mode', 'fix']
   if ctx.attr.build_file_name:
       cmds += ["--build_file_name", ctx.attr.build_file_name]
   if ctx.attr.rules_go_repo_only_for_internal_use:
@@ -62,7 +61,6 @@ _go_repository_attrs = {
     "remote": attr.string(),
     "commit": attr.string(),
     "tag": attr.string(),
-    "build_tags": attr.string_list(),
     "_fetch_repo": attr.label(
         default = Label("@io_bazel_rules_go_repository_tools//:bin/fetch_repo"),
         allow_files = True,

--- a/go/tools/gazelle/gazelle/main.go
+++ b/go/tools/gazelle/gazelle/main.go
@@ -37,7 +37,6 @@ import (
 
 var (
 	buildFileName  = flag.String("build_file_name", "BUILD", "name of output build files to generate.")
-	buildTags      = flag.String("build_tags", "", "comma-separated list of build tags. If not specified, GOOS and GOARCH are used.")
 	external       = flag.String("external", "external", "external: resolve external packages with new_go_repository\n\tvendored: resolve external packages as packages in vendor/")
 	goPrefix       = flag.String("go_prefix", "", "go_prefix of the target workspace")
 	repoRoot       = flag.String("repo_root", "", "path to a directory which corresponds to go_prefix, otherwise gazelle searches for it.")
@@ -72,7 +71,7 @@ func isValidBuildFileName(buildFileName string) bool {
 }
 
 func run(dirs []string, emit func(*bzl.File) error, external rules.ExternalResolver) error {
-	g, err := generator.New(*repoRoot, *goPrefix, *buildFileName, *buildTags, external)
+	g, err := generator.New(*repoRoot, *goPrefix, *buildFileName, external)
 	if err != nil {
 		return err
 	}

--- a/go/tools/gazelle/generator/generator.go
+++ b/go/tools/gazelle/generator/generator.go
@@ -53,29 +53,13 @@ type Generator struct {
 // "goPrefix" is the go_prefix corresponding to the repository root directory.
 // See also https://github.com/bazelbuild/rules_go#go_prefix.
 // "buildFileName" is the name of the BUILD file (BUILD or BUILD.bazel).
-// "buildTags" is a comma-delimited set of build tags to set in the build context.
 // "external" is how external packages should be resolved.
-func New(repoRoot, goPrefix, buildFileName, buildTags string, external rules.ExternalResolver) (*Generator, error) {
-	bctx := build.Default
-	// Ignore source files in $GOROOT and $GOPATH
-	bctx.GOROOT = ""
-	bctx.GOPATH = ""
+func New(repoRoot, goPrefix, buildFileName string, external rules.ExternalResolver) (*Generator, error) {
+	bctx := rules.NewContext()
 
 	repoRoot, err := filepath.Abs(repoRoot)
 	if err != nil {
 		return nil, err
-	}
-
-	// Explicitly do not import all files, use tags.
-	bctx.UseAllFiles = false
-
-	// By default, set build tags based on GOOS and GOARCH.
-	bctx.BuildTags = []string{bctx.GOARCH, bctx.GOOS}
-
-	// If we received custom buildTags, override the defaults with their comma-separated values.
-	// NOTE: GOOS and GOARCH will not be included as build tags automatically in this case.
-	if len(buildTags) != 0 {
-		bctx.BuildTags = strings.Split(buildTags, ",")
 	}
 
 	return &Generator{

--- a/go/tools/gazelle/generator/generator_test.go
+++ b/go/tools/gazelle/generator/generator_test.go
@@ -33,19 +33,6 @@ var (
 	buildTagRepoPath = "cgolib_with_build_tags"
 )
 
-func TestBuildTagOverride(t *testing.T) {
-	repo := filepath.Join(testdata.Dir(), "repo")
-	g, err := New(repo, "example.com/repo", "BUILD", "a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z", rules.External)
-	if err != nil {
-		t.Errorf(`New(%q, "example.com/repo") failed with %v; want success`, repo, err)
-		return
-	}
-
-	if len(g.bctx.BuildTags) != 26 {
-		t.Errorf("Got %d build tags; want 26", len(g.bctx.BuildTags))
-	}
-}
-
 func TestGenerator(t *testing.T) {
 	testGenerator(t, "BUILD")
 }
@@ -199,18 +186,21 @@ func testGenerator(t *testing.T, buildFileName string) {
 					},
 				},
 			},
+			"lib_with_ignored_main": {
+				{
+					Call: &bzl.CallExpr{
+						X: &bzl.LiteralExpr{Token: "go_library"},
+					},
+				},
+			},
 		},
 	}
 
 	repo := filepath.Join(testdata.Dir(), "repo")
-	g, err := New(repo, "example.com/repo", buildFileName, "", rules.External)
+	g, err := New(repo, "example.com/repo", buildFileName, rules.External)
 	if err != nil {
 		t.Errorf(`New(%q, "example.com/repo", %q, "", rules.External) failed with %v; want success`, repo, err, buildFileName)
 		return
-	}
-
-	if len(g.bctx.BuildTags) != 2 {
-		t.Errorf("Got %d build tags; want 2", len(g.bctx.BuildTags))
 	}
 	g.g = stub
 
@@ -286,18 +276,18 @@ func testGenerator(t *testing.T, buildFileName string) {
 			Path: "cgolib_with_build_tags/" + buildFileName,
 			Stmt: []bzl.Expr{
 				loadExpr("go_library", "go_test", "cgo_library"),
-				stub.fixtures["cgolib"][0].Call,
-				stub.fixtures["cgolib"][1].Call,
-				stub.fixtures["cgolib"][2].Call,
+				stub.fixtures["cgolib_with_build_tags"][0].Call,
+				stub.fixtures["cgolib_with_build_tags"][1].Call,
+				stub.fixtures["cgolib_with_build_tags"][2].Call,
 			},
 		},
 		{
 			Path: "allcgolib/" + buildFileName,
 			Stmt: []bzl.Expr{
 				loadExpr("go_library", "go_test", "cgo_library"),
-				stub.fixtures["cgolib"][0].Call,
-				stub.fixtures["cgolib"][1].Call,
-				stub.fixtures["cgolib"][2].Call,
+				stub.fixtures["allcgolib"][0].Call,
+				stub.fixtures["allcgolib"][1].Call,
+				stub.fixtures["allcgolib"][2].Call,
 			},
 		},
 		{
@@ -308,72 +298,19 @@ func testGenerator(t *testing.T, buildFileName string) {
 				stub.fixtures["tests_with_testdata"][1].Call,
 			},
 		},
+		{
+			Path: "lib_with_ignored_main/" + buildFileName,
+			Stmt: []bzl.Expr{
+				loadExpr("go_library"),
+				stub.fixtures["lib_with_ignored_main"][0].Call,
+			},
+		},
 	}
 
 	sort.Sort(fileSlice(want))
 
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("g.Generate(%q) = %s; want: %s", repo, prettyFiles(got), prettyFiles(want))
-	}
-
-	// Tests for build tag filtering.
-
-	// Counter for total files.
-	var otherfiles, linuxfiles int
-
-	// Ensure files were found for each type, as build tags are supported in C and assembly sources.
-	if _, ok := stub.goFiles[buildTagRepoPath]; !ok {
-		t.Errorf("got no Go source files for %q; want more than zero", buildTagRepoPath)
-	}
-	if _, ok := stub.sFiles[buildTagRepoPath]; !ok {
-		t.Errorf("got no assembly source files for %q; want more than zero", buildTagRepoPath)
-	}
-	if _, ok := stub.cFiles[buildTagRepoPath]; !ok {
-		t.Errorf("got no assembly source files for %q; want more than zero", buildTagRepoPath)
-	}
-
-	// Count the Go files in the package.
-	for _, file := range stub.goFiles[buildTagRepoPath] {
-		switch {
-		case strings.HasSuffix(file, "_linux.go"):
-			linuxfiles++
-		case strings.HasSuffix(file, "_other.go"):
-			otherfiles++
-		}
-	}
-
-	// We should have all otherfiles or all linux files depending on GOOS.
-	if otherfiles != 0 && linuxfiles != 0 {
-		t.Errorf("got %d Go source files for \"linux\" and %d for \"!linux\" tag; want one or the other", linuxfiles, otherfiles)
-	}
-
-	// Count the assembly files in the package.
-	for _, file := range stub.sFiles[buildTagRepoPath] {
-		switch {
-		case strings.HasSuffix(file, "_linux.S"):
-			linuxfiles++
-		case strings.HasSuffix(file, "_other.S"):
-			otherfiles++
-		}
-	}
-	// If we fail here, tags worked for Go files but not assembly.
-	if otherfiles != 0 && linuxfiles != 0 {
-		t.Errorf("got %d assembly files for \"linux\" and %d for \"!linux\" tag; want one or the other", linuxfiles, otherfiles)
-	}
-
-	// Count C files.
-	for _, file := range stub.cFiles[buildTagRepoPath] {
-		switch {
-		case strings.HasSuffix(file, "_linux.c"):
-			linuxfiles++
-		case strings.HasSuffix(file, "_other.c"):
-			otherfiles++
-		}
-	}
-
-	// If we fail here, tags worked for assembly and Go files, but not C.
-	if otherfiles != 0 && linuxfiles != 0 {
-		t.Errorf("got %d C files for \"linux\" and %d for \"!linux\" tag; want one or the other", linuxfiles, otherfiles)
 	}
 }
 

--- a/go/tools/gazelle/packages/walk.go
+++ b/go/tools/gazelle/packages/walk.go
@@ -43,12 +43,13 @@ func Walk(bctx build.Context, root string, f WalkFunc) error {
 		}
 
 		pkg, err := bctx.ImportDir(path, build.ImportComment)
-		if err != nil {
-			if _, ok := err.(*build.NoGoError); ok {
-				return nil
-			}
-			return err
+		switch err.(type) {
+		case *build.NoGoError:
+			return nil
+		case *build.MultiplePackageError:
+			return f(pkg)
+		default:
+			return f(pkg)
 		}
-		return f(pkg)
 	})
 }

--- a/go/tools/gazelle/rules/generator.go
+++ b/go/tools/gazelle/rules/generator.go
@@ -103,6 +103,17 @@ func NewGenerator(repoRoot string, goPrefix string, external ExternalResolver) G
 	}
 }
 
+// NewContext creates the Context used by Gazelle.
+// It ignores source files in $GOROOT and $GOPATH and matches all source
+// files with appropriate extensions, regardless of suffix or build tags.
+func NewContext() build.Context {
+	bctx := build.Default
+	bctx.GOROOT = ""
+	bctx.GOPATH = ""
+	bctx.UseAllFiles = true
+	return bctx
+}
+
 type generator struct {
 	repoRoot string
 	goPrefix string

--- a/go/tools/gazelle/rules/generator_test.go
+++ b/go/tools/gazelle/rules/generator_test.go
@@ -43,9 +43,12 @@ func format(rules []*bzl.Rule) string {
 
 func packageFromDir(t *testing.T, dir string) *build.Package {
 	dir = filepath.Join(testdata.Dir(), "repo", dir)
-	pkg, err := build.ImportDir(dir, build.ImportComment)
+	bctx := rules.NewContext()
+	pkg, err := bctx.ImportDir(dir, build.ImportComment)
 	if err != nil {
-		t.Fatalf("build.ImportDir(%q, build.ImportComment) failed with %v; want success", dir, err)
+		if _, ok := err.(*build.MultiplePackageError); !ok {
+			t.Fatalf("build.ImportDir(%q, build.ImportComment) failed with %v; want success", dir, err)
+		}
 	}
 	return pkg
 }
@@ -184,6 +187,48 @@ func TestGenerator(t *testing.T) {
 				)
 			`},
 		{
+			dir: "cgolib_with_build_tags",
+			want: `
+				cgo_library(
+					name = "cgo_default_library",
+					srcs = [
+						"foo.go",
+						"foo_linux.c",
+						"foo_other.c",
+						"foo.h",
+						"asm_linux.S",
+						"asm_other.S",
+					],
+					copts = ["-I/weird/path"],
+					clinkopts = ["-lweird"],
+					visibility = ["//visibility:private"],
+					deps = [
+						"//lib:go_default_library",
+						"//lib/deep:go_default_library",
+					],
+				)
+
+				go_library(
+					name = "go_default_library",
+					srcs = [
+						"pure_linux.go",
+						"pure_other.go",
+					],
+					library = ":cgo_default_library",
+					visibility = ["//visibility:public"],
+					deps = [
+						"//lib:go_default_library",
+						"//lib/deep:go_default_library",
+					],
+				)
+
+				go_test(
+					name = "go_default_test",
+					srcs = ["foo_test.go"],
+					library = ":go_default_library",
+				)
+			`},
+		{
 			dir: "allcgolib",
 			want: `
 				cgo_library(
@@ -222,6 +267,18 @@ func TestGenerator(t *testing.T) {
 					name = "go_default_xtest",
 					srcs = ["external_test.go"],
 					data = glob(["testdata/**"]),
+				)
+			`},
+		{
+			dir: "lib_with_ignored_main",
+			want: `
+				go_library(
+					name = "go_default_library",
+					srcs = [
+						"lib.go",
+						"main.go",
+					],
+					visibility = ["//visibility:public"],
 				)
 			`},
 	} {

--- a/go/tools/gazelle/testdata/repo/lib_with_ignored_main/lib.go
+++ b/go/tools/gazelle/testdata/repo/lib_with_ignored_main/lib.go
@@ -1,0 +1,16 @@
+/* Copyright 2017 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lib_with_ignored_main

--- a/go/tools/gazelle/testdata/repo/lib_with_ignored_main/main.go
+++ b/go/tools/gazelle/testdata/repo/lib_with_ignored_main/main.go
@@ -1,0 +1,18 @@
+/* Copyright 2017 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +build ignore
+
+package main


### PR DESCRIPTION
Since #311, the Bazel rules filter sources with build tags and
filename suffixes automatically.

Gazelle will no longer produce BUILD files which are pre-filtered.
This allows the same BUILD files to be used on multiple platforms.

Fixes #310