### PR TITLE
Harden _fetch_repository_tools_deps against repository renames

### DIFF
--- a/go/private/go_repositories.bzl
+++ b/go/private/go_repositories.bzl
@@ -53,9 +53,12 @@ def _fetch_repository_tools_deps(ctx, goroot, gopath):
     result = ctx.execute(['mkdir', '-p', ctx.path('src/' + dep.importpath)])
     if result.return_code:
       fail('failed to create directory: %s' % result.stderr)
-    ctx.download_and_extract(
-        '%s/archive/%s.zip' % (dep.repo, dep.commit),
-        'src/%s' % dep.importpath, '', 'zip', '%s-%s' % (name, dep.commit))
+    archive = name + '.tar.gz'
+    ctx.download(
+        url = '%s/archive/%s.tar.gz' % (dep.repo, dep.commit),
+        output = archive)
+    ctx.execute([
+        'tar', '-C', 'src/%s' % dep.importpath, '-xf', archive, '--strip', '1'])
 
   result = ctx.execute([
       'env', 'GOROOT=%s' % goroot, 'GOPATH=%s' % gopath, 'PATH=%s/bin' % goroot,


### PR DESCRIPTION
_fetch_repository_tools_deps is used to fetch
github.com/bazelbuild/buildtools (née buildifier) and
golang.org/x/tools into GOPATH so we can bootstrap fetch_repo and
gazelle. Previously, it used repository_ctx.download_and_extract to
download zip files and strip the first directory component.
The first directory component depends on the real name of the
repository, not the name we fetched it as. Bazel fails with an
IOException if the name doesn't match.

With this change, we download an archive with repository_ctx.download,
then use tar to remove the first component of the path, ignoring the
actual name of that component.

Fixes #361 (this is a more robust fix).