### PR TITLE
Reverse sense of manual flag in run_non_bazel_tests.bash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ script:
       --experimental_repository_cache="$HOME/.bazel_repository_cache" \
       --local_resources=400,1,1.0 \
       //...
-  - tests/run_non_bazel_tests.bash
+  - tests/run_non_bazel_tests.bash ci
 
 notifications:
   email: false

--- a/tests/run_non_bazel_tests.bash
+++ b/tests/run_non_bazel_tests.bash
@@ -26,7 +26,7 @@ manual_tests=(
   custom_go_toolchain/custom_go_toolchain.bash
   test_filter_test_1.7.5/test_filter_test_1.7.5.bash
 )
-if [ "$1" == "manual" ]; then
+if [ "$1" != "ci" ]; then
   tests+=("${manual_tests[@]}")
 fi
 


### PR DESCRIPTION
The "manual" flag is replaced with the "ci" flag, which has the
opposite meaning. Travis CI runs with the "ci" flag, so it won't run
slow tests. When the script is run by hand with no flag, the slow
tests will be run.