### PR TITLE
Adds support for Go 1.7.5

### DIFF
--- a/go/private/go_repositories.bzl
+++ b/go/private/go_repositories.bzl
@@ -190,6 +190,10 @@ _go_repository_select = repository_rule(
 )
 
 _GO_VERSIONS_SHA256 = {
+    '1.7.5': {
+        'linux': '2e4dd6c44f0693bef4e7b46cc701513d74c3cc44f2419bf519d7868b12931ac3',
+        'darwin': '2e2a5e0a5c316cf922cf7d59ee5724d49fc35b07a154f6c4196172adfc14b2ca',
+    },
     '1.8': {
         'linux': '53ab94104ee3923e228a2cb2116e5e462ad3ebaeea06ff04463479d7f12d27ca',
         'darwin': '6fdc9f98b76a28655a8770a1fc8197acd8ef746dd4d8a60589ce19604ba2a120',

--- a/tests/run_non_bazel_tests.bash
+++ b/tests/run_non_bazel_tests.bash
@@ -20,6 +20,7 @@ tests=(
 # Manual tests are not executed as part of CI.
 manual_tests=(
   custom_go_toolchain/custom_go_toolchain.bash
+  test_filter_test_1.7.5/test_filter_test_1.7.5.bash
 )
 if [ "$1" == "manual" ]; then
   tests+=("${manual_tests[@]}")

--- a/tests/test_filter_test_1.7.5/BUILD
+++ b/tests/test_filter_test_1.7.5/BUILD
@@ -1,0 +1,10 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_prefix", "go_test")
+
+go_prefix("github.com/bazelbuild/rules_go")
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = ["test_filter_test.go"],
+    tags = ["manual"],
+)

--- a/tests/test_filter_test_1.7.5/test_filter_test.go
+++ b/tests/test_filter_test_1.7.5/test_filter_test.go
@@ -1,0 +1,10 @@
+package test_filter
+
+import "testing"
+
+func TestShouldPass(t *testing.T) {
+}
+
+func TestShouldFail(t *testing.T) {
+	t.Fail()
+}

--- a/tests/test_filter_test_1.7.5/test_filter_test_1.7.5.bash
+++ b/tests/test_filter_test_1.7.5/test_filter_test_1.7.5.bash
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script checks that --test_filter works with go_test when using
+# Go 1.7.5. The generated test driver is different for Go 1.8, due to
+# incompatible upstream changes in the testing package.
+#
+# This is a manual test because it requires downloading Go 1.7.5. This
+# should be run manually when go_repositories or generate_test_main change.
+
+set -euo pipefail
+
+TEST_DIR=$(cd $(dirname "$0"); pwd)
+RULES_DIR=$(cd "$TEST_DIR/../.."; pwd)
+WORKSPACE_DIR=$(mktemp -d)
+TEST_FILES=(
+  BUILD
+  test_filter_test.go
+)
+
+function cleanup {
+  rm -rf "$WORKSPACE_DIR"
+}
+trap cleanup EXIT
+
+cat >"$WORKSPACE_DIR/WORKSPACE" <<EOF
+local_repository(
+    name = "io_bazel_rules_go",
+    path = "$RULES_DIR",
+)
+load("@io_bazel_rules_go//go:def.bzl", "go_repositories")
+go_repositories(go_version = "1.7.5")
+EOF
+
+for file in "${TEST_FILES[@]}"; do
+  cp "$TEST_DIR/$file" "$WORKSPACE_DIR/"
+done
+
+cd "$WORKSPACE_DIR"
+bazel test --test_filter=Pass :go_default_test


### PR DESCRIPTION
This PR fixes issues with not backward compatible unit test generator. This should unblock support for Go1.7.5. See #321