### PR TITLE
Absoulte paths for load statements

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,7 +1,7 @@
-load("//go:def.bzl", "go_prefix")
-load("//go/private:lines_sorted_test.bzl", "lines_sorted_test")
-load("//proto:go_proto_library.bzl", "go_google_protobuf")
-load("//go/private:bzl_format.bzl", "bzl_format_rules")
+load("@io_bazel_rules_go//go:def.bzl", "go_prefix")
+load("@io_bazel_rules_go//go/private:lines_sorted_test.bzl", "lines_sorted_test")
+load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_google_protobuf")
+load("@io_bazel_rules_go//go/private:bzl_format.bzl", "bzl_format_rules")
 
 go_prefix("github.com/bazelbuild/rules_go")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,6 @@
 workspace(name = "io_bazel_rules_go")
 
-load("//go:def.bzl", "go_repositories", "go_repository")
+load("@io_bazel_rules_go//go:def.bzl", "go_repositories", "go_repository")
 
 go_repositories()
 
@@ -13,6 +13,6 @@ go_repository(
 
 # Protocol buffers
 
-load("//proto:go_proto_library.bzl", "go_proto_repositories")
+load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_proto_repositories")
 
 go_proto_repositories()

--- a/examples/bin/BUILD
+++ b/examples/bin/BUILD
@@ -2,7 +2,7 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
-load("//go:def.bzl", "go_binary")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 
 go_binary(
     name = "bin",

--- a/examples/cgo/BUILD
+++ b/examples/cgo/BUILD
@@ -2,7 +2,7 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
-load("//go:def.bzl", "go_library", "go_test", "cgo_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test", "cgo_library")
 
 cgo_library(
     name = "cgo_lib",

--- a/examples/cgo/example_command/BUILD
+++ b/examples/cgo/example_command/BUILD
@@ -2,7 +2,7 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
-load("//go:def.bzl", "go_binary")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 
 go_binary(
     name = "example_command",

--- a/examples/cgo/skip_go_library/BUILD
+++ b/examples/cgo/skip_go_library/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//go:def.bzl", "go_library", "cgo_genrule")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "cgo_genrule")
 
 go_library(
     name = "go_default_library",

--- a/examples/external/BUILD
+++ b/examples/external/BUILD
@@ -1,4 +1,4 @@
-load("//go:def.bzl", "go_binary")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 
 go_binary(
     name = "record_log",

--- a/examples/lib/BUILD
+++ b/examples/lib/BUILD
@@ -2,7 +2,7 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
-load("//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",

--- a/examples/lib/deep/BUILD
+++ b/examples/lib/deep/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//examples/lib:__pkg__"])
 
-load("//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",

--- a/examples/monobuild/cmd/BUILD
+++ b/examples/monobuild/cmd/BUILD
@@ -2,7 +2,7 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
-load("//go:def.bzl", "go_binary")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 
 go_binary(
     name = "mycmd",

--- a/examples/monobuild/lib1/BUILD
+++ b/examples/monobuild/lib1/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//examples/monobuild/cmd:__pkg__"])
 
-load("//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",

--- a/examples/monobuild/lib2/BUILD
+++ b/examples/monobuild/lib2/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//examples/monobuild/cmd:__pkg__"])
 
-load("//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",

--- a/examples/proto/BUILD
+++ b/examples/proto/BUILD
@@ -1,4 +1,4 @@
-load("//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",

--- a/examples/proto/dep/BUILD
+++ b/examples/proto/dep/BUILD
@@ -1,4 +1,4 @@
-load("//proto:go_proto_library.bzl", "go_proto_library")
+load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_proto_library")
 
 go_proto_library(
     name = "useful_proto",

--- a/examples/proto/gostyle/BUILD
+++ b/examples/proto/gostyle/BUILD
@@ -1,4 +1,4 @@
-load("//proto:go_proto_library.bzl", "go_proto_library")
+load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_proto_library")
 
 genrule(
     name = "copy",

--- a/examples/proto/grpc/BUILD
+++ b/examples/proto/grpc/BUILD
@@ -1,5 +1,5 @@
-load("//go:def.bzl", "go_binary")
-load("//proto:go_proto_library.bzl", "go_proto_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_proto_library")
 
 go_proto_library(
     name = "my_svc_proto",

--- a/examples/proto/lib/BUILD
+++ b/examples/proto/lib/BUILD
@@ -1,4 +1,4 @@
-load("//proto:go_proto_library.bzl", "go_proto_library")
+load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_proto_library")
 
 go_proto_library(
     name = "lib_proto",

--- a/examples/stamped_bin/BUILD
+++ b/examples/stamped_bin/BUILD
@@ -1,4 +1,4 @@
-load("//go:def.bzl", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_xtest",

--- a/examples/stamped_bin/stamp/BUILD
+++ b/examples/stamped_bin/stamp/BUILD
@@ -1,4 +1,4 @@
-load("//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",

--- a/examples/vendor/github.com/user/vendored/BUILD
+++ b/examples/vendor/github.com/user/vendored/BUILD
@@ -2,7 +2,7 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
-load("//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//go/private:repositories.bzl", "go_repositories")
-load("//go/private:go_repository.bzl", "go_repository", "new_go_repository")
-load("//go/private:go_prefix.bzl", "go_prefix")
-load("//go/private:library.bzl", "go_library")
-load("//go/private:binary.bzl", "go_binary")
-load("//go/private:test.bzl", "go_test")
-load("//go/private:cgo.bzl", "cgo_library", "cgo_genrule")
+load("@io_bazel_rules_go//go/private:repositories.bzl", "go_repositories")
+load("@io_bazel_rules_go//go/private:go_repository.bzl", "go_repository", "new_go_repository")
+load("@io_bazel_rules_go//go/private:go_prefix.bzl", "go_prefix")
+load("@io_bazel_rules_go//go/private:library.bzl", "go_library")
+load("@io_bazel_rules_go//go/private:binary.bzl", "go_binary")
+load("@io_bazel_rules_go//go/private:test.bzl", "go_test")
+load("@io_bazel_rules_go//go/private:cgo.bzl", "cgo_library", "cgo_genrule")
 
 """These are bare-bones Go rules.
 

--- a/go/private/asm.bzl
+++ b/go/private/asm.bzl
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//go/private:common.bzl", "get_go_toolchain")
-load("//go/private:json.bzl", "json_marshal")
+load("@io_bazel_rules_go//go/private:common.bzl", "get_go_toolchain")
+load("@io_bazel_rules_go//go/private:json.bzl", "json_marshal")
 
 def emit_go_asm_action(ctx, source, hdrs, out_obj):
   """Construct the command line for compiling Go Assembly code.

--- a/go/private/binary.bzl
+++ b/go/private/binary.bzl
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//go/private:common.bzl", "get_go_toolchain", "emit_generate_params_action", "go_filetype")
-load("//go/private:library.bzl", "emit_library_actions")
+load("@io_bazel_rules_go//go/private:common.bzl", "get_go_toolchain", "emit_generate_params_action", "go_filetype")
+load("@io_bazel_rules_go//go/private:library.bzl", "emit_library_actions")
 
 def _go_binary_impl(ctx):
   """go_binary_impl emits actions for compiling and linking a go executable."""

--- a/go/private/cgo.bzl
+++ b/go/private/cgo.bzl
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//go/private:common.bzl", "get_go_toolchain", "emit_generate_params_action", "go_filetype", "cgo_filetype", "cc_hdr_filetype", "hdr_exts")
-load("//go/private:library.bzl", "go_library")
-load("//go/private:binary.bzl", "c_linker_options")
+load("@io_bazel_rules_go//go/private:common.bzl", "get_go_toolchain", "emit_generate_params_action", "go_filetype", "cgo_filetype", "cc_hdr_filetype", "hdr_exts")
+load("@io_bazel_rules_go//go/private:library.bzl", "go_library")
+load("@io_bazel_rules_go//go/private:binary.bzl", "c_linker_options")
 
 def _cgo_genrule_impl(ctx):
   return struct(

--- a/go/private/library.bzl
+++ b/go/private/library.bzl
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//go/private:common.bzl", "get_go_toolchain", "DEFAULT_LIB", "VENDOR_PREFIX", "go_filetype")
-load("//go/private:asm.bzl", "emit_go_asm_action")
+load("@io_bazel_rules_go//go/private:common.bzl", "get_go_toolchain", "DEFAULT_LIB", "VENDOR_PREFIX", "go_filetype")
+load("@io_bazel_rules_go//go/private:asm.bzl", "emit_go_asm_action")
 
 def emit_library_actions(ctx, sources, deps, cgo_object, library):
   go_toolchain = get_go_toolchain(ctx)

--- a/go/private/lines_sorted_test.bzl
+++ b/go/private/lines_sorted_test.bzl
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//go/private:files_equal_test.bzl", "files_equal_test")
+load("@io_bazel_rules_go//go/private:files_equal_test.bzl", "files_equal_test")
 
 def lines_sorted_test(name, file, cmd="cat $< >$@", visibility=None, **kwargs):
   """Tests that lines within a file are sorted."""

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -14,10 +14,10 @@
 
 # Once nested repositories work, this file should cease to exist.
 
-load("//go/private:toolchain.bzl", "go_sdk_repository", "go_repository_select")
-load("//go/private:repository_tools.bzl", "go_repository_tools")
-load("//go/private:bzl_format.bzl", "bzl_format_repositories")
-load("//go/private:go_repository.bzl", "go_repository")
+load("@io_bazel_rules_go//go/private:toolchain.bzl", "go_sdk_repository", "go_repository_select")
+load("@io_bazel_rules_go//go/private:repository_tools.bzl", "go_repository_tools")
+load("@io_bazel_rules_go//go/private:bzl_format.bzl", "bzl_format_repositories")
+load("@io_bazel_rules_go//go/private:go_repository.bzl", "go_repository")
 
 _sdk_repositories = {
     # 1.8.3 repositories

--- a/go/private/repository_tools.bzl
+++ b/go/private/repository_tools.bzl
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//go/private:go_repository.bzl", "go_repository", "new_go_repository")
-load("//go/private:bzl_format.bzl", "bzl_format_repositories")
+load("@io_bazel_rules_go//go/private:go_repository.bzl", "go_repository", "new_go_repository")
+load("@io_bazel_rules_go//go/private:bzl_format.bzl", "bzl_format_repositories")
 
 _GO_REPOSITORY_TOOLS_BUILD_FILE = """
 package(default_visibility = ["//visibility:public"])

--- a/go/private/test.bzl
+++ b/go/private/test.bzl
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//go/private:common.bzl", "get_go_toolchain", "emit_generate_params_action", "go_filetype")
-load("//go/private:library.bzl", "emit_library_actions", "go_importpath", "emit_go_compile_action", "get_gc_goopts", "emit_go_pack_action")
-load("//go/private:binary.bzl", "emit_go_link_action", "gc_linkopts")
+load("@io_bazel_rules_go//go/private:common.bzl", "get_go_toolchain", "emit_generate_params_action", "go_filetype")
+load("@io_bazel_rules_go//go/private:library.bzl", "emit_library_actions", "go_importpath", "emit_go_compile_action", "get_gc_goopts", "emit_go_pack_action")
+load("@io_bazel_rules_go//go/private:binary.bzl", "emit_go_link_action", "gc_linkopts")
 
 def _go_test_impl(ctx):
   """go_test_impl implements go testing.

--- a/go/tools/BUILD
+++ b/go/tools/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//go/private:go_tool_binary.bzl", "go_tool_binary")
+load("@io_bazel_rules_go//go/private:go_tool_binary.bzl", "go_tool_binary")
 
 # This binary is used implicitly by go_test().
 go_tool_binary(

--- a/go/tools/bazel/BUILD
+++ b/go/tools/bazel/BUILD
@@ -1,4 +1,4 @@
-load("//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",

--- a/go/tools/builders/BUILD
+++ b/go/tools/builders/BUILD
@@ -1,4 +1,4 @@
-load("//go/private:go_tool_binary.bzl", "go_tool_binary")
+load("@io_bazel_rules_go//go/private:go_tool_binary.bzl", "go_tool_binary")
 
 go_tool_binary(
     name = "asm",

--- a/go/tools/extract_package/BUILD
+++ b/go/tools/extract_package/BUILD
@@ -1,5 +1,5 @@
-load("//go/private:go_tool_binary.bzl", "go_tool_binary")
-load("//go:def.bzl", "go_test")
+load("@io_bazel_rules_go//go/private:go_tool_binary.bzl", "go_tool_binary")
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_tool_binary(
     name = "extract_package",

--- a/go/tools/fetch_repo/BUILD
+++ b/go/tools/fetch_repo/BUILD
@@ -1,4 +1,4 @@
-load("//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_binary(
     name = "fetch_repo",

--- a/go/tools/filter_exec/BUILD
+++ b/go/tools/filter_exec/BUILD
@@ -1,4 +1,4 @@
-load("//go/private:go_tool_binary.bzl", "go_tool_binary")
+load("@io_bazel_rules_go//go/private:go_tool_binary.bzl", "go_tool_binary")
 
 go_tool_binary(
     name = "filter_exec",

--- a/go/tools/filter_tags/BUILD
+++ b/go/tools/filter_tags/BUILD
@@ -1,5 +1,5 @@
-load("//go/private:go_tool_binary.bzl", "go_tool_binary")
-load("//go:def.bzl", "go_test")
+load("@io_bazel_rules_go//go/private:go_tool_binary.bzl", "go_tool_binary")
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_tool_binary(
     name = "filter_tags",

--- a/go/tools/gazelle/gazelle/BUILD
+++ b/go/tools/gazelle/gazelle/BUILD
@@ -1,4 +1,4 @@
-load("//go:def.bzl", "go_library", "go_binary", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_binary", "go_test")
 
 go_library(
     name = "go_default_library",

--- a/go/tools/gazelle/generator/BUILD
+++ b/go/tools/gazelle/generator/BUILD
@@ -1,4 +1,4 @@
-load("//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",

--- a/go/tools/gazelle/merger/BUILD
+++ b/go/tools/gazelle/merger/BUILD
@@ -1,4 +1,4 @@
-load("//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",

--- a/go/tools/gazelle/packages/BUILD
+++ b/go/tools/gazelle/packages/BUILD
@@ -1,4 +1,4 @@
-load("//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",

--- a/go/tools/gazelle/rules/BUILD
+++ b/go/tools/gazelle/rules/BUILD
@@ -1,4 +1,4 @@
-load("//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",

--- a/go/tools/gazelle/testdata/BUILD
+++ b/go/tools/gazelle/testdata/BUILD
@@ -3,7 +3,7 @@ package(
     default_visibility = ["//go/tools/gazelle:__subpackages__"],
 )
 
-load("//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",

--- a/go/tools/gazelle/wspace/BUILD
+++ b/go/tools/gazelle/wspace/BUILD
@@ -1,4 +1,4 @@
-load("//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",

--- a/go/tools/wtool/BUILD
+++ b/go/tools/wtool/BUILD
@@ -1,4 +1,4 @@
-load("//go:def.bzl", "go_binary")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 
 go_binary(
     name = "wtool",

--- a/tests/asm_include/BUILD
+++ b/tests/asm_include/BUILD
@@ -1,4 +1,4 @@
-load("//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 config_setting(
     name = "linux_amd64",

--- a/tests/binary_test_outputs/BUILD
+++ b/tests/binary_test_outputs/BUILD
@@ -1,8 +1,8 @@
 # This test checks that go_binary and go_test produce a single output file.
 # See documentation in single_output_test.bzl.
 
-load("//go:def.bzl", "go_binary", "go_test")
-load("//go/private:single_output_test.bzl", "single_output_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_test")
+load("@io_bazel_rules_go//go/private:single_output_test.bzl", "single_output_test")
 
 single_output_test(
     name = "binary_single_output_test",

--- a/tests/build_constraints/BUILD
+++ b/tests/build_constraints/BUILD
@@ -1,4 +1,4 @@
-load("//go:def.bzl", "cgo_library", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "cgo_library", "go_library", "go_test")
 
 go_test(
     name = "go_default_test",

--- a/tests/cgo_pthread_flag/BUILD
+++ b/tests/cgo_pthread_flag/BUILD
@@ -1,4 +1,4 @@
-load("//go:def.bzl", "cgo_library", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "cgo_library", "go_library", "go_test")
 
 cgo_library(
     name = "cgo_default_library",

--- a/tests/coverage/BUILD
+++ b/tests/coverage/BUILD
@@ -1,4 +1,4 @@
-load("//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_test(
     name = "go_default_test",

--- a/tests/extldflags_rpath/BUILD
+++ b/tests/extldflags_rpath/BUILD
@@ -1,4 +1,4 @@
-load("//go:def.bzl", "go_binary")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 
 go_binary(
     name = "extldflags_rpath",

--- a/tests/gc_opts_unsafe/BUILD
+++ b/tests/gc_opts_unsafe/BUILD
@@ -1,4 +1,4 @@
-load("//go:def.bzl", "cgo_library", "go_binary", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "cgo_library", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "unsafe_srcs_lib",

--- a/tests/proto_ignore_go_package_option/BUILD
+++ b/tests/proto_ignore_go_package_option/BUILD
@@ -1,4 +1,4 @@
-load("//proto:go_proto_library.bzl", "go_proto_library")
+load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_proto_library")
 
 go_proto_library(
     name = "a_proto",

--- a/tests/slash_names/BUILD
+++ b/tests/slash_names/BUILD
@@ -1,4 +1,4 @@
-load("//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name="a/pkg",

--- a/tests/test_build_constraints/BUILD
+++ b/tests/test_build_constraints/BUILD
@@ -1,4 +1,4 @@
-load("//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_test(
     name = "go_default_test",

--- a/tests/test_filter_test/BUILD
+++ b/tests/test_filter_test/BUILD
@@ -1,4 +1,4 @@
-load("//go:def.bzl", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",

--- a/tests/transitive_data/BUILD
+++ b/tests/transitive_data/BUILD
@@ -1,4 +1,4 @@
-load("//go:def.bzl", "cgo_library", "go_binary", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "cgo_library", "go_binary", "go_library", "go_test")
 
 go_test(
     name = "go_default_test",


### PR DESCRIPTION
Change all internal load statements to absolute paths otherwise we end up with
duplicate instances of the scripts, with thing like providers of the same name
that don't match.