### PR TITLE
Switching from new_go_repository to go_repository

### DIFF
--- a/go/private/go_repository.bzl
+++ b/go/private/go_repository.bzl
@@ -124,7 +124,7 @@ go_repository = repository_rule(
 # This is for legacy compatability
 # Originally this was the only rule that triggered BUILD file generation.
 def new_go_repository(name, **kwargs):
-  print("{0}: new_go_repository has been subsumed into go_repository".format(name))
+  print("{0}: new_go_repository is deprecated. Please migrate to go_repository soon.".format(name))
   return go_repository(name=name, **kwargs)
 
 def env_execute(ctx, arguments, environment = None, **kwargs):

--- a/go/private/go_repository.bzl
+++ b/go/private/go_repository.bzl
@@ -123,7 +123,9 @@ go_repository = repository_rule(
 
 # This is for legacy compatability
 # Originally this was the only rule that triggered BUILD file generation.
-new_go_repository = go_repository
+def new_go_repository(name, **kwargs):
+  print("{0}: new_go_repository has been subsumed into go_repository".format(name))
+  return go_repository(name=name, **kwargs)
 
 def env_execute(ctx, arguments, environment = None, **kwargs):
   """env_execute prepends "env -i" to "arguments" before passing it to

--- a/go/private/repository_tools.bzl
+++ b/go/private/repository_tools.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_go//go/private:go_repository.bzl", "go_repository", "new_go_repository", "env_execute")
+load("@io_bazel_rules_go//go/private:go_repository.bzl", "go_repository", "env_execute")
 
 _GO_REPOSITORY_TOOLS_BUILD_FILE = """
 package(default_visibility = ["//visibility:public"])

--- a/go/tools/gazelle/gazelle/main.go
+++ b/go/tools/gazelle/gazelle/main.go
@@ -154,7 +154,7 @@ func newConfiguration(args []string) (*config.Config, emitFunc, error) {
 
 	buildFileName := fs.String("build_file_name", "BUILD.bazel,BUILD", "comma-separated list of valid build file names.\nThe first element of the list is the name of output build files to generate.")
 	buildTags := fs.String("build_tags", "", "comma-separated list of build tags. If not specified, Gazelle will not\n\tfilter sources with build constraints.")
-	external := fs.String("external", "external", "external: resolve external packages with new_go_repository\n\tvendored: resolve external packages as packages in vendor/")
+	external := fs.String("external", "external", "external: resolve external packages with go_repository\n\tvendored: resolve external packages as packages in vendor/")
 	goPrefix := fs.String("go_prefix", "", "go_prefix of the target workspace")
 	repoRoot := fs.String("repo_root", "", "path to a directory which corresponds to go_prefix, otherwise gazelle searches for it.")
 	mode := fs.String("mode", "fix", "print: prints all of the updated BUILD files\n\tfix: rewrites all of the BUILD files in place\n\tdiff: computes the rewrite but then just does a diff")

--- a/go/tools/wtool/README.md
+++ b/go/tools/wtool/README.md
@@ -13,10 +13,10 @@ run `go install`
   
     wtool -asis github.com/golang/glog [<go-importpath2> ...]
   
-Which will add the HEAD commit of this dependency as a `new_go_repository` to your
+Which will add the HEAD commit of this dependency as a `go_repository` to your
 WORKSPACE file.
 
-    new_go_repository(
+    go_repository(
       name = "com_github_golang_glog",
       commit = "23def4e6c14b4da8ac2ed8007337bc5eb5007998",
       importpath = "github.com/golang/glog",

--- a/go/tools/wtool/main.go
+++ b/go/tools/wtool/main.go
@@ -1,9 +1,9 @@
 /*
-wtool augments your bazel WORKSPACE file with new_go_repository entries
+wtool augments your bazel WORKSPACE file with go_repository entries
 
 Example Usage:
   wtool com_github_golang_glog com_google_cloud_go
-will add 2 new_go_repository to your WORKSPACE
+will add 2 go_repository to your WORKSPACE
 by converting com_github_golang_glog -> github.com/golang/glog
 and so forth and then doing a 'git ls-remote' to get
 the latest commit.

--- a/proto/go_proto_library.bzl
+++ b/proto/go_proto_library.bzl
@@ -39,7 +39,7 @@ go_proto_library(
 )
 """
 
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "new_go_repository")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_repository")
 
 _DEFAULT_LIB = "go_default_library"  # matching go_library
 
@@ -323,7 +323,7 @@ def go_google_protobuf(name = _GO_GOOGLE_PROTOBUF):
 
 def go_proto_repositories(shared = 1):
   """Add this to your WORKSPACE to pull in all of the needed dependencies."""
-  new_go_repository(
+  go_repository(
       name = "com_github_golang_protobuf",
       importpath = "github.com/golang/protobuf",
       commit = "8ee79997227bf9b34611aee7946ae64735e6fd93",
@@ -338,12 +338,12 @@ def go_proto_repositories(shared = 1):
     )
 
   # Needed for gRPC, only loaded by bazel if used
-  new_go_repository(
+  go_repository(
       name = "org_golang_x_net",
       commit = "4971afdc2f162e82d185353533d3cf16188a9f4e",
       importpath = "golang.org/x/net",
   )
-  new_go_repository(
+  go_repository(
       name = "org_golang_google_grpc",
       tag = "v1.0.4",
       importpath = "google.golang.org/grpc",


### PR DESCRIPTION
Also adds a print to the compatibility shim to warn people to switch, and changes the documentation to not refer to new_go_repository any more.