### PR TITLE
Gazelle: refactor configuration plumbing

### DIFF
--- a/go/tools/gazelle/config/BUILD
+++ b/go/tools/gazelle/config/BUILD
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["config.go"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["config_test.go"],
+    library = ":go_default_library",
+)

--- a/go/tools/gazelle/config/config.go
+++ b/go/tools/gazelle/config/config.go
@@ -1,0 +1,128 @@
+/* Copyright 2017 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"go/build"
+)
+
+// Config holds information about how Gazelle should run. This is mostly
+// based on command-line arguments.
+type Config struct {
+	// Dirs is a list of absolute paths to directories where Gazelle should run.
+	Dirs []string
+
+	// RepoRoot is the absolute path to the root directory of the repository.
+	RepoRoot string
+
+	// ValidBuildFileNames is a list of base names that are considered valid
+	// build files. Some repositories may have files named "BUILD" that are not
+	// used by Bazel and should be ignored. Must contain at least one string.
+	ValidBuildFileNames []string
+
+	// GenericTags is a set of build constraints that are true on all platforms.
+	// It should not be nil.
+	GenericTags BuildTags
+
+	// Platforms contains a set of build constraints for each platform. Each set
+	// should include GenericTags. It should not be nil.
+	Platforms PlatformTags
+
+	// GoPrefix is the portion of the import path for the root of this repository.
+	// This is used to map imports to labels within the repository.
+	GoPrefix string
+
+	// DepMode determines how imports outside of GoPrefix are resolved.
+	DepMode DependencyMode
+}
+
+var DefaultValidBuildFileNames = []string{"BUILD.bazel", "BUILD"}
+
+func (c *Config) IsValidBuildFileName(name string) bool {
+	for _, n := range c.ValidBuildFileNames {
+		if name == n {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Config) DefaultBuildFileName() string {
+	return c.ValidBuildFileNames[0]
+}
+
+// BuildTags is a set of build constraints.
+type BuildTags map[string]bool
+
+// PlatformTags is a map from config_setting labels (for example,
+// "@io_bazel_rules_go//go/platform:linux_amd64") to a sets of build tags
+// that are true on each platform (for example, "linux,amd64").
+type PlatformTags map[string]BuildTags
+
+// DefaultPlatformTags is the default set of platforms that Gazelle
+// will generate files for. These are the platforms that both Go and Bazel
+// support.
+var DefaultPlatformTags PlatformTags
+
+func init() {
+	DefaultPlatformTags = make(PlatformTags)
+	arch := "amd64"
+	for _, os := range []string{"darwin", "linux", "windows"} {
+		label := fmt.Sprintf("@io_bazel_rules_go//go/platform:%s_%s", os, arch)
+		DefaultPlatformTags[label] = BuildTags{arch: true, os: true}
+	}
+}
+
+// PreprocessTags performs some automatic processing on generic and
+// platform-specific tags before they are used to match files.
+func (c *Config) PreprocessTags() {
+	c.GenericTags["cgo"] = true
+	c.GenericTags["gc"] = true
+	for _, t := range build.Default.ReleaseTags {
+		c.GenericTags[t] = true
+	}
+	for _, platformTags := range c.Platforms {
+		for t, _ := range c.GenericTags {
+			platformTags[t] = true
+		}
+	}
+}
+
+// DependencyMode determines how imports of packages outside of the prefix
+// are resolved.
+type DependencyMode int
+
+const (
+	// ExternalMode indicates imports should be resolved to external dependencies
+	// (declared in WORKSPACE).
+	ExternalMode DependencyMode = iota
+
+	// VendorMode indicates imports should be resolved to libraries in the
+	// vendor directory.
+	VendorMode
+)
+
+func DependencyModeFromString(s string) (DependencyMode, error) {
+	switch s {
+	case "external":
+		return ExternalMode, nil
+	case "vendor":
+		return VendorMode, nil
+	default:
+		return 0, fmt.Errorf("invalid dependency mode: %s", s)
+	}
+}

--- a/go/tools/gazelle/config/config_test.go
+++ b/go/tools/gazelle/config/config_test.go
@@ -1,0 +1,37 @@
+/* Copyright 2017 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import "testing"
+
+func TestPreprocessTags(t *testing.T) {
+	c := &Config{
+		GenericTags: map[string]bool{"a": true, "b": true},
+		Platforms:   DefaultPlatformTags,
+	}
+	c.PreprocessTags()
+	expectedTags := []string{"a", "b", "cgo", "gc", "go1.8", "go1.7"}
+	for _, tag := range expectedTags {
+		if !c.GenericTags[tag] {
+			t.Errorf("tag %q not set", tag)
+		}
+		for name, platformTags := range c.Platforms {
+			if !platformTags[tag] {
+				t.Errorf("on platform %q, tag %q not set", name, tag)
+			}
+		}
+	}
+}

--- a/go/tools/gazelle/gazelle/diff.go
+++ b/go/tools/gazelle/gazelle/diff.go
@@ -21,10 +21,11 @@ import (
 	"os/exec"
 
 	bzl "github.com/bazelbuild/buildtools/build"
+	"github.com/bazelbuild/rules_go/go/tools/gazelle/config"
 )
 
-func diffFile(file *bzl.File) error {
-	f, err := ioutil.TempFile("", getBuildFileName())
+func diffFile(c *config.Config, file *bzl.File) error {
+	f, err := ioutil.TempFile("", c.DefaultBuildFileName())
 	if err != nil {
 		return err
 	}

--- a/go/tools/gazelle/gazelle/fix.go
+++ b/go/tools/gazelle/gazelle/fix.go
@@ -19,9 +19,10 @@ import (
 	"io/ioutil"
 
 	bzl "github.com/bazelbuild/buildtools/build"
+	"github.com/bazelbuild/rules_go/go/tools/gazelle/config"
 )
 
-func fixFile(file *bzl.File) error {
+func fixFile(c *config.Config, file *bzl.File) error {
 	if err := ioutil.WriteFile(file.Path, bzl.Format(file), 0644); err != nil {
 		return err
 	}

--- a/go/tools/gazelle/gazelle/print.go
+++ b/go/tools/gazelle/gazelle/print.go
@@ -19,9 +19,10 @@ import (
 	"os"
 
 	bzl "github.com/bazelbuild/buildtools/build"
+	"github.com/bazelbuild/rules_go/go/tools/gazelle/config"
 )
 
-func printFile(f *bzl.File) error {
+func printFile(c *config.Config, f *bzl.File) error {
 	_, err := os.Stdout.Write(bzl.Format(f))
 	return err
 }

--- a/go/tools/gazelle/generator/BUILD
+++ b/go/tools/gazelle/generator/BUILD
@@ -5,6 +5,7 @@ go_library(
     srcs = ["generator.go"],
     visibility = ["//visibility:public"],
     deps = [
+        "//go/tools/gazelle/config:go_default_library",
         "//go/tools/gazelle/packages:go_default_library",
         "//go/tools/gazelle/rules:go_default_library",
         "@com_github_bazelbuild_buildtools//build:go_default_library",

--- a/go/tools/gazelle/packages/BUILD
+++ b/go/tools/gazelle/packages/BUILD
@@ -8,6 +8,7 @@ go_library(
         "package.go",
         "walk.go",
     ],
+    deps = ["//go/tools/gazelle/config:go_default_library"],
     visibility = ["//visibility:public"],
 )
 

--- a/go/tools/gazelle/packages/fileinfo.go
+++ b/go/tools/gazelle/packages/fileinfo.go
@@ -30,6 +30,8 @@ import (
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/bazelbuild/rules_go/go/tools/gazelle/config"
 )
 
 // fileInfo holds information used to decide how to build a file. This
@@ -172,8 +174,8 @@ func fileNameInfo(dir, name string) fileInfo {
 // goFileInfo returns information about a .go file. It will parse part of the
 // file to determine the package name and imports.
 // This function is intended to match go/build.Context.Import.
-func (pr *packageReader) goFileInfo(name string) (fileInfo, error) {
-	info := fileNameInfo(pr.dir, name)
+func goFileInfo(c *config.Config, dir, name string) (fileInfo, error) {
+	info := fileNameInfo(dir, name)
 	fset := token.NewFileSet()
 	pf, err := parser.ParseFile(fset, info.path, nil, parser.ImportsOnly|parser.ParseComments)
 	if err != nil {
@@ -216,7 +218,7 @@ func (pr *packageReader) goFileInfo(name string) (fileInfo, error) {
 						return fileInfo{}, err
 					}
 				}
-			} else if !pr.isStandard(path) {
+			} else if !isStandard(c.GoPrefix, path) {
 				info.imports = append(info.imports, path)
 			}
 		}
@@ -405,15 +407,15 @@ func safeCgoName(s string, spaces bool) bool {
 }
 
 // isStandard determines if importpath points a Go standard package.
-func (pr *packageReader) isStandard(importpath string) bool {
+func isStandard(goPrefix, importpath string) bool {
 	seg := strings.SplitN(importpath, "/", 2)[0]
-	return !strings.Contains(seg, ".") && !strings.HasPrefix(importpath, pr.goPrefix+"/")
+	return !strings.Contains(seg, ".") && !strings.HasPrefix(importpath, goPrefix+"/")
 }
 
 // otherFileInfo returns information about a non-.go file. It will parse
 // part of the file to determine build tags.
-func (pr *packageReader) otherFileInfo(name string) (fileInfo, error) {
-	info := fileNameInfo(pr.dir, name)
+func otherFileInfo(dir, name string) (fileInfo, error) {
+	info := fileNameInfo(dir, name)
 	if info.category == ignoredExt {
 		return info, nil
 	}

--- a/go/tools/gazelle/packages/walk_test.go
+++ b/go/tools/gazelle/packages/walk_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bazelbuild/rules_go/go/tools/gazelle/config"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/packages"
 )
 
@@ -73,8 +74,9 @@ func createFiles(files []fileSpec) (string, error) {
 }
 
 func walkPackages(repoRoot, goPrefix, dir string) []*packages.Package {
+	c := &config.Config{RepoRoot: repoRoot, GoPrefix: goPrefix}
 	var pkgs []*packages.Package
-	packages.Walk(nil, nil, repoRoot, goPrefix, dir, func(pkg *packages.Package) {
+	packages.Walk(c, dir, func(pkg *packages.Package) {
 		pkgs = append(pkgs, pkg)
 	})
 	return pkgs

--- a/go/tools/gazelle/rules/BUILD
+++ b/go/tools/gazelle/rules/BUILD
@@ -13,6 +13,7 @@ go_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//go/tools/gazelle/config:go_default_library",
         "//go/tools/gazelle/packages:go_default_library",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
         "@org_golang_x_tools//go/vcs:go_default_library",


### PR DESCRIPTION
* Added a new "config" package with a "Config" struct that contains
  most of the configuration information that Gazelle gets from flags
  (go prefix, repo root, etc.). Defaults and utility methods are also
  moved to this package.
* Added newConfiguration, a function which builds this
  configuration. Tags are preprocessed, and paths are canonicalized so
  we don't have to worry about that later.
* Functions which previously accepted arguments that are found in
  Config now just accept *config.Config.
* Deleted packageReader, since it had a very similar purpose.