### PR TITLE
Fix stamped_bin

### DIFF
--- a/examples/stamped_bin/BUILD
+++ b/examples/stamped_bin/BUILD
@@ -1,18 +1,8 @@
-package(
-    default_visibility = ["//visibility:public"],
-)
+load("//go:def.bzl", "go_test")
 
-load("//go:def.bzl", "go_binary", "go_library")
-
-go_library(
-    name = "go_default_library",
-    srcs = ["main.go"],
-    visibility = ["//visibility:private"],
+go_test(
+    name = "go_default_xtest",
+    srcs = ["stamped_bin_test.go"],
     deps = ["//examples/stamped_bin/stamp:go_default_library"],
-)
-
-go_binary(
-    name = "stamped_bin",
-    library = ":go_default_library",
-    visibility = ["//visibility:public"],
+    linkstamp = "github.com/bazelbuild/rules_go/examples/stamped_bin/stamp",
 )

--- a/examples/stamped_bin/stamp/stamp.go
+++ b/examples/stamped_bin/stamp/stamp.go
@@ -15,4 +15,5 @@ limitations under the License.
 
 package stamp
 
-var BUILD_TIMESTAMP = "fail"
+var NOT_A_TIMESTAMP = "fail"
+var BUILD_TIMESTAMP = NOT_A_TIMESTAMP

--- a/examples/stamped_bin/stamped_bin_test.go
+++ b/examples/stamped_bin/stamped_bin_test.go
@@ -13,18 +13,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package stamped_bin_test
 
 import (
-	"fmt"
-	"os"
+	"testing"
 
 	"github.com/bazelbuild/rules_go/examples/stamped_bin/stamp"
 )
 
-func main() {
-	fmt.Println(stamp.BUILD_TIMESTAMP)
-	if stamp.BUILD_TIMESTAMP == "fail" {
-		os.Exit(1)
+func TestStampedBin(t *testing.T) {
+	if stamp.BUILD_TIMESTAMP == stamp.NOT_A_TIMESTAMP {
+		t.Errorf("Expected timestamp to have been modified, got %s.", stamp.BUILD_TIMESTAMP)
 	}
 }


### PR DESCRIPTION
It was not actually doing any stamping, or testing wether the stamping worked.
It has been converted from a binary to a test, that validates that the timestamp variable in the included library is correctly replaced.