### PR TITLE
Fix Bazel install script in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,7 @@ before_install:
       OS=linux
     fi
     if [[ "${V}" == "HEAD" ]]; then
-      CI_BASE="http://ci.bazel.io/job/Bazel/JAVA_VERSION=1.8,PLATFORM_NAME=${OS}-x86_64/lastSuccessfulBuild/artifact/output/ci"
-      CI_ARTIFACT="`wget -qO- ${CI_BASE} | grep -o 'bazel-[^\"]*-installer.sh' | uniq`"
-      URL="${CI_BASE}/${CI_ARTIFACT}"
+      URL="http://ci.bazel.io/job/Bazel/JAVA_VERSION=1.8,PLATFORM_NAME=${OS}-x86_64/lastSuccessfulBuild/artifact/output/ci/bazel--installer.sh"
     else
       URL="https://github.com/bazelbuild/bazel/releases/download/${V}/bazel-${V}-installer-${OS}-x86_64.sh"
     fi


### PR DESCRIPTION
Bazel added an additional build artifact to Jenkins builds:
bazel--without-jdk-installer.sh. This confused our installer script,
which was grepping the artifact name out of the build page. Now there
are two matching artifacts instead of one.

With this change we always fetch bazel--installer.sh for builds with
Bazel HEAD.