### PR TITLE
Revert "Add gopkg.in to knownImports (#260)"

### DIFF
--- a/go/tools/gazelle/rules/resolve_external.go
+++ b/go/tools/gazelle/rules/resolve_external.go
@@ -73,7 +73,7 @@ func (e externalResolver) resolve(importpath, dir string) (label, error) {
 // knownImports are paths which are not static in the vcs package,
 // to allow load balancing between actual repos,
 // but for our case we only need to break the importpath in a known fashion.
-var knownImports = []string{"golang.org/x/", "google.golang.org/", "cloud.google.com/", "gopkg.in/"}
+var knownImports = []string{"golang.org/x/", "google.golang.org/", "cloud.google.com/"}
 
 // specialCases looks for matches in knownImports to avoid making a network call.
 func specialCases(importpath string) string {


### PR DESCRIPTION
This reverts commit bfa3601d9ab664b448ddb4cc7e48eea511217aaf.

This fails for "http://gopkg.in/natefinch/lumberjack.v2" for example.