### PR TITLE
Gazelle: don't abort on import path resolution errors

### DIFF
--- a/go/tools/gazelle/rules/generator.go
+++ b/go/tools/gazelle/rules/generator.go
@@ -385,7 +385,8 @@ func (g *generator) dependencies(imports []string, dir string) ([]string, error)
 		}
 		l, err := g.r.resolve(p, dir)
 		if err != nil {
-			return nil, err
+			log.Printf("in dir %q, could not resolve import path %q: %v", dir, p, err)
+			continue
 		}
 		deps = append(deps, l.String())
 	}

--- a/go/tools/gazelle/testdata/repo/lib/lib.go
+++ b/go/tools/gazelle/testdata/repo/lib/lib.go
@@ -17,6 +17,9 @@ package lib
 
 import (
 	"example.com/repo/lib/internal/deep"
+
+	// Gazelle should not abort when it finds import paths that don't exist.
+	_ "lib.invalid/does/not/exist"
 )
 
 // Answer returns the ultimate answer to life, the universe and everything.


### PR DESCRIPTION
Bogus import paths sometimes exist in .go files that won't actually
get built. For example, in
golang.org/x/tools/cmd/bundle/testdata/src/initial/b.go.

Gazelle won't always be able to tell if a .go file is actually a
source file or a data file, but we should attempt to generate a BUILD
file anyway. Gazelle should log a warning and continue instead of
failing.