### PR TITLE
Fix Travis CI flakiness for Bazel HEAD builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,11 @@ before_install:
       OS=linux
     fi
     if [[ "${V}" == "HEAD" ]]; then
-      URL="http://ci.bazel.io/job/Bazel/JAVA_VERSION=1.8,PLATFORM_NAME=${OS}-x86_64/lastSuccessfulBuild/artifact/output/ci/bazel--installer.sh"
+      # Determine artifact name for URL. This is normally, bazel--installer.sh,
+      # but it may be, for example, bazel-0.5rc2-installer.sh before a release.
+      CI_BASE="http://ci.bazel.io/job/Bazel/JAVA_VERSION=1.8,PLATFORM_NAME=${OS}-x86_64/lastSuccessfulBuild/artifact/output/ci"
+      CI_ARTIFACT=$(wget -qO- "${CI_BASE}" | grep -o 'bazel-[^\"-]*-installer.sh' | head -n 1)
+      URL="${CI_BASE}/${CI_ARTIFACT}"
     else
       URL="https://github.com/bazelbuild/bazel/releases/download/${V}/bazel-${V}-installer-${OS}-x86_64.sh"
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,19 @@ before_install:
       OS=linux
     fi
     if [[ "${V}" == "HEAD" ]]; then
-      # Determine artifact name for URL. This is normally, bazel--installer.sh,
+      # Determine last successful build number. This may change while we are
+      # downloading, so it's important to determine ahead of time, in case
+      # we need to resume the download.
+      CI_BASE="http://ci.bazel.io/job/Bazel/JAVA_VERSION=1.8,PLATFORM_NAME=${OS}-x86_64/"
+      CI_INDEX_URL="${CI_BASE}/lastSuccessfulBuild/"
+      wget -q -O build-index.html "${CI_INDEX_URL}"
+      CI_BUILD=$(grep '<title>' build-index.html | sed -e 's/^.*#\([0-9]*\).*$/\1/')
+
+      # Determine the artifact name. This is normally, bazel--installer.sh,
       # but it may be, for example, bazel-0.5rc2-installer.sh before a release.
-      CI_BASE="http://ci.bazel.io/job/Bazel/JAVA_VERSION=1.8,PLATFORM_NAME=${OS}-x86_64/lastSuccessfulBuild/artifact/output/ci"
-      CI_ARTIFACT=$(wget -qO- "${CI_BASE}" | grep -o 'bazel-[^\"-]*-installer.sh' | head -n 1)
-      URL="${CI_BASE}/${CI_ARTIFACT}"
+      CI_ARTIFACT=$(grep -o 'bazel-[^\"-]*-installer.sh' build-index.html | head -n 1)
+      URL="${CI_BASE}/${CI_BUILD}/artifact/output/ci/${CI_ARTIFACT}"
+      rm build-index.html
     else
       URL="https://github.com/bazelbuild/bazel/releases/download/${V}/bazel-${V}-installer-${OS}-x86_64.sh"
     fi


### PR DESCRIPTION
Previously, we always fetched bazel--installer.sh. It turns out there
can be a prerelease tag between the dashes, e.g.,
bazel-0.5rc2-installer.sh. We'll handle this again with this change.

This will still filter out non-JDK installers (see #426).