### PR TITLE
Don't include non-.go files as go_test srcs

### DIFF
--- a/go/tools/gazelle/packages/fileinfo.go
+++ b/go/tools/gazelle/packages/fileinfo.go
@@ -144,7 +144,7 @@ func fileNameInfo(dir, name string) fileInfo {
 	var goos, goarch string
 	l := strings.Split(name[:len(name)-len(ext)], "_")
 	if len(l) >= 2 && l[len(l)-1] == "test" {
-		isTest = true && category != unsupportedExt && category != ignoredExt
+		isTest = category == goExt
 		l = l[:len(l)-1]
 	}
 	switch {

--- a/go/tools/gazelle/packages/fileinfo.go
+++ b/go/tools/gazelle/packages/fileinfo.go
@@ -117,25 +117,6 @@ const (
 func fileNameInfo(dir, name string) fileInfo {
 	ext := path.Ext(name)
 
-	// Determine test, goos, and goarch. This is intended to match the logic
-	// in goodOSArchFile in go/build.
-	var isTest bool
-	var goos, goarch string
-	l := strings.Split(name[:len(name)-len(ext)], "_")
-	if len(l) >= 2 && l[len(l)-1] == "test" {
-		isTest = true
-		l = l[:len(l)-1]
-	}
-	switch {
-	case len(l) >= 3 && knownOS[l[len(l)-2]] && knownArch[l[len(l)-1]]:
-		goos = l[len(l)-2]
-		goarch = l[len(l)-1]
-	case len(l) >= 2 && knownOS[l[len(l)-1]]:
-		goos = l[len(l)-1]
-	case len(l) >= 2 && knownArch[l[len(l)-1]]:
-		goarch = l[len(l)-1]
-	}
-
 	// Categorize the file based on extension. Based on go/build.Context.Import.
 	var category extCategory
 	switch ext {
@@ -155,6 +136,25 @@ func fileNameInfo(dir, name string) fileInfo {
 		category = unsupportedExt
 	default:
 		category = ignoredExt
+	}
+
+	// Determine test, goos, and goarch. This is intended to match the logic
+	// in goodOSArchFile in go/build.
+	var isTest bool
+	var goos, goarch string
+	l := strings.Split(name[:len(name)-len(ext)], "_")
+	if len(l) >= 2 && l[len(l)-1] == "test" {
+		isTest = true && category != unsupportedExt && category != ignoredExt
+		l = l[:len(l)-1]
+	}
+	switch {
+	case len(l) >= 3 && knownOS[l[len(l)-2]] && knownArch[l[len(l)-1]]:
+		goos = l[len(l)-2]
+		goarch = l[len(l)-1]
+	case len(l) >= 2 && knownOS[l[len(l)-1]]:
+		goos = l[len(l)-1]
+	case len(l) >= 2 && knownArch[l[len(l)-1]]:
+		goarch = l[len(l)-1]
 	}
 
 	return fileInfo{

--- a/go/tools/gazelle/packages/fileinfo_test.go
+++ b/go/tools/gazelle/packages/fileinfo_test.go
@@ -455,6 +455,24 @@ func TestFileNameInfo(t *testing.T) {
 			},
 		},
 		{
+			"unsupported test file",
+			"foo_test.py",
+			fileInfo{
+				ext:     ".py",
+				isTest:  false,
+				isXTest: false,
+			},
+		},
+		{
+			"unsupported xtest file",
+			"foo_xtest.py",
+			fileInfo{
+				ext:     ".py",
+				isTest:  false,
+				isXTest: false,
+			},
+		},
+		{
 			"ignored file",
 			"foo.txt",
 			fileInfo{

--- a/go/tools/gazelle/packages/fileinfo_test.go
+++ b/go/tools/gazelle/packages/fileinfo_test.go
@@ -417,7 +417,17 @@ func TestFileNameInfo(t *testing.T) {
 			fileInfo{
 				ext:      ".cxx",
 				category: cExt,
-				isTest:   true,
+				isTest:   false,
+			},
+		},
+		{
+			"c os test file",
+			"foo_linux_test.c",
+			fileInfo{
+				ext:      ".c",
+				category: cExt,
+				isTest:   false,
+				goos:     "linux",
 			},
 		},
 		{
@@ -455,7 +465,7 @@ func TestFileNameInfo(t *testing.T) {
 			},
 		},
 		{
-			"unsupported test file",
+			"ignored test file",
 			"foo_test.py",
 			fileInfo{
 				ext:     ".py",
@@ -464,7 +474,7 @@ func TestFileNameInfo(t *testing.T) {
 			},
 		},
 		{
-			"unsupported xtest file",
+			"ignored xtest file",
 			"foo_xtest.py",
 			fileInfo{
 				ext:     ".py",

--- a/go/tools/gazelle/packages/package.go
+++ b/go/tools/gazelle/packages/package.go
@@ -172,6 +172,8 @@ func (ts *PlatformStrings) firstGoFile() string {
 // be added to any target (for example, .txt files).
 func (p *Package) addFile(info fileInfo, cgo bool, buildTags map[string]bool, platforms PlatformConstraints) error {
 	switch {
+	case info.category == ignoredExt || info.category == unsupportedExt:
+		return nil
 	case info.isXTest:
 		if info.isCgo {
 			return fmt.Errorf("%s: use of cgo in test not supported", info.path)


### PR DESCRIPTION
Non .go files (example: foo_test.py) were being included as go_test
sources despite fileInfo.isTest's comment indicating that it should
never be true for non-go files.

This change moves the detection of isTest after the extCategory is
calculated and only sets isTest to true if category is not .

Tested:
* go test github.com/bazelbuild/rules_go/go/tools/gazelle/packages
* bazel test //...