### PR TITLE
Support build constraints in C sources in cgo_library

### DIFF
--- a/tests/build_constraints/BUILD
+++ b/tests/build_constraints/BUILD
@@ -29,5 +29,16 @@ cgo_library(
         # Check that constraints apply to cgo files.
         "cgo_linux.go",
         "cgo_unknown.go",
+        "cgo_linux.c",
+        "cgo_unknown.c",
+        ":c_srcs_group",
+    ],
+)
+
+filegroup(
+    name = "c_srcs_group",
+    srcs = [
+        "cgo_group_linux.c",
+        "cgo_group_unknown.c",
     ],
 )

--- a/tests/build_constraints/build_constraints_test.go
+++ b/tests/build_constraints/build_constraints_test.go
@@ -40,6 +40,14 @@ func TestAsm(t *testing.T) {
 	}
 }
 
-func TestCgo(t *testing.T) {
-	check(cgo, t)
+func TestCgoGo(t *testing.T) {
+	check(cgoGo, t)
+}
+
+func TestCgoC(t *testing.T) {
+	check(cgoC, t)
+}
+
+func TestCgoCGroup(t *testing.T) {
+	check(cgoCGroup, t)
 }

--- a/tests/build_constraints/cgo_group_linux.c
+++ b/tests/build_constraints/cgo_group_linux.c
@@ -1,0 +1,1 @@
+const char* cgoCGroup = "linux";

--- a/tests/build_constraints/cgo_group_unknown.c
+++ b/tests/build_constraints/cgo_group_unknown.c
@@ -1,0 +1,3 @@
+// +build !linux
+
+const char* cgoCGroup = "unknown";

--- a/tests/build_constraints/cgo_linux.c
+++ b/tests/build_constraints/cgo_linux.c
@@ -1,0 +1,1 @@
+const char* cgoC = "linux";

--- a/tests/build_constraints/cgo_linux.go
+++ b/tests/build_constraints/cgo_linux.go
@@ -1,8 +1,12 @@
 package build_constraints
 
 /*
-const char* cgo = "linux";
+const char* cgoGo = "linux";
+const char* cgoC;
+const char* cgoCGroup;
 */
 import "C"
 
-var cgo = C.GoString(C.cgo)
+var cgoGo = C.GoString(C.cgoGo)
+var cgoC = C.GoString(C.cgoC)
+var cgoCGroup = C.GoString(C.cgoCGroup)

--- a/tests/build_constraints/cgo_unknown.c
+++ b/tests/build_constraints/cgo_unknown.c
@@ -1,0 +1,3 @@
+// +build !linux
+
+const char* cgoC = "unknown";

--- a/tests/build_constraints/cgo_unknown.go
+++ b/tests/build_constraints/cgo_unknown.go
@@ -3,8 +3,12 @@
 package build_constraints
 
 /*
-const char* cgo = "unknown";
+const char* cgoGo = "unknown";
+const char* cgoC;
+const char* cgoCGroup;
 */
 import "C"
 
-var cgo = C.GoString(C.cgo)
+var cgoGo = C.GoString(C.cgoGo)
+var cgoC = C.GoString(C.cgoC)
+var cgoCGroup = C.GoString(C.cgoCGroup)


### PR DESCRIPTION
C and C++ sources are now filtered using build constraints (tags and
suffixes) in cgo_library. This matches behavior in "go build".

Fixes #330