### PR TITLE
Gazelle: parse BUILD files in packages.Walk

### DIFF
--- a/go/tools/gazelle/packages/BUILD
+++ b/go/tools/gazelle/packages/BUILD
@@ -8,7 +8,10 @@ go_library(
         "package.go",
         "walk.go",
     ],
-    deps = ["//go/tools/gazelle/config:go_default_library"],
+    deps = [
+        "//go/tools/gazelle/config:go_default_library",
+        "@com_github_bazelbuild_buildtools//build:go_default_library",
+    ],
     visibility = ["//visibility:public"],
 )
 
@@ -28,6 +31,7 @@ go_test(
     deps = [
         ":go_default_library",
         "//go/tools/gazelle/config:go_default_library",
+        "@com_github_bazelbuild_buildtools//build:go_default_library",
     ],
     size = "small",
 )

--- a/go/tools/gazelle/rules/generator_test.go
+++ b/go/tools/gazelle/rules/generator_test.go
@@ -41,7 +41,7 @@ func testConfig(repoRoot, goPrefix string) *config.Config {
 
 func packageFromDir(c *config.Config, dir string) *packages.Package {
 	var pkg *packages.Package
-	packages.Walk(c, dir, func(p *packages.Package) {
+	packages.Walk(c, dir, func(p *packages.Package, _ *bzl.File) {
 		if p.Dir == dir {
 			pkg = p
 		}


### PR DESCRIPTION
This is in preparation for increased awareness of generated
code. packages.Walk now discovers and parses existing BUILD files. A
*bzl.File is passed to the callback if one was found.

Gazelle will need to read BUILD files in order to build
packages.Package structures for two reasons:

1. Gazelle will discover generated files by examining attributes of
rules in existing BUILD files.
2. Some files can be excluded using comments in BUILD files.

Related #557