### PR TITLE
In new_go_repository, generate BUILD.bazel files by default

### DIFF
--- a/go/private/go_repository.bzl
+++ b/go/private/go_repository.bzl
@@ -60,7 +60,7 @@ def _new_go_repository_impl(ctx):
 
 
 _go_repository_attrs = {
-    "build_file_name": attr.string(),
+    "build_file_name": attr.string(default="BUILD.bazel"),
     "importpath": attr.string(),
     "remote": attr.string(),
     "vcs": attr.string(default="", values=["", "git", "hg", "svn", "bzr"]),

--- a/tests/new_go_repository_build_name/local/BUILD
+++ b/tests/new_go_repository_build_name/local/BUILD
@@ -1,0 +1,10 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_prefix", "go_test")
+
+go_prefix("local")
+
+go_test(
+    name = "go_default_test",
+    srcs = ["local_test.go"],
+    tags = ["manual"],
+    deps = ["@remote//build:go_default_library"],
+)

--- a/tests/new_go_repository_build_name/local/WORKSPACE.in
+++ b/tests/new_go_repository_build_name/local/WORKSPACE.in
@@ -1,0 +1,14 @@
+local_repository(
+    name = "io_bazel_rules_go",
+    path = "@@RULES_DIR@@",
+)
+load("@io_bazel_rules_go//go:def.bzl", "go_repositories", "new_go_repository")
+go_repositories()
+
+new_go_repository(
+    name = "remote",
+    importpath = "remote",
+    remote = "@@WORKSPACE_DIR@@/remote",
+    vcs = "git",
+    tag = "1.0",
+)

--- a/tests/new_go_repository_build_name/local/local_test.go
+++ b/tests/new_go_repository_build_name/local/local_test.go
@@ -1,0 +1,13 @@
+package local
+
+import (
+	"testing"
+
+	"remote/build"
+)
+
+func TestBuildValue(t *testing.T) {
+	if got, want := build.Foo, 42; got != want {
+		t.Errorf("got %d; want %d", got, want)
+	}
+}

--- a/tests/new_go_repository_build_name/new_go_repository_build_name.bash
+++ b/tests/new_go_repository_build_name/new_go_repository_build_name.bash
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script tests that new_go_repository can be used to build a
+# package named "build" without explicitly specifying
+# "build_file_name". In #144, Gazelle would fail on case insensitive
+# file systems because "build" looks the same as "BUILD". In
+# new_go_repository, Gazelle should name files "BUILD.bazel" by
+# default.
+
+set -euo pipefail
+
+TEST_DIR=$(cd $(dirname "$0"); pwd)
+RULES_DIR=$(cd "$TEST_DIR/../.."; pwd)
+WORKSPACE_DIR=$(mktemp -d)
+
+function cleanup {
+  rm -rf "$WORKSPACE_DIR"
+}
+trap cleanup EXIT
+
+cp -r "$TEST_DIR"/* "$WORKSPACE_DIR"
+
+cd "$WORKSPACE_DIR/remote"
+git init
+git add -A .
+git commit -m 'initial commit'
+git tag 1.0
+
+cd "$WORKSPACE_DIR/local"
+sed \
+  -e "s|@@RULES_DIR@@|$RULES_DIR|" \
+  -e "s|@@WORKSPACE_DIR@@|$WORKSPACE_DIR|" \
+  <WORKSPACE.in >WORKSPACE
+bazel test \
+  --genrule_strategy=standalone \
+  --spawn_strategy=standalone \
+  //:go_default_test

--- a/tests/new_go_repository_build_name/remote/build/build.go
+++ b/tests/new_go_repository_build_name/remote/build/build.go
@@ -1,0 +1,3 @@
+package build
+
+const Foo = 42

--- a/tests/run_non_bazel_tests.bash
+++ b/tests/run_non_bazel_tests.bash
@@ -14,6 +14,7 @@ prefix=">>>>>>"
 
 tests=(
   gc_opts_unsafe/gc_opts_unsafe.bash
+  new_go_repository_build_name/new_go_repository_build_name.bash
   test_filter_test/test_filter_test.bash
 )
 


### PR DESCRIPTION
Generated BUILD files may conflict with other files or directories
named "build" on case insensitive file systems. "BUILD.bazel" is less
likely to conflict, and Bazel supports these files since 0.4.1.

The filename can still be overridden by specifying the build_file_name
attribute. This just changes the default.

Fixes #144