### PR TITLE
Kill the compile script

### DIFF
--- a/go/def.bzl
+++ b/go/def.bzl
@@ -170,13 +170,11 @@ def _go_importpath(ctx):
     path = path[1:]
   return path
 
-def _emit_go_compile_action(ctx, step, sources, deps, libpaths, out_object, gc_goopts):
+def _emit_go_compile_action(ctx, sources, deps, libpaths, out_object, gc_goopts):
   """Construct the command line for compiling Go code.
-  Constructs a symlink tree to accommodate for workspace name.
 
   Args:
     ctx: The skylark Context.
-    step: used to generate unique names for this step of a rule.
     sources: an iterable of source code artifacts (or CTs? or labels?)
     deps: an iterable of dependencies. Each dependency d should have an
       artifact in d.transitive_go_libraries representing all imported libraries.
@@ -184,62 +182,29 @@ def _emit_go_compile_action(ctx, step, sources, deps, libpaths, out_object, gc_g
     out_object: the object file that should be produced
     gc_goopts: additional flags to pass to the compiler.
   """
-  inputs = depset(sources)
-  prefix = _go_prefix(ctx)
-
-  cmds = []
-
-  # Filter source files using build tags.
-  cleaned_go_source_paths = [
-      i.path
-      for i in sources
-      if not i.basename.startswith("_cgo")]
-  cleaned_cgo_source_paths = [
-      i.path
-      for i in sources
-      if i.basename.startswith("_cgo")]
-  cmds += [
-      'UNFILTERED_GO_FILES=(%s)' % 
-          ' '.join(["'%s'" % f for f in cleaned_go_source_paths]),
-      'FILTERED_GO_FILES=(%s)' %
-          ' '.join(["'%s'" % f for f in cleaned_cgo_source_paths]),
-      'while read -r line; do',
-      '  if [ -n "$line" ]; then',
-      '    FILTERED_GO_FILES+=("$line")',
-      '  fi',
-      'done < <(\'%s\' -cgo "${UNFILTERED_GO_FILES[@]}")' % ctx.executable._filter_tags.path,
-      'if [ ${#FILTERED_GO_FILES[@]} -eq 0 ]; then',
-      '  echo no buildable Go source files in %s >&1' % str(ctx.label),
-      '  exit 1',
-      'fi',
-  ]
-
+  go_sources = ["" + i.path for i in sources if not i.basename.startswith("_cgo")]
+  cgo_sources = [i.path for i in sources if i.basename.startswith("_cgo")]
   # Compile filtered files.
   args = [
+      "-run", "-cgo",
       ctx.file.go_tool.path,
       "tool", "compile",
       "-o", out_object.path,
-      "-trimpath", "$(pwd)",
-      "-I", ".",
+      "-trimpath", "≡.",
+      "-I", "≡.",
   ]
+  inputs = depset(sources + ctx.files.toolchain)
   for dep in deps:
     inputs += dep.transitive_go_libraries
   for path in libpaths:
     args += ["-I", path]
-  args += gc_goopts + ['"${FILTERED_GO_FILES[@]}"']
-
-  # Pack extra objects into an archive, if provided.
-  # Set -p to the import path of the library, ie.
-  # (ctx.label.package + "/" ctx.label.name) for now.
-  cmds += [' '.join(args)]
-
-  f = _emit_generate_params_action(cmds, ctx, ctx.label.name + "." + step + ".GoCompileFile.params")
-  inputs += [f, ctx.executable._filter_tags] + ctx.files.toolchain
+  args += gc_goopts + go_sources + cgo_sources
   ctx.action(
       inputs = list(inputs),
       outputs = [out_object],
       mnemonic = "GoCompile",
-      command = f.path,
+      executable = ctx.executable._filter_tags,
+      arguments = args,
       env = go_environment_vars(ctx),
   )
 
@@ -313,7 +278,6 @@ def go_library_impl(ctx):
     transitive_go_library_paths += dep.transitive_go_library_paths
 
   _emit_go_compile_action(ctx,
-      step = "lib",
       sources = go_srcs,
       deps = deps,
       libpaths = transitive_go_library_paths, 
@@ -546,7 +510,6 @@ def go_test_impl(ctx):
 
   _emit_go_compile_action(
     ctx,
-    step="test",
     sources=depset([main_go]),
     deps=ctx.attr.deps + [lib_result],
     libpaths=lib_result.transitive_go_library_paths,

--- a/go/tools/filter_exec/BUILD
+++ b/go/tools/filter_exec/BUILD
@@ -1,0 +1,6 @@
+load("//go/private:go_tool_binary.bzl", "go_tool_binary")
+
+go_tool_binary(
+    name = "filter_exec",
+    srcs = ["filter_exec.go"],
+)

--- a/go/tools/filter_exec/filter_exec.go
+++ b/go/tools/filter_exec/filter_exec.go
@@ -1,0 +1,111 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/build"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	cgo  = flag.Bool("cgo", false, "Sets whether cgo-using files are allowed to pass the filter.")
+	tags = flag.String("tags", "", "Only pass through files that match these tags.")
+
+	absMarker    = "-abs-"
+	filterMarker = "-filter-"
+	escapeMarker = "-escape-"
+)
+
+// runCommand goes through it's arguments filtering out source code files that do not match
+// the supplied build context, and expanding the current working directory where needed.
+// It then invokes the executable with the remaining result.
+func runCommand(bctx build.Context, executable string, input []string) error {
+	var err error
+	args := []string{}
+	unfiltered := 0
+	filtered := 0
+	for _, in := range input {
+		if strings.HasPrefix(in, escapeMarker) {
+			// do no processing except to strip the escaping
+			args = append(args, in[len(escapeMarker):])
+			continue
+		}
+		abs := false
+		filter := false
+		if strings.HasPrefix(in, absMarker) {
+			in = in[len(absMarker):]
+			abs = true
+		}
+		if strings.HasPrefix(in, filterMarker) {
+			in = in[len(filterMarker):]
+			filter = true
+		}
+		if abs {
+			in, err = filepath.Abs(in)
+			if err != nil {
+				return err
+			}
+		}
+		if filter {
+			dir, base := filepath.Split(in)
+			matches, err := bctx.MatchFile(dir, base)
+			if err != nil {
+				//match test failure, return it
+				return err
+			}
+			if !matches {
+				// file should be filtered
+				filtered++
+				continue
+			}
+			unfiltered++
+		}
+		// entry has not been filtered
+		args = append(args, in)
+	}
+	// args should now be filtered
+	// if all possible filter candidates were removed, then don't run the command
+	if filtered > 0 && unfiltered == 0 {
+		return fmt.Errorf("All candidates %d were filtered", filtered)
+	}
+	// if we get here, we want to run the command itself
+	cmd := exec.Command(executable, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func main() {
+	flag.Parse()
+
+	bctx := build.Default
+	bctx.BuildTags = strings.Split(*tags, ",")
+	bctx.CgoEnabled = *cgo
+
+	args := flag.Args()
+	if len(args) <= 0 {
+		log.Fatal("filter_exec needs a command to run")
+	}
+	if err := runCommand(bctx, args[0], args[1:]); err != nil {
+		log.Fatalf("filter_exec error: %v\n", err)
+	}
+}

--- a/go/tools/filter_tags/filter_tags.go
+++ b/go/tools/filter_tags/filter_tags.go
@@ -21,6 +21,7 @@ import (
 	"go/build"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -29,6 +30,10 @@ var (
 	cgo   = flag.Bool("cgo", false, "Sets whether cgo-using files are allowed to pass the filter.")
 	quiet = flag.Bool("quiet", false, "Don't print filenames. Return code will be 0 if any files pass the filter.")
 	tags  = flag.String("tags", "", "Only pass through files that match these tags.")
+	run   = flag.Bool("run", false, "Run mode, filter a command line and then run it.")
+
+	absMarker    = "≡"
+	filterMarker = ""
 )
 
 // Returns an array of strings containing only the filenames that should build
@@ -55,6 +60,59 @@ func filterFilenames(bctx build.Context, inputs []string) ([]string, error) {
 	return outputs, nil
 }
 
+// Returns an array of strings containing only the filenames that should build
+// according to the Context given.
+func runCommand(bctx build.Context, inputs []string) error {
+	if len(inputs) <= 0 {
+		return fmt.Errorf("filter_tags in run mode but with no command to run")
+	}
+	executable := inputs[0]
+	args := []string{}
+	unfiltered := 0
+	filtered := 0
+	for _, in := range inputs[1:] {
+		if strings.HasPrefix(in, absMarker) {
+			in, _ = filepath.Abs(in[len(absMarker):])
+		}
+		if !strings.HasPrefix(in, filterMarker) {
+			// not a filter candidate
+			args = append(args, in)
+			continue
+		}
+		filename := in[len(filterMarker):]
+		fullPath, err := filepath.Abs(filename)
+		if _, err := os.Stat(filename); err != nil {
+			// not a valid file, don't filter
+			args = append(args, filename)
+			continue
+		}
+		dir, base := filepath.Split(fullPath)
+		matches, err := bctx.MatchFile(dir, base)
+		if err != nil {
+			//match test failure, return it
+			return err
+		}
+		if !matches {
+			// file should be filtered...
+			filtered++
+			continue
+		}
+		// not a match, add it
+		args = append(args, filename)
+		unfiltered++
+	}
+	// args should now be filtered
+	// if all possible filter candidates were removed, then don't run the command
+	if filtered > 0 && unfiltered == 0 {
+		os.Exit(1)
+	}
+	// if we get here, we want to run the command itself
+	cmd := exec.Command(executable, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
 func main() {
 	flag.Parse()
 
@@ -62,9 +120,16 @@ func main() {
 	bctx.BuildTags = strings.Split(*tags, ",")
 	bctx.CgoEnabled = *cgo
 
+	if *run {
+		if err := runCommand(bctx, flag.Args()); err != nil {
+			log.Fatalf("filter_tags error: %v\n", err)
+		}
+		return
+	}
+
 	filenames, err := filterFilenames(bctx, flag.Args())
 	if err != nil {
-		log.Fatalf("build_tags error: %v\n", err)
+		log.Fatalf("filter_tags error: %v\n", err)
 	}
 
 	if !*quiet {

--- a/go/tools/filter_tags/filter_tags.go
+++ b/go/tools/filter_tags/filter_tags.go
@@ -21,7 +21,6 @@ import (
 	"go/build"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -30,10 +29,6 @@ var (
 	cgo   = flag.Bool("cgo", false, "Sets whether cgo-using files are allowed to pass the filter.")
 	quiet = flag.Bool("quiet", false, "Don't print filenames. Return code will be 0 if any files pass the filter.")
 	tags  = flag.String("tags", "", "Only pass through files that match these tags.")
-	run   = flag.Bool("run", false, "Run mode, filter a command line and then run it.")
-
-	absMarker    = "≡"
-	filterMarker = ""
 )
 
 // Returns an array of strings containing only the filenames that should build
@@ -60,59 +55,6 @@ func filterFilenames(bctx build.Context, inputs []string) ([]string, error) {
 	return outputs, nil
 }
 
-// Returns an array of strings containing only the filenames that should build
-// according to the Context given.
-func runCommand(bctx build.Context, inputs []string) error {
-	if len(inputs) <= 0 {
-		return fmt.Errorf("filter_tags in run mode but with no command to run")
-	}
-	executable := inputs[0]
-	args := []string{}
-	unfiltered := 0
-	filtered := 0
-	for _, in := range inputs[1:] {
-		if strings.HasPrefix(in, absMarker) {
-			in, _ = filepath.Abs(in[len(absMarker):])
-		}
-		if !strings.HasPrefix(in, filterMarker) {
-			// not a filter candidate
-			args = append(args, in)
-			continue
-		}
-		filename := in[len(filterMarker):]
-		fullPath, err := filepath.Abs(filename)
-		if _, err := os.Stat(filename); err != nil {
-			// not a valid file, don't filter
-			args = append(args, filename)
-			continue
-		}
-		dir, base := filepath.Split(fullPath)
-		matches, err := bctx.MatchFile(dir, base)
-		if err != nil {
-			//match test failure, return it
-			return err
-		}
-		if !matches {
-			// file should be filtered...
-			filtered++
-			continue
-		}
-		// not a match, add it
-		args = append(args, filename)
-		unfiltered++
-	}
-	// args should now be filtered
-	// if all possible filter candidates were removed, then don't run the command
-	if filtered > 0 && unfiltered == 0 {
-		os.Exit(1)
-	}
-	// if we get here, we want to run the command itself
-	cmd := exec.Command(executable, args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
-}
-
 func main() {
 	flag.Parse()
 
@@ -120,16 +62,9 @@ func main() {
 	bctx.BuildTags = strings.Split(*tags, ",")
 	bctx.CgoEnabled = *cgo
 
-	if *run {
-		if err := runCommand(bctx, flag.Args()); err != nil {
-			log.Fatalf("filter_tags error: %v\n", err)
-		}
-		return
-	}
-
 	filenames, err := filterFilenames(bctx, flag.Args())
 	if err != nil {
-		log.Fatalf("filter_tags error: %v\n", err)
+		log.Fatalf("build_tags error: %v\n", err)
 	}
 
 	if !*quiet {


### PR DESCRIPTION
Add the ability to filter a command line and then run it to filter_tags
Add the ability to abs arguments to filter_tags
Use the new filter tags to kill the remnants of the compile bash script