### PR TITLE
Fix path to _cgo_filter_srcs script

### DIFF
--- a/go/def.bzl
+++ b/go/def.bzl
@@ -840,7 +840,10 @@ def _cgo_filter_srcs_impl(ctx):
     ]
     dsts.append(dst)
 
-  script_name = ctx.label.package + "/" + ctx.label.name + ".CGoFilterSrcs.params"
+  if ctx.label.package == "":
+    script_name = ctx.label.name + ".CGoFilterSrcs.params"
+  else:
+    script_name = ctx.label.package + "/" + ctx.label.name + ".CGoFilterSrcs.params"
   f = _emit_generate_params_action(cmds, ctx, script_name)
   ctx.action(
       inputs = [f, ctx.executable._filter_tags] + srcs,

--- a/tests/cgo_library_root_dir/BUILD
+++ b/tests/cgo_library_root_dir/BUILD
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "cgo_library", "go_prefix", "go_test")
+
+go_prefix("github.com/bazelbuild/rules_go/tests/cgo_library_root_dir")
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = ["cgo_test.go"],
+    library = ":cgo_default_library",
+    tags = ["manual"],
+)
+
+cgo_library(
+    name = "cgo_default_library",
+    srcs = [
+        "cgo.go",
+        "foo.c",
+    ],
+    tags = ["manual"],
+)

--- a/tests/cgo_library_root_dir/WORKSPACE.in
+++ b/tests/cgo_library_root_dir/WORKSPACE.in
@@ -1,0 +1,6 @@
+local_repository(
+    name = "io_bazel_rules_go",
+    path = "@@RULES_DIR@@",
+)
+load("@io_bazel_rules_go//go:def.bzl", "go_repositories")
+go_repositories()

--- a/tests/cgo_library_root_dir/cgo.go
+++ b/tests/cgo_library_root_dir/cgo.go
@@ -1,0 +1,8 @@
+package cgo_library_root_dir
+
+/*
+const int foo;
+*/
+import "C"
+
+var Foo = int(C.foo)

--- a/tests/cgo_library_root_dir/cgo_library_root_dir.bash
+++ b/tests/cgo_library_root_dir/cgo_library_root_dir.bash
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script tests that cgo_library targets can be built in the root
+# directory of a repository. This is a regression test for #382.
+
+set -euo pipefail
+
+TEST_DIR=$(cd $(dirname "$0"); pwd)
+RULES_DIR=$(cd "$TEST_DIR/../.."; pwd)
+WORKSPACE_DIR=$(mktemp -d)
+
+function cleanup {
+  rm -rf "$WORKSPACE_DIR"
+}
+trap cleanup EXIT
+
+cp -r "$TEST_DIR"/* "$WORKSPACE_DIR"
+cd "$WORKSPACE_DIR"
+sed -e "s|@@RULES_DIR@@|$RULES_DIR|" <WORKSPACE.in >WORKSPACE
+bazel test \
+  --genrule_strategy=standalone \
+  --spawn_strategy=standalone \
+  //:go_default_test

--- a/tests/cgo_library_root_dir/cgo_test.go
+++ b/tests/cgo_library_root_dir/cgo_test.go
@@ -1,0 +1,9 @@
+package cgo_library_root_dir
+
+import "testing"
+
+func TestFoo(t *testing.T) {
+	if got, want := Foo, 42; got != want {
+		t.Errorf("got %d; want %d", got, want)
+	}
+}

--- a/tests/cgo_library_root_dir/foo.c
+++ b/tests/cgo_library_root_dir/foo.c
@@ -1,0 +1,1 @@
+const int foo = 42;

--- a/tests/run_non_bazel_tests.bash
+++ b/tests/run_non_bazel_tests.bash
@@ -13,6 +13,7 @@ cd $(dirname "$0")
 prefix=">>>>>>"
 
 tests=(
+  cgo_library_root_dir/cgo_library_root_dir.bash
   gc_opts_unsafe/gc_opts_unsafe.bash
   test_filter_test/test_filter_test.bash
 )


### PR DESCRIPTION
The script name for this rule is based on the label package and
name. Previously, if the library was in the root directory of a
repository, the package name would be "", and the script name would
start with a "/", which prevented it from building.

This fix removes the "/" if the package is "".

Fixes #382