### PR TITLE
Gazelle: generate BUILD files for "testdata" directories containing code

### DIFF
--- a/go/tools/gazelle/generator/generator.go
+++ b/go/tools/gazelle/generator/generator.go
@@ -93,6 +93,7 @@ func (g *Generator) Generate(dir string) []*bzl.File {
 	}
 
 	var files []*bzl.File
+	haveTopFile := false
 	packages.Walk(g.buildTags, g.platforms, g.repoRoot, g.goPrefix, dir, func(pkg *packages.Package) {
 		rel, err := filepath.Rel(g.repoRoot, pkg.Dir)
 		if err != nil {
@@ -101,15 +102,20 @@ func (g *Generator) Generate(dir string) []*bzl.File {
 		}
 		if rel == "." {
 			rel = ""
-		}
-		if len(files) == 0 && rel != "" {
-			// "dir" was not a buildable Go package but still need a BUILD file
-			// for go_prefix.
-			files = append(files, g.emptyToplevel())
+			haveTopFile = true
 		}
 
 		files = append(files, g.generateOne(rel, pkg))
 	})
+
+	if !haveTopFile {
+		// The top directory of the repository did not contain buildable go
+		// files, but we still need a BUILD file for go_prefix.
+		// TODO: don't generate this file unless Gazelle is actually run on
+		// this directory.
+		files = append(files, g.emptyToplevel())
+	}
+
 	return files
 }
 

--- a/go/tools/gazelle/generator/generator_test.go
+++ b/go/tools/gazelle/generator/generator_test.go
@@ -60,7 +60,6 @@ func testGeneratedFileName(t *testing.T, buildFileName string) {
 		return
 	}
 	fs := g.Generate(filepath.Join(repo, "bin"))
-	fs = fs[1:] // ignore empty top-level file with go_prefix
 	if got, want := fs[0].Path, filepath.Join("bin", buildFileName); got != want {
 		t.Errorf("got file named %q; want %q", got, want)
 	}

--- a/go/tools/gazelle/packages/package.go
+++ b/go/tools/gazelle/packages/package.go
@@ -65,8 +65,9 @@ type Package struct {
 
 	Library, CgoLibrary, Binary, Test, XTest Target
 
-	Protos  []string
-	HasPbGo bool
+	Protos      []string
+	HasPbGo     bool
+	HasTestdata bool
 }
 
 // Target contains metadata about a buildable Go target in a package.

--- a/go/tools/gazelle/packages/walk.go
+++ b/go/tools/gazelle/packages/walk.go
@@ -66,7 +66,7 @@ func Walk(c *config.Config, dir string, f WalkFunc) {
 					hasTestdata = !hasPackage
 				}
 				subdirHasPackage = subdirHasPackage || hasPackage
-			} else if !f.IsDir() && (base == "BUILD" || base == "BUILD.bazel") {
+			} else if !f.IsDir() && c.IsValidBuildFileName(base) {
 				hasBuild = true
 			}
 		}

--- a/go/tools/gazelle/packages/walk_test.go
+++ b/go/tools/gazelle/packages/walk_test.go
@@ -228,3 +228,80 @@ func TestRootWithoutPrefix(t *testing.T) {
 		t.Errorf("got %v; want empty slice", got)
 	}
 }
+
+func TestTestdata(t *testing.T) {
+	files := []fileSpec{
+		{path: "raw/testdata/"},
+		{path: "raw/a.go", content: "package raw"},
+		{path: "with_build/testdata/BUILD"},
+		{path: "with_build/a.go", content: "package with_build"},
+		{path: "with_build_bazel/testdata/BUILD.bazel"},
+		{path: "with_build_bazel/a.go", content: "package with_build_bazel"},
+		{path: "with_build_nested/testdata/x/BUILD"},
+		{path: "with_build_nested/a.go", content: "package with_build_nested"},
+		{path: "with_go/testdata/a.go", content: "package testdata"},
+		{path: "with_go/a.go", content: "package with_go"},
+	}
+	want := []*packages.Package{
+		{
+			Name: "raw",
+			Dir:  "raw",
+			Library: packages.Target{
+				Sources: packages.PlatformStrings{
+					Generic: []string{"a.go"},
+				},
+			},
+			HasTestdata: true,
+		},
+		{
+			Name: "with_build",
+			Dir:  "with_build",
+			Library: packages.Target{
+				Sources: packages.PlatformStrings{
+					Generic: []string{"a.go"},
+				},
+			},
+			HasTestdata: false,
+		},
+		{
+			Name: "with_build_bazel",
+			Dir:  "with_build_bazel",
+			Library: packages.Target{
+				Sources: packages.PlatformStrings{
+					Generic: []string{"a.go"},
+				},
+			},
+			HasTestdata: false,
+		},
+		{
+			Name: "with_build_nested",
+			Dir:  "with_build_nested",
+			Library: packages.Target{
+				Sources: packages.PlatformStrings{
+					Generic: []string{"a.go"},
+				},
+			},
+			HasTestdata: false,
+		},
+		{
+			Name: "testdata",
+			Dir:  "with_go/testdata",
+			Library: packages.Target{
+				Sources: packages.PlatformStrings{
+					Generic: []string{"a.go"},
+				},
+			},
+		},
+		{
+			Name: "with_go",
+			Dir:  "with_go",
+			Library: packages.Target{
+				Sources: packages.PlatformStrings{
+					Generic: []string{"a.go"},
+				},
+			},
+			HasTestdata: false,
+		},
+	}
+	checkFiles(t, files, "", want)
+}

--- a/go/tools/gazelle/packages/walk_test.go
+++ b/go/tools/gazelle/packages/walk_test.go
@@ -74,7 +74,11 @@ func createFiles(files []fileSpec) (string, error) {
 }
 
 func walkPackages(repoRoot, goPrefix, dir string) []*packages.Package {
-	c := &config.Config{RepoRoot: repoRoot, GoPrefix: goPrefix}
+	c := &config.Config{
+		RepoRoot:            repoRoot,
+		GoPrefix:            goPrefix,
+		ValidBuildFileNames: config.DefaultValidBuildFileNames,
+	}
 	var pkgs []*packages.Package
 	packages.Walk(c, dir, func(pkg *packages.Package) {
 		pkgs = append(pkgs, pkg)

--- a/go/tools/gazelle/rules/generator.go
+++ b/go/tools/gazelle/rules/generator.go
@@ -18,7 +18,6 @@ package rules
 import (
 	"fmt"
 	"log"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -132,15 +131,11 @@ func (g *generator) Generate(rel string, pkg *packages.Package) []*bzl.Rule {
 		rules = append(rules, r)
 	}
 
-	testdataPath := filepath.Join(g.repoRoot, rel, "testdata")
-	st, err := os.Stat(testdataPath)
-	hasTestdata := err == nil && st.IsDir()
-
-	if r := g.generateTest(rel, pkg, library, hasTestdata); r != nil {
+	if r := g.generateTest(rel, pkg, library); r != nil {
 		rules = append(rules, r)
 	}
 
-	if r := g.generateXTest(rel, pkg, library, hasTestdata); r != nil {
+	if r := g.generateXTest(rel, pkg, library); r != nil {
 		rules = append(rules, r)
 	}
 
@@ -210,7 +205,7 @@ func (g *generator) filegroup(rel string, pkg *packages.Package) *bzl.Rule {
 	})
 }
 
-func (g *generator) generateTest(rel string, pkg *packages.Package, library string, hasTestdata bool) *bzl.Rule {
+func (g *generator) generateTest(rel string, pkg *packages.Package, library string) *bzl.Rule {
 	if !pkg.Test.HasGo() {
 		return nil
 	}
@@ -222,10 +217,10 @@ func (g *generator) generateTest(rel string, pkg *packages.Package, library stri
 		name = library + "_test"
 	}
 
-	return g.generateRule(rel, "go_test", name, "", library, hasTestdata, pkg.Test)
+	return g.generateRule(rel, "go_test", name, "", library, pkg.HasTestdata, pkg.Test)
 }
 
-func (g *generator) generateXTest(rel string, pkg *packages.Package, library string, hasTestdata bool) *bzl.Rule {
+func (g *generator) generateXTest(rel string, pkg *packages.Package, library string) *bzl.Rule {
 	if !pkg.XTest.HasGo() {
 		return nil
 	}
@@ -237,7 +232,7 @@ func (g *generator) generateXTest(rel string, pkg *packages.Package, library str
 		name = library + "_xtest"
 	}
 
-	return g.generateRule(rel, "go_test", name, "", "", hasTestdata, pkg.XTest)
+	return g.generateRule(rel, "go_test", name, "", "", pkg.HasTestdata, pkg.XTest)
 }
 
 func (g *generator) generateRule(rel, kind, name, visibility, library string, hasTestdata bool, target packages.Target) *bzl.Rule {

--- a/go/tools/gazelle/rules/generator_test.go
+++ b/go/tools/gazelle/rules/generator_test.go
@@ -38,7 +38,14 @@ func packageFromDir(t *testing.T, dir, repoRoot, goPrefix string) *packages.Pack
 	buildTags := map[string]bool{}
 	platforms := packages.DefaultPlatformConstraints
 	packages.PreprocessTags(buildTags, platforms)
-	return packages.FindPackage(dir, buildTags, platforms, repoRoot, goPrefix)
+
+	var pkg *packages.Package
+	packages.Walk(buildTags, platforms, repoRoot, goPrefix, dir, func(p *packages.Package) {
+		if p.Dir == dir {
+			pkg = p
+		}
+	})
+	return pkg
 }
 
 func TestGenerator(t *testing.T) {
@@ -55,6 +62,8 @@ func TestGenerator(t *testing.T) {
 		"lib/internal/deep",
 		"main_test_only",
 		"platforms",
+		"tests_import_testdata",
+		"tests_with_testdata",
 	} {
 		dir := filepath.Join(repoRoot, filepath.FromSlash(rel))
 		pkg := packageFromDir(t, dir, repoRoot, goPrefix)

--- a/go/tools/gazelle/testdata/repo/tests_import_testdata/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/tests_import_testdata/BUILD.want
@@ -1,0 +1,11 @@
+go_test(
+    name = "go_default_test",
+    srcs = ["internal_test.go"],
+    deps = ["//tests_import_testdata/testdata:go_default_library"],
+)
+
+go_test(
+    name = "go_default_xtest",
+    srcs = ["external_test.go"],
+    deps = ["//tests_import_testdata/testdata:go_default_library"],
+)

--- a/go/tools/gazelle/testdata/repo/tests_import_testdata/external_test.go
+++ b/go/tools/gazelle/testdata/repo/tests_import_testdata/external_test.go
@@ -1,0 +1,24 @@
+/* Copyright 2017 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests_import_testdata_test
+
+import (
+	"testing"
+
+	_ "example.com/repo/tests_import_testdata/testdata"
+)
+
+func TestStuff(t *testing.T) {}

--- a/go/tools/gazelle/testdata/repo/tests_import_testdata/internal_test.go
+++ b/go/tools/gazelle/testdata/repo/tests_import_testdata/internal_test.go
@@ -1,0 +1,24 @@
+/* Copyright 2017 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests_import_testdata
+
+import (
+	"testing"
+
+	_ "example.com/repo/tests_import_testdata/testdata"
+)
+
+func TestStuff(t *testing.T) {}

--- a/go/tools/gazelle/testdata/repo/tests_import_testdata/testdata/data.go
+++ b/go/tools/gazelle/testdata/repo/tests_import_testdata/testdata/data.go
@@ -1,0 +1,3 @@
+package testdata
+
+var Data = 42

--- a/tests/popular_repos/popular_repos.bash
+++ b/tests/popular_repos/popular_repos.bash
@@ -98,6 +98,10 @@ excludes=(
   -@org_golang_x_tools//refactor/importgraph:go_default_xtest
   -@org_golang_x_tools//refactor/rename:go_default_test
 
+  # ssh needs to accept incoming connections. Not allowed in CI or on Darwin.
+  -@org_golang_x_crypto//ssh:go_default_test
+  -@org_golang_x_crypto//ssh/test:go_default_test
+
   # icmp requires adjusting kernel options.
   -@org_golang_x_net//icmp:go_default_xtest
 

--- a/tests/popular_repos/popular_repos.bash
+++ b/tests/popular_repos/popular_repos.bash
@@ -35,6 +35,7 @@ cd "$WORKSPACE_DIR"
 touch BUILD
 
 targets=(
+  @org_golang_x_crypto//...
   @org_golang_x_net//...
   @org_golang_x_sys//...
   @org_golang_x_text//...
@@ -83,6 +84,9 @@ excludes=(
   -@org_golang_x_tools//go/ssa/ssautil:go_default_xtest
   -@org_golang_x_tools//go/ssa:go_default_xtest
   -@org_golang_x_tools//refactor/eg:go_default_xtest
+  -@org_golang_x_crypto//ed25519:go_default_test
+  -@org_golang_x_crypto//sha3:go_default_test
+  -@org_golang_x_crypto//ssh/agent:go_default_test
 
   # TODO(#546): deps don't get propagated from cgo_library through go_library
   # to go_test.
@@ -99,6 +103,18 @@ excludes=(
 
   # fiximports requires working GOROOT, not present in CI.
   -@org_golang_x_tools//cmd/fiximports:go_default_test
+
+  # tools tests have unbuildable Go code in testdata directories.
+  -@org_golang_x_tools//cmd/bundle/testdata/...
+  -@org_golang_x_tools//cmd/callgraph/testdata/...
+  -@org_golang_x_tools//cmd/cover/testdata/...
+  -@org_golang_x_tools//cmd/fiximports/testdata/...
+  -@org_golang_x_tools//cmd/goyacc/testdata/...
+  -@org_golang_x_tools//cmd/guru/testdata/...
+  -@org_golang_x_tools//cmd/stringer/testdata/...
+  -@org_golang_x_tools//go/gcimporter15/testdata/...
+  -@org_golang_x_tools//go/loader/testdata/...
+  -@org_golang_x_tools//go/pointer/testdata/...
 
   # some sqlite3 tests rely on sources in the library which are filtered out.
   -@com_github_mattn_go_sqlite3//_example/custom_func:all
@@ -125,9 +141,6 @@ case $(uname) in
 esac
 
 bazel_batch_test --keep_going -- "${targets[@]}" "${excludes[@]}"
-
-# TODO(#415): golang.org/x/crypto can't be built because there is a package
-# named "ssh/testdata", which gazelle doesn't recurse into.
 
 # TODO(#526): github.com/mattn/go-sqlite3 can't be built as an external
 # dependency due to an include issue with cgo.


### PR DESCRIPTION
Gazelle will now recurse into "testdata" directories and generate
BUILD files if there are buildable .go files present.

Generated go_test rules will only have 'data = glob(["testdata/**"])'
if a "testdata" directory exists and does not contain .go files or
BUILD or BUILD.bazel files in any subdirectory.

Fixes #415