### PR TITLE
Gazelle no longer applies build constraints by default

### DIFF
--- a/go/tools/gazelle/gazelle/main.go
+++ b/go/tools/gazelle/gazelle/main.go
@@ -36,7 +36,7 @@ import (
 
 var (
 	buildFileName  = flag.String("build_file_name", "BUILD", "name of output build files to generate.")
-	buildTags      = flag.String("build_tags", "", "comma-separated list of build tags. If not specified, GOOS and GOARCH are used.")
+	buildTags      = flag.String("build_tags", "", "comma-separated list of build tags. If not specified, Gazelle will not\n\tfilter sources with build constraints.")
 	external       = flag.String("external", "external", "external: resolve external packages with new_go_repository\n\tvendored: resolve external packages as packages in vendor/")
 	goPrefix       = flag.String("go_prefix", "", "go_prefix of the target workspace")
 	repoRoot       = flag.String("repo_root", "", "path to a directory which corresponds to go_prefix, otherwise gazelle searches for it.")

--- a/go/tools/gazelle/generator/generator.go
+++ b/go/tools/gazelle/generator/generator.go
@@ -62,15 +62,13 @@ func New(repoRoot, goPrefix, buildFileName, buildTags string, external rules.Ext
 		return nil, err
 	}
 
-	// Explicitly do not import all files, use tags.
-	bctx.UseAllFiles = false
-
-	// By default, set build tags based on GOOS and GOARCH.
-	bctx.BuildTags = []string{bctx.GOARCH, bctx.GOOS}
-
-	// If we received custom buildTags, override the defaults with their comma-separated values.
-	// NOTE: GOOS and GOARCH will not be included as build tags automatically in this case.
-	if len(buildTags) != 0 {
+	// If build tags are not specified, do not apply build constraints.
+	// The rules filter files at compile time, so it's not usually necessary
+	// to filter when generating BUILD files, too.
+	if buildTags == "" {
+		bctx.UseAllFiles = true
+	} else {
+		bctx.UseAllFiles = false
 		bctx.BuildTags = strings.Split(buildTags, ",")
 	}
 


### PR DESCRIPTION
The Go rules now apply build constraints to files in srcs of
go_library, cgo_library, go_test, and go_binary, so it's not usually
necessary to perform this filtering in Gazelle as well. Gazelle will
not apply build constraints (GOOS and GOARCH) by default anymore.
Generated BUILD files will be the same for all platforms.

Build tags can still be specified on the command flag, with -build_tags.
This can still be done with new_go_repository.

Fixes #339