### PR TITLE
Switch library search path to a depset

### DIFF
--- a/go/def.bzl
+++ b/go/def.bzl
@@ -299,7 +299,7 @@ def go_library_impl(ctx):
   search_path = out_lib.path[:-len(lib_name)]
   gc_goopts = _gc_goopts(ctx)
   transitive_go_libraries = depset([out_lib])
-  transitive_go_library_paths = [search_path]
+  transitive_go_library_paths = depset([search_path])
   for dep in deps:
     transitive_go_libraries += dep.transitive_go_libraries
     transitive_cgo_deps += dep.transitive_cgo_deps


### PR DESCRIPTION
This removes duplicate entries from the list passed to the compile step