### PR TITLE
Rename SDK repositories

### DIFF
--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -66,6 +66,7 @@ def go_repositories(
     for suffix in [".tar.gz", ".zip"]:
       if name.endswith(suffix):
         name = name[:-len(suffix)]
+    name = name.replace("-", "_").replace(".", "_")
     go_sdk_repository(
         name = name,
         url = "https://storage.googleapis.com/golang/" + filename,

--- a/go/private/repository_tools.bzl
+++ b/go/private/repository_tools.bzl
@@ -41,9 +41,9 @@ def _go_repository_tools_impl(ctx):
 
   # We work this out here because you can't use a toolchain from a repository rule
   if ctx.os.name == 'linux':
-    go_tool = ctx.path(Label("@go1.8.3.linux-amd64//:bin/go"))
+    go_tool = ctx.path(Label("@go1_8_3_linux_amd64//:bin/go"))
   elif ctx.os.name == 'mac os x':
-    go_tool = ctx.path(Label("@go1.8.3.darwin-amd64//:bin/go"))
+    go_tool = ctx.path(Label("@go1_8_3_darwin_amd64//:bin/go"))
   else:
     fail("Unsupported operating system: " + ctx.os.name)
 

--- a/go/toolchain/toolchains.bzl
+++ b/go/toolchain/toolchains.bzl
@@ -135,7 +135,7 @@ def generate_toolchains():
       darwin_amd64: [linux_amd64],
   }
 
-  # Use all the above information to generate all the possible toolchain's we might support
+  # Use all the above information to generate all the possible toolchains we might support
   toolchains = []
   for version in versions:
     major = "go%d" % (version.semver[0])
@@ -143,10 +143,10 @@ def generate_toolchains():
     point = "%s.%d" % (minor, version.semver[2])
     version_constraints = [":" + major, ":" + minor, ":" + point]
     for host in version.hosts:
-      distribution = minor
+      distribution = "@go%d_%d_" % (version.semver[0], version.semver[1])
       if version.semver[2]:
-        distribution = point
-      distribution = "@" + distribution + "." + host.os.goos + "-" + host.arch.goarch
+        distribution += "%d_" % version.semver[2]
+      distribution += "%s_%s" % (host.os.goos, host.arch.goarch)
       for target in [host] + cross_targets.get(host, []):
         toolchain_name = point + "-" + host.os.name + "-" + host.arch.name
         is_cross = host != target


### PR DESCRIPTION
Use underscores instead of dots and dashes. Bazel doesn't allow these
characters in workspace names, but it appears it doesn't enforce this
restriction in Skylark repository names.