### PR TITLE
Move filtering logic into test harness generator

### DIFF
--- a/go/tools/builders/BUILD
+++ b/go/tools/builders/BUILD
@@ -39,6 +39,7 @@ go_tool_binary(
 go_tool_binary(
     name = "generate_test_main",
     srcs = [
+        "filter.go",
         "generate_test_main.go",
     ],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
This kills one more use of bash, normalises the filtering logic, and cleans up
the rules a little more.