### PR TITLE
Adding a ignore_go_package_option option to the go_proto_library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,21 +125,21 @@ a command line tool which is part of this repository.
 
 * You can install Gazelle using the command below. This assumes this repository
   is checked out under [GOPATH](https://github.com/golang/go/wiki/GOPATH).
-  
+
 ```
 go install github.com/bazelbuild/rules_go/go/tools/gazelle/gazelle
 ```
 
 * To run Gazelle for the first time, run the command below from your project
   root directory.
-  
+
 ```
 gazelle -go_prefix github.com/joe/project
 ```
 
 * To update your `BUILD` files later, just run `gazelle`.
 * By default, Gazelle assumes external dependencies are present in
-  your `WORKSPACE` file, following a certain naming convention. For example, it 
+  your `WORKSPACE` file, following a certain naming convention. For example, it
   expects the repository for `github.com/jane/utils` to be named
   `@com_github_jane_utils`. If you prefer to use vendoring, run `gazelle` with
   `-external vendored`. See [Vendoring.md](Vendoring.md).
@@ -183,7 +183,7 @@ in the directory `foo/bar/bar`.
 
 In order to avoid this conflict, you can name your library `go_default_library`.
 The full Bazel label for this library would be `//foo/bar:go_default_library`.
-The import path would be `github.com/joe/project/foo/bar`. 
+The import path would be `github.com/joe/project/foo/bar`.
 
 `BUILD` files generated with Gazelle, including those in external projects
 imported with [`go_repository`](#go_repository), will have libraries named
@@ -805,6 +805,16 @@ go_proto_library(name, srcs, deps, has_services)
         <code>integer, optional, defaults to 0</code>
         <p>If 1, will generate with <code>plugins=grpc</code>
         and add the required dependencies.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>ignore_go_package_option</code></td>
+      <td>
+        <code>integer, optional, defaults to 0</code>
+        <p>If 1, will ignore the go_package option in the srcs proto files.
+        Note: this will not work if the go_package options are specified in more
+        than one line.
+        </p>
       </td>
     </tr>
   </tbody>

--- a/proto/go_proto_library.bzl
+++ b/proto/go_proto_library.bzl
@@ -138,9 +138,8 @@ def _go_proto_library_gen_impl(ctx):
     #
     # NOTE: Using sed does not provide a perfect solution, build will break if
     # the go_package option splits multiple lines. Use with caution.
-    cmds += ["/bin/sed '/^ *option  *go_package/d' %s > %s/%s" % (s.path, work_dir,
-                                                                  _drop_external(s.short_path))
-             for s in srcs]
+    cmds += ["/bin/sed '/^ *option  *go_package/d' %s > %s/%s" %
+             (s.path, work_dir, _drop_external(s.short_path)) for s in srcs]
     cmds += ["/bin/cp %s %s/%s" % (s.path, work_dir, _drop_external(s.short_path))
              for s in protos]
   else:

--- a/proto/go_proto_library.bzl
+++ b/proto/go_proto_library.bzl
@@ -131,8 +131,21 @@ def _go_proto_library_gen_impl(ctx):
   dirs = set([s.short_path[:-1-len(s.basename)]
               for s in srcs + protos])
   cmds += ["/bin/mkdir -p %s/%s" % (work_dir, _drop_external(d)) for d in dirs if d]
-  cmds += ["/bin/cp %s %s/%s" % (s.path, work_dir, _drop_external(s.short_path))
-           for s in srcs + protos]
+
+  if ctx.attr.ignore_go_package_option:
+    # Strip the "option go_package" line from the proto file before compiling,
+    # c.f., https://github.com/bazelbuild/rules_go/issues/323
+    #
+    # NOTE: Using sed does not provide a perfect solution, build will break if
+    # the go_package option splits multiple lines. Use with caution.
+    cmds += ["/bin/sed '/^ *option  *go_package/d' %s > %s/%s" % (s.path, work_dir,
+                                                                  _drop_external(s.short_path))
+             for s in srcs]
+    cmds += ["/bin/cp %s %s/%s" % (s.path, work_dir, _drop_external(s.short_path))
+             for s in protos]
+  else:
+    cmds += ["/bin/cp %s %s/%s" % (s.path, work_dir, _drop_external(s.short_path))
+             for s in srcs + protos]
   cmds += ["cd %s" % work_dir,
            "%s/%s --go_out=%s%s:. %s" % (root_prefix, ctx.executable.protoc.path,
                                          use_grpc, m_import_path,
@@ -164,6 +177,7 @@ _go_proto_library_gen = rule(
         ),
         "grpc": attr.int(default = 0),
         "outs": attr.output_list(mandatory = True),
+        "ignore_go_package_option": attr.int(default = 0),
         "protoc": attr.label(
             default = Label("@com_github_google_protobuf//:protoc"),
             executable = True,
@@ -207,6 +221,7 @@ def _well_known_proto_deps(deps, repo):
 def go_proto_library(name, srcs = None, deps = None,
                      has_services = 0,
                      testonly = 0, visibility = None,
+                     ignore_go_package_option = 0,
                      rules_go_repo_only_for_internal_use = "@io_bazel_rules_go",
                      **kwargs):
   """Macro which generates and compiles protobufs for Go.
@@ -222,6 +237,8 @@ def go_proto_library(name, srcs = None, deps = None,
     has_services: indicates the proto has gRPC services and deps
     testonly: mark as testonly
     visibility: visibility to use on underlying go_library
+    ignore_go_package_option: if 1, ignore the "option go_package" statement in
+                              the srcs proto files.
     rules_go_repo_only_for_internal_use: don't use this, only to allow
                                          internal tests to work.
     **kwargs: any other args which are passed through to the underlying go_library
@@ -248,6 +265,7 @@ def go_proto_library(name, srcs = None, deps = None,
       outs = outs,
       testonly = testonly,
       visibility = visibility,
+      ignore_go_package_option = ignore_go_package_option,
       grpc = has_services,
   )
   grpc_deps = []

--- a/tests/proto_ignore_go_package_option/BUILD
+++ b/tests/proto_ignore_go_package_option/BUILD
@@ -1,0 +1,20 @@
+load("//proto:go_proto_library.bzl", "go_proto_library")
+
+go_proto_library(
+    name = "a_proto",
+    srcs = ["a.proto"],
+    deps = [
+        "@com_github_golang_protobuf//ptypes/struct:go_default_library",
+    ],
+    ignore_go_package_option = 1,
+)
+
+go_proto_library(
+    name = "b_proto",
+    srcs = ["b.proto"],
+    deps = [
+        ":a_proto",
+        "@com_github_golang_protobuf//ptypes/any:go_default_library",
+    ],
+    ignore_go_package_option = 1,
+)

--- a/tests/proto_ignore_go_package_option/a.proto
+++ b/tests/proto_ignore_go_package_option/a.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+// This is a fake go_package that would be ignored by specifying
+// ignore_go_package_option = 1.
+option go_package = "foo.com/bar/bla;boo";
+
+// Importing google proto is not affected by ignore_go_package_option.
+import "google/protobuf/struct.proto";
+
+package foo;
+
+message Foo {
+  int a = 1;
+  google.protobuf.Struct s = 2;
+}

--- a/tests/proto_ignore_go_package_option/a.proto
+++ b/tests/proto_ignore_go_package_option/a.proto
@@ -10,6 +10,6 @@ import "google/protobuf/struct.proto";
 package foo;
 
 message Foo {
-  int a = 1;
+  int32 a = 1;
   google.protobuf.Struct s = 2;
 }

--- a/tests/proto_ignore_go_package_option/b.proto
+++ b/tests/proto_ignore_go_package_option/b.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+// This is a fake go_package that would be ignored when specifying
+// ignore_go_package_option.
+option go_package = "foo.com/bar/blabla;blu";
+
+// Mixing imports from google and local repository will work just fine.
+import "google/protobuf/any.proto";
+import "tests/proto_ignore_go_package_option/a.proto";
+
+package bar;
+
+message Bar {
+  foo.Foo foo = 1;
+  google.protobuf.Any a = 2;
+}


### PR DESCRIPTION
Once the option is on, we will first strip the option go_package = ... line from
the .proto file then compile, which avoids the problem where the compiled .pb.go
file is in the directory unexpected by bazel.

This partially resolves https://github.com/bazelbuild/rules_go/issues/323.