### PR TITLE
Gazelle select (2/x): add Package, Target, PlatformStrings

### DIFF
--- a/go/tools/gazelle/packages/BUILD
+++ b/go/tools/gazelle/packages/BUILD
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "doc.go",
+        "package.go",
         "walk.go",
     ],
     visibility = ["//visibility:public"],

--- a/go/tools/gazelle/packages/package.go
+++ b/go/tools/gazelle/packages/package.go
@@ -57,21 +57,20 @@ func (p *Package) HasGo() bool {
 	return p.Library.HasGo() || p.CgoLibrary.HasGo() || p.Binary.HasGo() || p.Test.HasGo() || p.XTest.HasGo()
 }
 
-// firstGoFile returns the name of a .go file and true if the package contains
-// at least one .go file, or "" and false otherwise. Used by HasGo and for
-// error reporting.
-func (p *Package) firstGoFile() (string, bool) {
-	if f, ok := p.Library.firstGoFile(); ok {
-		return f, true
+// firstGoFile returns the name of a .go file if the package contains at least
+// one .go file, or "" otherwise. Used by HasGo and for error reporting.
+func (p *Package) firstGoFile() string {
+	if f := p.Library.firstGoFile(); f != "" {
+		return f
 	}
-	if f, ok := p.CgoLibrary.firstGoFile(); ok {
-		return f, true
+	if f := p.CgoLibrary.firstGoFile(); f != "" {
+		return f
 	}
-	if f, ok := p.Binary.firstGoFile(); ok {
-		return f, true
+	if f := p.Binary.firstGoFile(); f != "" {
+		return f
 	}
-	if f, ok := p.Test.firstGoFile(); ok {
-		return f, true
+	if f := p.Test.firstGoFile(); f != "" {
+		return f
 	}
 	return p.XTest.firstGoFile()
 }
@@ -80,13 +79,12 @@ func (t *Target) HasGo() bool {
 	return t.Sources.HasGo()
 }
 
-func (t *Target) firstGoFile() (string, bool) {
+func (t *Target) firstGoFile() string {
 	return t.Sources.firstGoFile()
 }
 
 func (ts *PlatformStrings) HasGo() bool {
-	_, ok := ts.firstGoFile()
-	return ok
+	return ts.firstGoFile() != ""
 }
 
 func (ts *PlatformStrings) IsEmpty() bool {
@@ -101,18 +99,18 @@ func (ts *PlatformStrings) IsEmpty() bool {
 	return true
 }
 
-func (ts *PlatformStrings) firstGoFile() (string, bool) {
+func (ts *PlatformStrings) firstGoFile() string {
 	for _, f := range ts.Generic {
 		if strings.HasSuffix(f, ".go") {
-			return f, true
+			return f
 		}
 	}
 	for _, fs := range ts.Platform {
 		for _, f := range fs {
 			if strings.HasSuffix(f, ".go") {
-				return f, true
+				return f
 			}
 		}
 	}
-	return "", false
+	return ""
 }

--- a/go/tools/gazelle/packages/package.go
+++ b/go/tools/gazelle/packages/package.go
@@ -1,0 +1,118 @@
+/* Copyright 2017 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package packages
+
+import "strings"
+
+// Package contains metadata about a Go package extracted from a directory.
+// It fills a similar role to go/build.Package, but it separates files by
+// target instead of by type, and it supports multiple platforms.
+type Package struct {
+	Dir  string
+	Name string
+
+	Library, CgoLibrary, Binary, Test, XTest Target
+}
+
+// Target contains metadata about a buildable Go target in a package.
+type Target struct {
+	Sources, Imports PlatformStrings
+	COpts, CLinkOpts PlatformStrings
+}
+
+// PlatformStrings contains a set of strings associated with a buildable
+// Go target in a package. This is used to store source file names,
+// import paths, and flags.
+type PlatformStrings struct {
+	// Generic is a list of strings not specific to any platform.
+	Generic []string
+
+	// Platform is a map of lists of platform-specific strings. The map is keyed
+	// by the name of the platform.
+	Platform map[string][]string
+}
+
+// IsCommand returns true if the package name is "main".
+func (p *Package) IsCommand() bool {
+	return p.Name == "main"
+}
+
+// HasGo returns true if at least one target in the package contains a
+// .go source file. If a package does not contain Go code, Gazelle will
+// not generate rules for it.
+func (p *Package) HasGo() bool {
+	return p.Library.HasGo() || p.CgoLibrary.HasGo() || p.Binary.HasGo() || p.Test.HasGo() || p.XTest.HasGo()
+}
+
+// firstGoFile returns the name of a .go file and true if the package contains
+// at least one .go file, or "" and false otherwise. Used by HasGo and for
+// error reporting.
+func (p *Package) firstGoFile() (string, bool) {
+	if f, ok := p.Library.firstGoFile(); ok {
+		return f, true
+	}
+	if f, ok := p.CgoLibrary.firstGoFile(); ok {
+		return f, true
+	}
+	if f, ok := p.Binary.firstGoFile(); ok {
+		return f, true
+	}
+	if f, ok := p.Test.firstGoFile(); ok {
+		return f, true
+	}
+	return p.XTest.firstGoFile()
+}
+
+func (t *Target) HasGo() bool {
+	return t.Sources.HasGo()
+}
+
+func (t *Target) firstGoFile() (string, bool) {
+	return t.Sources.firstGoFile()
+}
+
+func (ts *PlatformStrings) HasGo() bool {
+	_, ok := ts.firstGoFile()
+	return ok
+}
+
+func (ts *PlatformStrings) IsEmpty() bool {
+	if len(ts.Generic) > 0 {
+		return false
+	}
+	for _, s := range ts.Platform {
+		if len(s) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func (ts *PlatformStrings) firstGoFile() (string, bool) {
+	for _, f := range ts.Generic {
+		if strings.HasSuffix(f, ".go") {
+			return f, true
+		}
+	}
+	for _, fs := range ts.Platform {
+		for _, f := range fs {
+			if strings.HasSuffix(f, ".go") {
+				return f, true
+			}
+		}
+	}
+	return "", false
+}


### PR DESCRIPTION
Added three structs that contain metadata for a Go package in a
directory. These will be used to generate rules in place of
go/build.Context.

The main difference between these and go/build.Context is that these
structs divide files by target instead of type, and they are capable
of list platform-specific files, imports, and flags for multiple
platforms.

Related: #409