### PR TITLE
Gazelle: treat release tags as unknown

### DIFF
--- a/go/tools/gazelle/config/config.go
+++ b/go/tools/gazelle/config/config.go
@@ -17,7 +17,6 @@ package config
 
 import (
 	"fmt"
-	"go/build"
 )
 
 // Config holds information about how Gazelle should run. This is mostly
@@ -92,9 +91,6 @@ func init() {
 func (c *Config) PreprocessTags() {
 	c.GenericTags["cgo"] = true
 	c.GenericTags["gc"] = true
-	for _, t := range build.Default.ReleaseTags {
-		c.GenericTags[t] = true
-	}
 	for _, platformTags := range c.Platforms {
 		for t, _ := range c.GenericTags {
 			platformTags[t] = true

--- a/go/tools/gazelle/config/config_test.go
+++ b/go/tools/gazelle/config/config_test.go
@@ -23,7 +23,7 @@ func TestPreprocessTags(t *testing.T) {
 		Platforms:   DefaultPlatformTags,
 	}
 	c.PreprocessTags()
-	expectedTags := []string{"a", "b", "cgo", "gc", "go1.8", "go1.7"}
+	expectedTags := []string{"a", "b", "cgo", "gc"}
 	for _, tag := range expectedTags {
 		if !c.GenericTags[tag] {
 			t.Errorf("tag %q not set", tag)
@@ -31,6 +31,17 @@ func TestPreprocessTags(t *testing.T) {
 		for name, platformTags := range c.Platforms {
 			if !platformTags[tag] {
 				t.Errorf("on platform %q, tag %q not set", name, tag)
+			}
+		}
+	}
+	unexpectedTags := []string{"x", "go1.8", "go1.7"}
+	for _, tag := range unexpectedTags {
+		if c.GenericTags[tag] {
+			t.Errorf("tag %q unexpectedly set")
+		}
+		for name, platformTags := range c.Platforms {
+			if platformTags[tag] {
+				t.Errorf("on platform %q, tag %q unexpectedly set", name, tag)
 			}
 		}
 	}

--- a/go/tools/gazelle/packages/fileinfo.go
+++ b/go/tools/gazelle/packages/fileinfo.go
@@ -539,10 +539,31 @@ func checkTags(line string, tags map[string]bool) bool {
 			if not {
 				tag = tag[1:]
 			}
+			if isReleaseTag(tag) {
+				// Release tags are treated as "unknown" and are considered true,
+				// whether or not they are negated.
+				continue
+			}
 			_, ok := tags[tag]
 			groupOk = groupOk && (not != ok)
 		}
 		lineOk = lineOk || groupOk
 	}
 	return lineOk
+}
+
+// isReleaseTag returns whether the tag matches the pattern "go[0-9]\.[0-9]+".
+func isReleaseTag(tag string) bool {
+	if len(tag) < 5 || !strings.HasPrefix(tag, "go") {
+		return false
+	}
+	if tag[2] < '0' || tag[2] > '9' || tag[3] != '.' {
+		return false
+	}
+	for _, c := range tag[4:] {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
 }

--- a/go/tools/gazelle/packages/fileinfo_test.go
+++ b/go/tools/gazelle/packages/fileinfo_test.go
@@ -1004,6 +1004,18 @@ func TestCheckTags(t *testing.T) {
 			"bar",
 			false,
 		},
+		{
+			"release tags",
+			"go1.7,go1.8,go1.9,go1.91,go2.0",
+			"",
+			true,
+		},
+		{
+			"release tag negated",
+			"!go1.8",
+			"",
+			true,
+		},
 	} {
 		if got := checkTags(tc.line, parseTags(tc.tags)); got != tc.want {
 			t.Errorf("case %q: got %#v; want %#v", tc.desc, got, tc.want)

--- a/go/tools/gazelle/testdata/repo/platforms/release.go
+++ b/go/tools/gazelle/testdata/repo/platforms/release.go
@@ -1,3 +1,3 @@
-// +build go1.7
+// +build go1.7 !go1.8
 
 package platforms


### PR DESCRIPTION
Gazelle will no longer filter files based on release tag
(e.g., "go1.8"). Release tags are not currently part of the
config_settings used to select files, and they are difficult to detect
at that point. So we'll include files with these tags, whether or not
they are negated, and we'll let the rules sort it out.

Fixes #563