### PR TITLE
Fix infinite recursion

### DIFF
--- a/go/tools/gazelle/wspace/finder.go
+++ b/go/tools/gazelle/wspace/finder.go
@@ -33,5 +33,9 @@ func Find(dir string) (string, error) {
 	if !os.IsNotExist(err) {
 		return "", err
 	}
-	return Find(filepath.Dir(dir))
+	parent := filepath.Dir(dir)
+	if dir == parent {
+		return "", os.ErrNotExist
+	}
+	return Find(parent)
 }


### PR DESCRIPTION
On windows, you get something that matches none of the terminating conditions, but filepath.Dir(dir) returns dir unchanged.