### PR TITLE
Gazelle: simplify error handling

### DIFF
--- a/go/tools/gazelle/gazelle/fix_test.go
+++ b/go/tools/gazelle/gazelle/fix_test.go
@@ -86,9 +86,7 @@ func TestCreateFile(t *testing.T) {
 	}
 
 	// Check that Gazelle creates a new file named "BUILD.bazel".
-	if err = run([]string{dir}, fixFile, rules.External); err != nil {
-		t.Fatalf("error running Gazelle: %v", err)
-	}
+	run([]string{dir}, nil, fixFile, rules.External)
 
 	buildFile := filepath.Join(dir, "BUILD.bazel")
 	if _, err = os.Stat(buildFile); err != nil {
@@ -116,7 +114,7 @@ func TestUpdateFile(t *testing.T) {
 	}
 
 	// Check that Gazelle updates the BUILD file in place.
-	err = run([]string{dir}, fixFile, rules.External)
+	run([]string{dir}, nil, fixFile, rules.External)
 	if st, err := os.Stat(buildFile); err != nil {
 		t.Errorf("could not stat BUILD: %v", err)
 	} else if st.Size() == 0 {

--- a/go/tools/gazelle/generator/generator_test.go
+++ b/go/tools/gazelle/generator/generator_test.go
@@ -27,7 +27,8 @@ import (
 
 func TestBuildTagOverride(t *testing.T) {
 	repo := filepath.Join(testdata.Dir(), "repo")
-	g, err := New(repo, "example.com/repo", "BUILD", "a,b", rules.External)
+	buildTags := map[string]bool{"a": true, "b": true}
+	g, err := New(repo, "example.com/repo", "BUILD", buildTags, rules.External)
 	if err != nil {
 		t.Errorf(`New(%q, "example.com/repo") failed with %v; want success`, repo, err)
 		return
@@ -53,16 +54,12 @@ func TestGeneratedFileName(t *testing.T) {
 
 func testGeneratedFileName(t *testing.T, buildFileName string) {
 	repo := filepath.Join(testdata.Dir(), "repo")
-	g, err := New(repo, "example.com/repo", buildFileName, "", rules.External)
+	g, err := New(repo, "example.com/repo", buildFileName, nil, rules.External)
 	if err != nil {
 		t.Errorf("error creating generator: %v", err)
 		return
 	}
-	fs, err := g.Generate(filepath.Join(repo, "bin"))
-	if err != nil {
-		t.Errorf("error generating files: %v", err)
-		return
-	}
+	fs := g.Generate(filepath.Join(repo, "bin"))
 	fs = fs[1:] // ignore empty top-level file with go_prefix
 	if got, want := fs[0].Path, filepath.Join("bin", buildFileName); got != want {
 		t.Errorf("got file named %q; want %q", got, want)

--- a/go/tools/gazelle/merger/merger_test.go
+++ b/go/tools/gazelle/merger/merger_test.go
@@ -446,17 +446,16 @@ func TestMergeWithExisting(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", tc.desc, err)
 		}
-		afterF, err := MergeWithExisting(newF, tmp.Name())
-		if _, ok := err.(GazelleIgnoreError); ok {
+		afterF := MergeWithExisting(newF, tmp.Name())
+		if afterF == nil {
 			if !tc.ignore {
-				t.Fatalf("%s: unexpected ignore: %v", tc.desc, err)
+				t.Errorf("%s: got nil; want file", tc.desc)
 			}
 			continue
-		} else if err != nil {
-			t.Fatalf("%s: %v", tc.desc, err)
 		}
-		if tc.ignore {
-			t.Errorf("%s: expected ignore", tc.desc)
+		if afterF != nil && tc.ignore {
+			t.Errorf("%s: got file; want nil", tc.desc)
+			continue
 		}
 
 		want := tc.expected
@@ -498,10 +497,7 @@ func TestMergeWithExistingDifferentName(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	afterF, err := MergeWithExisting(newF, tmp.Name())
-	if err != nil {
-		t.Error(err)
-	}
+	afterF := MergeWithExisting(newF, tmp.Name())
 	if s := string(bzl.Format(afterF)); s != expected {
 		t.Errorf("got %s; want %s", s, expected)
 	}

--- a/go/tools/gazelle/packages/fileinfo.go
+++ b/go/tools/gazelle/packages/fileinfo.go
@@ -212,7 +212,7 @@ func (pr *packageReader) goFileInfo(name string) (fileInfo, error) {
 					cg = d.Doc
 				}
 				if cg != nil {
-					if err := pr.saveCgo(&info, cg); err != nil {
+					if err := saveCgo(&info, cg); err != nil {
 						return fileInfo{}, err
 					}
 				}
@@ -234,7 +234,7 @@ func (pr *packageReader) goFileInfo(name string) (fileInfo, error) {
 // saveCgo extracts CFLAGS, CPPFLAGS, CXXFLAGS, and LDFLAGS directives
 // from a comment above a "C" import. This is intended to match logic in
 // go/build.Context.saveCgo.
-func (pr *packageReader) saveCgo(info *fileInfo, cg *ast.CommentGroup) error {
+func saveCgo(info *fileInfo, cg *ast.CommentGroup) error {
 	text := cg.Text()
 	for _, line := range strings.Split(text, "\n") {
 		orig := line
@@ -283,7 +283,7 @@ func (pr *packageReader) saveCgo(info *fileInfo, cg *ast.CommentGroup) error {
 		case "LDFLAGS":
 			info.clinkopts = append(info.clinkopts, taggedOpts{tags, opts})
 		case "pkg-config":
-			pr.warn(fmt.Errorf("%s: pkg-config not supported: %s", info.path, orig))
+			return fmt.Errorf("%s: pkg-config not supported: %s", info.path, orig)
 		default:
 			return fmt.Errorf("%s: invalid #cgo verb: %s", info.path, orig)
 		}
@@ -418,11 +418,11 @@ func (pr *packageReader) otherFileInfo(name string) (fileInfo, error) {
 		return info, nil
 	}
 	if info.category == unsupportedExt {
-		return info, fmt.Errorf("%s: file extension not yet supported", name)
+		return fileInfo{}, fmt.Errorf("%s: file extension not yet supported", name)
 	}
 
 	if tags, err := readTags(info.path); err != nil {
-		pr.warn(err)
+		return fileInfo{}, err
 	} else {
 		info.tags = tags
 	}

--- a/go/tools/gazelle/packages/walk_test.go
+++ b/go/tools/gazelle/packages/walk_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package packages_test
 
 import (
-	"go/build"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -46,10 +45,7 @@ func checkFiles(t *testing.T, files []fileSpec, goPrefix string, want []*package
 		p.Dir = filepath.Join(dir, filepath.FromSlash(p.Dir))
 	}
 
-	got, err := walkPackages(dir, goPrefix, dir)
-	if err != nil {
-		t.Errorf("walkPackages(%q) failed with %v; want success", dir, err)
-	}
+	got := walkPackages(dir, goPrefix, dir)
 	checkPackages(t, got, want)
 }
 
@@ -76,16 +72,12 @@ func createFiles(files []fileSpec) (string, error) {
 	return dir, nil
 }
 
-func walkPackages(repoRoot, goPrefix, dir string) ([]*packages.Package, error) {
+func walkPackages(repoRoot, goPrefix, dir string) []*packages.Package {
 	var pkgs []*packages.Package
-	err := packages.Walk(nil, nil, repoRoot, goPrefix, dir, func(pkg *packages.Package) error {
+	packages.Walk(nil, nil, repoRoot, goPrefix, dir, func(pkg *packages.Package) {
 		pkgs = append(pkgs, pkg)
-		return nil
 	})
-	if err != nil {
-		return nil, err
-	}
-	return pkgs, nil
+	return pkgs
 }
 
 func checkPackages(t *testing.T, got []*packages.Package, want []*packages.Package) {
@@ -196,9 +188,9 @@ func TestMultiplePackagesWithoutDefault(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	_, err = walkPackages(dir, "", dir)
-	if _, ok := err.(*build.MultiplePackageError); !ok {
-		t.Errorf("got %v; want MultiplePackageError", err)
+	got := walkPackages(dir, "", dir)
+	if len(got) > 0 {
+		t.Errorf("got %v; want empty slice", got)
 	}
 }
 
@@ -231,8 +223,8 @@ func TestRootWithoutPrefix(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	_, err = walkPackages(dir, "", dir)
-	if _, ok := err.(*build.MultiplePackageError); !ok {
-		t.Errorf("got %v; want MultiplePackageError", err)
+	got := walkPackages(dir, "", dir)
+	if len(got) > 0 {
+		t.Errorf("got %v; want empty slice", got)
 	}
 }

--- a/go/tools/gazelle/rules/generator_test.go
+++ b/go/tools/gazelle/rules/generator_test.go
@@ -38,12 +38,7 @@ func packageFromDir(t *testing.T, dir, repoRoot, goPrefix string) *packages.Pack
 	buildTags := map[string]bool{}
 	platforms := packages.DefaultPlatformConstraints
 	packages.PreprocessTags(buildTags, platforms)
-
-	pkg, err := packages.FindPackage(dir, buildTags, platforms, repoRoot, goPrefix)
-	if err != nil {
-		t.Fatalf("packages.FindPackage(%q, ...) failed with %v; want success", dir, err)
-	}
-	return pkg
+	return packages.FindPackage(dir, buildTags, platforms, repoRoot, goPrefix)
 }
 
 func TestGenerator(t *testing.T) {
@@ -63,11 +58,7 @@ func TestGenerator(t *testing.T) {
 	} {
 		dir := filepath.Join(repoRoot, filepath.FromSlash(rel))
 		pkg := packageFromDir(t, dir, repoRoot, goPrefix)
-		rules, err := g.Generate(rel, pkg)
-		if err != nil {
-			t.Errorf("g.Generate(%q, %#v) failed with %v; want success", rel, pkg, err)
-			continue
-		}
+		rules := g.Generate(rel, pkg)
 		got := format(rules)
 
 		wantPath := filepath.Join(pkg.Dir, "BUILD.want")
@@ -90,10 +81,7 @@ func TestGeneratorGoPrefix(t *testing.T) {
 	g := rules.NewGenerator(repoRoot, goPrefix, rules.External)
 	dir := filepath.Join(repoRoot, "lib")
 	pkg := packageFromDir(t, dir, repoRoot, goPrefix)
-	rules, err := g.Generate("", pkg)
-	if err != nil {
-		t.Errorf("g.Generate(%q, %#v) failed with %v; want success", "", pkg, err)
-	}
+	rules := g.Generate("", pkg)
 
 	if got, want := len(rules), 1; got < want {
 		t.Errorf("len(rules) < %d; want >= %d", got, want)


### PR DESCRIPTION
* Most errors in Gazelle are non-fatal. Most entry points in each
  package no longer return errors. Errors will generally be logged
  using log.Print, and a nil value or a partial success value will be
  returned.
* packageReader.warn is replaced by log.Print. There is no longer a
  meaningful difference between warnings and errors.
* In cases where errors could only occur due to bugs in Gazelle (i.e.,
  most of rules), log.Panic is used instead of log.Print.