### PR TITLE
Our tests are all small

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -11,6 +11,7 @@ lines_sorted_test(
     cmd = "grep -v '^#' $< | grep -v '^$$' >$@",
     error_message = "Contributors must be sorted by first name",
     file = "CONTRIBUTORS",
+    size = "small",
 )
 
 lines_sorted_test(
@@ -18,4 +19,5 @@ lines_sorted_test(
     cmd = "grep -v '^#' $< | grep -v '^$$' >$@",
     error_message = "Authors must be sorted by first name",
     file = "AUTHORS",
+    size = "small",
 )

--- a/examples/cgo/BUILD
+++ b/examples/cgo/BUILD
@@ -39,6 +39,7 @@ go_test(
     name = "cgo_lib_test",
     srcs = ["cgo_lib_test.go"],
     library = ":cgo_lib",
+    size = "small",
 )
 
 genrule(

--- a/examples/lib/BUILD
+++ b/examples/lib/BUILD
@@ -21,6 +21,7 @@ go_test(
         "lib_test.go",
     ],
     library = ":go_default_library",
+    size = "small",
 )
 
 go_test(
@@ -38,4 +39,5 @@ go_test(
     deps = [
         ":go_default_library",
     ],
+    size = "small",
 )

--- a/examples/proto/BUILD
+++ b/examples/proto/BUILD
@@ -14,4 +14,5 @@ go_test(
     name = "proto_test",
     srcs = ["proto_test.go"],
     deps = ["//examples/proto/lib:lib_proto"],
+    size = "small",
 )

--- a/examples/stamped_bin/BUILD
+++ b/examples/stamped_bin/BUILD
@@ -10,6 +10,7 @@ go_test(
         "github.com/bazelbuild/rules_go/examples/stamped_bin/stamp.XdefInvalid": "{Undefined_Var}",  # undefined should leave the var alone
     },
     deps = ["//examples/stamped_bin/stamp:go_default_library"],
+    size = "small",
 )
 
 go_test(
@@ -22,6 +23,7 @@ go_test(
         "github.com/bazelbuild/rules_go/examples/stamped_bin/stamp.XdefInvalid": "{Undefined_Var}",  # undefined should leave the var alone
     },
     deps = ["//examples/stamped_bin/stamp:go_default_library"],
+    size = "small",
 )
 
 go_test(
@@ -34,4 +36,5 @@ go_test(
         "github.com/bazelbuild/rules_go/examples/stamped_bin/stamp.XdefInvalid": "{Undefined_Var}",  # undefined should leave the var alone
     },
     deps = ["//examples/stamped_bin/stamp:go_default_library"],
+    size = "small",
 )

--- a/go/tools/bazel/BUILD
+++ b/go/tools/bazel/BUILD
@@ -13,4 +13,5 @@ go_test(
         "README.md",
     ],
     library = ":go_default_library",
+    size = "small",
 )

--- a/go/tools/builders/BUILD
+++ b/go/tools/builders/BUILD
@@ -7,6 +7,7 @@ go_test(
         "filter.go",
         "filter_test.go",
     ],
+    size = "small",
 )
 
 go_tool_binary(

--- a/go/tools/extract_package/BUILD
+++ b/go/tools/extract_package/BUILD
@@ -13,4 +13,5 @@ go_test(
         "extract.go",
         "extract_test.go",
     ],
+    size = "small",
 )

--- a/go/tools/fetch_repo/BUILD
+++ b/go/tools/fetch_repo/BUILD
@@ -17,4 +17,5 @@ go_test(
     srcs = ["fetch_repo_test.go"],
     library = ":go_default_library",
     deps = ["@org_golang_x_tools//go/vcs:go_default_library"],
+    size = "small",
 )

--- a/go/tools/gazelle/config/BUILD
+++ b/go/tools/gazelle/config/BUILD
@@ -10,4 +10,5 @@ go_test(
     name = "go_default_test",
     srcs = ["config_test.go"],
     library = ":go_default_library",
+    size = "small",
 )

--- a/go/tools/gazelle/merger/BUILD
+++ b/go/tools/gazelle/merger/BUILD
@@ -12,4 +12,5 @@ go_test(
     srcs = ["merger_test.go"],
     library = ":go_default_library",
     deps = ["@com_github_bazelbuild_buildtools//build:go_default_library"],
+    size = "small",
 )

--- a/go/tools/gazelle/packages/BUILD
+++ b/go/tools/gazelle/packages/BUILD
@@ -19,10 +19,12 @@ go_test(
         "package_test.go",
     ],
     library = ":go_default_library",
+    size = "small",
 )
 
 go_test(
     name = "go_default_xtest",
     srcs = ["walk_test.go"],
     deps = [":go_default_library"],
+    size = "small",
 )

--- a/go/tools/gazelle/rules/BUILD
+++ b/go/tools/gazelle/rules/BUILD
@@ -28,6 +28,7 @@ go_test(
         "resolve_test.go",
     ],
     library = ":go_default_library",
+    size = "small",
 )
 
 go_test(
@@ -39,4 +40,5 @@ go_test(
         "//go/tools/gazelle/testdata:go_default_library",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
     ],
+    size = "small",
 )

--- a/go/tools/gazelle/wspace/BUILD
+++ b/go/tools/gazelle/wspace/BUILD
@@ -10,4 +10,5 @@ go_test(
     name = "go_default_test",
     srcs = ["finder_test.go"],
     library = ":go_default_library",
+    size = "small",
 )

--- a/tests/asm_include/BUILD
+++ b/tests/asm_include/BUILD
@@ -31,4 +31,5 @@ go_test(
     name = "go_default_test",
     srcs = ["foo_test.go"],
     library = ":go_default_library",
+    size = "small",
 )

--- a/tests/binary_test_outputs/BUILD
+++ b/tests/binary_test_outputs/BUILD
@@ -7,6 +7,7 @@ load("@io_bazel_rules_go//go/private:single_output_test.bzl", "single_output_tes
 single_output_test(
     name = "binary_single_output_test",
     dep = ":bin",
+    size = "small",
 )
 
 go_binary(
@@ -18,10 +19,12 @@ go_binary(
 single_output_test(
     name = "test_single_output_test",
     dep = ":test",
+    size = "small",
 )
 
 go_test(
     name = "test",
     srcs = ["test.go"],
     tags = ["manual"],
+    size = "small",
 )

--- a/tests/cgo_select/BUILD
+++ b/tests/cgo_select/BUILD
@@ -45,4 +45,5 @@ go_test(
     name = "go_default_test",
     srcs = ["cgo_select_test.go"],
     library = ":cgo_default_library",
+    size = "small",
 )

--- a/tests/cgo_sys_hdr/BUILD
+++ b/tests/cgo_sys_hdr/BUILD
@@ -12,4 +12,5 @@ go_test(
     name = "go_default_test",
     srcs = ["foo_test.go"],
     library = ":cgo_default_library",
+    size = "small",
 )

--- a/tests/cgo_trans_deps/BUILD
+++ b/tests/cgo_trans_deps/BUILD
@@ -15,4 +15,5 @@ go_test(
     name = "go_default_test",
     srcs = ["cgo_test.go"],
     library = ":go_default_library",
+    size = "small",
 )

--- a/tests/extldflags_rpath/BUILD
+++ b/tests/extldflags_rpath/BUILD
@@ -18,4 +18,5 @@ sh_test(
     srcs = ["extldflags_rpath_test.sh"],
     args = ["$(location :extldflags_rpath)"],
     data = [":extldflags_rpath"],
+    size = "small",
 )

--- a/tests/gc_opts_unsafe/BUILD
+++ b/tests/gc_opts_unsafe/BUILD
@@ -38,12 +38,14 @@ go_test(
     ],
     gc_goopts = ["-u"],
     tags = ["manual"],
+    size = "small",
 )
 
 go_test(
     name = "unsafe_library_test",
     library = ":unsafe_srcs_lib",
     tags = ["manual"],
+    size = "small",
 )
 
 cgo_library(
@@ -77,4 +79,5 @@ go_test(
     ],
     gc_linkopts = ["-u"],
     tags = ["manual"],
+    size = "small",
 )

--- a/tests/new_go_repository_build_name/local/BUILD
+++ b/tests/new_go_repository_build_name/local/BUILD
@@ -7,4 +7,5 @@ go_test(
     srcs = ["local_test.go"],
     tags = ["manual"],
     deps = ["@remote//build:go_default_library"],
+    size = "small",
 )

--- a/tests/slash_names/BUILD
+++ b/tests/slash_names/BUILD
@@ -14,4 +14,5 @@ go_test(
     name = "go_default_test",
     srcs = ["slash_test.go"],
     deps = [":a/pkg", ":b/pkg"],
+    size = "small",
 )

--- a/tests/test_build_constraints/BUILD
+++ b/tests/test_build_constraints/BUILD
@@ -10,6 +10,7 @@ go_test(
         "bar_unknown_test.go",
     ],
     library = ":go_default_library",
+    size = "small",
 )
 
 # Contains more test cases. Checks that build constraints are applied to

--- a/tests/test_chdir/local/sub/BUILD
+++ b/tests/test_chdir/local/sub/BUILD
@@ -4,4 +4,5 @@ go_test(
     name = "go_default_test",
     srcs = ["local_test.go"],
     data = ["local.txt"],
+    size = "small",
 )

--- a/tests/test_chdir/remote/sub/BUILD
+++ b/tests/test_chdir/remote/sub/BUILD
@@ -4,4 +4,5 @@ go_test(
     name = "go_default_test",
     srcs = ["remote_test.go"],
     data = ["remote.txt"],
+    size = "small",
 )

--- a/tests/transitive_data/BUILD
+++ b/tests/transitive_data/BUILD
@@ -9,6 +9,7 @@ go_test(
         "c_data.txt",
     ],
     deps = [":go_lib"],
+    size = "small",
 )
 
 go_library(


### PR DESCRIPTION
Tagging them as such so bazel stops complaining and test filters work as
expected.