### PR TITLE
Don't use shared attribute declarations

### DIFF
--- a/go/private/binary.bzl
+++ b/go/private/binary.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//go/private:common.bzl", "get_go_toolchain", "go_library_attrs", "go_link_attrs", "emit_generate_params_action")
+load("//go/private:common.bzl", "get_go_toolchain", "emit_generate_params_action", "go_filetype")
 load("//go/private:library.bzl", "go_library_impl")
 
 def go_binary_impl(ctx):
@@ -35,7 +35,34 @@ def go_binary_impl(ctx):
 
 go_binary = rule(
     go_binary_impl,
-    attrs = go_library_attrs + go_link_attrs,
+    attrs = {
+        "data": attr.label_list(allow_files = True, cfg = "data"),
+        "srcs": attr.label_list(allow_files = go_filetype),
+        "deps": attr.label_list(
+            providers = [
+                "transitive_go_library_paths",
+                "transitive_go_libraries",
+                "transitive_cgo_deps",
+            ],
+        ),
+        "importpath": attr.string(),
+        "library": attr.label(
+            providers = [
+                "direct_deps",
+                "go_sources",
+                "asm_sources",
+                "cgo_object",
+                "gc_goopts",
+            ],
+        ),
+        "gc_goopts": attr.string_list(),
+        "gc_linkopts": attr.string_list(),
+        "linkstamp": attr.string(),
+        "x_defs": attr.string_dict(),
+        #TODO(toolchains): Remove _toolchain attribute when real toolchains arrive
+        "_go_toolchain": attr.label(default = Label("@io_bazel_rules_go_toolchain//:go_toolchain")),
+        "_go_prefix": attr.label(default=Label("//:go_prefix", relative_to_caller_repository = True)),
+    },
     executable = True,
     fragments = ["cpp"],
 )

--- a/go/private/cgo.bzl
+++ b/go/private/cgo.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//go/private:common.bzl", "get_go_toolchain", "emit_generate_params_action", "go_env_attrs", "go_filetype", "cgo_filetype", "cc_hdr_filetype", "hdr_exts")
+load("//go/private:common.bzl", "get_go_toolchain", "emit_generate_params_action", "go_filetype", "cgo_filetype", "cc_hdr_filetype", "hdr_exts")
 load("//go/private:library.bzl", "go_library")
 load("//go/private:binary.bzl", "c_linker_options")
 
@@ -165,10 +165,12 @@ def _cgo_filter_srcs_impl(ctx):
 
 _cgo_filter_srcs = rule(
     implementation = _cgo_filter_srcs_impl,
-    attrs = go_env_attrs + {
+    attrs = {
         "srcs": attr.label_list(
             allow_files = cgo_filetype,
         ),
+        #TODO(toolchains): Remove _toolchain attribute when real toolchains arrive
+        "_go_toolchain": attr.label(default = Label("@io_bazel_rules_go_toolchain//:go_toolchain")),
     },
     fragments = ["cpp"],
 )
@@ -262,7 +264,7 @@ def _cgo_codegen_impl(ctx):
 
 _cgo_codegen_rule = rule(
     _cgo_codegen_impl,
-    attrs = go_env_attrs + {
+    attrs = {
         "srcs": attr.label_list(
             allow_files = go_filetype,
             non_empty = True,
@@ -281,6 +283,8 @@ _cgo_codegen_rule = rule(
             mandatory = True,
             non_empty = True,
         ),
+        #TODO(toolchains): Remove _toolchain attribute when real toolchains arrive
+        "_go_toolchain": attr.label(default = Label("@io_bazel_rules_go_toolchain//:go_toolchain")),
     },
     fragments = ["cpp"],
     output_to_genfiles = True,
@@ -311,7 +315,7 @@ def _cgo_import_impl(ctx):
 
 _cgo_import = rule(
     _cgo_import_impl,
-    attrs = go_env_attrs + {
+    attrs = {
         "cgo_o": attr.label(
             allow_files = True,
             single_file = True,
@@ -323,6 +327,8 @@ _cgo_import = rule(
         "out": attr.output(
             mandatory = True,
         ),
+        #TODO(toolchains): Remove _toolchain attribute when real toolchains arrive
+        "_go_toolchain": attr.label(default = Label("@io_bazel_rules_go_toolchain//:go_toolchain")),
     },
     fragments = ["cpp"],
 )
@@ -371,7 +377,7 @@ def _cgo_object_impl(ctx):
 
 _cgo_object = rule(
     _cgo_object_impl,
-    attrs = go_env_attrs + {
+    attrs = {
         "src": attr.label(
             mandatory = True,
             providers = ["cc"],
@@ -383,6 +389,8 @@ _cgo_object = rule(
         "out": attr.output(
             mandatory = True,
         ),
+        #TODO(toolchains): Remove _toolchain attribute when real toolchains arrive
+        "_go_toolchain": attr.label(default = Label("@io_bazel_rules_go_toolchain//:go_toolchain")),
     },
     fragments = ["cpp"],
 )

--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -50,44 +50,6 @@ cgo_filetype = FileType([
     ".hxx",
 ])
 
-go_env_attrs = {
-    #TODO(toolchains): Remove _toolchain attribute when real toolchains arrive
-    "_go_toolchain": attr.label(default = Label("@io_bazel_rules_go_toolchain//:go_toolchain")),
-    "_go_prefix": attr.label(default=Label("//:go_prefix", relative_to_caller_repository = True)),
-}
-
-go_library_attrs = go_env_attrs + {
-    "data": attr.label_list(
-        allow_files = True,
-        cfg = "data",
-    ),
-    "srcs": attr.label_list(allow_files = go_filetype),
-    "deps": attr.label_list(
-        providers = [
-            "transitive_go_library_paths",
-            "transitive_go_libraries",
-            "transitive_cgo_deps",
-        ],
-    ),
-    "importpath": attr.string(),
-    "library": attr.label(
-        providers = [
-            "direct_deps",
-            "go_sources",
-            "asm_sources",
-            "cgo_object",
-            "gc_goopts",
-        ],
-    ),
-    "gc_goopts": attr.string_list(),
-}
-
-go_link_attrs = go_library_attrs + {
-    "gc_linkopts": attr.string_list(),
-    "linkstamp": attr.string(),
-    "x_defs": attr.string_dict(),
-}
-
 def get_go_toolchain(ctx):
     return ctx.attr._go_toolchain #TODO(toolchains): ctx.toolchains[go_toolchain_type]
 

--- a/go/private/test.bzl
+++ b/go/private/test.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//go/private:common.bzl", "get_go_toolchain", "emit_generate_params_action", "go_library_attrs", "go_link_attrs")
+load("//go/private:common.bzl", "get_go_toolchain", "emit_generate_params_action", "go_filetype")
 load("//go/private:library.bzl", "go_library_impl", "go_importpath", "emit_go_compile_action", "get_gc_goopts", "emit_go_pack_action")
 load("//go/private:binary.bzl", "emit_go_link_action", "gc_linkopts")
 
@@ -89,7 +89,34 @@ def go_test_impl(ctx):
 
 go_test = rule(
     go_test_impl,
-    attrs = go_library_attrs + go_link_attrs,
+    attrs = {
+        "data": attr.label_list(allow_files = True, cfg = "data"),
+        "srcs": attr.label_list(allow_files = go_filetype),
+        "deps": attr.label_list(
+            providers = [
+                "transitive_go_library_paths",
+                "transitive_go_libraries",
+                "transitive_cgo_deps",
+            ],
+        ),
+        "importpath": attr.string(),
+        "library": attr.label(
+            providers = [
+                "direct_deps",
+                "go_sources",
+                "asm_sources",
+                "cgo_object",
+                "gc_goopts",
+            ],
+        ),
+        "gc_goopts": attr.string_list(),
+        "gc_linkopts": attr.string_list(),
+        "linkstamp": attr.string(),
+        "x_defs": attr.string_dict(),
+        #TODO(toolchains): Remove _toolchain attribute when real toolchains arrive
+        "_go_toolchain": attr.label(default = Label("@io_bazel_rules_go_toolchain//:go_toolchain")),
+        "_go_prefix": attr.label(default=Label("//:go_prefix", relative_to_caller_repository = True)),
+    },
     executable = True,
     fragments = ["cpp"],
     test = True,


### PR DESCRIPTION
It makes it much harder to read a rule and understand it's parameters.
This is also needed for me to remove attributes that don't belong on rules but
were there in the shared blocks, and to change the acceptable provider types
accepted in shared names (like deps, srcs and library)