### PR TITLE
Fix bazel test result

### DIFF
--- a/tests/bazel_tests.bzl
+++ b/tests/bazel_tests.bzl
@@ -49,6 +49,7 @@ def _bazel_test_script_impl(ctx):
   script_content += 'result=$?\n'
   if ctx.attr.check:
     script_content += ctx.attr.check
+  script_content += "exit $result\n"
   script_file = ctx.new_file(ctx.label.name+".bash")
   ctx.file_action(output=script_file, executable=True, content=script_content)
   # finalise the bazel options

--- a/tests/trans_dep_error/BUILD
+++ b/tests/trans_dep_error/BUILD
@@ -8,7 +8,9 @@ bazel_test(
     check = """
 if [ "$result" -eq 0 ]; then
   echo "error: build succeeded unexpectedly" >&2
-  exit 1
+  result=1
+else
+  result=0
 fi
 """,
 )


### PR DESCRIPTION
We need to return the result code no matter what the "check" part does