### PR TITLE
Gazelles select (10/10): wire in new package logic

### DIFF
--- a/go/tools/gazelle/generator/generator_test.go
+++ b/go/tools/gazelle/generator/generator_test.go
@@ -25,10 +25,6 @@ import (
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/testdata"
 )
 
-var (
-	buildTagRepoPath = "cgolib_with_build_tags"
-)
-
 func TestBuildTagOverride(t *testing.T) {
 	repo := filepath.Join(testdata.Dir(), "repo")
 	g, err := New(repo, "example.com/repo", "BUILD", "a,b", rules.External)

--- a/go/tools/gazelle/generator/generator_test.go
+++ b/go/tools/gazelle/generator/generator_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	bzl "github.com/bazelbuild/buildtools/build"
-	"github.com/bazelbuild/rules_go/go/tools/gazelle/packages"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/rules"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/testdata"
 )
@@ -32,19 +31,21 @@ var (
 
 func TestBuildTagOverride(t *testing.T) {
 	repo := filepath.Join(testdata.Dir(), "repo")
-	g, err := New(repo, "example.com/repo", "BUILD", "a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z", rules.External)
+	g, err := New(repo, "example.com/repo", "BUILD", "a,b", rules.External)
 	if err != nil {
 		t.Errorf(`New(%q, "example.com/repo") failed with %v; want success`, repo, err)
 		return
 	}
 
-	if got, want := len(g.bctx.BuildTags), 26; got != want {
-		t.Errorf("Got %d build tags; want %d", got, want)
-	}
-
-	for name, platformTags := range g.platforms {
-		if got, want := len(platformTags), len(packages.DefaultPlatformConstraints[name]); got != want {
-			t.Errorf("on platform %q, got %d build tags; want %d", name, got, want)
+	expectedTags := []string{"a", "b", "cgo", "go1.8", "go1.7"}
+	for _, tag := range expectedTags {
+		if !g.buildTags[tag] {
+			t.Errorf("tag %q not set", tag)
+		}
+		for name, platformTags := range g.platforms {
+			if !platformTags[tag] {
+				t.Errorf("on platform %q, tag %q not set", name, tag)
+			}
 		}
 	}
 }

--- a/go/tools/gazelle/packages/fileinfo.go
+++ b/go/tools/gazelle/packages/fileinfo.go
@@ -107,6 +107,9 @@ const (
 	// csExt is applied to other assembly files, ending with .S. These are built
 	// with the C compiler if cgo code is present.
 	csExt
+
+	// protoExt is applied to .proto files.
+	protoExt
 )
 
 // fileNameInfo returns information that can be inferred from the name of
@@ -146,6 +149,8 @@ func fileNameInfo(dir, name string) fileInfo {
 		category = sExt
 	case ".S":
 		category = csExt
+	case ".proto":
+		category = protoExt
 	case ".m", ".f", ".F", ".for", ".f90", ".swig", ".swigcxx", ".syso":
 		category = unsupportedExt
 	default:

--- a/go/tools/gazelle/packages/package.go
+++ b/go/tools/gazelle/packages/package.go
@@ -17,6 +17,7 @@ package packages
 
 import (
 	"fmt"
+	"go/build"
 	"sort"
 	"strings"
 )
@@ -40,6 +41,20 @@ func init() {
 	}
 }
 
+// PreprocessTags performs some automatic processing on generic and
+// platform-specific tags before they are used to match files.
+func PreprocessTags(genericTags map[string]bool, platforms PlatformConstraints) {
+	genericTags["cgo"] = true
+	for _, t := range build.Default.ReleaseTags {
+		genericTags[t] = true
+	}
+	for _, platformTags := range platforms {
+		for t, _ := range genericTags {
+			platformTags[t] = true
+		}
+	}
+}
+
 // Package contains metadata about a Go package extracted from a directory.
 // It fills a similar role to go/build.Package, but it separates files by
 // target instead of by type, and it supports multiple platforms.
@@ -48,6 +63,9 @@ type Package struct {
 	Name string
 
 	Library, CgoLibrary, Binary, Test, XTest Target
+
+	Protos  []string
+	HasPbGo bool
 }
 
 // Target contains metadata about a buildable Go target in a package.
@@ -167,7 +185,14 @@ func (p *Package) addFile(info fileInfo, cgo bool, buildTags map[string]bool, pl
 		p.CgoLibrary.addFile(info, buildTags, platforms)
 	case info.category == goExt || info.category == sExt || info.category == hExt:
 		p.Library.addFile(info, buildTags, platforms)
+	case info.category == protoExt:
+		p.Protos = append(p.Protos, info.name)
 	}
+
+	if strings.HasSuffix(info.name, ".pb.go") {
+		p.HasPbGo = true
+	}
+
 	return nil
 }
 
@@ -286,21 +311,30 @@ func uniq(ss []string) []string {
 // Map applies a function to the strings in "ps" and returns a new
 // PlatformStrings with the results. This is useful for converting import
 // paths to labels.
-func (ps *PlatformStrings) Map(f func(string) string) PlatformStrings {
-	result := PlatformStrings{Generic: make([]string, len(ps.Generic))}
-	for i, s := range ps.Generic {
-		result.Generic[i] = f(s)
+func (ps *PlatformStrings) Map(f func(string) (string, error)) (PlatformStrings, []error) {
+	result := PlatformStrings{Generic: make([]string, 0, len(ps.Generic))}
+	var errors []error
+	for _, s := range ps.Generic {
+		if r, err := f(s); err != nil {
+			errors = append(errors, err)
+		} else {
+			result.Generic = append(result.Generic, r)
+		}
 	}
 
 	if ps.Platform != nil {
 		result.Platform = make(map[string][]string)
 		for n, ss := range ps.Platform {
-			result.Platform[n] = make([]string, len(ss))
-			for i, s := range ss {
-				result.Platform[n][i] = f(s)
+			result.Platform[n] = make([]string, 0, len(ss))
+			for _, s := range ss {
+				if r, err := f(s); err != nil {
+					errors = append(errors, err)
+				} else {
+					result.Platform[n] = append(result.Platform[n], r)
+				}
 			}
 		}
 	}
 
-	return result
+	return result, errors
 }

--- a/go/tools/gazelle/packages/package.go
+++ b/go/tools/gazelle/packages/package.go
@@ -229,6 +229,9 @@ func (ps *PlatformStrings) addGenericOpts(platforms PlatformConstraints, opts []
 
 		for name, tags := range platforms {
 			if checkTags(t.tags, tags) {
+				if ps.Platform == nil {
+					ps.Platform = make(map[string][]string)
+				}
 				ps.Platform[name] = append(ps.Platform[name], t.opts...)
 			}
 		}
@@ -243,11 +246,11 @@ func (ps *PlatformStrings) addPlatformStrings(name string, ss ...string) {
 }
 
 func (ps *PlatformStrings) addTaggedOpts(name string, opts []taggedOpts, tags map[string]bool) {
-	if ps.Platform == nil {
-		ps.Platform = make(map[string][]string)
-	}
 	for _, t := range opts {
 		if t.tags == "" || checkTags(t.tags, tags) {
+			if ps.Platform == nil {
+				ps.Platform = make(map[string][]string)
+			}
 			ps.Platform[name] = append(ps.Platform[name], t.opts...)
 		}
 	}

--- a/go/tools/gazelle/packages/package.go
+++ b/go/tools/gazelle/packages/package.go
@@ -45,6 +45,7 @@ func init() {
 // platform-specific tags before they are used to match files.
 func PreprocessTags(genericTags map[string]bool, platforms PlatformConstraints) {
 	genericTags["cgo"] = true
+	genericTags["gc"] = true
 	for _, t := range build.Default.ReleaseTags {
 		genericTags[t] = true
 	}

--- a/go/tools/gazelle/rules/BUILD
+++ b/go/tools/gazelle/rules/BUILD
@@ -32,9 +32,9 @@ go_test(
 go_test(
     name = "go_default_xtest",
     srcs = ["generator_test.go"],
-    data = glob(["testdata/**/*"]),
     deps = [
         ":go_default_library",
+        "//go/tools/gazelle/packages:go_default_library",
         "//go/tools/gazelle/testdata:go_default_library",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
     ],

--- a/go/tools/gazelle/rules/generator_test.go
+++ b/go/tools/gazelle/rules/generator_test.go
@@ -56,6 +56,7 @@ func TestGenerator(t *testing.T) {
 		"bin",
 		"bin_with_tests",
 		"cgolib",
+		"cgolib_with_build_tags",
 		"allcgolib",
 		"platforms",
 	} {

--- a/go/tools/gazelle/rules/generator_test.go
+++ b/go/tools/gazelle/rules/generator_test.go
@@ -16,12 +16,12 @@ limitations under the License.
 package rules_test
 
 import (
-	"go/build"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
 
 	bzl "github.com/bazelbuild/buildtools/build"
+	"github.com/bazelbuild/rules_go/go/tools/gazelle/packages"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/rules"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/testdata"
 )
@@ -34,30 +34,36 @@ func format(rules []*bzl.Rule) string {
 	return string(bzl.Format(&f))
 }
 
-func packageFromDir(t *testing.T, dir string) *build.Package {
-	dir = filepath.Join(testdata.Dir(), "repo", dir)
-	pkg, err := build.ImportDir(dir, build.ImportComment)
+func packageFromDir(t *testing.T, dir, repoRoot, goPrefix string) *packages.Package {
+	buildTags := map[string]bool{}
+	platforms := packages.DefaultPlatformConstraints
+	packages.PreprocessTags(buildTags, platforms)
+
+	pkg, err := packages.FindPackage(dir, buildTags, platforms, repoRoot, goPrefix)
 	if err != nil {
-		t.Fatalf("build.ImportDir(%q, build.ImportComment) failed with %v; want success", dir, err)
+		t.Fatalf("packages.FindPackage(%q, ...) failed with %v; want success", dir, err)
 	}
 	return pkg
 }
 
 func TestGenerator(t *testing.T) {
 	repoRoot := filepath.Join(testdata.Dir(), "repo")
-	g := rules.NewGenerator(repoRoot, "example.com/repo", rules.External)
-	for _, dir := range []string{
+	goPrefix := "example.com/repo"
+	g := rules.NewGenerator(repoRoot, goPrefix, rules.External)
+	for _, rel := range []string{
 		"lib",
 		"lib/internal/deep",
 		"bin",
 		"bin_with_tests",
 		"cgolib",
 		"allcgolib",
+		"platforms",
 	} {
-		pkg := packageFromDir(t, filepath.FromSlash(dir))
-		rules, err := g.Generate(dir, pkg)
+		dir := filepath.Join(repoRoot, filepath.FromSlash(rel))
+		pkg := packageFromDir(t, dir, repoRoot, goPrefix)
+		rules, err := g.Generate(rel, pkg)
 		if err != nil {
-			t.Errorf("g.Generate(%q, %#v) failed with %v; want success", dir, pkg, err)
+			t.Errorf("g.Generate(%q, %#v) failed with %v; want success", rel, pkg, err)
 			continue
 		}
 		got := format(rules)
@@ -71,15 +77,17 @@ func TestGenerator(t *testing.T) {
 		want := string(wantBytes)
 
 		if got != want {
-			t.Errorf("g.Generate(%q, %#v) = %s; want %s", dir, pkg, got, want)
+			t.Errorf("g.Generate(%q, %#v) = %s; want %s", rel, pkg, got, want)
 		}
 	}
 }
 
 func TestGeneratorGoPrefix(t *testing.T) {
 	repoRoot := filepath.Join(testdata.Dir(), "repo")
-	g := rules.NewGenerator(repoRoot, "example.com/repo/lib", rules.External)
-	pkg := packageFromDir(t, filepath.FromSlash("lib"))
+	goPrefix := "example.com/repo/lib"
+	g := rules.NewGenerator(repoRoot, goPrefix, rules.External)
+	dir := filepath.Join(repoRoot, "lib")
+	pkg := packageFromDir(t, dir, repoRoot, goPrefix)
 	rules, err := g.Generate("", pkg)
 	if err != nil {
 		t.Errorf("g.Generate(%q, %#v) failed with %v; want success", "", pkg, err)

--- a/go/tools/gazelle/testdata/repo/allcgolib/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/allcgolib/BUILD.want
@@ -12,7 +12,6 @@ go_library(
     name = "go_default_library",
     library = ":cgo_default_library",
     visibility = ["//visibility:public"],
-    deps = ["//lib:go_default_library"],
 )
 
 go_test(

--- a/go/tools/gazelle/testdata/repo/cgolib/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/cgolib/BUILD.want
@@ -2,17 +2,14 @@ cgo_library(
     name = "cgo_default_library",
     srcs = [
         "foo.go",
+        "asm.S",
         "foo.c",
         "foo.h",
-        "asm.S",
     ],
-    copts = ["-I/weird/path"],
     clinkopts = ["-lweird"],
+    copts = ["-I/weird/path"],
     visibility = ["//visibility:private"],
-    deps = [
-        "//lib:go_default_library",
-        "//lib/deep:go_default_library",
-    ],
+    deps = ["//lib:go_default_library"],
 )
 
 go_library(
@@ -21,8 +18,8 @@ go_library(
     library = ":cgo_default_library",
     visibility = ["//visibility:public"],
     deps = [
-        "//lib:go_default_library",
         "//lib/deep:go_default_library",
+        "//lib:go_default_library",
     ],
 )
 

--- a/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/BUILD.want
@@ -1,0 +1,56 @@
+cgo_library(
+    name = "cgo_default_library",
+    srcs = [
+        "foo.go",
+        "asm_other.S",
+        "foo.h",
+        "foo_other.c",
+    ] + select({
+        "@io_bazel_rules_go//go/platform:linux_amd64": [
+            "asm_linux.S",
+            "foo_linux.c",
+        ],
+        "//conditions:default": [],
+    }),
+    clinkopts = ["-lweird"],
+    copts = [
+        "-I/weird/path",
+    ] + select({
+        "@io_bazel_rules_go//go/platform:darwin_amd64": [
+            "-DGOOS=darwin",
+        ],
+        "@io_bazel_rules_go//go/platform:linux_amd64": [
+            "-DGOOS=linux",
+        ],
+        "@io_bazel_rules_go//go/platform:windows_amd64": [
+            "-DGOOS=windows",
+        ],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:private"],
+    deps = ["//lib:go_default_library"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "pure_other.go",
+    ] + select({
+        "@io_bazel_rules_go//go/platform:linux_amd64": [
+            "pure_linux.go",
+        ],
+        "//conditions:default": [],
+    }),
+    library = ":cgo_default_library",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//lib/deep:go_default_library",
+        "//lib:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["foo_test.go"],
+    library = ":go_default_library",
+)

--- a/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/foo.go
+++ b/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/foo.go
@@ -17,6 +17,9 @@ package cgolibwithtags
 
 /**
 #cgo CFLAGS: -I/weird/path
+#cgo linux CFLAGS: -DGOOS=linux
+#cgo darwin CFLAGS: -DGOOS=darwin
+#cgo windows CFLAGS: -DGOOS=windows
 #cgo LDFLAGS: -lweird
 **/
 import "C"

--- a/go/tools/gazelle/testdata/repo/lib/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/lib/BUILD.want
@@ -3,8 +3,8 @@ go_library(
     srcs = [
         "doc.go",
         "lib.go",
-        "asm.s",
         "asm.h",
+        "asm.s",
     ],
     visibility = ["//visibility:public"],
     deps = ["//lib/internal/deep:go_default_library"],

--- a/go/tools/gazelle/testdata/repo/platforms/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/platforms/BUILD.want
@@ -1,0 +1,73 @@
+cgo_library(
+    name = "cgo_default_library",
+    srcs = [
+        "cgo_generic.go",
+        "cgo_generic.c",
+    ] + select({
+        "@io_bazel_rules_go//go/platform:linux_amd64": [
+            "cgo_linux.go",
+            "cgo_linux.c",
+        ],
+        "//conditions:default": [],
+    }),
+    copts = [
+        "-DGENERIC",
+    ] + select({
+        "@io_bazel_rules_go//go/platform:linux_amd64": [
+            "-DLINUX",
+        ],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:private"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "generic.go",
+        "release.go",
+    ] + select({
+        "@io_bazel_rules_go//go/platform:darwin_amd64": [
+            "suffix_amd64.go",
+            "suffix_darwin.go",
+            "tag_a.go",
+            "tag_d.go",
+        ],
+        "@io_bazel_rules_go//go/platform:linux_amd64": [
+            "suffix_amd64.go",
+            "suffix_linux.go",
+            "tag_a.go",
+            "tag_l.go",
+        ],
+        "@io_bazel_rules_go//go/platform:windows_amd64": [
+            "suffix_amd64.go",
+            "tag_a.go",
+        ],
+        "//conditions:default": [],
+    }),
+    library = ":cgo_default_library",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//platforms/generic:go_default_library",
+    ] + select({
+        "@io_bazel_rules_go//go/platform:darwin_amd64": [
+            "//platforms/darwin:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:linux_amd64": [
+            "//platforms/linux:go_default_library",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+go_test(
+    name = "go_default_xtest",
+    srcs = [
+        "generic_test.go",
+    ] + select({
+        "@io_bazel_rules_go//go/platform:linux_amd64": [
+            "suffix_linux_test.go",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/go/tools/gazelle/testdata/repo/platforms/cgo_generic.go
+++ b/go/tools/gazelle/testdata/repo/platforms/cgo_generic.go
@@ -1,0 +1,6 @@
+package platforms
+
+/*
+#cgo CFLAGS: -DGENERIC
+*/
+import "C"

--- a/go/tools/gazelle/testdata/repo/platforms/cgo_linux.go
+++ b/go/tools/gazelle/testdata/repo/platforms/cgo_linux.go
@@ -1,0 +1,6 @@
+package platforms
+
+/*
+#cgo CFLAGS: -DLINUX
+*/
+import "C"

--- a/go/tools/gazelle/testdata/repo/platforms/generic.go
+++ b/go/tools/gazelle/testdata/repo/platforms/generic.go
@@ -1,0 +1,3 @@
+package platforms
+
+import _ "example.com/repo/platforms/generic"

--- a/go/tools/gazelle/testdata/repo/platforms/generic_test.go
+++ b/go/tools/gazelle/testdata/repo/platforms/generic_test.go
@@ -1,0 +1,1 @@
+package platforms_test

--- a/go/tools/gazelle/testdata/repo/platforms/ignored.go
+++ b/go/tools/gazelle/testdata/repo/platforms/ignored.go
@@ -1,0 +1,3 @@
+// +build ignore
+
+package platforms

--- a/go/tools/gazelle/testdata/repo/platforms/no_cgo.go
+++ b/go/tools/gazelle/testdata/repo/platforms/no_cgo.go
@@ -1,0 +1,3 @@
+// +build !cgo
+
+package platforms

--- a/go/tools/gazelle/testdata/repo/platforms/release.go
+++ b/go/tools/gazelle/testdata/repo/platforms/release.go
@@ -1,0 +1,3 @@
+// +build go1.7
+
+package platforms

--- a/go/tools/gazelle/testdata/repo/platforms/suffix_amd64.go
+++ b/go/tools/gazelle/testdata/repo/platforms/suffix_amd64.go
@@ -1,0 +1,1 @@
+package platforms

--- a/go/tools/gazelle/testdata/repo/platforms/suffix_arm.go
+++ b/go/tools/gazelle/testdata/repo/platforms/suffix_arm.go
@@ -1,0 +1,1 @@
+package platforms

--- a/go/tools/gazelle/testdata/repo/platforms/suffix_darwin.go
+++ b/go/tools/gazelle/testdata/repo/platforms/suffix_darwin.go
@@ -1,0 +1,6 @@
+package platforms
+
+import (
+	_ "example.com/repo/platforms/darwin"
+	_ "example.com/repo/platforms/generic"
+)

--- a/go/tools/gazelle/testdata/repo/platforms/suffix_linux.go
+++ b/go/tools/gazelle/testdata/repo/platforms/suffix_linux.go
@@ -1,0 +1,6 @@
+package platforms
+
+import (
+	_ "example.com/repo/platforms/generic"
+	_ "example.com/repo/platforms/linux"
+)

--- a/go/tools/gazelle/testdata/repo/platforms/suffix_linux_test.go
+++ b/go/tools/gazelle/testdata/repo/platforms/suffix_linux_test.go
@@ -1,0 +1,1 @@
+package platforms_test

--- a/go/tools/gazelle/testdata/repo/platforms/tag_a.go
+++ b/go/tools/gazelle/testdata/repo/platforms/tag_a.go
@@ -1,0 +1,3 @@
+//+build amd64
+
+package platforms

--- a/go/tools/gazelle/testdata/repo/platforms/tag_d.go
+++ b/go/tools/gazelle/testdata/repo/platforms/tag_d.go
@@ -1,0 +1,5 @@
+//+build darwin
+
+package platforms
+
+import _ "example.com/repo/platforms/darwin"

--- a/go/tools/gazelle/testdata/repo/platforms/tag_l.go
+++ b/go/tools/gazelle/testdata/repo/platforms/tag_l.go
@@ -1,0 +1,5 @@
+//+build linux
+
+package platforms
+
+import _ "example.com/repo/platforms/linux"

--- a/tests/popular_repos/WORKSPACE.in
+++ b/tests/popular_repos/WORKSPACE.in
@@ -5,14 +5,9 @@ local_repository(
 load("@io_bazel_rules_go//go:def.bzl", "go_repositories", "go_repository")
 go_repositories()
 
-# TODO(#409): don't specify build tags for repositories. We should generate
-# platform-independent BUILD files without hints.
-BUILD_TAGS = ["amd64", "@@GOOS@@"]
-
 go_repository(
     name = "org_golang_x_crypto",
     importpath = "golang.org/x/crypto",
-    build_tags = BUILD_TAGS,
     urls = ["https://codeload.github.com/golang/crypto/zip/efac7f277b17c19894091e358c6130cb6bd51117"],
     strip_prefix = "crypto-efac7f277b17c19894091e358c6130cb6bd51117",
     type = "zip",
@@ -22,19 +17,16 @@ go_repository(
     name = "org_golang_x_net",
     importpath = "golang.org/x/net",
     commit = "5602c733f70afc6dcec6766be0d5034d4c4f14de",
-    build_tags = BUILD_TAGS,
 )
 
 go_repository(
     name = "org_golang_x_text",
     importpath = "golang.org/x/text",
     commit = "a9a820217f98f7c8a207ec1e45a874e1fe12c478",
-    build_tags = BUILD_TAGS,
 )
 
 go_repository(
     name = "org_golang_x_tools",
     importpath = "golang.org/x/tools",
     commit = "663269851cdddc898f963782f74ea574bcd5c814",
-    build_tags = BUILD_TAGS,
 )

--- a/tests/popular_repos/popular_repos.bash
+++ b/tests/popular_repos/popular_repos.bash
@@ -29,10 +29,8 @@ function cleanup {
 }
 trap cleanup EXIT
 
-GOOS=$(uname | tr '[:upper:]' '[:lower:]')
 sed -e "s|@@RULES_DIR@@|$RULES_DIR|" \
-    -e "s|@@GOOS@@|$GOOS|" \
-    <"$TEST_DIR/WORKSPACE.in" >"$WORKSPACE_DIR/WORKSPACE"
+  <"$TEST_DIR/WORKSPACE.in" >"$WORKSPACE_DIR/WORKSPACE"
 cd "$WORKSPACE_DIR"
 touch BUILD
 
@@ -86,6 +84,15 @@ excludes=(
   -@org_golang_x_tools//refactor/importgraph:go_default_xtest
   -@org_golang_x_tools//refactor/rename:go_default_test
 )
+
+case $(uname) in
+  Linux)
+    excludes+=(
+      # TODO: cgo_library dependency only has darwin sources.
+      @org_golang_x_text//collate/tools/colcmp
+    )
+    ;;
+esac
 
 bazel_batch_test --keep_going -- "${targets[@]}" "${excludes[@]}"
 

--- a/tests/popular_repos/popular_repos.bash
+++ b/tests/popular_repos/popular_repos.bash
@@ -88,8 +88,8 @@ excludes=(
 case $(uname) in
   Linux)
     excludes+=(
-      # TODO: cgo_library dependency only has darwin sources.
-      @org_golang_x_text//collate/tools/colcmp
+      # route only supports BSD variants.
+      -@org_golang_x_net//route:all
     )
     ;;
 esac


### PR DESCRIPTION
* Rewrite packages/walk.go. Instead of producing build.Package using
  go/build, we now produce packages.Package using the logic that has
  been added in the last several changes in this series.
* Rewrite generator functions in rules/generator.go. We now produce
  rules using packages.Package. There is a new generic rule-creating
  method, generateRule, which the other methods are implemented with.

Fixes #409