### PR TITLE
Allow tests to be tagged as "not ci"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ script:
       test \
       --experimental_repository_cache="$HOME/.bazel_repository_cache" \
       --local_resources=400,1,1.0 \
+      --test_tag_filters=-dev \
       //...
   - tests/run_non_bazel_tests.bash ci
 


### PR DESCRIPTION
Adding "dev" to a tests tags now causes it to be excluded from ci builds.