### PR TITLE
Allow setting custom Go version in go_repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,12 +194,82 @@ imported with [`go_repository`](#go_repository), will have libraries named
 ### `go_repositories`
 
 ``` bzl
-go_repositories()
+go_repositories(go_version, go_linux, go_darwin)
 ```
 
-Instantiates external dependencies to Go toolchain in a WORKSPACE.
-All the other workspace rules and build rules assume that this rule is
-placed in the WORKSPACE.
+Adds Go-related external dependencies to the WORKSPACE, including the Go
+toolchain and standard library. All the other workspace rules and build rules
+assume that this rule is placed in the WORKSPACE.
+
+<table class="table table-condensed table-bordered table-params">
+  <colgroup>
+    <col class="col-param" />
+    <col class="param-description" />
+  </colgroup>
+  <thead>
+    <tr>
+      <th colspan="2">Attributes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>go_version</code></td>
+      <td>
+        <code>String, optional</code>
+        <p>The Go version to use. If none of the parameters are specified, the
+        most recent stable version of Go will be used.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>go_linux</code></td>
+      <td>
+        <code>String, optional</code>
+        <p>A custom Go repository to use when building on Linux. See below for
+        an example. This cannot be specified at the same time as
+        <code>go_version</code>.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>go_darwin</code></td>
+      <td>
+        <code>String, optional</code>
+        <p>A custom Go repository to use when building on macOS. See below for
+        an example. This cannot be specified at the same time as
+        <code>go_version</code>.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+#### Example:
+
+Suppose you have your own fork of Go, perhaps with some custom patches
+applied. To use that toolchain with these rules, declare the toolchain
+repository with a workspace rule, such as `new_git_repository` or
+`local_repository`, then pass it to `go_repositories` as below. The rules expect
+Go binaries and libraries to be present in the `bin/` and `pkg/` directories, so
+you'll need a different repository for each supported host platform.
+
+``` bzl
+new_git_repository(
+    name = "custom_go_linux",
+    remote = "https://github.com/j_r_hacker/go_linux",
+    tag = "2.5",
+    build_file_content = "",
+)
+
+new_git_repository(
+    name = "custom_go_darwin",
+    remote = "https://github.com/j_r_hacker/go_darwin",
+    tag = "2.5",
+    build_file_content = "",
+)
+
+go_repositories(
+    go_linux = "@custom_go_linux",
+    go_darwin = "@custom_go_darwin",
+)
+```
 
 ### `go_repository`
 

--- a/tests/custom_go_toolchain/BUILD
+++ b/tests/custom_go_toolchain/BUILD
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_prefix", "go_binary")
+
+go_prefix("github.com/bazelbuild/rules_go/tests/custom_go_toolchain")
+
+go_binary(
+    name = "print_version",
+    srcs = ["print_version.go"],
+    tags = ["manual"],
+)

--- a/tests/custom_go_toolchain/custom_go_toolchain.bash
+++ b/tests/custom_go_toolchain/custom_go_toolchain.bash
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script tests custom Go toolchains specified with the go_repositories
+# rule. It downloads an old version of Go, creates a workspace that references
+# it, and verifies that a go_binary can be built in that workspace.
+#
+# This test is expensive because of the large download, so it is not run as
+# part of continuous integration at this time. Run it manually when
+# go_repositories changes.
+
+set -euo pipefail
+
+TEST_DIR=$(cd $(dirname "$0"); pwd)
+RULES_DIR=$(cd "$TEST_DIR/../.."; pwd)
+
+GO_VERSION=1.7.5
+WORKSPACE_DIR=$(mktemp -d)
+GO_ARCHIVE=$(mktemp)
+GO_DIR=$(mktemp -d)
+
+case $(uname) in
+Linux)
+  OS=linux
+  HASH=2e4dd6c44f0693bef4e7b46cc701513d74c3cc44f2419bf519d7868b12931ac3
+  ;;
+Darwin)
+  OS=darwin
+  HASH=2e2a5e0a5c316cf922cf7d59ee5724d49fc35b07a154f6c4196172adfc14b2ca
+  ;;
+*)
+  echo Unknown operating system: $(uname) >&1
+  exit 1
+esac
+URL="https://storage.googleapis.com/golang/go$GO_VERSION.$OS-amd64.tar.gz"
+
+function cleanup {
+  rm -rf "$WORKSPACE_DIR" "$GO_ARCHIVE" "$GO_DIR"
+}
+trap cleanup EXIT
+
+curl "$URL" >"$GO_ARCHIVE"
+ACTUAL_HASH=$(shasum -a 256 "$GO_ARCHIVE" | awk '{print $1}')
+if [ "$ACTUAL_HASH" != "$HASH" ]; then
+  echo "error: downloaded archive does not match SHA-256 sum" >&1
+  echo "  got:  $ACTUAL_HASH" >&1
+  echo "  want: $HASH" >&1
+  exit 1
+fi
+tar -xz --directory="$GO_DIR" --file="$GO_ARCHIVE" --strip-components=1 go
+
+cat >"$WORKSPACE_DIR/WORKSPACE" <<EOF
+new_local_repository(
+    name = "local_go",
+    path = "$GO_DIR",
+    build_file_content = "",
+)
+local_repository(
+    name = "io_bazel_rules_go",
+    path = "$RULES_DIR",
+)
+load("@io_bazel_rules_go//go:def.bzl", "go_repositories")
+go_repositories(go_$OS = "@local_go")
+EOF
+
+cp "$TEST_DIR"/BUILD "$WORKSPACE_DIR"
+cp "$TEST_DIR"/print_version.go "$WORKSPACE_DIR"
+pushd "$WORKSPACE_DIR"
+ACTUAL_VERSION=$(bazel \
+                   run \
+                   --genrule_strategy=standalone \
+                   --spawn_strategy=standalone \
+                   //:print_version)
+popd
+if [ "$ACTUAL_VERSION" != "go$GO_VERSION" ]; then
+  echo "bad version; got $ACTUAL_VERSION, want $GO_VERSION" >&1
+  exit 1
+fi

--- a/tests/custom_go_toolchain/print_version.go
+++ b/tests/custom_go_toolchain/print_version.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func main() {
+	fmt.Println(runtime.Version())
+}

--- a/tests/run_non_bazel_tests.bash
+++ b/tests/run_non_bazel_tests.bash
@@ -17,6 +17,14 @@ tests=(
   test_filter_test/test_filter_test.bash
 )
 
+# Manual tests are not executed as part of CI.
+manual_tests=(
+  custom_go_toolchain/custom_go_toolchain.bash
+)
+if [ "$1" == "manual" ]; then
+  tests+=("${manual_tests[@]}")
+fi
+
 passing_tests=()
 failing_tests=()
 


### PR DESCRIPTION
go_repositories accepts three optional new arguments which allow
developers to use a custom version of Go.

* go_version: Go version string to use. Defaults to "1.8". Only "1.8"
  is supported now, but support will be added for new version in the
  future.
* go_linux, go_darwin: name of a repository containing the Go
  toolchain. This is useful for developers who want to fetch Go from
  an alternate source.

If go_linux or go_darwin is provided, go_version cannot also be
provided.

The omit_go argument is no longer supported.

TODO: manual (non-CI) tests.
TODO: update README.md.

Fixes #223