### PR TITLE
Automatic bzl formatting using yapf

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,7 @@
 load("//go:def.bzl", "go_prefix")
 load("//go/private:lines_sorted_test.bzl", "lines_sorted_test")
 load("//proto:go_proto_library.bzl", "go_google_protobuf")
+load("//go/private:bzl_format.bzl", "bzl_format_rules")
 
 go_prefix("github.com/bazelbuild/rules_go")
 
@@ -19,3 +20,5 @@ lines_sorted_test(
     error_message = "Authors must be sorted by first name",
     file = "AUTHORS",
 )
+
+bzl_format_rules()

--- a/go/private/bzl_format.bzl
+++ b/go/private/bzl_format.bzl
@@ -1,0 +1,82 @@
+# Copyright 2016 The Bazel Go Rules Authors. All rights reserved.
+# Copyright 2016 The Closure Rules Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Rules to support automatic formatting of bzl files
+"""
+
+def _bzl_format_yapf_repository_impl(ctx):
+  ctx.download_and_extract(
+      url = "https://codeload.github.com/google/yapf/zip/021238214778cf6bcce04dff3bef1f3f0da15530",
+      stripPrefix="yapf-021238214778cf6bcce04dff3bef1f3f0da15530",
+      type = "zip")
+  ctx.file("BUILD","""
+alias(
+    name="yapf",
+    actual="//yapf:yapf",
+    visibility = ["//visibility:public"],
+)
+""")
+  ctx.file("yapf/BUILD","""
+py_binary(
+    name="yapf",
+    srcs=glob(["**/*.py"]),
+    main="__main__.py",
+    visibility = ["//visibility:public"],
+)""")
+
+_bzl_format_yapf_repository = repository_rule(
+    implementation = _bzl_format_yapf_repository_impl,
+    attrs = {},
+)
+
+def bzl_format_repositories():
+    _bzl_format_yapf_repository(name="bzl_format_yapf")
+
+def _run_yapf_impl(ctx):
+    run_script = ctx.new_file("run_yapf.sh")
+    yapf = ctx.attr.yapf.files_to_run.executable.short_path
+    ctx.file_action(
+        run_script,
+        content="\n".join([
+            "BASE=$(dirname $(readlink WORKSPACE))",
+            "find $BASE -name *.bzl -exec " + yapf + " -i {} \\; ",
+            "",
+        ])
+    )
+    return struct(
+        files=depset([run_script])
+    )
+
+_run_yapf = rule(
+    _run_yapf_impl,
+    attrs = {
+        "yapf": attr.label(),
+    },
+)
+
+def bzl_format_rules():
+  _run_yapf(
+      name = "run_yapf",
+      yapf="@bzl_format_yapf//:yapf",
+  )
+  native.sh_binary(
+      name="bzl_format",
+      data=[
+          "//:WORKSPACE",
+          "@bzl_format_yapf//:yapf",
+      ],
+      srcs=[":run_yapf"],
+      visibility = ["//visibility:public"],
+  )

--- a/go/private/bzl_format.bzl
+++ b/go/private/bzl_format.bzl
@@ -1,5 +1,4 @@
 # Copyright 2016 The Bazel Go Rules Authors. All rights reserved.
-# Copyright 2017 The Closure Rules Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/go/private/bzl_format.bzl
+++ b/go/private/bzl_format.bzl
@@ -1,5 +1,5 @@
 # Copyright 2016 The Bazel Go Rules Authors. All rights reserved.
-# Copyright 2016 The Closure Rules Authors. All rights reserved.
+# Copyright 2017 The Closure Rules Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,23 +12,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """ Rules to support automatic formatting of bzl files
 """
 
+
 def _bzl_format_yapf_repository_impl(ctx):
   ctx.download_and_extract(
-      url = "https://codeload.github.com/google/yapf/zip/021238214778cf6bcce04dff3bef1f3f0da15530",
-      stripPrefix="yapf-021238214778cf6bcce04dff3bef1f3f0da15530",
+      url =
+      "https://codeload.github.com/google/yapf/zip/021238214778cf6bcce04dff3bef1f3f0da15530",
+      stripPrefix = "yapf-021238214778cf6bcce04dff3bef1f3f0da15530",
       type = "zip")
-  ctx.file("BUILD","""
+  ctx.file("BUILD", """
 alias(
     name="yapf",
     actual="//yapf:yapf",
     visibility = ["//visibility:public"],
 )
 """)
-  ctx.file("yapf/BUILD","""
+  ctx.file("yapf/BUILD", """
 py_binary(
     name="yapf",
     srcs=glob(["**/*.py"]),
@@ -36,47 +37,47 @@ py_binary(
     visibility = ["//visibility:public"],
 )""")
 
+
 _bzl_format_yapf_repository = repository_rule(
     implementation = _bzl_format_yapf_repository_impl,
-    attrs = {},
-)
+    attrs = {})
+
 
 def bzl_format_repositories():
-    _bzl_format_yapf_repository(name="bzl_format_yapf")
+  _bzl_format_yapf_repository(name = "bzl_format_yapf")
+
 
 def _run_yapf_impl(ctx):
-    run_script = ctx.new_file("run_yapf.sh")
-    yapf = ctx.attr.yapf.files_to_run.executable.short_path
-    ctx.file_action(
-        run_script,
-        content="\n".join([
-            "BASE=$(dirname $(readlink WORKSPACE))",
-            "find $BASE -name *.bzl -exec " + yapf + " -i {} \\; ",
-            "",
-        ])
-    )
-    return struct(
-        files=depset([run_script])
-    )
+  run_script = ctx.new_file("run_yapf.sh")
+  yapf = ctx.attr.yapf.files_to_run.executable.short_path
+  ctx.file_action(
+      run_script,
+      content = "\n".join([
+          "BASE=$(dirname $(readlink WORKSPACE))",
+          "find $BASE -name *.bzl -exec " + yapf +
+          " -i --style='{based_on_style: chromium, spaces_around_default_or_named_assign: True}' {} \\; ",
+          "",
+      ]))
+  return struct(files = depset([run_script]))
+
 
 _run_yapf = rule(
     _run_yapf_impl,
     attrs = {
         "yapf": attr.label(),
-    },
-)
+    })
+
 
 def bzl_format_rules():
   _run_yapf(
       name = "run_yapf",
-      yapf="@bzl_format_yapf//:yapf",
-  )
+      yapf = "@bzl_format_yapf//:yapf",
+      visibility = ["//visibility:private"])
   native.sh_binary(
-      name="bzl_format",
-      data=[
+      name = "bzl_format",
+      data = [
           "//:WORKSPACE",
           "@bzl_format_yapf//:yapf",
       ],
-      srcs=[":run_yapf"],
-      visibility = ["//visibility:public"],
-  )
+      srcs = [":run_yapf"],
+      visibility = ["//visibility:private"])

--- a/go/private/go_repositories.bzl
+++ b/go/private/go_repositories.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("//go/private:go_repository.bzl", "go_repository", "new_go_repository")
+load("//go/private:bzl_format.bzl", "bzl_format_repositories")
 
 repository_tool_deps = {
     'buildtools': struct(
@@ -42,6 +43,7 @@ def go_internal_tools_deps():
       commit = repository_tool_deps['tools'].commit,
       importpath = repository_tool_deps['tools'].importpath,
   )
+  bzl_format_repositories()
 
 def _fetch_repository_tools_deps(ctx, goroot, gopath):
   for name, dep in repository_tool_deps.items():


### PR DESCRIPTION
This downloads and "builds" yapf
It also adds a special sh_binary target such that
   bazel run //:bzl_format
Will reformat all the bzl files in the repository.
We need to pick a style we like before we actually do this for the first time,
but this allows us to fully automate it.