### PR TITLE
go_binary and go_test no longer provide a library to other rules

### DIFF
--- a/go/def.bzl
+++ b/go/def.bzl
@@ -604,7 +604,7 @@ def go_binary_impl(ctx):
     lib=lib_out, executable=executable,
     gc_linkopts=_gc_linkopts(ctx))
 
-  return struct(files = set([executable]) + lib_result.files,
+  return struct(files = set([executable]),
                 runfiles = lib_result.runfiles,
                 cgo_object = lib_result.cgo_object)
 
@@ -672,7 +672,10 @@ def go_test_impl(ctx):
   # without code changes.
   runfiles = ctx.runfiles(files = [ctx.outputs.executable])
   runfiles = runfiles.merge(lib_result.runfiles)
-  return struct(runfiles=runfiles)
+  return struct(
+      files = set([ctx.outputs.executable]),
+      runfiles = runfiles,
+  )
 
 go_env_attrs = {
     "toolchain": attr.label(

--- a/go/private/single_output_test.bzl
+++ b/go/private/single_output_test.bzl
@@ -1,0 +1,37 @@
+# Copyright 2017 The Bazel Go Rules Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def _impl(ctx):
+  ctx.file_action(
+      output = ctx.outputs.executable,
+      content = "",
+      executable = True,
+  )
+
+single_output_test = rule(
+    implementation = _impl,
+    attrs = {
+        "dep": attr.label(allow_single_file = True),
+    },
+    test = True,
+)
+"""Checks that a dependency produces a single output file.
+
+This test works by setting `allow_single_file = True` on the `dep` attribute.
+If `dep` provides zero or multiple files in its `files` provider, Bazel will
+fail to build this rule during analysis. The actual test does nothing.]
+
+Args:
+  dep: a label for the rule to check.
+"""

--- a/tests/binary_test_outputs/BUILD
+++ b/tests/binary_test_outputs/BUILD
@@ -1,0 +1,27 @@
+# This test checks that go_binary and go_test produce a single output file.
+# See documentation in single_output_test.bzl.
+
+load("//go:def.bzl", "go_binary", "go_test")
+load("//go/private:single_output_test.bzl", "single_output_test")
+
+single_output_test(
+    name = "binary_single_output_test",
+    dep = ":bin",
+)
+
+go_binary(
+    name = "bin",
+    srcs = ["bin.go"],
+    tags = ["manual"],
+)
+
+single_output_test(
+    name = "test_single_output_test",
+    dep = ":test",
+)
+
+go_test(
+    name = "test",
+    srcs = ["test.go"],
+    tags = ["manual"],
+)

--- a/tests/binary_test_outputs/bin.go
+++ b/tests/binary_test_outputs/bin.go
@@ -1,0 +1,3 @@
+package main
+
+func Main() {}

--- a/tests/binary_test_outputs/test.go
+++ b/tests/binary_test_outputs/test.go
@@ -1,0 +1,1 @@
+package binary_test_outputs


### PR DESCRIPTION
Previously, go_binary and go_test provided both an executable and the
library built from srcs as outputs to other rules. This was
inconsistent with other binary rules (cc_binary, etc.) and confusing
for rules that expected a single output. With this change, only the
executable file is exposed through the files provider.

Fixes #379