### PR TITLE
Gazelle select (6/x): polish

### DIFF
--- a/go/tools/gazelle/merger/merger.go
+++ b/go/tools/gazelle/merger/merger.go
@@ -190,6 +190,7 @@ func mergeExpr(gen, old bzl.Expr) (bzl.Expr, error) {
 	if mergedSelect == nil {
 		return mergedList, nil
 	}
+	mergedList.ForceMultiLine = true
 	return &bzl.BinaryExpr{
 		X:  mergedList,
 		Op: "+",
@@ -215,23 +216,23 @@ func exprListAndDict(expr bzl.Expr) (*bzl.ListExpr, *bzl.DictExpr, error) {
 		}
 	case *bzl.BinaryExpr:
 		if expr.Op != "+" {
-			return nil, nil, fmt.Errorf("expression could not be matched")
+			return nil, nil, fmt.Errorf("expression could not be matched: unknown operator: %s", expr.Op)
 		}
 		l, ok := expr.X.(*bzl.ListExpr)
 		if !ok {
-			return nil, nil, fmt.Errorf("expression could not be matched")
+			return nil, nil, fmt.Errorf("expression could not be matched: left operand not a list")
 		}
 		call, ok := expr.Y.(*bzl.CallExpr)
 		if !ok || len(call.List) != 1 {
-			return nil, nil, fmt.Errorf("expression could not be matched")
+			return nil, nil, fmt.Errorf("expression could not be matched: right operand not a call with one argument")
 		}
 		x, ok := call.X.(*bzl.LiteralExpr)
 		if !ok || x.Token != "select" {
-			return nil, nil, fmt.Errorf("expression could not be matched")
+			return nil, nil, fmt.Errorf("expression could not be matched: right operand not a call to select")
 		}
 		d, ok := call.List[0].(*bzl.DictExpr)
 		if !ok {
-			return nil, nil, fmt.Errorf("expression could not be matched")
+			return nil, nil, fmt.Errorf("expression could not be matched: argument to right operand not a dict")
 		}
 		return l, d, nil
 	}

--- a/go/tools/gazelle/merger/merger_test.go
+++ b/go/tools/gazelle/merger/merger_test.go
@@ -198,7 +198,9 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["baz.go"] + select({
+    srcs = [
+        "baz.go",
+    ] + select({
         "linux_arm": [
             "foo_linux_arm.go",  # keep
             "bar_linux_arm.go",  # keep


### PR DESCRIPTION
* In exprListAndDict, improve error messages when matching binary exprs.
* Force multi-line formatting for lists that are part of binary exprs
  and lists that are dict values. This is done for both generated and
  merged expressions.
* Fix a recursive call to newValue for map values.

Related #409