### PR TITLE
merge go_repository rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,15 +285,14 @@ go_repositories(
 ### `go_repository`
 
 ```bzl
-go_repository(name, importpath, remote, vcs, commit, tag)
+go_repository(name, importpath, remote, vcs, commit, tag, build_tags, url, string_prefix, type, sha256, build_file_name, disable_build_file_generation)
 ```
 
-Fetches a remote repository of a Go project, expecting it contains `BUILD`
-files. It is an analogy to `git_repository` but it recognizes importpath
-redirection of Go.
+Fetches a remote repository of a Go project, and generates `BUILD`
+files if needed.
+In vcs mode it recognizes importpath redirection of Go.
 
-Either `importpath` or `remote` may be specified. To bypass importpath
-redirection, specify both `remote` and `vcs`.
+The `importpath` import path must always be specified. If url is specified, it is expected to be the url for a source archive. If `remote` and `vcs` are both specified, they control the source repository to be cloned for the import path. If neither a vcs nor a url are specified, the vcs will be inferred from the import path using the normal go logic.
 
 <table class="table table-condensed table-bordered table-params">
   <colgroup>
@@ -353,74 +352,57 @@ redirection, specify both `remote` and `vcs`.
         <p>Note that one of either <code>commit</code> or <code>tag</code> must be defined.</p>
       </td>
     </tr>
-  </tbody>
-</table>
-
-### `new_go_repository`
-
-```bzl
-new_go_repository(name, importpath, remote, vcs, commit, tag)
-```
-
-Fetches a remote repository of a Go project and automatically generates
-`BUILD` files in it.  It is an analogy to `new_git_repository` but it recognizes
-importpath redirection of Go.
-
-<table class="table table-condensed table-bordered table-params">
-  <colgroup>
-    <col class="col-param" />
-    <col class="param-description" />
-  </colgroup>
-  <thead>
     <tr>
-      <th colspan="2">Attributes</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>name</code></td>
+      <td><code>build_tags</code></td>
       <td>
-        <code>String, required</code>
-        <p>A unique name for this external dependency.</p>
+        <code>String, optional</code>
+        <p>The set of tags to pass to gazelle when generating build files.</p>
       </td>
     </tr>
     <tr>
-      <td><code>importpath</code></td>
+      <td><code>url</code></td>
       <td>
         <code>String, optional</code>
-        <p>An import path in Go, which also provides a default value for the
-        root of the target remote repository</p>
+        <p>The url for a source code archive.</p>
+        <p>See [http_archive](https://bazel.build/versions/master/docs/be/workspace.html#http_archive) for more details.</p>
       </td>
     </tr>
     <tr>
-      <td><code>remote</code></td>
+      <td><code>strip_prefix</code></td>
       <td>
         <code>String, optional</code>
-        <p>The URI of the target remote repository, if this differs from the
-        value of <code>importpath</code></p>
+        <p>The internal path prefix to strip when the archive is extracted.</p>
+        <p>See [http_archive](https://bazel.build/versions/master/docs/be/workspace.html#http_archive) for more details.</p>
       </td>
     </tr>
     <tr>
-      <td><code>vcs</code></td>
+      <td><code>type</code></td>
       <td>
         <code>String, optional</code>
-        <p>The version control system to use for fetching the repository.</p>
+        <p>The type of the archive, only needed if it cannot be inferred from the file extension.</p>
+        <p>See [http_archive](https://bazel.build/versions/master/docs/be/workspace.html#http_archive) for more details.</p>
       </td>
     </tr>
     <tr>
-      <td><code>commit</code></td>
+      <td><code>sha256</code></td>
       <td>
         <code>String, optional</code>
-        <p>The commit hash to checkout in the repository.</p>
-        <p>Note that one of either <code>commit</code> or <code>tag</code> must be defined.</p>
+        <p>The expected SHA-256 hash of the file downloaded.</p>
+        <p>See [http_archive](https://bazel.build/versions/master/docs/be/workspace.html#http_archive) for more details.</p>
       </td>
     </tr>
     <tr>
-      <td><code>tag</code></td>
+      <td><code>build_file_name</code></td>
       <td>
         <code>String, optional</code>
-        <p>The tag to checkout in the repository.</p>
-        <p>Note that one of either <code>commit</code> or <code>tag</code> must be defined.</p>
+        <p>The name to use for the generated build files, defaults to BUILD.bazel.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>disable_build_file_generation</code></td>
+      <td>
+        <code>String, optional</code>
+        <p>Used to force build file generation to not run, even when the repository does not have a root build file.</p>
       </td>
     </tr>
   </tbody>

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ go_repositories(
 ### `go_repository`
 
 ```bzl
-go_repository(name, importpath, remote, vcs, commit, tag, build_tags, url, string_prefix, type, sha256, build_file_name, disable_build_file_generation)
+go_repository(name, importpath, remote, vcs, commit, tag, build_tags, url, string_prefix, type, sha256, build_file_name, build_file_generation)
 ```
 
 Fetches a remote repository of a Go project, and generates `BUILD`
@@ -399,10 +399,13 @@ The `importpath` import path must always be specified. If url is specified, it i
       </td>
     </tr>
     <tr>
-      <td><code>disable_build_file_generation</code></td>
+      <td><code>build_file_generation</code></td>
       <td>
         <code>String, optional</code>
-        <p>Used to force build file generation to not run, even when the repository does not have a root build file.</p>
+        <p>Used to force build file generation.</p>
+        <p>off means do not generate build files</p>
+        <p>on means always run gazelle, even if build files are already present</p>
+        <p>auto is the default and runs gazelle only if there is no root build file</p>
       </td>
     </tr>
   </tbody>

--- a/go/private/go_repository.bzl
+++ b/go/private/go_repository.bzl
@@ -14,8 +14,8 @@
 
 
 def _go_repository_impl(ctx):
-  fetch_repo = ctx.path(ctx.attr._fetch_repo)
-
+  # TODO(iancottrell): Decide if commit and tag apply to non vcs forms
+  # TODO(iancottrell): Decide if commit and tag should remain mutually exclusive
   if ctx.attr.commit and ctx.attr.tag:
     fail("cannot specify both of commit and tag", "commit")
   if ctx.attr.commit:
@@ -25,67 +25,84 @@ def _go_repository_impl(ctx):
   else:
     fail("neither commit or tag is specified", "commit")
 
-  # TODO(yugui): support submodule?
-  # c.f. https://www.bazel.io/versions/master/docs/be/workspace.html#git_repository.init_submodules
-  remote = ctx.attr.remote
-  vcs = ctx.attr.vcs
-  importpath = ctx.attr.importpath
-  result = ctx.execute([
-      fetch_repo,
-      '--dest', ctx.path(''),
-      '--remote', remote,
-      '--rev', rev,
-      '--vcs', vcs,
-      '--importpath', importpath])
-  if result.return_code:
-    fail("failed to fetch %s: %s" % (ctx.name, result.stderr))
+  if ctx.attr.url:
+    # explicit source url
+    if ctx.attr.vcs:
+        fail("cannot specify both of vcs and url")
+    ctx.download_and_extract(
+        url = ctx.attr.url,
+        sha256 = ctx.attr.sha256,
+        stripPrefix = ctx.attr.strip_prefix,
+        type = ctx.attr.type,
+    )
+  else:
+    # Using fetch repo
+    if ctx.attr.vcs and not ctx.attr.remote:
+      fail("if vcs is specified, remote must also be")
+    # TODO(yugui): support submodule?
+    # c.f. https://www.bazel.io/versions/master/docs/be/workspace.html#git_repository.init_submodules
+    result = ctx.execute([
+        ctx.path(ctx.attr._fetch_repo),
+        '--dest', ctx.path(''),
+        '--remote', ctx.attr.remote,
+        '--rev', rev,
+        '--vcs', ctx.attr.vcs,
+        '--importpath', ctx.attr.importpath,
+    ])
+    if result.return_code:
+      fail("failed to fetch %s: %s" % (ctx.name, result.stderr))
 
+  if (ctx.attr.disable_build_file_generation or 
+      ctx.path('BUILD').exists or 
+      ctx.path(ctx.attr.build_file_name).exists):
+    # Do not generate build files for this repository
+    return
 
-def _new_go_repository_impl(ctx):
-  _go_repository_impl(ctx)
+  # Build file generation is needed
   gazelle = ctx.path(ctx.attr._gazelle)
-
   cmds = [gazelle, '--go_prefix', ctx.attr.importpath, '--mode', 'fix',
           '--repo_root', ctx.path(''),
           "--build_tags", ",".join(ctx.attr.build_tags)]
   if ctx.attr.build_file_name:
       cmds += ["--build_file_name", ctx.attr.build_file_name]
-
   cmds += [ctx.path('')]
-
   result = ctx.execute(cmds)
   if result.return_code:
-    fail("failed to generate BUILD files for %s: %s" % (
-        ctx.attr.importpath, result.stderr))
-
-
-_go_repository_attrs = {
-    "build_file_name": attr.string(default="BUILD.bazel"),
-    "importpath": attr.string(),
-    "remote": attr.string(),
-    "vcs": attr.string(default="", values=["", "git", "hg", "svn", "bzr"]),
-    "commit": attr.string(),
-    "tag": attr.string(),
-    "build_tags": attr.string_list(),
-    "_fetch_repo": attr.label(
-        default = Label("@io_bazel_rules_go_repository_tools//:bin/fetch_repo"),
-        allow_files = True,
-        single_file = True,
-        executable = True,
-        cfg = "host",
-    ),
-}
+      fail("failed to generate BUILD files for %s: %s" % (
+          ctx.attr.importpath, result.stderr))
 
 
 go_repository = repository_rule(
     implementation = _go_repository_impl,
-    attrs = _go_repository_attrs,
-)
+    attrs = {
+        # Fundamental attributes of a go repository
+        "importpath": attr.string(mandatory = True),
+        "commit": attr.string(),
+        "tag": attr.string(),
+        "build_tags": attr.string_list(),
 
+        # Attributes for a repository that cannot be inferred from the import path
+        "vcs": attr.string(default="", values=["", "git", "hg", "svn", "bzr"]),
+        "remote": attr.string(),
 
-new_go_repository = repository_rule(
-    implementation = _new_go_repository_impl,
-    attrs = _go_repository_attrs + {
+        # Attributes for a repository that comes from a source blob not a vcs
+        "url": attr.string(),
+        "strip_prefix": attr.string(),
+        "type": attr.string(),
+        "sha256": attr.string(),
+
+        # Attributes for a repository that needs automatic build file generation
+        "build_file_name": attr.string(default="BUILD.bazel"),
+        "disable_build_file_generation": attr.bool(default=False),
+
+        # Hidden attributes for tool dependancies
+        "_fetch_repo": attr.label(
+            default = Label("@io_bazel_rules_go_repository_tools//:bin/fetch_repo"),
+            allow_files = True,
+            single_file = True,
+            executable = True,
+            cfg = "host",
+        ),
         "_gazelle": attr.label(
             default = Label("@io_bazel_rules_go_repository_tools//:bin/gazelle"),
             allow_files = True,
@@ -95,3 +112,5 @@ new_go_repository = repository_rule(
         ),
     },
 )
+
+new_go_repository = go_repository

--- a/go/private/go_repository.bzl
+++ b/go/private/go_repository.bzl
@@ -14,8 +14,6 @@
 
 
 def _go_repository_impl(ctx):
-  # TODO(iancottrell): Decide if commit and tag apply to non vcs forms
-  # TODO(iancottrell): Decide if commit and tag should remain mutually exclusive
   if ctx.attr.commit and ctx.attr.tag:
     fail("cannot specify both of commit and tag", "commit")
   if ctx.attr.commit:
@@ -28,7 +26,7 @@ def _go_repository_impl(ctx):
   if ctx.attr.url:
     # explicit source url
     if ctx.attr.vcs:
-        fail("cannot specify both of vcs and url")
+      fail("cannot specify both of vcs and url")
     ctx.download_and_extract(
         url = ctx.attr.url,
         sha256 = ctx.attr.sha256,
@@ -68,8 +66,8 @@ def _go_repository_impl(ctx):
   cmds += [ctx.path('')]
   result = ctx.execute(cmds)
   if result.return_code:
-      fail("failed to generate BUILD files for %s: %s" % (
-          ctx.attr.importpath, result.stderr))
+    fail("failed to generate BUILD files for %s: %s" % (
+        ctx.attr.importpath, result.stderr))
 
 
 go_repository = repository_rule(
@@ -113,4 +111,6 @@ go_repository = repository_rule(
     },
 )
 
+# This is for legacy compatability
+# Originally this was the only rule that triggered BUILD file generation.
 new_go_repository = go_repository

--- a/tests/popular_repos/WORKSPACE.in
+++ b/tests/popular_repos/WORKSPACE.in
@@ -2,7 +2,7 @@ local_repository(
     name = "io_bazel_rules_go",
     path = "@@RULES_DIR@@",
 )
-load("@io_bazel_rules_go//go:def.bzl", "go_repositories", "new_go_repository")
+load("@io_bazel_rules_go//go:def.bzl", "go_repositories", "go_repository", "new_go_repository")
 go_repositories()
 
 # TODO(#409): don't specify build tags for repositories. We should generate

--- a/tests/popular_repos/WORKSPACE.in
+++ b/tests/popular_repos/WORKSPACE.in
@@ -9,11 +9,14 @@ go_repositories()
 # platform-independent BUILD files without hints.
 BUILD_TAGS = ["amd64", "@@GOOS@@"]
 
-new_go_repository(
+go_repository(
     name = "org_golang_x_crypto",
     importpath = "golang.org/x/crypto",
     commit = "efac7f277b17c19894091e358c6130cb6bd51117",
     build_tags = BUILD_TAGS,
+    url = "https://codeload.github.com/golang/crypto/zip/efac7f277b17c19894091e358c6130cb6bd51117",
+    strip_prefix = "crypto-efac7f277b17c19894091e358c6130cb6bd51117",
+    type = "zip",
 )
 
 new_go_repository(


### PR DESCRIPTION
This is a proof of concept change to merge new_go_repository into
go_repository.
Instead it autmatically runs gazelle on repositories that do not
supply a build file.
It also adds the ability to fetch a go repository by source blob
instead, with the same automatic running of gazelle if needed.
This is fully backwards compatible, but going forward would allow
gazelle to only generate go_repository rules, and to automatically
switch to source blobs when it knows it can resolve one (rather
than using the vcs)