### PR TITLE
Support stamping in x_def attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,8 +715,15 @@ directly.
       <td>
         <code>Dict of strings; optional</code>
         <p>Additional -X flags to pass to the linker. Keys and values in this
-        dict are passed as `-X key=value`. This can be used to set static
-        information that doesn't change in each build.</p>
+        dict are passed as <code>-X key=value</code>. This can be used to set
+        static information that doesn't change in each build.</p>
+        <p>If the value is surrounded by curly brackets (e.g.
+        <code>{VAR}</code>), then the value of the corresponding workspace
+        status variable will be used instead. Valid workspace status variables
+        include <code>BUILD_USER</code>, <code>BUILD_EMBED_LABEL</code>, and
+        custom variables provided through a
+        <code>--workspace_status_command</code> as described in
+        <code>linkstamp</code>.</p>
       </td>
     </tr>
     <tr>

--- a/examples/stamped_bin/BUILD
+++ b/examples/stamped_bin/BUILD
@@ -1,8 +1,34 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
-    name = "go_default_xtest",
+    name = "stamp_with_linkstamp",
     srcs = ["stamped_bin_test.go"],
-    deps = ["//examples/stamped_bin/stamp:go_default_library"],
     linkstamp = "github.com/bazelbuild/rules_go/examples/stamped_bin/stamp",
+    x_defs = {
+        "github.com/bazelbuild/rules_go/examples/stamped_bin/stamp.PassIfEmpty": "",
+        "github.com/bazelbuild/rules_go/examples/stamped_bin/stamp.XdefBuildTimestamp": "pass",
+    },
+    deps = ["//examples/stamped_bin/stamp:go_default_library"],
+)
+
+go_test(
+    name = "stamp_with_x_defs",
+    srcs = ["stamped_bin_test.go"],
+    x_defs = {
+        "github.com/bazelbuild/rules_go/examples/stamped_bin/stamp.BUILD_TIMESTAMP": "{BUILD_TIMESTAMP}",
+        "github.com/bazelbuild/rules_go/examples/stamped_bin/stamp.XdefBuildTimestamp": "{BUILD_TIMESTAMP}",
+        "github.com/bazelbuild/rules_go/examples/stamped_bin/stamp.PassIfEmpty": "{Undefined_Var}",  # undefined should set the var to empty
+    },
+    deps = ["//examples/stamped_bin/stamp:go_default_library"],
+)
+
+go_test(
+    name = "stamp_with_linkstamp_and_x_defs",
+    srcs = ["stamped_bin_test.go"],
+    linkstamp = "github.com/bazelbuild/rules_go/examples/stamped_bin/stamp",
+    x_defs = {
+        "github.com/bazelbuild/rules_go/examples/stamped_bin/stamp.XdefBuildTimestamp": "{BUILD_TIMESTAMP}",
+        "github.com/bazelbuild/rules_go/examples/stamped_bin/stamp.PassIfEmpty": "",
+    },
+    deps = ["//examples/stamped_bin/stamp:go_default_library"],
 )

--- a/examples/stamped_bin/stamp/stamp.go
+++ b/examples/stamped_bin/stamp/stamp.go
@@ -17,3 +17,9 @@ package stamp
 
 var NOT_A_TIMESTAMP = "fail"
 var BUILD_TIMESTAMP = NOT_A_TIMESTAMP
+
+// an xdef should set this to ""
+var PassIfEmpty = "fail"
+
+// an xdef should set this to nonempty
+var XdefBuildTimestamp = ""

--- a/examples/stamped_bin/stamped_bin_test.go
+++ b/examples/stamped_bin/stamped_bin_test.go
@@ -22,7 +22,16 @@ import (
 )
 
 func TestStampedBin(t *testing.T) {
-	if stamp.BUILD_TIMESTAMP == stamp.NOT_A_TIMESTAMP {
+	// If we use an x_def when linking to override BUILD_TIMESTAMP but fail to
+	// pass through the workspace status value, it'll be set to empty string -
+	// overridden but still wrong. Check for that case too.
+	if stamp.BUILD_TIMESTAMP == stamp.NOT_A_TIMESTAMP || stamp.BUILD_TIMESTAMP == "" {
 		t.Errorf("Expected timestamp to have been modified, got %s.", stamp.BUILD_TIMESTAMP)
+	}
+	if stamp.XdefBuildTimestamp == "" {
+		t.Errorf("Expected XdefBuildTimestamp to have been modified, got %s.", stamp.XdefBuildTimestamp)
+	}
+	if stamp.PassIfEmpty != "" {
+		t.Errorf("Expected PassIfEmpty to have been set to '', got %s.", stamp.PassIfEmpty)
 	}
 }

--- a/go/private/binary.bzl
+++ b/go/private/binary.bzl
@@ -30,7 +30,8 @@ def _go_binary_impl(ctx):
     cgo_deps=lib_result.transitive_cgo_deps,
     libs=lib_result.files,
     executable=ctx.outputs.executable,
-    gc_linkopts=gc_linkopts(ctx))
+    gc_linkopts=gc_linkopts(ctx),
+    x_defs=ctx.attr.x_defs)
 
   return struct(
       files = depset([ctx.outputs.executable]),
@@ -41,7 +42,10 @@ def _go_binary_impl(ctx):
 go_binary = rule(
     _go_binary_impl,
     attrs = {
-        "data": attr.label_list(allow_files = True, cfg = "data"),
+        "data": attr.label_list(
+            allow_files = True,
+            cfg = "data",
+        ),
         "srcs": attr.label_list(allow_files = go_filetype),
         "deps": attr.label_list(
             providers = [
@@ -66,7 +70,10 @@ go_binary = rule(
         "x_defs": attr.string_dict(),
         #TODO(toolchains): Remove _toolchain attribute when real toolchains arrive
         "_go_toolchain": attr.label(default = Label("@io_bazel_rules_go_toolchain//:go_toolchain")),
-        "_go_prefix": attr.label(default=Label("//:go_prefix", relative_to_caller_repository = True)),
+        "_go_prefix": attr.label(default = Label(
+            "//:go_prefix",
+            relative_to_caller_repository = True,
+        )),
     },
     executable = True,
     fragments = ["cpp"],
@@ -99,8 +106,6 @@ def c_linker_options(ctx, blacklist=[]):
 def gc_linkopts(ctx):
   gc_linkopts = [ctx.expand_make_variables("gc_linkopts", f, {})
                  for f in ctx.attr.gc_linkopts]
-  for k, v in ctx.attr.x_defs.items():
-    gc_linkopts += ["-X", "%s='%s'" % (k, v)]
   return gc_linkopts
 
 def _extract_extldflags(gc_linkopts, extldflags):
@@ -128,7 +133,7 @@ def _extract_extldflags(gc_linkopts, extldflags):
   return filtered_gc_linkopts, extldflags
 
 def emit_go_link_action(ctx, transitive_go_library_paths, transitive_go_libraries, cgo_deps, libs,
-                         executable, gc_linkopts):
+                         executable, gc_linkopts, x_defs):
   """Sets up a symlink tree to libraries to link together."""
   go_toolchain = get_go_toolchain(ctx)
   config_strip = len(ctx.configuration.bin_dir.path) + 1
@@ -142,6 +147,7 @@ def emit_go_link_action(ctx, transitive_go_library_paths, transitive_go_librarie
     if d.basename.endswith('.so'):
       short_dir = d.dirname[len(d.root.path):]
       extldflags += ["-Wl,-rpath,$ORIGIN/" + ("../" * pkg_depth) + short_dir]
+
   gc_linkopts, extldflags = _extract_extldflags(gc_linkopts, extldflags)
 
   link_cmd = [
@@ -153,9 +159,12 @@ def emit_go_link_action(ctx, transitive_go_library_paths, transitive_go_librarie
     link_cmd += ["-L", path]
   link_cmd += [
       "-o", executable.path,
-  ] + gc_linkopts + ['"${STAMP_XDEFS[@]}"']
+  ] + gc_linkopts
 
-  link_cmd += go_toolchain.link_flags + [
+  for k, v in x_defs.items():
+    link_cmd += ["-X", "%s='%s'" % (k, v)]
+
+  link_cmd += ['"${STAMP_XDEFS[@]}"'] + go_toolchain.link_flags + [
       "-extld", ld,
       "-extldflags", "'%s'" % " ".join(extldflags),
   ] + [lib.path for lib in libs]
@@ -193,4 +202,3 @@ def emit_go_link_action(ctx, transitive_go_library_paths, transitive_go_librarie
       mnemonic = "GoLink",
       env = go_toolchain.env,
   )
-

--- a/go/private/test.bzl
+++ b/go/private/test.bzl
@@ -80,7 +80,8 @@ def _go_test_impl(ctx):
     cgo_deps=lib_result.transitive_cgo_deps,
     libs=[main_lib],
     executable=ctx.outputs.executable,
-    gc_linkopts=gc_linkopts(ctx))
+    gc_linkopts=gc_linkopts(ctx),
+    x_defs=ctx.attr.x_defs)
 
   # TODO(bazel-team): the Go tests should do a chdir to the directory
   # holding the data files, so open-source go tests continue to work
@@ -95,7 +96,10 @@ def _go_test_impl(ctx):
 go_test = rule(
     _go_test_impl,
     attrs = {
-        "data": attr.label_list(allow_files = True, cfg = "data"),
+        "data": attr.label_list(
+            allow_files = True,
+            cfg = "data",
+        ),
         "srcs": attr.label_list(allow_files = go_filetype),
         "deps": attr.label_list(
             providers = [
@@ -120,10 +124,12 @@ go_test = rule(
         "x_defs": attr.string_dict(),
         #TODO(toolchains): Remove _toolchain attribute when real toolchains arrive
         "_go_toolchain": attr.label(default = Label("@io_bazel_rules_go_toolchain//:go_toolchain")),
-        "_go_prefix": attr.label(default=Label("//:go_prefix", relative_to_caller_repository = True)),
+        "_go_prefix": attr.label(default = Label(
+            "//:go_prefix",
+            relative_to_caller_repository = True,
+        )),
     },
     executable = True,
     fragments = ["cpp"],
     test = True,
 )
-


### PR DESCRIPTION
This PR fixes #432 by augmenting the `x_defs` attribute of `go_binary` and `go_test` rules to refer to variables in the workspace status files.

This uses the unofficial `{VAR}` syntax I [implemented](https://github.com/bazelbuild/rules_docker/pull/17) in the `rules_docker` repo, as suggested by @mikedanese in https://github.com/bazelbuild/rules_go/issues/432#issuecomment-300245203; I'm not sure if there's a consensus style for this sort of thing, yet.

As of now this implicitly turns on stamping if it finds any `x_defs` in the `{VAR}` style, but we could also potentially make it explicit with a `stamp=1` attribute.