### PR TITLE
Consolidate Bazel flags in a single place for tests

### DIFF
--- a/.test-bazelrc
+++ b/.test-bazelrc
@@ -1,0 +1,4 @@
+# This file contains options passed to Bazel when running tests.
+# They are used by Travis CI and by non-Bazel test scripts.
+build --verbose_failures --sandbox_debug --test_output=errors --spawn_strategy=standalone --genrule_strategy=standalone
+test --test_strategy=standalone

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,9 @@ script:
       --batch \
       --host_jvm_args=-Xmx500m \
       --host_jvm_args=-Xms500m \
+      --bazelrc=.test-bazelrc \
       test \
-      --verbose_failures \
-      --sandbox_debug \
-      --test_output=errors \
-      --test_strategy=standalone \
-      --spawn_strategy=standalone \
-      --genrule_strategy=standalone \
+      --experimental_repository_cache="$HOME/.bazel_repository_cache" \
       --local_resources=400,1,1.0 \
       //...
   - tests/run_non_bazel_tests.bash

--- a/tests/cgo_library_root_dir/cgo_library_root_dir.bash
+++ b/tests/cgo_library_root_dir/cgo_library_root_dir.bash
@@ -20,7 +20,8 @@
 set -euo pipefail
 
 TEST_DIR=$(cd $(dirname "$0"); pwd)
-RULES_DIR=$(cd "$TEST_DIR/../.."; pwd)
+source "$TEST_DIR/../non_bazel_tests_common.bash"
+
 WORKSPACE_DIR=$(mktemp -d)
 
 function cleanup {
@@ -31,7 +32,4 @@ trap cleanup EXIT
 cp -r "$TEST_DIR"/* "$WORKSPACE_DIR"
 cd "$WORKSPACE_DIR"
 sed -e "s|@@RULES_DIR@@|$RULES_DIR|" <WORKSPACE.in >WORKSPACE
-bazel test \
-  --genrule_strategy=standalone \
-  --spawn_strategy=standalone \
-  //:go_default_test
+bazel_batch_test //:go_default_test

--- a/tests/custom_go_toolchain/custom_go_toolchain.bash
+++ b/tests/custom_go_toolchain/custom_go_toolchain.bash
@@ -25,7 +25,7 @@
 set -euo pipefail
 
 TEST_DIR=$(cd $(dirname "$0"); pwd)
-RULES_DIR=$(cd "$TEST_DIR/../.."; pwd)
+source "$TEST_DIR/../non_bazel_tests_common.bash"
 
 GO_VERSION=1.7.5
 WORKSPACE_DIR=$(mktemp -d)
@@ -79,11 +79,7 @@ EOF
 cp "$TEST_DIR"/BUILD "$WORKSPACE_DIR"
 cp "$TEST_DIR"/print_version.go "$WORKSPACE_DIR"
 pushd "$WORKSPACE_DIR"
-ACTUAL_VERSION=$(bazel \
-                   run \
-                   --genrule_strategy=standalone \
-                   --spawn_strategy=standalone \
-                   //:print_version)
+ACTUAL_VERSION=$(bazel_batch_run //:print_version)
 popd
 if [ "$ACTUAL_VERSION" != "go$GO_VERSION" ]; then
   echo "bad version; got $ACTUAL_VERSION, want $GO_VERSION" >&1

--- a/tests/gc_opts_unsafe/gc_opts_unsafe.bash
+++ b/tests/gc_opts_unsafe/gc_opts_unsafe.bash
@@ -10,6 +10,7 @@
 # error message.
 
 cd $(dirname "$0")
+source ../non_bazel_tests_common.bash
 
 result=0
 
@@ -17,7 +18,7 @@ function check_build_fails {
   local target=$1
   local message=$2
   local outfile=$(mktemp)
-  bazel build "$target" 2>&1 | tee "$outfile"
+  bazel_build "$target" 2>&1 | tee "$outfile"
   local target_result=${PIPESTATUS[0]}
   if [ $target_result -eq 0 ]; then
     echo "build of $target succeeded but should have failed" >&2

--- a/tests/new_go_repository_build_name/new_go_repository_build_name.bash
+++ b/tests/new_go_repository_build_name/new_go_repository_build_name.bash
@@ -24,7 +24,8 @@
 set -euo pipefail
 
 TEST_DIR=$(cd $(dirname "$0"); pwd)
-RULES_DIR=$(cd "$TEST_DIR/../.."; pwd)
+source "$TEST_DIR/../non_bazel_tests_common.bash"
+
 WORKSPACE_DIR=$(mktemp -d)
 
 function cleanup {
@@ -45,7 +46,4 @@ sed \
   -e "s|@@RULES_DIR@@|$RULES_DIR|" \
   -e "s|@@WORKSPACE_DIR@@|$WORKSPACE_DIR|" \
   <WORKSPACE.in >WORKSPACE
-bazel test \
-  --genrule_strategy=standalone \
-  --spawn_strategy=standalone \
-  //:go_default_test
+bazel_batch_test //:go_default_test

--- a/tests/non_bazel_tests_common.bash
+++ b/tests/non_bazel_tests_common.bash
@@ -1,0 +1,38 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export RULES_DIR=$(cd $(dirname "${BASH_SOURCE[0]}")/..; pwd)
+export BAZELRC=$RULES_DIR/.test-bazelrc
+export BAZEL_BUILD_OPTS="--experimental_repository_cache=$HOME/.bazel_repository_cache"
+
+function bazel_build {
+  bazel --bazelrc="$BAZELRC" build $BAZEL_BUILD_OPTS "$@"
+}
+function bazel_batch_build {
+  bazel --bazelrc="$BAZELRC" --batch build $BAZEL_BUILD_OPTS "$@"
+}
+function bazel_test {
+  bazel --bazelrc="$BAZELRC" test $BAZEL_BUILD_OPTS "$@"
+}
+function bazel_batch_test {
+  bazel --bazelrc="$BAZELRC" --batch test $BAZEL_BUILD_OPTS "$@"
+}
+function bazel_run {
+  bazel --bazelrc="$BAZELRC" run $BAZEL_BUILD_OPTS "$@"
+}
+function bazel_batch_run {
+  bazel --bazelrc="$BAZELRC" --batch run $BAZEL_BUILD_OPTS "$@"
+}
+export -f bazel_build bazel_test bazel_run
+export -f bazel_batch_build bazel_batch_test bazel_batch_run

--- a/tests/test_filter_test/test_filter_test.bash
+++ b/tests/test_filter_test/test_filter_test.bash
@@ -2,4 +2,6 @@
 
 # Check that --test_filter can be used to avoid a failing test case.
 cd $(dirname "$0")
-exec bazel test --test_filter=Pass :go_default_test
+source ../non_bazel_tests_common.bash
+
+bazel_test --test_filter=Pass :go_default_test

--- a/tests/test_filter_test_1.7.5/test_filter_test_1.7.5.bash
+++ b/tests/test_filter_test_1.7.5/test_filter_test_1.7.5.bash
@@ -24,7 +24,7 @@
 set -euo pipefail
 
 TEST_DIR=$(cd $(dirname "$0"); pwd)
-RULES_DIR=$(cd "$TEST_DIR/../.."; pwd)
+source "$TEST_DIR/../non_bazel_tests_common.bash"
 WORKSPACE_DIR=$(mktemp -d)
 TEST_FILES=(
   BUILD
@@ -50,8 +50,4 @@ for file in "${TEST_FILES[@]}"; do
 done
 
 cd "$WORKSPACE_DIR"
-bazel test \
-  --test_filter=Pass \
-  --genrule_strategy=standalone \
-  --spawn_strategy=standalone \
-  :go_default_test
+bazel_batch_test --test_filter=Pass //:go_default_test


### PR DESCRIPTION
* Test flags are now stored in .test-bazelrc. This is referenced by
  .travis.yml and by all non-Bazel test scripts.
* Common functionality for non-Bazel test scripts is now in
  non_bazel_tests_common.bash. This includes Bash functions that help
  run Bazel with appropriate options. All test scripts source this.
* Scripts that create new workspaces now run in batch mode. This
  prevents Bazel servers from hanging around in memory.