### PR TITLE
Gazelle select (5/x): rewrite merge logic

### DIFF
--- a/go/tools/gazelle/merger/merger.go
+++ b/go/tools/gazelle/merger/merger.go
@@ -35,7 +35,7 @@ type GazelleIgnoreError struct {
 }
 
 func (e GazelleIgnoreError) Error() string {
-	return fmt.Sprintf("%s found on line %d", gazelleIgnore, e.posn)
+	return fmt.Sprintf("%s found on line %d", gazelleIgnore, e.posn.Line)
 }
 
 var (
@@ -46,43 +46,317 @@ var (
 	}
 )
 
-// MergeWithExisting merges newfile with an existing build file at
-// existingFilePath and returns newfile.
-func MergeWithExisting(newfile *bzl.File, existingFilePath string) (*bzl.File, error) {
-	b, err := ioutil.ReadFile(existingFilePath)
+// MergeWithExisting merges genfile with an existing build file at
+// existingFilePath and returns genfile.
+func MergeWithExisting(genFile *bzl.File, existingFilePath string) (*bzl.File, error) {
+	oldData, err := ioutil.ReadFile(existingFilePath)
 	if err != nil {
 		return nil, err
 	}
-	f, err := bzl.Parse(newfile.Path, b)
+	oldFile, err := bzl.Parse(genFile.Path, oldData)
 	if err != nil {
 		return nil, err
 	}
-	if err := shouldIgnore(f); err != nil {
+	if err := shouldIgnore(oldFile); err != nil {
 		return nil, err
 	}
 
+	oldStmt := oldFile.Stmt
 	var newStmt []bzl.Expr
-	for _, s := range newfile.Stmt {
-		c, ok := s.(*bzl.CallExpr)
+	for _, s := range genFile.Stmt {
+		genRule, ok := s.(*bzl.CallExpr)
 		if !ok {
-			return nil, fmt.Errorf("got %v expected only CallExpr in %q", s, newfile.Path)
+			return nil, fmt.Errorf("got %v expected only CallExpr in %q", s, genFile.Path)
 		}
-		other, err := match(f, c)
+		i, oldRule := match(oldFile, genRule)
+		if oldRule == nil {
+			newStmt = append(newStmt, genRule)
+			continue
+		}
+
+		var mergedRule bzl.Expr
+		if kind(oldRule) == "load" {
+			mergedRule = mergeLoad(genRule, oldRule, oldFile)
+		} else {
+			mergedRule = mergeRule(genRule, oldRule)
+		}
+		oldStmt[i] = mergedRule
+	}
+
+	oldFile.Stmt = append(oldStmt, newStmt...)
+	return oldFile, nil
+}
+
+// merge combines information from gen and old and returns an updated rule.
+// Both rules must be non-nil and must have the same kind and same name.
+func mergeRule(gen, old *bzl.CallExpr) *bzl.CallExpr {
+	genRule := bzl.Rule{Call: gen}
+	oldRule := bzl.Rule{Call: old}
+	merged := *old
+	merged.List = nil
+	mergedRule := bzl.Rule{Call: &merged}
+
+	for _, k := range oldRule.AttrKeys() {
+		oldAttr := oldRule.Attr(k)
+		var mergedAttr bzl.Expr
+		if !mergeableFields[k] {
+			mergedAttr = oldAttr
+		} else {
+			genAttr := genRule.Attr(k)
+			var err error
+			mergedAttr, err = mergeAttr(genAttr, oldAttr)
+			if err != nil {
+				// TODO: add a verbose mode and log errors like this.
+				mergedAttr = genAttr
+			}
+		}
+
+		if mergedAttr != nil {
+			mergedRule.SetAttr(k, mergedAttr)
+		}
+	}
+
+	for _, k := range genRule.AttrKeys() {
+		if mergedRule.Attr(k) == nil {
+			mergedRule.SetAttr(k, genRule.Attr(k))
+		}
+	}
+
+	return &merged
+}
+
+// mergeAttr combines information from gen and old and returns an updated attr.
+// The attrs may be strings, lists, a select call with a dict, or a list plus
+// a select call. An error is returned if the attrs can't be merged, for example
+// because they are in a format Gazelle doesn't understand.
+func mergeAttr(gen, old bzl.Expr) (bzl.Expr, error) {
+	if _, ok := gen.(*bzl.StringExpr); ok {
+		if shouldKeep(old) {
+			return old, nil
+		}
+		return gen, nil
+	}
+
+	genList, genDict, err := attrListAndDict(gen)
+	if err != nil {
+		return nil, err
+	}
+	oldList, oldDict, err := attrListAndDict(old)
+	if err != nil {
+		return nil, err
+	}
+
+	mergedList := mergeList(genList, oldList)
+	mergedDict, err := mergeDict(genDict, oldDict)
+	if err != nil {
+		return nil, err
+	}
+
+	var mergedSelect bzl.Expr
+	if mergedDict != nil {
+		mergedSelect = &bzl.CallExpr{
+			X:    &bzl.LiteralExpr{Token: "select"},
+			List: []bzl.Expr{mergedDict},
+		}
+	}
+
+	if mergedList == nil {
+		return mergedSelect, nil
+	}
+	if mergedSelect == nil {
+		return mergedList, nil
+	}
+	return &bzl.BinaryExpr{
+		X:  mergedList,
+		Op: "+",
+		Y:  mergedSelect,
+	}, nil
+}
+
+// attrListAndDict matches an expression and attempts to extract either a list
+// of expressions, a call to select with a dictionary, or both.
+// An error is returned if the expression could not be matched.
+func attrListAndDict(expr bzl.Expr) (*bzl.ListExpr, *bzl.DictExpr, error) {
+	if expr == nil {
+		return nil, nil, nil
+	}
+	switch expr := expr.(type) {
+	case *bzl.ListExpr:
+		return expr, nil, nil
+	case *bzl.CallExpr:
+		if x, ok := expr.X.(*bzl.LiteralExpr); ok && x.Token == "select" && len(expr.List) == 1 {
+			if d, ok := expr.List[0].(*bzl.DictExpr); ok {
+				return nil, d, nil
+			}
+		}
+	case *bzl.BinaryExpr:
+		if expr.Op == "+" {
+			if l, ok := expr.X.(*bzl.ListExpr); ok {
+				if call, ok := expr.Y.(*bzl.CallExpr); ok && len(call.List) == 1 {
+					if x, ok := call.X.(*bzl.LiteralExpr); ok && x.Token == "select" {
+						if d, ok := call.List[0].(*bzl.DictExpr); ok {
+							return l, d, nil
+						}
+					}
+				}
+			}
+		}
+	}
+	return nil, nil, fmt.Errorf("expression could not be matched")
+}
+
+func mergeList(gen, old *bzl.ListExpr) *bzl.ListExpr {
+	if old == nil {
+		return gen
+	}
+	if gen == nil {
+		gen = &bzl.ListExpr{List: []bzl.Expr{}}
+	}
+
+	// Build a list of elements from the old list with "# keep" comments. We
+	// must not duplicate these elements, since duplicate elements will be
+	// removed when we rewrite the AST.
+	var merged []bzl.Expr
+	kept := make(map[string]bool)
+	for _, v := range old.List {
+		if shouldKeep(v) {
+			merged = append(merged, v)
+			if s := stringValue(v); s != "" {
+				kept[s] = true
+			}
+		}
+	}
+
+	for _, v := range gen.List {
+		if s := stringValue(v); kept[s] {
+			continue
+		}
+		merged = append(merged, v)
+	}
+
+	if len(merged) == 0 {
+		return nil
+	}
+	return &bzl.ListExpr{List: merged}
+}
+
+func mergeDict(gen, old *bzl.DictExpr) (*bzl.DictExpr, error) {
+	if old == nil {
+		return gen, nil
+	}
+	if gen == nil {
+		gen = &bzl.DictExpr{List: []bzl.Expr{}}
+	}
+
+	var entries []*dictEntry
+	entryMap := make(map[string]*dictEntry)
+
+	for _, kv := range old.List {
+		k, v, err := dictEntryKeyValue(kv)
 		if err != nil {
 			return nil, err
 		}
-		if other == nil {
-			newStmt = append(newStmt, c)
-			continue
+		if _, ok := entryMap[k]; ok {
+			return nil, fmt.Errorf("old dict contains more than one case named %q", k)
 		}
-		if name(c) == "load" {
-			mergeLoad(c, other, f)
-		} else {
-			merge(c, other)
+		e := &dictEntry{key: k, oldValue: v}
+		entries = append(entries, e)
+		entryMap[k] = e
+	}
+
+	for _, kv := range gen.List {
+		k, v, err := dictEntryKeyValue(kv)
+		if err != nil {
+			return nil, err
+		}
+		e, ok := entryMap[k]
+		if !ok {
+			e = &dictEntry{key: k}
+			entries = append(entries, e)
+			entryMap[k] = e
+		}
+		e.genValue = v
+	}
+
+	keys := make([]string, 0, len(entries))
+	haveDefault := false
+	for _, e := range entries {
+		e.mergedValue = mergeList(e.genValue, e.oldValue)
+		if e.key == "//conditions:default" {
+			// Keep the default case, even if it's empty.
+			haveDefault = true
+			if e.mergedValue == nil {
+				e.mergedValue = &bzl.ListExpr{}
+			}
+		} else if e.mergedValue != nil {
+			keys = append(keys, e.key)
 		}
 	}
-	f.Stmt = append(f.Stmt, newStmt...)
-	return f, nil
+	if len(keys) == 0 && (!haveDefault || len(entryMap["//conditions:default"].mergedValue.List) == 0) {
+		return nil, nil
+	}
+	sort.Strings(keys)
+	// Always put the default case last.
+	if haveDefault {
+		keys = append(keys, "//conditions:default")
+	}
+
+	mergedEntries := make([]bzl.Expr, len(keys))
+	for i, k := range keys {
+		e := entryMap[k]
+		mergedEntries[i] = &bzl.KeyValueExpr{
+			Key:   &bzl.StringExpr{Value: e.key},
+			Value: e.mergedValue,
+		}
+	}
+
+	return &bzl.DictExpr{List: mergedEntries, ForceMultiLine: true}, nil
+}
+
+type dictEntry struct {
+	key                             string
+	oldValue, genValue, mergedValue *bzl.ListExpr
+}
+
+func dictEntryKeyValue(e bzl.Expr) (string, *bzl.ListExpr, error) {
+	kv, ok := e.(*bzl.KeyValueExpr)
+	if !ok {
+		return "", nil, fmt.Errorf("dict entry was not a key-value pair: %#v", e)
+	}
+	k, ok := kv.Key.(*bzl.StringExpr)
+	if !ok {
+		return "", nil, fmt.Errorf("dict key was not string: %#v", kv.Key)
+	}
+	v, ok := kv.Value.(*bzl.ListExpr)
+	if !ok {
+		return "", nil, fmt.Errorf("dict value was not list: %#v", kv.Value)
+	}
+	return k.Value, v, nil
+}
+
+func mergeLoad(gen, old *bzl.CallExpr, oldfile *bzl.File) *bzl.CallExpr {
+	vals := make(map[string]bzl.Expr)
+	for _, v := range gen.List[1:] {
+		vals[stringValue(v)] = v
+	}
+	for _, v := range old.List[1:] {
+		rule := stringValue(v)
+		if _, ok := vals[rule]; !ok && ruleUsed(rule, oldfile) {
+			vals[rule] = v
+		}
+	}
+	keys := make([]string, 0, len(vals))
+	for k := range vals {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	merged := *old
+	merged.List = old.List[:1]
+	for _, k := range keys {
+		merged.List = append(merged.List, vals[k])
+	}
+	return &merged
 }
 
 // shouldIgnore checks whether "gazelle:ignore" appears at the beginning of
@@ -103,69 +377,11 @@ func shouldIgnore(oldFile *bzl.File) error {
 	return nil
 }
 
-// merge takes new info from src and merges into dest.
-// pre: these calls are the same X and 'name'
-func merge(src, dest *bzl.CallExpr) {
-	destRule := &bzl.Rule{dest}
-	srcRule := &bzl.Rule{src}
-	todo := make(map[string]bool)
-	for k, v := range mergeableFields {
-		todo[k] = v
-	}
-	for _, k := range srcRule.AttrKeys() {
-		if !mergeableFields[k] {
-			continue
-		}
-		keepIfRequested(srcRule.Attr(k), destRule.Attr(k))
-		destRule.SetAttr(k, srcRule.Attr(k))
-		delete(todo, k)
-	}
-	for k := range todo {
-		destRule.DelAttr(k)
-	}
-}
-
-// keepIfRequested takes two ListExpr and looks for any '# keep' suffixes in discard to preserve
-func keepIfRequested(replace, discard bzl.Expr) {
-	r, ok := replace.(*bzl.ListExpr)
-	if !ok {
-		return
-	}
-	d, ok := discard.(*bzl.ListExpr)
-	if !ok {
-		return
-	}
-	for _, v := range d.List {
-		c := v.Comment()
-		if len(c.Suffix) == 0 {
-			continue
-		}
-		if strings.HasPrefix(c.Suffix[0].Token, keep) {
-			r.List = append(r.List, v)
-		}
-	}
-}
-
-func mergeLoad(src, dest *bzl.CallExpr, oldfile *bzl.File) {
-	vals := make(map[string]bzl.Expr)
-	for _, v := range src.List[1:] {
-		vals[stringValue(v)] = v
-	}
-	for _, v := range dest.List[1:] {
-		rule := stringValue(v)
-		if _, ok := vals[rule]; !ok && ruleUsed(rule, oldfile) {
-			vals[rule] = v
-		}
-	}
-	keys := make([]string, 0, len(vals))
-	for k := range vals {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	dest.List = dest.List[:1]
-	for _, k := range keys {
-		dest.List = append(dest.List, vals[k])
-	}
+// shouldKeep returns whether an expression from the original file should be
+// preserved. This is true if it has a trailing comment that starts with "keep".
+func shouldKeep(e bzl.Expr) bool {
+	c := e.Comment()
+	return len(c.Suffix) > 0 && strings.HasPrefix(c.Suffix[0].Token, keep)
 }
 
 func ruleUsed(rule string, oldfile *bzl.File) bool {
@@ -176,26 +392,26 @@ func ruleUsed(rule string, oldfile *bzl.File) bool {
 // i.e. two 'go_library(name = "foo", ...)' are considered matches
 // despite the values of the other fields.
 // exception: if c is a 'load' statement, the match is done on the first value.
-func match(f *bzl.File, c *bzl.CallExpr) (*bzl.CallExpr, error) {
+func match(f *bzl.File, c *bzl.CallExpr) (int, *bzl.CallExpr) {
 	var m matcher
-	if x := name(c); x == "load" {
+	if kind := kind(c); kind == "load" {
 		if len(c.List) == 0 {
-			return nil, nil
+			return -1, nil
 		}
 		m = &loadMatcher{stringValue(c.List[0])}
 	} else {
-		m = &nameMatcher{x, (&bzl.Rule{c}).AttrString("name")}
+		m = &nameMatcher{kind, name(c)}
 	}
-	for _, s := range f.Stmt {
+	for i, s := range f.Stmt {
 		other, ok := s.(*bzl.CallExpr)
 		if !ok {
 			continue
 		}
 		if m.match(other) {
-			return other, nil
+			return i, other
 		}
 	}
-	return nil, nil
+	return -1, nil
 }
 
 type matcher interface {
@@ -203,11 +419,11 @@ type matcher interface {
 }
 
 type nameMatcher struct {
-	x, name string
+	kind, name string
 }
 
 func (m *nameMatcher) match(c *bzl.CallExpr) bool {
-	return m.x == name(c) && m.name == (&bzl.Rule{c}).AttrString("name")
+	return m.kind == kind(c) && m.name == name(c)
 }
 
 type loadMatcher struct {
@@ -215,11 +431,15 @@ type loadMatcher struct {
 }
 
 func (m *loadMatcher) match(c *bzl.CallExpr) bool {
-	return name(c) == "load" && len(c.List) > 0 && m.load == stringValue(c.List[0])
+	return kind(c) == "load" && len(c.List) > 0 && m.load == stringValue(c.List[0])
+}
+
+func kind(c *bzl.CallExpr) string {
+	return (&bzl.Rule{c}).Kind()
 }
 
 func name(c *bzl.CallExpr) string {
-	return (&bzl.Rule{c}).Kind()
+	return (&bzl.Rule{c}).Name()
 }
 
 func stringValue(e bzl.Expr) string {

--- a/go/tools/gazelle/merger/merger_test.go
+++ b/go/tools/gazelle/merger/merger_test.go
@@ -9,7 +9,20 @@ import (
 	bzl "github.com/bazelbuild/buildtools/build"
 )
 
-const oldData = `
+// should fix
+// * updated srcs from new
+// * data and size preserved from old
+// * load stmt fixed to those in use and sorted
+
+type testCase struct {
+	desc, previous, current, expected string
+	ignore                            bool
+}
+
+var testCases = []testCase{
+	{
+		desc: "basic functionality",
+		previous: `
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test", "go_binary")
 
 go_library(
@@ -27,9 +40,8 @@ go_test(
     data = glob(["testdata/*"]),
     library = ":go_default_library",
 )
-`
-
-const newData = `
+`,
+		current: `
 load("@io_bazel_rules_go//go:def.bzl", "go_test", "go_library")
 
 go_library(
@@ -48,13 +60,9 @@ go_test(
     ],
     library = ":go_default_library",
 )
-`
-
-// should fix
-// * updated srcs from new
-// * data and size preserved from old
-// * load stmt fixed to those in use and sorted
-const expected = `load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+`,
+		expected: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -68,16 +76,17 @@ go_test(
     name = "go_default_test",
     size = "small",
     srcs = [
+        "gen_test.go",  # keep
         "parse_test.go",
         "print_test.go",
-        "gen_test.go",  # keep
     ],
     data = glob(["testdata/*"]),
     library = ":go_default_library",
 )
-`
-
-const ignoreTop = `# gazelle:ignore
+`},
+	{
+		desc: "ignore top",
+		previous: `# gazelle:ignore
 
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
@@ -88,19 +97,294 @@ go_library(
         "print.go",
     ],
 )
-`
-
-const ignoreBefore = `# gazelle:ignore
+`,
+		ignore: true,
+	}, {
+		desc: "ignore before first",
+		previous: `
+# gazelle:ignore
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-`
-
-const ignoreAfterLast = `
+`,
+		ignore: true,
+	}, {
+		desc: "ignore after last",
+		previous: `
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-# gazelle:ignore`
+# gazelle:ignore`,
+		ignore: true,
+	}, {
+		desc: "merge dicts",
+		previous: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
-type testCase struct {
-	previous, current, expected string
-	ignore                      bool
+go_library(
+    name = "go_default_library",
+    srcs = select({
+        "darwin_amd64": [
+            "foo_darwin_amd64.go", # keep
+            "bar_darwin_amd64.go",
+        ],
+        "linux_arm": [
+            "foo_linux_arm.go", # keep
+            "bar_linux_arm.go",
+        ],
+    }),
+)
+`,
+		current: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = select({
+        "linux_arm": ["baz_linux_arm.go"],
+        "darwin_amd64": ["baz_darwin_amd64.go"],
+        "//conditions:default": [],
+    }),
+)
+`,
+		expected: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = select({
+        "darwin_amd64": [
+            "foo_darwin_amd64.go",  # keep
+            "baz_darwin_amd64.go",
+        ],
+        "linux_arm": [
+            "foo_linux_arm.go",  # keep
+            "baz_linux_arm.go",
+        ],
+        "//conditions:default": [],
+    }),
+)
+`,
+	}, {
+		desc: "merge old dict with gen list",
+		previous: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = select({
+        "linux_arm": [
+            "foo_linux_arm.go", # keep
+            "bar_linux_arm.go", # keep
+        ],
+        "darwin_amd64": [
+            "bar_darwin_amd64.go",
+        ],
+    }),
+)
+`,
+		current: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["baz.go"],
+)
+`,
+		expected: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["baz.go"] + select({
+        "linux_arm": [
+            "foo_linux_arm.go",  # keep
+            "bar_linux_arm.go",  # keep
+        ],
+    }),
+)
+`,
+	}, {
+		desc: "merge old list with gen dict",
+		previous: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "foo.go", # keep
+        "bar.go", # keep
+    ],
+)
+`,
+		current: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = select({
+        "linux_arm": [
+            "foo_linux_arm.go",
+            "bar_linux_arm.go",
+        ],
+        "darwin_amd64": [
+            "bar_darwin_amd64.go",
+        ],
+        "//conditions:default": [],
+    }),
+)
+`,
+		expected: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "foo.go",  # keep
+        "bar.go",  # keep
+    ] + select({
+        "linux_arm": [
+            "foo_linux_arm.go",
+            "bar_linux_arm.go",
+        ],
+        "darwin_amd64": [
+            "bar_darwin_amd64.go",
+        ],
+        "//conditions:default": [],
+    }),
+)
+`,
+	}, {
+		desc: "merge old list and dict with gen list and dict",
+		previous: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "foo.go",  # keep
+        "bar.go",
+    ] + select({
+        "linux_arm": [
+            "foo_linux_arm.go",  # keep
+        ],
+        "//conditions:default": [],
+    }),
+)
+`,
+		current: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["baz.go"] + select({
+        "linux_arm": ["bar_linux_arm.go"],
+        "darwin_amd64": ["foo_darwin_amd64.go"],
+        "//conditions:default": [],
+    }),
+)
+`,
+		expected: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "foo.go",  # keep
+        "baz.go",
+    ] + select({
+        "darwin_amd64": ["foo_darwin_amd64.go"],
+        "linux_arm": [
+            "foo_linux_arm.go",  # keep
+            "bar_linux_arm.go",
+        ],
+        "//conditions:default": [],
+    }),
+)
+`,
+	}, {
+		desc: "delete empty list",
+		previous: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["deleted.go"],
+)
+`,
+		current: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = select({
+        "linux_arm": ["foo_linux_arm.go"],
+    }),
+)
+`,
+		expected: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = select({
+        "linux_arm": ["foo_linux_arm.go"],
+    }),
+)
+`,
+	}, {
+		desc: "delete empty dict",
+		previous: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = select({
+        "linux_arm": ["foo_linux_arm.go"],
+        "//conditions:default": [],
+    }),
+)
+`,
+		current: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["foo.go"],
+)
+`,
+		expected: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["foo.go"],
+)
+`,
+	}, {
+		desc: "delete empty attr",
+		previous: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["foo.go"],
+    deps = ["deleted"],
+)
+`,
+		current: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["foo.go"],
+)
+`,
+		expected: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["foo.go"],
+)
+`,
+	},
 }
 
 func TestMergeWithExisting(t *testing.T) {
@@ -112,38 +396,46 @@ func TestMergeWithExisting(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.Remove(tmp.Name())
-	for _, tc := range []testCase{
-		{oldData, newData, expected, false},
-		{ignoreTop, newData, "", true},
-		{ignoreBefore, newData, "", true},
-		{ignoreAfterLast, newData, "", true},
-	} {
+	for _, tc := range testCases {
 		if err := ioutil.WriteFile(tmp.Name(), []byte(tc.previous), 0755); err != nil {
-			t.Fatal(err)
+			t.Fatalf("%s: %v", tc.desc, err)
 		}
-		newF, err := bzl.Parse(tmp.Name(), []byte(tc.current))
+		newF, err := bzl.Parse("current", []byte(tc.current))
 		if err != nil {
-			t.Fatal(err)
+			t.Fatalf("%s: %v", tc.desc, err)
 		}
 		afterF, err := MergeWithExisting(newF, tmp.Name())
 		if _, ok := err.(GazelleIgnoreError); ok {
 			if !tc.ignore {
-				t.Fatalf("unexpected ignore: %v", err)
+				t.Fatalf("%s: unexpected ignore: %v", tc.desc, err)
 			}
 			continue
 		} else if err != nil {
-			t.Fatal(err)
+			t.Fatalf("%s: %v", tc.desc, err)
 		}
 		if tc.ignore {
-			t.Error("expected ignore")
+			t.Errorf("%s: expected ignore", tc.desc)
 		}
-		if s := string(bzl.Format(afterF)); s != tc.expected {
-			t.Errorf("bzl.Format, want %s; got %s", tc.expected, s)
+
+		want := tc.expected
+		if len(want) > 0 && want[0] == '\n' {
+			want = want[1:]
+		}
+
+		if got := string(bzl.Format(afterF)); got != want {
+			t.Errorf("%s: got %s; want %s", tc.desc, got, want)
 		}
 	}
 }
 
 func TestMergeWithExistingDifferentName(t *testing.T) {
+	oldData := testCases[0].previous
+	newData := testCases[0].current
+	expected := testCases[0].expected
+	if len(expected) > 0 && expected[0] == '\n' {
+		expected = expected[1:]
+	}
+
 	tmp, err := ioutil.TempFile(os.Getenv("TEST_TMPDIR"), "BUILD")
 	if err != nil {
 		t.Fatal(err)
@@ -169,6 +461,6 @@ func TestMergeWithExistingDifferentName(t *testing.T) {
 		t.Error(err)
 	}
 	if s := string(bzl.Format(afterF)); s != expected {
-		t.Errorf("bzl.Format, want %s; got %s", expected, s)
+		t.Errorf("got %s; want %s", s, expected)
 	}
 }

--- a/go/tools/gazelle/merger/merger_test.go
+++ b/go/tools/gazelle/merger/merger_test.go
@@ -23,7 +23,9 @@ var testCases = []testCase{
 	{
 		desc: "basic functionality",
 		previous: `
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test", "go_binary")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_prefix", "go_test")
+
+go_prefix("github.com/jr_hacker/tools")
 
 go_library(
     name = "go_default_library",
@@ -44,6 +46,8 @@ go_test(
 		current: `
 load("@io_bazel_rules_go//go:def.bzl", "go_test", "go_library")
 
+go_prefix("")
+
 go_library(
     name = "go_default_library",
     srcs = [
@@ -62,7 +66,9 @@ go_test(
 )
 `,
 		expected: `
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_prefix", "go_test")
+
+go_prefix("github.com/jr_hacker/tools")
 
 go_library(
     name = "go_default_library",
@@ -381,6 +387,40 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
+    srcs = ["foo.go"],
+)
+`,
+	}, {
+		desc: "merge comments",
+		previous: `
+# load
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+# rule
+go_library(
+    # unmerged attr
+    name = "go_default_library",
+    # merged attr
+    srcs = ["foo.go"],
+)
+`,
+		current: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["foo.go"],
+)
+`,
+		expected: `
+# load
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+# rule
+go_library(
+    # unmerged attr
+    name = "go_default_library",
+    # merged attr
     srcs = ["foo.go"],
 )
 `,


### PR DESCRIPTION
* Merging logic now handles calls to select with dictionaries for
  conditional srcs and deps.
* Most of the merging logic is rewritten. Instead of having "src and
  "dest" and modifying dest in place, most functions now have "old"
  and "gen" and return "merged".

Fixes #480
Related to #409