### PR TITLE
Enable mono repos

### DIFF
--- a/examples/monobuild/cmd/BUILD
+++ b/examples/monobuild/cmd/BUILD
@@ -1,0 +1,14 @@
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+load("//go:def.bzl", "go_binary")
+
+go_binary(
+    name = "mycmd",
+    srcs = ["mycmd.go"],
+    deps = [
+        "//examples/monobuild/lib1:go_default_library",
+        "//examples/monobuild/lib2:go_default_library",
+    ],
+)

--- a/examples/monobuild/cmd/mycmd.go
+++ b/examples/monobuild/cmd/mycmd.go
@@ -1,0 +1,28 @@
+/* Copyright 2017 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+
+	"full/import/path/to/lib1"
+	"totally/different/import/for/lib2"
+)
+
+func main() {
+	fmt.Println("lib1: ", lib1.Name())
+	fmt.Println("lib2: ", lib2.Description())
+}

--- a/examples/monobuild/lib1/BUILD
+++ b/examples/monobuild/lib1/BUILD
@@ -1,0 +1,11 @@
+package(default_visibility = ["//examples/monobuild/cmd:__pkg__"])
+
+load("//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "lib1.go",
+    ],
+    import_path = "full/import/path/to/lib1",
+)

--- a/examples/monobuild/lib1/BUILD
+++ b/examples/monobuild/lib1/BUILD
@@ -7,5 +7,5 @@ go_library(
     srcs = [
         "lib1.go",
     ],
-    import_path = "full/import/path/to/lib1",
+    importpath = "full/import/path/to/lib1",
 )

--- a/examples/monobuild/lib1/lib1.go
+++ b/examples/monobuild/lib1/lib1.go
@@ -1,0 +1,20 @@
+/* Copyright 2017 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lib1
+
+func Name() string {
+	return "I am lib 1"
+}

--- a/examples/monobuild/lib2/BUILD
+++ b/examples/monobuild/lib2/BUILD
@@ -7,5 +7,5 @@ go_library(
     srcs = [
         "lib2.go",
     ],
-    import_path = "totally/different/import/for/lib2",
+    importpath = "totally/different/import/for/lib2",
 )

--- a/examples/monobuild/lib2/BUILD
+++ b/examples/monobuild/lib2/BUILD
@@ -1,0 +1,11 @@
+package(default_visibility = ["//examples/monobuild/cmd:__pkg__"])
+
+load("//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "lib2.go",
+    ],
+    import_path = "totally/different/import/for/lib2",
+)

--- a/examples/monobuild/lib2/lib2.go
+++ b/examples/monobuild/lib2/lib2.go
@@ -1,0 +1,20 @@
+/* Copyright 2017 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lib2
+
+func Description() string {
+	return "I am lib 2"
+}

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -69,13 +69,6 @@ cgo_filetype = FileType([
 
 ################
 
-def _go_prefix(ctx):
-  """slash terminated go-prefix"""
-  prefix = ctx.attr.go_prefix.go_prefix
-  if prefix != "" and not prefix.endswith("/"):
-    prefix = prefix + "/"
-  return prefix
-
 def go_environment_vars(ctx):
   """Return a map of environment variables for use with actions, based on
   the arguments. Uses the ctx.fragments.cpp.cpu attribute, if present,
@@ -159,7 +152,12 @@ def _go_importpath(ctx):
   Returns:
     Go importpath of the library
   """
-  path = _go_prefix(ctx)[:-1]
+  path = ctx.attr.import_path
+  if path != "":
+    return path
+  path = ctx.attr.go_prefix.go_prefix
+  if path.endswith("/"):
+    path = path[:-1]
   if ctx.label.package:
     path += "/" + ctx.label.package
   if ctx.label.name != _DEFAULT_LIB:
@@ -374,14 +372,11 @@ def _emit_go_link_action(ctx, transitive_go_library_paths, transitive_go_librari
   """Sets up a symlink tree to libraries to link together."""
   config_strip = len(ctx.configuration.bin_dir.path) + 1
   pkg_depth = executable.dirname[config_strip:].count('/') + 1
-  prefix = _go_prefix(ctx)
 
   ld = "%s" % ctx.fragments.cpp.compiler_executable
   extldflags = _c_linker_options(ctx) + [
       "-Wl,-rpath,$ORIGIN/" + ("../" * pkg_depth),
   ]
-  if prefix:
-    extldflags.append("-L" + prefix)
   for d in cgo_deps:
     if d.basename.endswith('.so'):
       short_dir = d.dirname[len(d.root.path):]
@@ -473,7 +468,6 @@ def go_test_impl(ctx):
   main_go = ctx.new_file(ctx.label.name + "_main_test.go")
   main_object = ctx.new_file(ctx.label.name + "_main_test.o")
   main_lib = ctx.new_file(ctx.label.name + "_main_test.a")
-  prefix = _go_prefix(ctx)
   go_import = _go_importpath(ctx)
 
   cmds = [
@@ -607,6 +601,7 @@ go_library_attrs = go_env_attrs + {
             "transitive_cgo_deps",
         ],
     ),
+    "import_path": attr.string(),
     "library": attr.label(
         providers = [
             "direct_deps",

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -152,7 +152,7 @@ def _go_importpath(ctx):
   Returns:
     Go importpath of the library
   """
-  path = ctx.attr.import_path
+  path = ctx.attr.importpath
   if path != "":
     return path
   path = ctx.attr.go_prefix.go_prefix
@@ -601,7 +601,7 @@ go_library_attrs = go_env_attrs + {
             "transitive_cgo_deps",
         ],
     ),
-    "import_path": attr.string(),
+    "importpath": attr.string(),
     "library": attr.label(
         providers = [
             "direct_deps",


### PR DESCRIPTION
The previous work on cleaning up the library system now allows arbitrary remapping of library import paths.
This exposes that functionality directly on the library rule, and adds an example of using it.
The enables “mono” repos, where different sub directories represents radically different import paths.