### PR TITLE
Restore -external flag value to vendored

### DIFF
--- a/go/tools/gazelle/config/config.go
+++ b/go/tools/gazelle/config/config.go
@@ -123,7 +123,7 @@ func DependencyModeFromString(s string) (DependencyMode, error) {
 	switch s {
 	case "external":
 		return ExternalMode, nil
-	case "vendor":
+	case "vendored":
 		return VendorMode, nil
 	default:
 		return 0, fmt.Errorf("unrecognized dependency mode: %q", s)


### PR DESCRIPTION
Commit cafe930223abe6f5faa0561d40435b52fbea77b9 inadvertently changed
the flag value from `vendored` to `vendor`.