### PR TITLE
Filter go_test sources before generating test main file

### DIFF
--- a/go/def.bzl
+++ b/go/def.bzl
@@ -581,19 +581,36 @@ def go_test_impl(ctx):
   lib_result = go_library_impl(ctx)
   main_go = ctx.outputs.main_go
   prefix = _go_prefix(ctx)
-
   go_import = _go_importpath(ctx)
 
-  args = (["--package", go_import, "--output", ctx.outputs.main_go.path] +
-          [i.path for i in lib_result.go_sources])
-
-  inputs = list(lib_result.go_sources) + list(ctx.files.toolchain)
+  cmds = [
+      'UNFILTERED_TEST_FILES=(%s)' %
+          ' '.join(["'%s'" % f.path for f in lib_result.go_sources]),
+      'FILTERED_TEST_FILES=()',
+      'while read -r line; do',
+      '  if [ -n "$line" ]; then',
+      '    FILTERED_TEST_FILES+=("$line")',
+      '  fi',
+      'done < <(\'%s\' -cgo "${UNFILTERED_TEST_FILES[@]}")' %
+          ctx.executable._filter_tags.path,
+      ' '.join([
+          "'%s'" % ctx.executable.test_generator.path,
+          '--package',
+          go_import,
+          '--output',
+          "'%s'" % ctx.outputs.main_go.path,
+          '"${FILTERED_TEST_FILES[@]}"',
+      ]),
+  ]
+  f = _emit_generate_params_action(
+      cmds, ctx, main_go.path + ".GoTestGenTest.params")
+  inputs = (list(lib_result.go_sources) + list(ctx.files.toolchain) +
+            [f, ctx.executable._filter_tags, ctx.executable.test_generator])
   ctx.action(
       inputs = inputs,
-      executable = ctx.executable.test_generator,
       outputs = [main_go],
+      command = f.path,
       mnemonic = "GoTestGenTest",
-      arguments = args,
       env = dict(go_environment_vars(ctx), RUNDIR=ctx.label.package))
 
   _emit_go_compile_action(

--- a/tests/test_build_constraints/BUILD
+++ b/tests/test_build_constraints/BUILD
@@ -1,0 +1,23 @@
+load("//go:def.bzl", "go_library", "go_test")
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        # Filtered by filename suffix
+        "foo_linux_test.go",
+        # Filtered by tag
+        "foo_unknown_test.go",
+        "bar_unknown_test.go",
+    ],
+    library = ":go_default_library",
+)
+
+# Contains more test cases. Checks that build constraints are applied to
+# sources found through the library attribute.
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "baz_linux_test.go",
+        "baz_unknown_test.go",
+    ],
+)

--- a/tests/test_build_constraints/bar_l_test.go
+++ b/tests/test_build_constraints/bar_l_test.go
@@ -1,0 +1,14 @@
+// +build linux
+
+package test_build_constraints
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestBarLinux(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Errorf("got %s; want linux", runtime.GOOS)
+	}
+}

--- a/tests/test_build_constraints/bar_unknown_test.go
+++ b/tests/test_build_constraints/bar_unknown_test.go
@@ -1,0 +1,14 @@
+// +build !linux
+
+package test_build_constraints
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestBarUnknown(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Errorf("got %s; want not linux", runtime.GOOS)
+	}
+}

--- a/tests/test_build_constraints/baz_linux_test.go
+++ b/tests/test_build_constraints/baz_linux_test.go
@@ -1,0 +1,12 @@
+package test_build_constraints
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestBazLinux(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Errorf("got %s; want linux", runtime.GOOS)
+	}
+}

--- a/tests/test_build_constraints/baz_unknown_test.go
+++ b/tests/test_build_constraints/baz_unknown_test.go
@@ -1,0 +1,14 @@
+// +build !linux
+
+package test_build_constraints
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestBazUnknown(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Errorf("got %s; want not linux", runtime.GOOS)
+	}
+}

--- a/tests/test_build_constraints/foo_linux_test.go
+++ b/tests/test_build_constraints/foo_linux_test.go
@@ -1,0 +1,12 @@
+package test_build_constraints
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestFooLinux(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Errorf("got %s; want linux", runtime.GOOS)
+	}
+}

--- a/tests/test_build_constraints/foo_unknown_test.go
+++ b/tests/test_build_constraints/foo_unknown_test.go
@@ -1,0 +1,14 @@
+// +build !linux
+
+package test_build_constraints
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestFooUnknown(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Errorf("got %s; want not linux", runtime.GOOS)
+	}
+}


### PR DESCRIPTION
generate_test_main now receives a list of source files filtered
according to build constraints (build tags and suffixes) using
filter_tags. This prevents generate_test_main from emitting calls to
functions that won't be compiled or linked into the test binary.

Fixes #340.