### PR TITLE
Hide go_prefix

### DIFF
--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -53,15 +53,7 @@ cgo_filetype = FileType([
 go_env_attrs = {
     #TODO(toolchains): Remove _toolchain attribute when real toolchains arrive
     "_go_toolchain": attr.label(default = Label("@io_bazel_rules_go_toolchain//:go_toolchain")),
-    "go_prefix": attr.label(
-        providers = ["go_prefix"],
-        default = Label(
-            "//:go_prefix",
-            relative_to_caller_repository = True,
-        ),
-        allow_files = False,
-        cfg = "host",
-    ),
+    "_go_prefix": attr.label(default=Label("//:go_prefix", relative_to_caller_repository = True)),
 }
 
 go_library_attrs = go_env_attrs + {

--- a/go/private/library.bzl
+++ b/go/private/library.bzl
@@ -124,7 +124,7 @@ def go_importpath(ctx):
   path = ctx.attr.importpath
   if path != "":
     return path
-  path = ctx.attr.go_prefix.go_prefix
+  path = ctx.attr._go_prefix.go_prefix
   if path.endswith("/"):
     path = path[:-1]
   if ctx.label.package:


### PR DESCRIPTION
There is no reason now we have importpath to ever set the go_prefix attribute
directly on a rule.