### PR TITLE
Revert "Add another workaround instead of the previous commit for Bazel 0.3.2

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,17 +3,12 @@ workspace(name = "io_bazel_rules_go")
 load("//go:def.bzl", "go_repositories", "new_go_repository")
 load("//go/private:go_repositories.bzl", "go_internal_tools_deps")
 
-go_repositories(
-    # DO NOT specify this internal attribute outside of rules_go project itself.
-    rules_go_repo_only_for_internal_use = "@",
-)
+go_repositories()
 
 new_go_repository(
     name = "com_github_golang_glog",
     commit = "23def4e6c14b4da8ac2ed8007337bc5eb5007998",
     importpath = "github.com/golang/glog",
-    # DO NOT specify this internal attribute outside of rules_go project itself.
-    rules_go_repo_only_for_internal_use = "@",
 )
 
 go_internal_tools_deps()
@@ -22,7 +17,4 @@ go_internal_tools_deps()
 
 load("//proto:go_proto_library.bzl", "go_proto_repositories")
 
-go_proto_repositories(
-    # DO NOT specify this internal attribute outside of rules_go project itself.
-    rules_go_repo_only_for_internal_use = "@",
-)
+go_proto_repositories()

--- a/go/private/go_repositories.bzl
+++ b/go/private/go_repositories.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//go/private:go_repository.bzl", "buildifier_repository_only_for_internal_use", "new_go_repository")
+load("//go/private:go_repository.bzl", "go_repository", "new_go_repository")
 
 repository_tool_deps = {
     'buildtools': struct(
@@ -29,9 +29,7 @@ repository_tool_deps = {
 
 def go_internal_tools_deps():
   """only for internal use in rules_go"""
-  # c.f. #135
-  # TODO(yugui) Simply use go_repository when we drop support of Bazel 0.3.2.
-  buildifier_repository_only_for_internal_use(
+  go_repository(
       name = "com_github_bazelbuild_buildifier",
       commit = repository_tool_deps['buildtools'].commit,
       importpath = repository_tool_deps['buildtools'].importpath,
@@ -43,9 +41,6 @@ def go_internal_tools_deps():
       name = "org_golang_x_tools",
       commit = repository_tool_deps['tools'].commit,
       importpath = repository_tool_deps['tools'].importpath,
-      # c.f. #135
-      # TODO(yugui) Remove this attribute when we drop support of Bazel 0.3.2.
-      rules_go_repo_only_for_internal_use = "@",
   )
 
 def _fetch_repository_tools_deps(ctx, goroot, gopath):
@@ -114,7 +109,7 @@ _go_repository_tools = repository_rule(
 )
 
 GO_TOOLCHAIN_BUILD_FILE = """
-load("{rules_go_repo}//go/private:go_root.bzl", "go_root")
+load("@io_bazel_rules_go//go/private:go_root.bzl", "go_root")
 
 package(
   default_visibility = [ "//visibility:public" ])
@@ -169,17 +164,12 @@ def _go_repository_select_impl(ctx):
 
   ctx.file("BUILD", GO_TOOLCHAIN_BUILD_FILE.format(
     goroot = goroot,
-    rules_go_repo = ctx.attr.rules_go_repo_only_for_internal_use,
   ))
 
 
 _go_repository_select = repository_rule(
     _go_repository_select_impl,
     attrs = {
-        "rules_go_repo_only_for_internal_use": attr.string(
-            default = "@io_bazel_rules_go",
-        ),
-
         "go_linux_version": attr.label(
             allow_files = True,
             single_file = True,
@@ -206,11 +196,7 @@ _GO_VERSIONS_SHA256 = {
     },
 }
 
-# c.f. #135
-# TODO(yugui) remove the attribute rules_go_repo_only_for_internal_use when we
-# drop support of Bazel 0.3.2
 def go_repositories(
-    rules_go_repo_only_for_internal_use = "@io_bazel_rules_go",
     go_version = None,
     go_linux = None,
     go_darwin = None):
@@ -250,7 +236,6 @@ def go_repositories(
       name = "io_bazel_rules_go_toolchain",
       go_linux_version = go_linux_version,
       go_darwin_version = go_darwin_version,
-      rules_go_repo_only_for_internal_use = rules_go_repo_only_for_internal_use,
   )
   _go_repository_tools(
       name = "io_bazel_rules_go_repository_tools",

--- a/go/private/go_repository.bzl
+++ b/go/private/go_repository.bzl
@@ -50,9 +50,7 @@ def _new_go_repository_impl(ctx):
           "--build_tags", ",".join(ctx.attr.build_tags)]
   if ctx.attr.build_file_name:
       cmds += ["--build_file_name", ctx.attr.build_file_name]
-  if ctx.attr.rules_go_repo_only_for_internal_use:
-    cmds += ["--go_rules_bzl_only_for_internal_use",
-             "%s//go:def.bzl" % ctx.attr.rules_go_repo_only_for_internal_use]
+
   cmds += [ctx.path('')]
 
   result = ctx.execute(cmds)
@@ -95,25 +93,5 @@ new_go_repository = repository_rule(
             executable = True,
             cfg = "host",
         ),
-        # See also #135.
-        # TODO(yugui) Remove this attribute when we drop support of Bazel 0.3.2.
-        "rules_go_repo_only_for_internal_use": attr.string(),
     },
-)
-
-# See also #135.
-# TODO(yugui) Remove this rule when we drop support of Bazel 0.3.2.
-def _buildifier_repository_impl(ctx):
-  _go_repository_impl(ctx)
-  result = ctx.execute([
-      "find", ctx.path(''), '(', '-name', 'BUILD', '-or', '-name', '*.bzl', ')',
-      '-exec',
-      'sed', '-i', '', '-e', 's!@io_bazel_rules_go//!@//!', '{}',
-      ';'])
-  if result.return_code:
-    fail("Failed to postprocess BUILD files in buildifier: %s" % result.stderr)
-
-buildifier_repository_only_for_internal_use = repository_rule(
-    implementation = _buildifier_repository_impl,
-    attrs = _go_repository_attrs,
 )

--- a/go/tools/gazelle/gazelle/main.go
+++ b/go/tools/gazelle/gazelle/main.go
@@ -44,12 +44,6 @@ var (
 	buildFileNames = []string{"BUILD.bazel", "BUILD"}
 )
 
-func init() {
-	// See also #135.
-	// TODO(yugui): Remove this flag when we drop support of Bazel 0.3.2
-	flag.StringVar(&generator.GoRulesBzl, "go_rules_bzl_only_for_internal_use", "@io_bazel_rules_go//go:def.bzl", "hacky flag to build rules_go repository itself")
-}
-
 var externalResolverFromName = map[string]rules.ExternalResolver{
 	"external": rules.External,
 	"vendored": rules.Vendored,

--- a/go/tools/gazelle/generator/generator.go
+++ b/go/tools/gazelle/generator/generator.go
@@ -29,13 +29,9 @@ import (
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/rules"
 )
 
-var (
-	// GoRulesBzl is the label of the Skylark file which provides Go rules
-	// You usually don't need to overwrite this variable.
-	//
-	// See also #135.
-	// TODO(yugui): Make it a constant when we drop support of Bazel 0.3.2.
-	GoRulesBzl = "@io_bazel_rules_go//go:def.bzl"
+const (
+	// goRulesBzl is the label of the Skylark file which provides Go rules
+	goRulesBzl = "@io_bazel_rules_go//go:def.bzl"
 )
 
 // Generator generates BUILD files for a Go repository.
@@ -184,7 +180,7 @@ func loadExpr(rules ...string) *bzl.CallExpr {
 	sort.Strings(rules)
 
 	list := []bzl.Expr{
-		&bzl.StringExpr{Value: GoRulesBzl},
+		&bzl.StringExpr{Value: goRulesBzl},
 	}
 	for _, r := range rules {
 		list = append(list, &bzl.StringExpr{Value: r})

--- a/proto/go_proto_library.bzl
+++ b/proto/go_proto_library.bzl
@@ -39,7 +39,7 @@ go_proto_library(
 )
 """
 
-load("//go:def.bzl", "go_library", "new_go_repository")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "new_go_repository")
 
 _DEFAULT_LIB = "go_default_library"  # matching go_library
 
@@ -315,16 +315,12 @@ def go_google_protobuf(name = _GO_GOOGLE_PROTOBUF):
       visibility = ["//visibility:public"],
   )
 
-# c.f. #135
-# TODO(yugui) Remove rules_go_repo_only_for_internal_use argument when we drop
-# support of Bazel 0.3.2.
-def go_proto_repositories(shared=1, rules_go_repo_only_for_internal_use=None):
+def go_proto_repositories(shared = 1):
   """Add this to your WORKSPACE to pull in all of the needed dependencies."""
   new_go_repository(
       name = "com_github_golang_protobuf",
       importpath = "github.com/golang/protobuf",
       commit = "8ee79997227bf9b34611aee7946ae64735e6fd93",
-      rules_go_repo_only_for_internal_use = rules_go_repo_only_for_internal_use,
   )
   if shared:
     # if using multiple *_proto_library, allows caller to skip this.
@@ -340,11 +336,9 @@ def go_proto_repositories(shared=1, rules_go_repo_only_for_internal_use=None):
       name = "org_golang_x_net",
       commit = "4971afdc2f162e82d185353533d3cf16188a9f4e",
       importpath = "golang.org/x/net",
-      rules_go_repo_only_for_internal_use = rules_go_repo_only_for_internal_use,
   )
   new_go_repository(
       name = "org_golang_google_grpc",
       tag = "v1.0.4",
       importpath = "google.golang.org/grpc",
-      rules_go_repo_only_for_internal_use = rules_go_repo_only_for_internal_use,
   )

--- a/tests/test_filter_test_1.7.5/test_filter_test_1.7.5.bash
+++ b/tests/test_filter_test_1.7.5/test_filter_test_1.7.5.bash
@@ -50,4 +50,8 @@ for file in "${TEST_FILES[@]}"; do
 done
 
 cd "$WORKSPACE_DIR"
-bazel test --test_filter=Pass :go_default_test
+bazel test \
+  --test_filter=Pass \
+  --genrule_strategy=standalone \
+  --spawn_strategy=standalone \
+  :go_default_test


### PR DESCRIPTION
This reverts commit 6fb0656d40af9de82bcaec78324a251eaf70f338.

Also disabled sandboxing for test_filter_test_1.7.5 (manual test),
which started failing with this change. custom_go_toolchain already
needed sandboxing disabled; not sure why this one didn't before.

Fixes #151
Fixes #344