### PR TITLE
Remove renaming functionality from Gazelle

### DIFF
--- a/go/tools/gazelle/gazelle/fix.go
+++ b/go/tools/gazelle/gazelle/fix.go
@@ -17,8 +17,6 @@ package main
 
 import (
 	"io/ioutil"
-	"os"
-	"path/filepath"
 
 	bzl "github.com/bazelbuild/buildtools/build"
 )
@@ -26,9 +24,6 @@ import (
 func fixFile(file *bzl.File) error {
 	if err := ioutil.WriteFile(file.Path, bzl.Format(file), 0644); err != nil {
 		return err
-	}
-	if filepath.Base(file.Path) != getBuildFileName() {
-		return os.Rename(file.Path, filepath.Join(filepath.Dir(file.Path), getBuildFileName()))
 	}
 	return nil
 }

--- a/go/tools/gazelle/gazelle/main.go
+++ b/go/tools/gazelle/gazelle/main.go
@@ -114,11 +114,6 @@ func run(dirs []string, emit func(*bzl.File) error, external rules.ExternalResol
 			if err := emit(f); err != nil {
 				return err
 			}
-			if *mode == "fix" && f.Path != existingFilePath {
-				if err := os.Remove(existingFilePath); err != nil {
-					return err
-				}
-			}
 		}
 	}
 	return nil

--- a/go/tools/gazelle/merger/merger.go
+++ b/go/tools/gazelle/merger/merger.go
@@ -53,7 +53,7 @@ func MergeWithExisting(genFile *bzl.File, existingFilePath string) (*bzl.File, e
 	if err != nil {
 		return nil, err
 	}
-	oldFile, err := bzl.Parse(genFile.Path, oldData)
+	oldFile, err := bzl.Parse(existingFilePath, oldData)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Gazelle will no longer rename files in any situation. This was
previously done using the first name in -build_file_name.

Fixes #506