### PR TITLE
Gazelle: refactor tests

### DIFF
--- a/go/tools/gazelle/rules/generator_test.go
+++ b/go/tools/gazelle/rules/generator_test.go
@@ -17,6 +17,7 @@ package rules_test
 
 import (
 	"go/build"
+	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -24,14 +25,6 @@ import (
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/rules"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/testdata"
 )
-
-func canonicalize(t *testing.T, filename, content string) string {
-	f, err := bzl.Parse(filename, []byte(content))
-	if err != nil {
-		t.Fatalf("bzl.Parse(%q, %q) failed with %v; want success", filename, content, err)
-	}
-	return string(bzl.Format(f))
-}
 
 func format(rules []*bzl.Rule) string {
 	var f bzl.File
@@ -53,186 +46,32 @@ func packageFromDir(t *testing.T, dir string) *build.Package {
 func TestGenerator(t *testing.T) {
 	repoRoot := filepath.Join(testdata.Dir(), "repo")
 	g := rules.NewGenerator(repoRoot, "example.com/repo", rules.External)
-	for _, spec := range []struct {
-		dir  string
-		want string
-	}{
-		{
-			dir: "lib",
-			want: `
-				go_library(
-					name = "go_default_library",
-					srcs = [
-						"doc.go",
-						"lib.go",
-						"asm.s",
-            "asm.h",
-					],
-					visibility = ["//visibility:public"],
-					deps = ["//lib/internal/deep:go_default_library"],
-				)
-
-				go_test(
-					name = "go_default_test",
-					srcs = ["lib_test.go"],
-					library = ":go_default_library",
-				)
-
-				go_test(
-					name = "go_default_xtest",
-					srcs = ["lib_external_test.go"],
-					deps = [":go_default_library"],
-				)
-			`,
-		},
-		{
-			dir: "lib/internal/deep",
-			want: `
-				go_library(
-					name = "go_default_library",
-					srcs = ["thought.go"],
-					visibility = ["//lib:__subpackages__"],
-				)
-			`,
-		},
-		{
-			dir: "lib/relativeimporter",
-			want: `
-				go_library(
-					name = "go_default_library",
-					srcs = ["importer.go"],
-					visibility = ["//visibility:public"],
-					deps = ["//lib/internal/deep:go_default_library"],
-				)
-			`,
-		},
-		{
-			dir: "bin",
-			want: `
-				go_library(
-					name = "go_default_library",
-					srcs = ["main.go"],
-					visibility = ["//visibility:private"],
-					deps = ["//lib:go_default_library"],
-				)
-
-				go_binary(
-					name = "bin",
-					library = ":go_default_library",
-					visibility = ["//visibility:public"],
-				)
-			`,
-		},
-		{
-			dir: "bin_with_tests",
-			want: `
-				go_library(
-					name = "go_default_library",
-					srcs = ["main.go"],
-					visibility = ["//visibility:private"],
-					deps = ["//lib:go_default_library"],
-				)
-
-				go_binary(
-					name = "bin_with_tests",
-					library = ":go_default_library",
-					visibility = ["//visibility:public"],
-				)
-
-				go_test(
-					name = "go_default_test",
-					srcs = ["bin_test.go"],
-					library = ":go_default_library",
-				)
-			`,
-		},
-		{
-			dir: "cgolib",
-			want: `
-				cgo_library(
-					name = "cgo_default_library",
-					srcs = [
-						"foo.go",
-						"foo.c",
-						"foo.h",
-						"asm.S",
-					],
-					copts = ["-I/weird/path"],
-					clinkopts = ["-lweird"],
-					visibility = ["//visibility:private"],
-					deps = [
-						"//lib:go_default_library",
-						"//lib/deep:go_default_library",
-					],
-				)
-
-				go_library(
-					name = "go_default_library",
-					srcs = ["pure.go"],
-					library = ":cgo_default_library",
-					visibility = ["//visibility:public"],
-					deps = [
-						"//lib:go_default_library",
-						"//lib/deep:go_default_library",
-					],
-				)
-
-				go_test(
-					name = "go_default_test",
-					srcs = ["foo_test.go"],
-					library = ":go_default_library",
-				)
-			`},
-		{
-			dir: "allcgolib",
-			want: `
-				cgo_library(
-					name = "cgo_default_library",
-					srcs = [
-						"foo.go",
-						"foo.c",
-					],
-					visibility = ["//visibility:private"],
-					deps = ["//lib:go_default_library"],
-				)
-
-				go_library(
-					name = "go_default_library",
-					library = ":cgo_default_library",
-					visibility = ["//visibility:public"],
-					deps = ["//lib:go_default_library"],
-				)
-
-				go_test(
-					name = "go_default_test",
-					srcs = ["foo_test.go"],
-					library = ":go_default_library",
-				)
-			`},
-		{
-			dir: "tests_with_testdata",
-			want: `
-				go_test(
-					name = "go_default_test",
-					srcs = ["internal_test.go"],
-					data = glob(["testdata/**"]),
-				)
-
-				go_test(
-					name = "go_default_xtest",
-					srcs = ["external_test.go"],
-					data = glob(["testdata/**"]),
-				)
-			`},
+	for _, dir := range []string{
+		"lib",
+		"lib/internal/deep",
+		"bin",
+		"bin_with_tests",
+		"cgolib",
+		"allcgolib",
 	} {
-		pkg := packageFromDir(t, filepath.FromSlash(spec.dir))
-		rules, err := g.Generate(spec.dir, pkg)
+		pkg := packageFromDir(t, filepath.FromSlash(dir))
+		rules, err := g.Generate(dir, pkg)
 		if err != nil {
-			t.Errorf("g.Generate(%q, %#v) failed with %v; want success", spec.dir, pkg, err)
+			t.Errorf("g.Generate(%q, %#v) failed with %v; want success", dir, pkg, err)
+			continue
 		}
+		got := format(rules)
 
-		if got, want := format(rules), canonicalize(t, spec.dir+"/BUILD", spec.want); got != want {
-			t.Errorf("g.Generate(%q, %#v) = %s; want %s", spec.dir, pkg, got, want)
+		wantPath := filepath.Join(pkg.Dir, "BUILD.want")
+		wantBytes, err := ioutil.ReadFile(wantPath)
+		if err != nil {
+			t.Errorf("error reading %s: %v", wantPath, err)
+			continue
+		}
+		want := string(wantBytes)
+
+		if got != want {
+			t.Errorf("g.Generate(%q, %#v) = %s; want %s", dir, pkg, got, want)
 		}
 	}
 }

--- a/go/tools/gazelle/testdata/BUILD
+++ b/go/tools/gazelle/testdata/BUILD
@@ -8,18 +8,5 @@ load("//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["testdata.go"],
-    data = glob([
-        "repo/**/*.go",
-        "repo/**/*.s",
-        "repo/**/*.S",
-        "repo/**/*.c",
-        "repo/**/*.cc",
-        "repo/**/*.cxx",
-        "repo/**/*.cpp",
-        "repo/**/*.h",
-        "repo/**/*.hh",
-        "repo/**/*.hxx",
-        "repo/**/*.hpp",
-        "repo/**/testdata/**",
-    ]),
+    data = glob(["repo/**"]),
 )

--- a/go/tools/gazelle/testdata/repo/allcgolib/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/allcgolib/BUILD.want
@@ -1,0 +1,22 @@
+cgo_library(
+    name = "cgo_default_library",
+    srcs = [
+        "foo.go",
+        "foo.c",
+    ],
+    visibility = ["//visibility:private"],
+    deps = ["//lib:go_default_library"],
+)
+
+go_library(
+    name = "go_default_library",
+    library = ":cgo_default_library",
+    visibility = ["//visibility:public"],
+    deps = ["//lib:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["foo_test.go"],
+    library = ":go_default_library",
+)

--- a/go/tools/gazelle/testdata/repo/bin/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/bin/BUILD.want
@@ -1,0 +1,12 @@
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    visibility = ["//visibility:private"],
+    deps = ["//lib:go_default_library"],
+)
+
+go_binary(
+    name = "bin",
+    library = ":go_default_library",
+    visibility = ["//visibility:public"],
+)

--- a/go/tools/gazelle/testdata/repo/bin_with_tests/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/bin_with_tests/BUILD.want
@@ -1,0 +1,18 @@
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    visibility = ["//visibility:private"],
+    deps = ["//lib:go_default_library"],
+)
+
+go_binary(
+    name = "bin_with_tests",
+    library = ":go_default_library",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["bin_test.go"],
+    library = ":go_default_library",
+)

--- a/go/tools/gazelle/testdata/repo/cgolib/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/cgolib/BUILD.want
@@ -1,0 +1,33 @@
+cgo_library(
+    name = "cgo_default_library",
+    srcs = [
+        "foo.go",
+        "foo.c",
+        "foo.h",
+        "asm.S",
+    ],
+    copts = ["-I/weird/path"],
+    clinkopts = ["-lweird"],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//lib:go_default_library",
+        "//lib/deep:go_default_library",
+    ],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["pure.go"],
+    library = ":cgo_default_library",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//lib:go_default_library",
+        "//lib/deep:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["foo_test.go"],
+    library = ":go_default_library",
+)

--- a/go/tools/gazelle/testdata/repo/lib/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/lib/BUILD.want
@@ -1,0 +1,23 @@
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "lib.go",
+        "asm.s",
+        "asm.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = ["//lib/internal/deep:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["lib_test.go"],
+    library = ":go_default_library",
+)
+
+go_test(
+    name = "go_default_xtest",
+    srcs = ["lib_external_test.go"],
+    deps = [":go_default_library"],
+)

--- a/go/tools/gazelle/testdata/repo/lib/internal/deep/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/lib/internal/deep/BUILD.want
@@ -1,0 +1,5 @@
+go_library(
+    name = "go_default_library",
+    srcs = ["thought.go"],
+    visibility = ["//lib:__subpackages__"],
+)

--- a/go/tools/gazelle/testdata/repo/lib/relativeimporter/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/lib/relativeimporter/BUILD.want
@@ -1,0 +1,6 @@
+go_library(
+    name = "go_default_library",
+    srcs = ["importer.go"],
+    visibility = ["//visibility:public"],
+    deps = ["//lib/internal/deep:go_default_library"],
+)

--- a/go/tools/gazelle/testdata/repo/tests_with_testdata/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/tests_with_testdata/BUILD.want
@@ -1,0 +1,11 @@
+go_test(
+    name = "go_default_test",
+    srcs = ["internal_test.go"],
+    data = glob(["testdata/**"]),
+)
+
+go_test(
+    name = "go_default_xtest",
+    srcs = ["external_test.go"],
+    data = glob(["testdata/**"]),
+)


### PR DESCRIPTION
* Remove redundant tests from generator/generator_test.go. These are
  somewhat tautological. This functionality is covered by
  rules/generator_test.go anyway.
* In rules/generator_test.go, move expected content of BUILD files
  out of the test source and into "BUILD.want" files in testdata.