### PR TITLE
Set bazel_test timeout to moderate

### DIFF
--- a/tests/bazel_tests.bzl
+++ b/tests/bazel_tests.bzl
@@ -99,7 +99,7 @@ def bazel_test(name, batch = None, command = None, args=None, subdir = None, tar
   native.sh_test(
       name = name,
       size = "large",
-      timeout = "short",
+      timeout = "moderate",
       srcs = [script_name],
       tags = ["local", "bazel"] + tags,
       data = native.glob(["**/*"]) + externals + [


### PR DESCRIPTION
bazel_tests time out when run concurrently because Bazel takes a long
time to unpack itself in a new workspace. Increasing the timeout works
around failures until we have a proper fix.