### PR TITLE
Gazelle: be aware of generated and excluded files

### DIFF
--- a/go/tools/gazelle/packages/walk.go
+++ b/go/tools/gazelle/packages/walk.go
@@ -60,10 +60,11 @@ func Walk(c *config.Config, dir string, f WalkFunc) {
 		haveError := false
 		for _, base := range c.ValidBuildFileNames {
 			oldPath := filepath.Join(path, base)
-			oldData, err := ioutil.ReadFile(oldPath)
-			if os.IsNotExist(err) {
+			st, err := os.Stat(oldPath)
+			if os.IsNotExist(err) || err == nil && st.IsDir() {
 				continue
 			}
+			oldData, err := ioutil.ReadFile(oldPath)
 			if err != nil {
 				log.Print(err)
 				haveError = true

--- a/go/tools/gazelle/packages/walk.go
+++ b/go/tools/gazelle/packages/walk.go
@@ -19,6 +19,7 @@ import (
 	"go/build"
 	"io/ioutil"
 	"log"
+	"os"
 	"path"
 	"path/filepath"
 	"sort"
@@ -53,54 +54,90 @@ func Walk(c *config.Config, dir string, f WalkFunc) {
 	// data dependencies.
 	var visit func(string) bool
 	visit = func(path string) bool {
+		// Look for an existing BUILD file. Directives in this file may influence
+		// the rest of the process.
+		var oldFile *bzl.File
+		haveError := false
+		for _, base := range c.ValidBuildFileNames {
+			oldPath := filepath.Join(path, base)
+			oldData, err := ioutil.ReadFile(oldPath)
+			if os.IsNotExist(err) {
+				continue
+			}
+			if err != nil {
+				log.Print(err)
+				haveError = true
+				continue
+			}
+			if oldFile != nil {
+				log.Printf("in directory %s, multiple Bazel files are present: %s, %s",
+					path, filepath.Base(oldFile.Path), base)
+				haveError = true
+				continue
+			}
+			oldFile, err = bzl.Parse(oldPath, oldData)
+			if err != nil {
+				log.Print(err)
+				haveError = true
+				continue
+			}
+		}
+
+		var excluded map[string]bool
+		if oldFile != nil {
+			excluded = findExcludedFiles(oldFile)
+		}
+
+		// List files and subdirectories.
 		files, err := ioutil.ReadDir(path)
 		if err != nil {
 			log.Print(err)
 			return false
 		}
-		subdirHasPackage := false
-		var oldFile *bzl.File
-		hasTestdata := false
-		skip := false
+
+		var goFiles, otherFiles, subdirs []string
 		for _, f := range files {
 			base := f.Name()
-			if f.IsDir() && base != "" && base[0] != '.' {
-				hasPackage := visit(filepath.Join(path, base))
-				if base == "testdata" {
-					hasTestdata = !hasPackage
-				}
-				subdirHasPackage = subdirHasPackage || hasPackage
-			} else if !f.IsDir() && c.IsValidBuildFileName(base) {
-				if oldFile != nil {
-					log.Printf("in directory %s, multiple Bazel files are present: %s, %s",
-						path, filepath.Base(oldFile.Path), base)
-					skip = true
-					continue
-				}
-				oldPath := filepath.Join(path, base)
-				oldData, err := ioutil.ReadFile(oldPath)
-				if err != nil {
-					log.Print(err)
-					skip = true
-					continue
-				}
-				oldFile, err = bzl.Parse(oldPath, oldData)
-				if err != nil {
-					log.Print(err)
-					skip = true
-					continue
-				}
+			switch {
+			case base == "" || base[0] == '.' || base[0] == '_' || excluded != nil && excluded[base]:
+				continue
+
+			case f.IsDir():
+				subdirs = append(subdirs, base)
+
+			case strings.HasSuffix(base, ".go"):
+				goFiles = append(goFiles, base)
+
+			default:
+				otherFiles = append(otherFiles, base)
 			}
 		}
 
+		// Recurse into subdirectories.
+		hasTestdata := false
+		subdirHasPackage := false
+		for _, sub := range subdirs {
+			hasPackage := visit(filepath.Join(path, sub))
+			if sub == "testdata" && !hasPackage {
+				hasTestdata = true
+			}
+			subdirHasPackage = subdirHasPackage || hasPackage
+		}
+
 		hasPackage := subdirHasPackage || oldFile != nil
-		if skip {
+		if haveError {
 			return hasPackage
 		}
 
-		if pkg := findPackage(c, path, oldFile, hasTestdata); pkg != nil {
+		// Build a package from files in this directory.
+		var genGoFiles []string
+		if oldFile != nil {
+			genGoFiles = findGenGoFiles(oldFile, excluded)
+		}
+		pkg := buildPackage(c, path, oldFile, goFiles, genGoFiles, otherFiles, hasTestdata)
+		if pkg != nil {
 			f(pkg, oldFile)
-			return true
+			hasPackage = true
 		}
 		return hasPackage
 	}
@@ -108,7 +145,7 @@ func Walk(c *config.Config, dir string, f WalkFunc) {
 	visit(dir)
 }
 
-// findPackage reads source files in a given directory and returns a Package
+// buildPackage reads source files in a given directory and returns a Package
 // containing information about those files and how to build them.
 //
 // If no buildable .go files are found in the directory, nil will be returned.
@@ -116,7 +153,7 @@ func Walk(c *config.Config, dir string, f WalkFunc) {
 // name matches the directory base name will be returned. If there is no such
 // package or if an error occurs, an error will be logged, and nil will be
 // returned.
-func findPackage(c *config.Config, dir string, oldFile *bzl.File, hasTestdata bool) *Package {
+func buildPackage(c *config.Config, dir string, oldFile *bzl.File, goFiles, genGoFiles, otherFiles []string, hasTestdata bool) *Package {
 	rel, err := filepath.Rel(c.RepoRoot, dir)
 	if err != nil {
 		log.Print(err)
@@ -127,40 +164,7 @@ func findPackage(c *config.Config, dir string, oldFile *bzl.File, hasTestdata bo
 		rel = ""
 	}
 
-	// If an existing BUILD file is present, look for comments that exclude
-	// files and rules that produce .go files.
-	var genGoFiles []string
-	var excluded map[string]bool
-	if oldFile == nil {
-		excluded = make(map[string]bool)
-	} else {
-		genGoFiles = findGenGoFiles(oldFile)
-		excluded = findExcludedFiles(oldFile)
-	}
-
-	// List the files in the directory and split into .go files and other files.
-	// We need to process the Go files first to determine which package we'll
-	// generate rules for if there are multiple packages.
-	var goFiles, otherFiles []string
-	files, err := ioutil.ReadDir(dir)
-	if err != nil {
-		log.Print(err)
-		return nil
-	}
-	for _, file := range files {
-		name := file.Name()
-		if file.IsDir() || name == "" || name[0] == '.' || name[0] == '_' || excluded[name] {
-			continue
-		}
-
-		if strings.HasSuffix(name, ".go") {
-			goFiles = append(goFiles, name)
-		} else {
-			otherFiles = append(otherFiles, name)
-		}
-	}
-
-	// Process the .go files.
+	// Process the .go files first.
 	packageMap := make(map[string]*Package)
 	cgo := false
 	for _, goFile := range goFiles {
@@ -204,7 +208,7 @@ func findPackage(c *config.Config, dir string, oldFile *bzl.File, hasTestdata bo
 	// will look at the content of static files, assuming they will be the same.
 	for _, goFile := range genGoFiles {
 		i := sort.SearchStrings(goFiles, goFile)
-		if excluded[goFile] || i < len(goFiles) && goFiles[i] == goFile {
+		if i < len(goFiles) && goFiles[i] == goFile {
 			// Explicitly excluded or found a static file with the same name.
 			continue
 		}
@@ -258,7 +262,7 @@ func selectPackage(c *config.Config, dir string, packageMap map[string]*Package)
 		// Add the first file for each package for the error message.
 		// Error() method expects these lists to be the same length. File
 		// lists must be non-empty. These lists are only created by
-		// findPackageFiles for packages with .go files present.
+		// buildPackage for packages with .go files present.
 		err.Packages = append(err.Packages, name)
 		err.Files = append(err.Files, pkg.firstGoFile())
 	}
@@ -277,7 +281,7 @@ func defaultPackageName(c *config.Config, dir string) string {
 	return name
 }
 
-func findGenGoFiles(f *bzl.File) []string {
+func findGenGoFiles(f *bzl.File, excluded map[string]bool) []string {
 	var strs []string
 	for _, r := range f.Rules("") {
 		for _, key := range []string{"out", "outs"} {
@@ -296,7 +300,7 @@ func findGenGoFiles(f *bzl.File) []string {
 
 	var goFiles []string
 	for _, s := range strs {
-		if strings.HasSuffix(s, ".go") {
+		if !excluded[s] && strings.HasSuffix(s, ".go") {
 			goFiles = append(goFiles, s)
 		}
 	}

--- a/go/tools/gazelle/rules/generator_test.go
+++ b/go/tools/gazelle/rules/generator_test.go
@@ -33,7 +33,7 @@ func testConfig(repoRoot, goPrefix string) *config.Config {
 		GoPrefix:            goPrefix,
 		GenericTags:         config.BuildTags{},
 		Platforms:           config.DefaultPlatformTags,
-		ValidBuildFileNames: config.DefaultValidBuildFileNames,
+		ValidBuildFileNames: []string{"BUILD.old"},
 	}
 	c.PreprocessTags()
 	return c
@@ -60,6 +60,7 @@ func TestGenerator(t *testing.T) {
 		"bin_with_tests",
 		"cgolib",
 		"cgolib_with_build_tags",
+		"gen_and_exclude",
 		"lib",
 		"lib/internal/deep",
 		"main_test_only",

--- a/go/tools/gazelle/testdata/repo/gen_and_exclude/BUILD.old
+++ b/go/tools/gazelle/testdata/repo/gen_and_exclude/BUILD.old
@@ -1,0 +1,13 @@
+# gazelle:exclude gen_excluded.go
+# gazelle:exclude static_excluded.go
+
+genrule(
+    name = "gen_srcs",
+    outs = [
+        "gen.go",
+        "gen_static_darwin.go",
+        "gen_static_ignore.go",
+        "gen_linux.go",
+        "gen_excluded.go",
+    ],
+)

--- a/go/tools/gazelle/testdata/repo/gen_and_exclude/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/gen_and_exclude/BUILD.want
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "static.go",
+        "gen.go",
+    ] + select({
+        "@io_bazel_rules_go//go/platform:darwin_amd64": [
+            "gen_static_darwin.go",
+        ],
+        "@io_bazel_rules_go//go/platform:linux_amd64": [
+            "gen_linux.go",
+        ],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+    deps = select({
+        "@io_bazel_rules_go//go/platform:darwin_amd64": [
+            "@com_github_jr_hacker_darwin//:go_default_library",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/go/tools/gazelle/testdata/repo/gen_and_exclude/gen_static_darwin.go
+++ b/go/tools/gazelle/testdata/repo/gen_and_exclude/gen_static_darwin.go
@@ -1,0 +1,3 @@
+package gen_and_exclude
+
+import _ "github.com/jr_hacker/darwin"

--- a/go/tools/gazelle/testdata/repo/gen_and_exclude/gen_static_ignore.go
+++ b/go/tools/gazelle/testdata/repo/gen_and_exclude/gen_static_ignore.go
@@ -1,0 +1,3 @@
+// +build ignore
+
+package gen_and_exclude

--- a/go/tools/gazelle/testdata/repo/gen_and_exclude/static.go
+++ b/go/tools/gazelle/testdata/repo/gen_and_exclude/static.go
@@ -1,0 +1,1 @@
+package gen_and_exclude

--- a/tests/popular_repos/popular_repos.bash
+++ b/tests/popular_repos/popular_repos.bash
@@ -119,11 +119,6 @@ excludes=(
   -@org_golang_x_tools//go/gcimporter15/testdata/...
   -@org_golang_x_tools//go/loader/testdata/...
   -@org_golang_x_tools//go/pointer/testdata/...
-
-  # some sqlite3 tests rely on sources in the library which are filtered out.
-  -@com_github_mattn_go_sqlite3//_example/custom_func:all
-  -@com_github_mattn_go_sqlite3//_example/trace:all
-  -@com_github_mattn_go_sqlite3//_example/vtable:all
 )
 
 case $(uname) in


### PR DESCRIPTION
Gazelle now detects files generated inside rules of existing BUILD
files and incorporates them into the rules it generates. For example,
if a genrule lists "foo.go" in its "outs" attribute, Gazelle will add
"foo.go" to the go_library it generates.

Files may be excluded by adding a comment of the form:
"# gazelle:exclude foo.go"

The exclusion applies both to existing files and generated files.

Fixes #557