### PR TITLE
Improve non-Bazel integration test output

### DIFF
--- a/tests/gc_opts_unsafe/gc_opts_unsafe.bash
+++ b/tests/gc_opts_unsafe/gc_opts_unsafe.bash
@@ -16,13 +16,15 @@ result=0
 function check_build_fails {
   local target=$1
   local message=$2
-  bazel build "$target" 2>&1 | tee output.txt
+  local outfile=$(mktemp)
+  bazel build "$target" 2>&1 | tee "$outfile"
   local target_result=${PIPESTATUS[0]}
   if [ $target_result -eq 0 ]; then
     echo "build of $target succeeded but should have failed" >&2
+    echo "wrote output to $outfile" >&2
     return 1
   fi
-  if ! grep -q "$message" output.txt; then
+  if ! grep -q "$message" "$outfile"; then
     echo "build of $target failed for a different reason" >&2
     return 1
   fi

--- a/tests/run_non_bazel_tests.bash
+++ b/tests/run_non_bazel_tests.bash
@@ -10,21 +10,29 @@
 
 cd $(dirname "$0")
 
+prefix=">>>>>>"
+
 tests=(
   gc_opts_unsafe/gc_opts_unsafe.bash
   test_filter_test/test_filter_test.bash
 )
 
-result=0
+passing_tests=()
+failing_tests=()
+
 for test in "${tests[@]}"; do
-  echo "Running $test" >&2
+  echo "$prefix Running $test" >&2
   $test
   if [ $? -ne 0 ]; then
-    echo "Finished $test: FAIL" >&2
-    result=1
+    echo "$prefix Finished $test: FAIL" >&2
+    failing_tests+=("$test")
   else
-    echo "Finished $test: PASS" >&2
+    echo "$prefix Finished $test: PASS" >&2
+    passing_tests+=("$test")
   fi
 done
 
-exit $result
+echo
+echo "$prefix Executed ${#tests[@]} tests: ${#passing_tests[@]} passed, ${#failing_tests[@]} failed"
+
+[ ${#failing_tests[@]} -eq 0 ]


### PR DESCRIPTION
run_non_bazel_tests.bash now prints how many tests passed and
failed. It also prints a prefix before each message to make the
failing tests easier to find.