### PR TITLE
Add trimpath to compile action

### DIFF
--- a/go/def.bzl
+++ b/go/def.bzl
@@ -300,6 +300,7 @@ def _emit_go_compile_action(ctx, sources, deps, out_lib,
       "-o", out_lib.path, "-pack",
       "-I", ".",
       "-I", out_dir,
+      "-trimpath", "$(pwd)",
   ] + gc_goopts + ['"${FILTERED_GO_FILES[@]}"']
 
   # Pack extra objects into an archive, if provided.


### PR DESCRIPTION
This removes the excessive bazel paths from the stack traces.
It does mean that stack traces no longer have an absolute path in them, but I suspect that any tooling trying to use that from a bazel build is already in trouble as it used to get a path to a temporary softlink not the real source anyway.