### PR TITLE
Adding rules for running gazelle

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -22,9 +22,9 @@ lines_sorted_test(
     file = "AUTHORS",
 )
 
-# This could be any file, used as an anchor point for the directory in tests
-exports_files(["README.md"])
-
 gazelle(
     name = "gazelle",
 )
+
+# This could be any file, used as an anchor point for the directory in tests
+exports_files(["README.md"])

--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_prefix")
+load("@io_bazel_rules_go//go:def.bzl", "gazelle", "go_prefix")
 load("@io_bazel_rules_go//go/private:lines_sorted_test.bzl", "lines_sorted_test")
 load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_google_protobuf")
 
@@ -8,19 +8,23 @@ go_google_protobuf()
 
 lines_sorted_test(
     name = "contributors_sorted_test",
+    size = "small",
     cmd = "grep -v '^#' $< | grep -v '^$$' >$@",
     error_message = "Contributors must be sorted by first name",
     file = "CONTRIBUTORS",
-    size = "small",
 )
 
 lines_sorted_test(
     name = "authors_sorted_test",
+    size = "small",
     cmd = "grep -v '^#' $< | grep -v '^$$' >$@",
     error_message = "Authors must be sorted by first name",
     file = "AUTHORS",
-    size = "small",
 )
 
 # This could be any file, used as an anchor point for the directory in tests
 exports_files(["README.md"])
+
+gazelle(
+    name = "gazelle",
+)

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -19,6 +19,7 @@ load("@io_bazel_rules_go//go/private:library.bzl", "go_library")
 load("@io_bazel_rules_go//go/private:binary.bzl", "go_binary")
 load("@io_bazel_rules_go//go/private:test.bzl", "go_test")
 load("@io_bazel_rules_go//go/private:cgo.bzl", "cgo_library", "cgo_genrule")
+load("@io_bazel_rules_go//go/private:gazelle.bzl", "gazelle")
 
 """These are bare-bones Go rules.
 

--- a/go/private/gazelle.bzl
+++ b/go/private/gazelle.bzl
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+_script_content = """
+BASE=$(pwd)
+WORKSPACE=$(dirname $(readlink WORKSPACE))
+cd "$WORKSPACE"
+$BASE/{gazelle} {args} $@
+"""
+
 def _gazelle_script_impl(ctx):
-  script_content = ''
   args = ctx.attr.args
-  script_content += 'BASE=$(pwd)\n'
-  script_content += 'WORKSPACE=$(dirname $(readlink WORKSPACE))\n'
-  script_content += 'cd $WORKSPACE\n'
   args = [
       "-repo_root", "$WORKSPACE",
       "-go_prefix", ctx.attr._go_prefix.go_prefix,
@@ -26,7 +29,7 @@ def _gazelle_script_impl(ctx):
   ]
   if ctx.attr.build_tags:
     args += ["-build_tags", ",".join(ctx.attr.build_tags)]
-  script_content += '$BASE/{0} {1} $@\n'.format(ctx.file._gazelle.short_path, " ".join(args))
+  script_content = _script_content.format(gazelle=ctx.file._gazelle.short_path, args=" ".join(args))
   script_file = ctx.new_file(ctx.label.name+".bash")
   ctx.file_action(output=script_file, executable=True, content=script_content)
   return struct(

--- a/go/private/gazelle.bzl
+++ b/go/private/gazelle.bzl
@@ -1,0 +1,73 @@
+# Copyright 2016 The Bazel Go Rules Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def _gazelle_script_impl(ctx):
+  script_content = ''
+  args = ctx.attr.args
+  script_content += 'BASE=$(pwd)\n'
+  script_content += 'WORKSPACE=$(dirname $(readlink WORKSPACE))\n'
+  script_content += 'cd $WORKSPACE\n'
+  args = [
+      "-repo_root", "$WORKSPACE",
+      "-go_prefix", ctx.attr._go_prefix.go_prefix,
+      "-external", ctx.attr.external,
+      "-mode", ctx.attr.mode,
+  ]
+  if ctx.attr.build_tags:
+    args += ["-build_tags", ",".join(ctx.attr.build_tags)]
+  script_content += '$BASE/{0} {1} $@\n'.format(ctx.file._gazelle.short_path, " ".join(args))
+  script_file = ctx.new_file(ctx.label.name+".bash")
+  ctx.file_action(output=script_file, executable=True, content=script_content)
+  return struct(
+    files = depset([script_file]),
+    runfiles = ctx.runfiles([ctx.file._gazelle])
+  )
+
+_gazelle_script = rule(
+    _gazelle_script_impl,
+    attrs = {
+        "mode": attr.string(mandatory=True, values=["print", "fix", "diff"]),
+        "external": attr.string(mandatory=True, values=["external", "vendored"]),
+        "build_tags": attr.string_list(mandatory=True),
+        "args": attr.string_list(mandatory=True),
+        "_gazelle": attr.label(
+            default = Label("@io_bazel_rules_go//go/tools/gazelle/gazelle:gazelle"),
+            allow_files = True,
+            single_file = True,
+            executable = True,
+            cfg = "host"
+        ),
+        "_go_prefix": attr.label(default = Label(
+            "//:go_prefix",
+            relative_to_caller_repository = True,
+        )),
+    }
+)
+
+def gazelle(name, mode = "fix", external="external", build_tags=[], args = []):
+  script_name = name+"_script"
+  _gazelle_script(
+      name = script_name,
+      mode = mode,
+      external = external,
+      build_tags = build_tags,
+      args = args,
+      tags = ["manual"],
+  )
+  native.sh_binary(
+      name = name,
+      srcs = [script_name],
+      data = ["//:WORKSPACE"],
+      tags = ["manual"],
+  )


### PR DESCRIPTION
These are still experimental, and subject to change, but they seem useful.

Add
    load("@io_bazel_rules_go//go:def.bzl", "gazelle")
    gazelle(name = "gazelle")
to your build file, and then do
    bazel run //:gazelle
to automatically fix all build files.
You can make as many of these rules as you like with different names to run
gazelle in different modes or with different options.