### PR TITLE
Gazelle select (3/x): add fileInfo and related methods

### DIFF
--- a/go/tools/gazelle/packages/BUILD
+++ b/go/tools/gazelle/packages/BUILD
@@ -4,10 +4,17 @@ go_library(
     name = "go_default_library",
     srcs = [
         "doc.go",
+        "fileinfo.go",
         "package.go",
         "walk.go",
     ],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["fileinfo_test.go"],
+    library = ":go_default_library",
 )
 
 go_test(

--- a/go/tools/gazelle/packages/fileinfo.go
+++ b/go/tools/gazelle/packages/fileinfo.go
@@ -80,7 +80,7 @@ type taggedOpts struct {
 	opts []string
 }
 
-// extCategory indicates how a file should be treated, based on extention.
+// extCategory indicates how a file should be treated, based on extension.
 type extCategory int
 
 const (
@@ -118,23 +118,19 @@ func fileNameInfo(dir, name string) fileInfo {
 	// in goodOSArchFile in go/build.
 	var isTest bool
 	var goos, goarch string
-	i := strings.Index(name, "_")
-	if i >= 0 {
-		stem := name[i : len(name)-len(ext)]
-		l := strings.Split(stem, "_")
-		if n := len(l); n > 0 && l[n-1] == "test" {
-			isTest = true
-			l = l[:n-1]
-		}
-		n := len(l)
-		if n >= 2 && knownOS[l[n-2]] && knownArch[l[n-1]] {
-			goos = l[n-2]
-			goarch = l[n-1]
-		} else if n >= 1 && knownOS[l[n-1]] {
-			goos = l[n-1]
-		} else if n >= 1 && knownArch[l[n-1]] {
-			goarch = l[n-1]
-		}
+	l := strings.Split(name[:len(name)-len(ext)], "_")
+	if len(l) >= 2 && l[len(l)-1] == "test" {
+		isTest = true
+		l = l[:len(l)-1]
+	}
+	switch {
+	case len(l) >= 3 && knownOS[l[len(l)-2]] && knownArch[l[len(l)-1]]:
+		goos = l[len(l)-2]
+		goarch = l[len(l)-1]
+	case len(l) >= 2 && knownOS[l[len(l)-1]]:
+		goos = l[len(l)-1]
+	case len(l) >= 2 && knownArch[l[len(l)-1]]:
+		goarch = l[len(l)-1]
 	}
 
 	// Categorize the file based on extension. Based on go/build.Context.Import.

--- a/go/tools/gazelle/packages/fileinfo.go
+++ b/go/tools/gazelle/packages/fileinfo.go
@@ -1,0 +1,538 @@
+/* Copyright 2017 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package packages
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// fileInfo holds information used to decide how to build a file. This
+// information comes from the file's name, from package and import declarations
+// (in .go files), and from +build and cgo comments.
+type fileInfo struct {
+	path, dir, name, ext string
+
+	// packageName is the Go package name of a .go file, without the
+	// "_test" suffix if it was present. It is empty for non-Go files.
+	packageName string
+
+	// category is the type of file, based on extension.
+	category extCategory
+
+	// isTest is true if the file stem (the part before the extension)
+	// ends with "_test.go". This is never true for non-Go files.
+	isTest bool
+
+	// isXTest is true for test Go files whose declared package name ends
+	// with "_test".
+	isXTest bool
+
+	// imports is a list of packages imported by a file. It does not include
+	// "C" or anything from the standard library.
+	imports []string
+
+	// isCgo is true for .go files that import "C".
+	isCgo bool
+
+	// goos and goarch contain the OS and architecture suffixes in the filename,
+	// if they were present.
+	goos, goarch string
+
+	// tags is a list of build tag lines. Each entry is the trimmed text of
+	// a line after a "+build" prefix.
+	tags []string
+
+	// copts and clinkopts contain flags that are part of CFLAGS, CPPFLAGS,
+	// CXXFLAGS, and LDFLAGS directives in cgo comments.
+	copts, clinkopts []taggedOpts
+}
+
+// taggedOpts a list of compile or link options which should only be applied
+// if the given set of build tags are satisfied.
+type taggedOpts struct {
+	tags string
+	opts []string
+}
+
+// extCategory indicates how a file should be treated, based on extention.
+type extCategory int
+
+const (
+	// ignoredExt is applied to files which are not part of a build.
+	ignoredExt extCategory = iota
+
+	// unsupportedExt is applied to files that we don't support but would be
+	// built with "go build".
+	unsupportedExt
+
+	// goExt is applied to .go files.
+	goExt
+
+	// cExt is applied to C and C++ files.
+	cExt
+
+	// hExt is applied to header files. If cgo code is present, these may be
+	// C or C++ headers. If not, they are treated as Go assembly headers.
+	hExt
+
+	// sExt is applied to Go assembly files, ending with .s.
+	sExt
+
+	// csExt is applied to other assembly files, ending with .S. These are built
+	// with the C compiler if cgo code is present.
+	csExt
+)
+
+// fileNameInfo returns information that can be inferred from the name of
+// a file. It does not read data from the file.
+func fileNameInfo(dir, name string) fileInfo {
+	ext := path.Ext(name)
+
+	// Determine test, goos, and goarch. This is intended to match the logic
+	// in goodOSArchFile in go/build.
+	var isTest bool
+	var goos, goarch string
+	i := strings.Index(name, "_")
+	if i >= 0 {
+		stem := name[i : len(name)-len(ext)]
+		l := strings.Split(stem, "_")
+		if n := len(l); n > 0 && l[n-1] == "test" {
+			isTest = true
+			l = l[:n-1]
+		}
+		n := len(l)
+		if n >= 2 && knownOS[l[n-2]] && knownArch[l[n-1]] {
+			goos = l[n-2]
+			goarch = l[n-1]
+		} else if n >= 1 && knownOS[l[n-1]] {
+			goos = l[n-1]
+		} else if n >= 1 && knownArch[l[n-1]] {
+			goarch = l[n-1]
+		}
+	}
+
+	// Categorize the file based on extension. Based on go/build.Context.Import.
+	var category extCategory
+	switch ext {
+	case ".go":
+		category = goExt
+	case ".c", ".cc", ".cpp", ".cxx":
+		category = cExt
+	case ".h", ".hh", ".hpp", ".hxx":
+		category = hExt
+	case ".s":
+		category = sExt
+	case ".S":
+		category = csExt
+	case ".m", ".f", ".F", ".for", ".f90", ".swig", ".swigcxx", ".syso":
+		category = unsupportedExt
+	default:
+		category = ignoredExt
+	}
+
+	return fileInfo{
+		path:     filepath.Join(dir, name),
+		dir:      dir,
+		name:     name,
+		ext:      ext,
+		category: category,
+		isTest:   isTest,
+		goos:     goos,
+		goarch:   goarch,
+	}
+}
+
+// goFileInfo returns information about a .go file. It will parse part of the
+// file to determine the package name and imports.
+// This function is intended to match go/build.Context.Import.
+func (pr *packageReader) goFileInfo(name string) (fileInfo, error) {
+	info := fileNameInfo(pr.dir, name)
+	fset := token.NewFileSet()
+	pf, err := parser.ParseFile(fset, info.path, nil, parser.ImportsOnly|parser.ParseComments)
+	if err != nil {
+		return fileInfo{}, err
+	}
+
+	info.packageName = pf.Name.Name
+	if info.isTest && strings.HasSuffix(info.packageName, "_test") {
+		info.isXTest = true
+		info.packageName = info.packageName[:len(info.packageName)-len("_test")]
+	}
+
+	for _, decl := range pf.Decls {
+		d, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		for _, dspec := range d.Specs {
+			spec, ok := dspec.(*ast.ImportSpec)
+			if !ok {
+				continue
+			}
+			quoted := spec.Path.Value
+			path, err := strconv.Unquote(quoted)
+			if err != nil {
+				return fileInfo{}, err
+			}
+
+			if path == "C" {
+				if info.isTest {
+					return fileInfo{}, fmt.Errorf("%s: use of cgo in test not supported", info.path)
+				}
+				info.isCgo = true
+				cg := spec.Doc
+				if cg == nil && len(d.Specs) == 1 {
+					cg = d.Doc
+				}
+				if cg != nil {
+					if err := pr.saveCgo(&info, cg); err != nil {
+						return fileInfo{}, err
+					}
+				}
+			} else if !pr.isStandard(path) {
+				info.imports = append(info.imports, path)
+			}
+		}
+	}
+
+	tags, err := readTags(info.path)
+	if err != nil {
+		return fileInfo{}, err
+	}
+	info.tags = tags
+
+	return info, nil
+}
+
+// saveCgo extracts CFLAGS, CPPFLAGS, CXXFLAGS, and LDFLAGS directives
+// from a comment above a "C" import. This is intended to match logic in
+// go/build.Context.saveCgo.
+func (pr *packageReader) saveCgo(info *fileInfo, cg *ast.CommentGroup) error {
+	text := cg.Text()
+	for _, line := range strings.Split(text, "\n") {
+		orig := line
+
+		// Line is
+		//	#cgo [GOOS/GOARCH...] LDFLAGS: stuff
+		//
+		line = strings.TrimSpace(line)
+		if len(line) < 5 || line[:4] != "#cgo" || (line[4] != ' ' && line[4] != '\t') {
+			continue
+		}
+
+		// Split at colon.
+		line = strings.TrimSpace(line[4:])
+		i := strings.Index(line, ":")
+		if i < 0 {
+			return fmt.Errorf("%s: invalid #cgo line: %s", info.path, orig)
+		}
+		line, optstr := strings.TrimSpace(line[:i]), strings.TrimSpace(line[i+1:])
+
+		// Parse tags and verb.
+		f := strings.Fields(line)
+		if len(f) < 1 {
+			return fmt.Errorf("%s: invalid #cgo line: %s", info.path, orig)
+		}
+		verb := f[len(f)-1]
+		tags := strings.Join(f[:len(f)-1], " ")
+
+		// Parse options.
+		opts, err := splitQuoted(optstr)
+		if err != nil {
+			return fmt.Errorf("%s: invalid #cgo line: %s", info.path, orig)
+		}
+		var ok bool
+		for i, opt := range opts {
+			if opt, ok = expandSrcDir(opt, info.dir); !ok {
+				return fmt.Errorf("%s: malformed #cgo argument: %s", info.path, orig)
+			}
+			opts[i] = opt
+		}
+
+		// Add tags to appropriate list.
+		switch verb {
+		case "CFLAGS", "CPPFLAGS", "CXXFLAGS":
+			info.copts = append(info.copts, taggedOpts{tags, opts})
+		case "LDFLAGS":
+			info.clinkopts = append(info.clinkopts, taggedOpts{tags, opts})
+		case "pkg-config":
+			pr.warn(fmt.Errorf("%s: pkg-config not supported: %s", info.path, orig))
+		default:
+			return fmt.Errorf("%s: invalid #cgo verb: %s", info.path, orig)
+		}
+	}
+	return nil
+}
+
+// splitQuoted splits the string s around each instance of one or more consecutive
+// white space characters while taking into account quotes and escaping, and
+// returns an array of substrings of s or an empty list if s contains only white space.
+// Single quotes and double quotes are recognized to prevent splitting within the
+// quoted region, and are removed from the resulting substrings. If a quote in s
+// isn't closed err will be set and r will have the unclosed argument as the
+// last element. The backslash is used for escaping.
+//
+// For example, the following string:
+//
+//     a b:"c d" 'e''f'  "g\""
+//
+// Would be parsed as:
+//
+//     []string{"a", "b:c d", "ef", `g"`}
+//
+// Copied from go/build.splitQuoted
+func splitQuoted(s string) (r []string, err error) {
+	var args []string
+	arg := make([]rune, len(s))
+	escaped := false
+	quoted := false
+	quote := '\x00'
+	i := 0
+	for _, rune := range s {
+		switch {
+		case escaped:
+			escaped = false
+		case rune == '\\':
+			escaped = true
+			continue
+		case quote != '\x00':
+			if rune == quote {
+				quote = '\x00'
+				continue
+			}
+		case rune == '"' || rune == '\'':
+			quoted = true
+			quote = rune
+			continue
+		case unicode.IsSpace(rune):
+			if quoted || i > 0 {
+				quoted = false
+				args = append(args, string(arg[:i]))
+				i = 0
+			}
+			continue
+		}
+		arg[i] = rune
+		i++
+	}
+	if quoted || i > 0 {
+		args = append(args, string(arg[:i]))
+	}
+	if quote != 0 {
+		err = errors.New("unclosed quote")
+	} else if escaped {
+		err = errors.New("unfinished escaping")
+	}
+	return args, err
+}
+
+// expandSrcDir expands any occurrence of ${SRCDIR}, making sure
+// the result is safe for the shell.
+//
+// Copied from go/build.expandSrcDir
+func expandSrcDir(str string, srcdir string) (string, bool) {
+	// "\" delimited paths cause safeCgoName to fail
+	// so convert native paths with a different delimiter
+	// to "/" before starting (eg: on windows).
+	srcdir = filepath.ToSlash(srcdir)
+
+	// Spaces are tolerated in ${SRCDIR}, but not anywhere else.
+	chunks := strings.Split(str, "${SRCDIR}")
+	if len(chunks) < 2 {
+		return str, safeCgoName(str, false)
+	}
+	ok := true
+	for _, chunk := range chunks {
+		ok = ok && (chunk == "" || safeCgoName(chunk, false))
+	}
+	ok = ok && (srcdir == "" || safeCgoName(srcdir, true))
+	res := strings.Join(chunks, srcdir)
+	return res, ok && res != ""
+}
+
+// NOTE: $ is not safe for the shell, but it is allowed here because of linker options like -Wl,$ORIGIN.
+// We never pass these arguments to a shell (just to programs we construct argv for), so this should be okay.
+// See golang.org/issue/6038.
+// The @ is for OS X. See golang.org/issue/13720.
+// The % is for Jenkins. See golang.org/issue/16959.
+const safeString = "+-.,/0123456789=ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz:$@%"
+const safeSpaces = " "
+
+var safeBytes = []byte(safeSpaces + safeString)
+
+// Copied from go/build.safeCgoName
+func safeCgoName(s string, spaces bool) bool {
+	if s == "" {
+		return false
+	}
+	safe := safeBytes
+	if !spaces {
+		safe = safe[len(safeSpaces):]
+	}
+	for i := 0; i < len(s); i++ {
+		if c := s[i]; c < utf8.RuneSelf && bytes.IndexByte(safe, c) < 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// isStandard determines if importpath points a Go standard package.
+func (pr *packageReader) isStandard(importpath string) bool {
+	seg := strings.SplitN(importpath, "/", 2)[0]
+	return !strings.Contains(seg, ".") && !strings.HasPrefix(importpath, pr.goPrefix+"/")
+}
+
+// otherFileInfo returns information about a non-.go file. It will parse
+// part of the file to determine build tags.
+func (pr *packageReader) otherFileInfo(name string) (fileInfo, error) {
+	info := fileNameInfo(pr.dir, name)
+	if info.category == ignoredExt {
+		return info, nil
+	}
+	if info.category == unsupportedExt {
+		return info, fmt.Errorf("%s: file extension not yet supported", name)
+	}
+
+	if tags, err := readTags(info.path); err != nil {
+		pr.warn(err)
+	} else {
+		info.tags = tags
+	}
+	return info, nil
+}
+
+// Copied from go/build. Keep in sync as new platforms are added.
+const goosList = "android darwin dragonfly freebsd linux nacl netbsd openbsd plan9 solaris windows zos "
+const goarchList = "386 amd64 amd64p32 arm armbe arm64 arm64be ppc64 ppc64le mips mipsle mips64 mips64le mips64p32 mips64p32le ppc s390 s390x sparc sparc64 "
+
+var knownOS = make(map[string]bool)
+var knownArch = make(map[string]bool)
+
+func init() {
+	for _, v := range strings.Fields(goosList) {
+		knownOS[v] = true
+	}
+	for _, v := range strings.Fields(goarchList) {
+		knownArch[v] = true
+	}
+}
+
+// readTags reads and extracts build tags from the block of comments and
+// newlines at the start of a file. Each string in the returned slice is
+// the trimmed text of a line after a "+build" prefix.
+func readTags(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+
+	var buildComments []string
+	var prevLineBlank bool
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			prevLineBlank = true
+		} else if strings.HasPrefix(line, "//") {
+			prevLineBlank = false
+			line = strings.TrimSpace(line[len("//"):])
+			fields := strings.Fields(line)
+			if len(fields) > 0 && fields[0] == "+build" {
+				line = strings.TrimSpace(line[len("+build"):])
+				buildComments = append(buildComments, line)
+			}
+		} else {
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if !prevLineBlank {
+		return nil, nil
+	}
+	return buildComments, nil
+}
+
+// hasConstraints returns true if a file has goos, goarch filename suffixes
+// or build tags.
+func (fi *fileInfo) hasConstraints() bool {
+	return fi.goos != "" || fi.goarch != "" || len(fi.tags) > 0
+}
+
+// checkConstraints determines whether a file should be built on a platform
+// with the given tags. It returns true for files without constraints.
+func (fi *fileInfo) checkConstraints(tags map[string]bool) bool {
+	// TODO: linux should match on android.
+	if fi.goos != "" {
+		if _, ok := tags[fi.goos]; !ok {
+			return false
+		}
+	}
+	if fi.goarch != "" {
+		if _, ok := tags[fi.goarch]; !ok {
+			return false
+		}
+	}
+
+	for _, line := range fi.tags {
+		if !checkTags(line, tags) {
+			return false
+		}
+	}
+	return true
+}
+
+// checkTags determines whether the build tags on a given line are satisfied.
+// The line should be a whitespace-separated list of groups of comma-separated
+// tags. The constraints are satisfied for the line if any of the groups are
+// satisfied. A group is satisfied if all of the tags in it are true. A tag can
+// be negated with a "!" prefix, but double negatation ("!!") is not allowed.
+func checkTags(line string, tags map[string]bool) bool {
+	// TODO: linux should match on android.
+	lineOk := false
+	for _, group := range strings.Fields(line) {
+		groupOk := true
+		for _, tag := range strings.Split(group, ",") {
+			if strings.HasPrefix(tag, "!!") { // bad syntax, reject always
+				return false
+			}
+			not := strings.HasPrefix(tag, "!")
+			if not {
+				tag = tag[1:]
+			}
+			_, ok := tags[tag]
+			groupOk = groupOk && (not != ok)
+		}
+		lineOk = lineOk || groupOk
+	}
+	return lineOk
+}

--- a/go/tools/gazelle/packages/fileinfo_test.go
+++ b/go/tools/gazelle/packages/fileinfo_test.go
@@ -1,0 +1,987 @@
+/* Copyright 2017 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package packages
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestGoFileInfo(t *testing.T) {
+	pr := packageReader{goPrefix: "github.com/local/project"}
+	for _, tc := range []struct {
+		desc, name, source string
+		want               fileInfo
+	}{
+		{
+			"empty file",
+			"foo.go",
+			"package foo\n",
+			fileInfo{
+				packageName: "foo",
+			},
+		},
+		{
+			"xtest file",
+			"foo_test.go",
+			"package foo_test\n",
+			fileInfo{
+				packageName: "foo",
+				isTest:      true,
+				isXTest:     true,
+			},
+		},
+		{
+			"xtest suffix on non-test",
+			"foo_xtest.go",
+			"package foo_test\n",
+			fileInfo{
+				packageName: "foo_test",
+				isTest:      false,
+				isXTest:     false,
+			},
+		},
+		{
+			"single import",
+			"foo.go",
+			`package foo
+
+import "github.com/foo/bar"
+`,
+			fileInfo{
+				packageName: "foo",
+				imports:     []string{"github.com/foo/bar"},
+			},
+		},
+		{
+			"multiple imports",
+			"foo.go",
+			`package foo
+
+import (
+	"github.com/foo/bar"
+	x "github.com/local/project/y"
+)
+`,
+			fileInfo{
+				packageName: "foo",
+				imports:     []string{"github.com/foo/bar", "github.com/local/project/y"},
+			},
+		},
+		{
+			"standard imports not included",
+			"foo.go",
+			`package foo
+
+import "fmt"
+`,
+			fileInfo{
+				packageName: "foo",
+			},
+		},
+		{
+			"cgo",
+			"foo.go",
+			`package foo
+
+import "C"
+`,
+			fileInfo{
+				packageName: "foo",
+				isCgo:       true,
+			},
+		},
+		{
+			"build tags",
+			"foo.go",
+			`// +build linux darwin
+
+// +build !ignore
+
+package foo
+`,
+			fileInfo{
+				packageName: "foo",
+				tags:        []string{"linux darwin", "!ignore"},
+			},
+		},
+	} {
+		if err := ioutil.WriteFile(tc.name, []byte(tc.source), 0600); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(tc.name)
+
+		got, err := pr.goFileInfo(tc.name)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Clear fields we don't care about for testing.
+		got = fileInfo{
+			packageName: got.packageName,
+			isTest:      got.isTest,
+			isXTest:     got.isXTest,
+			imports:     got.imports,
+			isCgo:       got.isCgo,
+			tags:        got.tags,
+		}
+
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("case %q: got %#v; want %#v", tc.desc, got, tc.want)
+		}
+	}
+}
+
+func TestGoFileInfoFailures(t *testing.T) {
+	var pr packageReader
+	for _, tc := range []struct {
+		desc, name, source, wantError string
+	}{
+		{
+			"parse error",
+			"foo.go",
+			"pakcage foo",
+			"expected 'package'",
+		},
+		{
+			"cgo error",
+			"foo.go",
+			`package foo
+
+// #cgo !
+import "C"
+`,
+			"invalid #cgo line",
+		},
+		{
+			"cgo in test",
+			"foo_test.go",
+			`package foo
+
+import "C"
+`,
+			"use of cgo in test not supported",
+		},
+	} {
+		if err := ioutil.WriteFile(tc.name, []byte(tc.source), 0600); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(tc.name)
+
+		var errorText string
+		if _, err := pr.goFileInfo(tc.name); err != nil {
+			errorText = err.Error()
+		}
+
+		if tc.wantError == "" && errorText != "" || tc.wantError != "" && !strings.Contains(errorText, tc.wantError) {
+			t.Errorf("case %q: got error %q; want error containing %q", tc.desc, errorText, tc.wantError)
+		}
+	}
+}
+
+func TestOtherFileInfo(t *testing.T) {
+	var pr packageReader
+	for _, tc := range []struct {
+		desc, name, source string
+		wantTags           []string
+	}{
+		{
+			"empty file",
+			"foo.c",
+			"",
+			nil,
+		},
+		{
+			"tags file",
+			"foo.c",
+			`// +build foo bar
+// +build baz,!ignore
+
+`,
+			[]string{"foo bar", "baz,!ignore"},
+		},
+	} {
+		if err := ioutil.WriteFile(tc.name, []byte(tc.source), 0600); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(tc.name)
+
+		got, err := pr.otherFileInfo(tc.name)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Only check that we can extract tags. Everything else is covered
+		// by other tests.
+		if !reflect.DeepEqual(got.tags, tc.wantTags) {
+			t.Errorf("case %q: got %#v; want %#v", got.tags, tc.wantTags)
+		}
+	}
+}
+
+func TestOtherFileInfoFailures(t *testing.T) {
+	for _, tc := range []struct {
+		desc, name, source, wantError, wantWarning string
+	}{
+		{
+			"ignored file",
+			"foo.txt",
+			"",
+			"",
+			"",
+		},
+		{
+			"unsupported file",
+			"foo.m",
+			"",
+			"file extension not yet supported",
+			"",
+		},
+	} {
+		if err := ioutil.WriteFile(tc.name, []byte(tc.source), 0600); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(tc.name)
+
+		var warningText string
+		pr := packageReader{warnHook: func(err error) { warningText = err.Error() }}
+
+		var errorText string
+		if _, err := pr.otherFileInfo(tc.name); err != nil {
+			errorText = err.Error()
+		}
+
+		if tc.wantError == "" && errorText != "" || tc.wantError != "" && !strings.Contains(errorText, tc.wantError) {
+			t.Errorf("case %q: got error %q; want error containing %q", tc.desc, errorText, tc.wantError)
+		}
+		if tc.wantWarning == "" && warningText != "" || tc.wantWarning != "" && !strings.Contains(warningText, tc.wantWarning) {
+			t.Errorf("case %q: got warning %q; want warning containing %q", tc.desc, warningText, tc.wantWarning)
+		}
+	}
+}
+
+func TestFileNameInfo(t *testing.T) {
+	for _, tc := range []struct {
+		desc, name string
+		want       fileInfo
+	}{
+		{
+			"simple go file",
+			"simple.go",
+			fileInfo{
+				ext:      ".go",
+				category: goExt,
+			},
+		},
+		{
+			"simple go test",
+			"foo_test.go",
+			fileInfo{
+				ext:      ".go",
+				category: goExt,
+				isTest:   true,
+			},
+		},
+		{
+			"test source",
+			"test.go",
+			fileInfo{
+				ext:      ".go",
+				category: goExt,
+				isTest:   false,
+			},
+		},
+		{
+			"_test source",
+			"_test.go",
+			fileInfo{
+				ext:      ".go",
+				category: goExt,
+				isTest:   true,
+			},
+		},
+		{
+			"source with goos",
+			"foo_linux.go",
+			fileInfo{
+				ext:      ".go",
+				category: goExt,
+				goos:     "linux",
+			},
+		},
+		{
+			"source with goarch",
+			"foo_amd64.go",
+			fileInfo{
+				ext:      ".go",
+				category: goExt,
+				goarch:   "amd64",
+			},
+		},
+		{
+			"source with goos then goarch",
+			"foo_linux_amd64.go",
+			fileInfo{
+				ext:      ".go",
+				category: goExt,
+				goos:     "linux",
+				goarch:   "amd64",
+			},
+		},
+		{
+			"source with goarch then goos",
+			"foo_amd64_linux.go",
+			fileInfo{
+				ext:      ".go",
+				category: goExt,
+				goos:     "linux",
+			},
+		},
+		{
+			"test with goos and goarch",
+			"foo_linux_amd64_test.go",
+			fileInfo{
+				ext:      ".go",
+				category: goExt,
+				goos:     "linux",
+				goarch:   "amd64",
+				isTest:   true,
+			},
+		},
+		{
+			"test then goos",
+			"foo_test_linux.go",
+			fileInfo{
+				ext:      ".go",
+				category: goExt,
+				goos:     "linux",
+			},
+		},
+		{
+			"goos source",
+			"linux.go",
+			fileInfo{
+				ext:      ".go",
+				category: goExt,
+				goos:     "",
+			},
+		},
+		{
+			"goarch source",
+			"amd64.go",
+			fileInfo{
+				ext:      ".go",
+				category: goExt,
+				goarch:   "",
+			},
+		},
+		{
+			"goos test",
+			"linux_test.go",
+			fileInfo{
+				ext:      ".go",
+				category: goExt,
+				goos:     "",
+				isTest:   true,
+			},
+		},
+		{
+			"c file",
+			"foo_test.cxx",
+			fileInfo{
+				ext:      ".cxx",
+				category: cExt,
+				isTest:   true,
+			},
+		},
+		{
+			"h file",
+			"foo_linux.h",
+			fileInfo{
+				ext:      ".h",
+				category: hExt,
+				goos:     "linux",
+			},
+		},
+		{
+			"go asm file",
+			"foo_amd64.s",
+			fileInfo{
+				ext:      ".s",
+				category: sExt,
+				goarch:   "amd64",
+			},
+		},
+		{
+			"c asm file",
+			"foo.S",
+			fileInfo{
+				ext:      ".S",
+				category: csExt,
+			},
+		},
+		{
+			"unsupported file",
+			"foo.m",
+			fileInfo{
+				ext:      ".m",
+				category: unsupportedExt,
+			},
+		},
+		{
+			"ignored file",
+			"foo.txt",
+			fileInfo{
+				ext:      ".txt",
+				category: ignoredExt,
+			},
+		},
+	} {
+		tc.want.name = tc.name
+		tc.want.dir = "dir"
+		tc.want.path = filepath.Join("dir", tc.name)
+
+		if got := fileNameInfo("dir", tc.name); !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("case %q: got %#v; want %#v", tc.desc, got, tc.want)
+		}
+	}
+}
+
+func TestCgo(t *testing.T) {
+	var pr packageReader
+	for _, tc := range []struct {
+		desc, source string
+		want         fileInfo
+	}{
+		{
+			"not cgo",
+			"package foo\n",
+			fileInfo{isCgo: false},
+		},
+		{
+			"empty cgo",
+			`package foo
+
+import "C"
+`,
+			fileInfo{isCgo: true},
+		},
+		{
+			"simple flags",
+			`package foo
+
+/*
+#cgo CFLAGS: -O0
+	#cgo CPPFLAGS: -O1
+#cgo   CXXFLAGS:   -O2
+#cgo LDFLAGS: -O3 -O4
+*/
+import "C"
+`,
+			fileInfo{
+				isCgo: true,
+				copts: []taggedOpts{
+					{opts: []string{"-O0"}},
+					{opts: []string{"-O1"}},
+					{opts: []string{"-O2"}},
+				},
+				clinkopts: []taggedOpts{
+					{opts: []string{"-O3", "-O4"}},
+				},
+			},
+		},
+		{
+			"cflags with conditions",
+			`package foo
+
+/*
+#cgo foo bar,!baz CFLAGS: -O0
+*/
+import "C"
+`,
+			fileInfo{
+				isCgo: true,
+				copts: []taggedOpts{
+					{tags: "foo bar,!baz", opts: []string{"-O0"}},
+				},
+			},
+		},
+		{
+			"slashslash comments",
+			`package foo
+
+// #cgo CFLAGS: -O0
+// #cgo CFLAGS: -O1
+import "C"
+`,
+			fileInfo{
+				isCgo: true,
+				copts: []taggedOpts{
+					{opts: []string{"-O0"}},
+					{opts: []string{"-O1"}},
+				},
+			},
+		},
+		{
+			"comment above single import group",
+			`package foo
+
+/*
+#cgo CFLAGS: -O0
+*/
+import ("C")
+`,
+			fileInfo{
+				isCgo: true,
+				copts: []taggedOpts{
+					{opts: []string{"-O0"}},
+				},
+			},
+		},
+	} {
+		path := "TestCgo.go"
+		if err := ioutil.WriteFile(path, []byte(tc.source), 0600); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(path)
+
+		got, err := pr.goFileInfo(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Clear fields we don't care about for testing.
+		got = fileInfo{isCgo: got.isCgo, copts: got.copts, clinkopts: got.clinkopts}
+
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("case %q: got %#v; want %#v", tc.desc, got, tc.want)
+		}
+	}
+}
+
+func TestCgoFailures(t *testing.T) {
+	for _, tc := range []struct {
+		desc, source, wantError, wantWarning string
+	}{
+		{
+			"bad go file",
+			"pakcage foo",
+			"expected 'package'",
+			"",
+		},
+		{
+			"unknown cgo verb",
+			`package foo
+
+// #cgo FFLAGS: -O0
+import "C"
+`,
+			"invalid #cgo verb",
+			"",
+		},
+		{
+			"unsupported cgo verb",
+			`package foo
+
+// #cgo pkg-config: foo
+import "C"
+`,
+			"",
+			"not supported",
+		},
+		{
+			"bad cgo quoting",
+			`package foo
+
+// #cgo CFLAGS: 'foo bar'
+import "C"
+`,
+			"malformed #cgo argument",
+			"",
+		},
+	} {
+		path := "TestCgoFailures.go"
+		if err := ioutil.WriteFile(path, []byte(tc.source), 0600); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(path)
+
+		var warningText string
+		pr := packageReader{warnHook: func(err error) { warningText = err.Error() }}
+
+		var errorText string
+		if _, err := pr.goFileInfo(path); err != nil {
+			errorText = err.Error()
+		}
+
+		if tc.wantError == "" && errorText != "" || tc.wantError != "" && !strings.Contains(errorText, tc.wantError) {
+			t.Errorf("case %q: got error %q; want error containing %q", tc.desc, errorText, tc.wantError)
+		}
+		if tc.wantWarning == "" && warningText != "" || tc.wantWarning != "" && !strings.Contains(warningText, tc.wantWarning) {
+			t.Errorf("case %q: got warning %q; want warning containing %q", tc.desc, warningText, tc.wantWarning)
+		}
+	}
+}
+
+// Copied from go/build build_test.go
+var (
+	expandSrcDirPath = filepath.Join(string(filepath.Separator)+"projects", "src", "add")
+)
+
+// Copied from go/build build_test.go
+var expandSrcDirTests = []struct {
+	input, expected string
+}{
+	{"-L ${SRCDIR}/libs -ladd", "-L /projects/src/add/libs -ladd"},
+	{"${SRCDIR}/add_linux_386.a -pthread -lstdc++", "/projects/src/add/add_linux_386.a -pthread -lstdc++"},
+	{"Nothing to expand here!", "Nothing to expand here!"},
+	{"$", "$"},
+	{"$$", "$$"},
+	{"${", "${"},
+	{"$}", "$}"},
+	{"$FOO ${BAR}", "$FOO ${BAR}"},
+	{"Find me the $SRCDIRECTORY.", "Find me the $SRCDIRECTORY."},
+	{"$SRCDIR is missing braces", "$SRCDIR is missing braces"},
+}
+
+// Copied from go/build build_test.go
+func TestExpandSrcDir(t *testing.T) {
+	for _, test := range expandSrcDirTests {
+		output, _ := expandSrcDir(test.input, expandSrcDirPath)
+		if output != test.expected {
+			t.Errorf("%q expands to %q with SRCDIR=%q when %q is expected", test.input, output, expandSrcDirPath, test.expected)
+		} else {
+			t.Logf("%q expands to %q with SRCDIR=%q", test.input, output, expandSrcDirPath)
+		}
+	}
+}
+
+// Copied from go/build build_test.go
+func TestShellSafety(t *testing.T) {
+	tests := []struct {
+		input, srcdir, expected string
+		result                  bool
+	}{
+		{"-I${SRCDIR}/../include", "/projects/src/issue 11868", "-I/projects/src/issue 11868/../include", true},
+		{"-I${SRCDIR}", "wtf$@%", "-Iwtf$@%", true},
+		{"-X${SRCDIR}/1,${SRCDIR}/2", "/projects/src/issue 11868", "-X/projects/src/issue 11868/1,/projects/src/issue 11868/2", true},
+		{"-I/tmp -I/tmp", "/tmp2", "-I/tmp -I/tmp", false},
+		{"-I/tmp", "/tmp/[0]", "-I/tmp", true},
+		{"-I${SRCDIR}/dir", "/tmp/[0]", "-I/tmp/[0]/dir", false},
+	}
+	for _, test := range tests {
+		output, ok := expandSrcDir(test.input, test.srcdir)
+		if ok != test.result {
+			t.Errorf("Expected %t while %q expands to %q with SRCDIR=%q; got %t", test.result, test.input, output, test.srcdir, ok)
+		}
+		if output != test.expected {
+			t.Errorf("Expected %q while %q expands with SRCDIR=%q; got %q", test.expected, test.input, test.srcdir, output)
+		}
+	}
+}
+
+func TestIsStandard(t *testing.T) {
+	for _, tc := range []struct {
+		goPrefix, importpath string
+		want                 bool
+	}{
+		{"", "fmt", true},
+		{"", "encoding/json", true},
+		{"", "foo/bar", true},
+		{"", "foo.com/bar", false},
+		{"foo", "fmt", true},
+		{"foo", "encoding/json", true},
+		{"foo", "foo", true},
+		{"foo", "foo/bar", false},
+		{"foo", "foo.com/bar", false},
+		{"foo.com/bar", "fmt", true},
+		{"foo.com/bar", "encoding/json", true},
+		{"foo.com/bar", "foo/bar", true},
+		{"foo.com/bar", "foo.com/bar", false},
+	} {
+		pr := packageReader{goPrefix: tc.goPrefix}
+		if got := pr.isStandard(tc.importpath); got != tc.want {
+			t.Errorf("for prefix %q, importpath %q: got %#v; want %#v", tc.goPrefix, tc.importpath, got, tc.want)
+		}
+	}
+}
+
+func TestReadTags(t *testing.T) {
+	for _, tc := range []struct {
+		desc, source string
+		want         []string
+	}{
+		{
+			"empty file",
+			"",
+			nil,
+		},
+		{
+			"single comment without blank line",
+			"// +build foo\npackage main",
+			nil,
+		},
+		{
+			"multiple comments without blank link",
+			`// +build foo
+
+// +build bar
+package main
+
+`,
+			nil,
+		},
+		{
+			"single comment",
+			"// +build foo\n\n",
+			[]string{"foo"},
+		},
+		{
+			"multiple comments",
+			`// +build foo
+// +build bar
+
+package main`,
+			[]string{"foo", "bar"},
+		},
+		{
+			"multiple comments with blank",
+			`// +build foo
+
+// +build bar
+
+package main`,
+			[]string{"foo", "bar"},
+		},
+		{
+			"comment with space",
+			"  //   +build   foo   bar  \n\n",
+			[]string{"foo   bar"},
+		},
+		{
+			"slash star comment",
+			"/* +build foo */\n\n",
+			nil,
+		},
+	} {
+		f, err := ioutil.TempFile(".", "TestReadTags")
+		if err != nil {
+			t.Fatal(err)
+		}
+		path := f.Name()
+		defer os.Remove(path)
+		if err = f.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err = ioutil.WriteFile(path, []byte(tc.source), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		if got, err := readTags(path); err != nil {
+			t.Fatal(err)
+		} else if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("case %q: got %#v; want %#v", tc.desc, got, tc.want)
+		}
+	}
+}
+
+func TestCheckConstraints(t *testing.T) {
+	for _, tc := range []struct {
+		desc string
+		fi   fileInfo
+		tags string
+		want bool
+	}{
+		{
+			"unconstrained",
+			fileInfo{},
+			"",
+			true,
+		},
+		{
+			"goos satisfied",
+			fileInfo{goos: "linux"},
+			"linux",
+			true,
+		},
+		{
+			"goos unsatisfied",
+			fileInfo{goos: "linux"},
+			"darwin",
+			false,
+		},
+		{
+			"goarch satisfied",
+			fileInfo{goarch: "amd64"},
+			"amd64",
+			true,
+		},
+		{
+			"goarch unsatisfied",
+			fileInfo{goarch: "amd64"},
+			"arm",
+			false,
+		},
+		{
+			"goos goarch satisfied",
+			fileInfo{goos: "linux", goarch: "amd64"},
+			"linux,amd64",
+			true,
+		},
+		{
+			"goos goarch unsatisfied",
+			fileInfo{goos: "linux", goarch: "amd64"},
+			"darwin,amd64",
+			false,
+		},
+		{
+			"tags all satisfied",
+			fileInfo{tags: []string{"foo", "bar"}},
+			"foo,bar",
+			true,
+		},
+		{
+			"tags some unsatisfied",
+			fileInfo{tags: []string{"foo", "bar"}},
+			"foo",
+			false,
+		},
+		{
+			"goos unsatisfied tags satisfied",
+			fileInfo{goos: "linux", tags: []string{"foo"}},
+			"darwin,foo",
+			false,
+		},
+	} {
+		if got := tc.fi.checkConstraints(parseTags(tc.tags)); got != tc.want {
+			t.Errorf("case %q: got %#v; want %#v", tc.desc, got, tc.want)
+		}
+	}
+}
+
+func TestCheckTags(t *testing.T) {
+	for _, tc := range []struct {
+		desc, line, tags string
+		want             bool
+	}{
+		{
+			"empty tags",
+			"",
+			"",
+			false,
+		},
+		{
+			"ignored",
+			"ignore",
+			"",
+			false,
+		},
+		{
+			"single satisfied",
+			"foo",
+			"foo",
+			true,
+		},
+		{
+			"single unsatisfied",
+			"foo",
+			"bar",
+			false,
+		},
+		{
+			"NOT satisfied",
+			"!foo",
+			"",
+			true,
+		},
+		{
+			"NOT unsatisfied",
+			"!foo",
+			"foo",
+			false,
+		},
+		{
+			"double negative fails",
+			"yes !!yes yes",
+			"yes",
+			false,
+		},
+		{
+			"AND satisfied",
+			"foo,bar",
+			"foo,bar",
+			true,
+		},
+		{
+			"AND NOT satisfied",
+			"foo,!bar",
+			"foo",
+			true,
+		},
+		{
+			"AND unsatisfied",
+			"foo,bar",
+			"foo",
+			false,
+		},
+		{
+			"AND NOT unsatisfied",
+			"foo,!bar",
+			"foo,bar",
+			false,
+		},
+		{
+			"OR satisfied",
+			"foo bar",
+			"foo",
+			true,
+		},
+		{
+			"OR NOT satisfied",
+			"foo !bar",
+			"",
+			true,
+		},
+		{
+			"OR unsatisfied",
+			"foo bar",
+			"",
+			false,
+		},
+		{
+			"OR NOT unsatisfied",
+			"foo !bar",
+			"bar",
+			false,
+		},
+	} {
+		if got := checkTags(tc.line, parseTags(tc.tags)); got != tc.want {
+			t.Errorf("case %q: got %#v; want %#v", tc.desc, got, tc.want)
+		}
+	}
+}
+
+func parseTags(tags string) map[string]bool {
+	tagMap := make(map[string]bool)
+	for _, t := range strings.Split(tags, ",") {
+		tagMap[t] = true
+	}
+	return tagMap
+}

--- a/go/tools/gazelle/packages/walk.go
+++ b/go/tools/gazelle/packages/walk.go
@@ -79,6 +79,7 @@ func Walk(bctx build.Context, repoRoot, goPrefix, dir string, f WalkFunc) error 
 type packageReader struct {
 	bctx                    build.Context
 	repoRoot, goPrefix, dir string
+	warnHook                func(error)
 }
 
 func (pr *packageReader) findPackage() (*build.Package, error) {
@@ -188,5 +189,9 @@ func (pr *packageReader) selectPackageName(packageGoFiles map[string][]os.FileIn
 }
 
 func (pr *packageReader) warn(err error) {
+	if pr.warnHook != nil {
+		pr.warnHook(err)
+		return
+	}
 	log.Println(err)
 }


### PR DESCRIPTION
fileInfo holds information used to decide how to build a file.

packageReader.goFileInfo and .otherFileInfo create fileInfo. These
methods examine file name, build tags, package declaration, imports,
and cgo directives.

The functions in this change imitate logic from go/build. Unexported
functions from go/build are copied where possible.

Related: #409