### PR TITLE
Rename import symbol bzl to bf in all tools

### DIFF
--- a/go/tools/gazelle/gazelle/diff.go
+++ b/go/tools/gazelle/gazelle/diff.go
@@ -20,18 +20,18 @@ import (
 	"os"
 	"os/exec"
 
-	bzl "github.com/bazelbuild/buildtools/build"
+	bf "github.com/bazelbuild/buildtools/build"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/config"
 )
 
-func diffFile(c *config.Config, file *bzl.File) error {
+func diffFile(c *config.Config, file *bf.File) error {
 	f, err := ioutil.TempFile("", c.DefaultBuildFileName())
 	if err != nil {
 		return err
 	}
 	defer os.Remove(f.Name())
 	defer f.Close()
-	if _, err := f.Write(bzl.Format(file)); err != nil {
+	if _, err := f.Write(bf.Format(file)); err != nil {
 		return err
 	}
 	if err := f.Sync(); err != nil {

--- a/go/tools/gazelle/gazelle/fix.go
+++ b/go/tools/gazelle/gazelle/fix.go
@@ -18,12 +18,12 @@ package main
 import (
 	"io/ioutil"
 
-	bzl "github.com/bazelbuild/buildtools/build"
+	bf "github.com/bazelbuild/buildtools/build"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/config"
 )
 
-func fixFile(c *config.Config, file *bzl.File) error {
-	if err := ioutil.WriteFile(file.Path, bzl.Format(file), 0644); err != nil {
+func fixFile(c *config.Config, file *bf.File) error {
+	if err := ioutil.WriteFile(file.Path, bf.Format(file), 0644); err != nil {
 		return err
 	}
 	return nil

--- a/go/tools/gazelle/gazelle/fix_test.go
+++ b/go/tools/gazelle/gazelle/fix_test.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	bzl "github.com/bazelbuild/buildtools/build"
+	bf "github.com/bazelbuild/buildtools/build"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/config"
 )
 
@@ -52,16 +52,16 @@ func TestFixFile(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	stubFile := &bzl.File{
+	stubFile := &bf.File{
 		Path: filepath.Join(dir, "BUILD.bazel"),
-		Stmt: []bzl.Expr{
-			&bzl.CallExpr{
-				X: &bzl.LiteralExpr{Token: "foo_rule"},
-				List: []bzl.Expr{
-					&bzl.BinaryExpr{
-						X:  &bzl.LiteralExpr{Token: "name"},
+		Stmt: []bf.Expr{
+			&bf.CallExpr{
+				X: &bf.LiteralExpr{Token: "foo_rule"},
+				List: []bf.Expr{
+					&bf.BinaryExpr{
+						X:  &bf.LiteralExpr{Token: "name"},
 						Op: "=",
-						Y:  &bzl.StringExpr{Value: "bar"},
+						Y:  &bf.StringExpr{Value: "bar"},
 					},
 				},
 			},
@@ -79,7 +79,7 @@ func TestFixFile(t *testing.T) {
 		t.Errorf("ioutil.ReadFile(%q) failed with %v; want success", stubFile.Path, err)
 		return
 	}
-	if got, want := string(buf), bzl.FormatString(stubFile); got != want {
+	if got, want := string(buf), bf.FormatString(stubFile); got != want {
 		t.Errorf("buf = %q; want %q", got, want)
 	}
 }

--- a/go/tools/gazelle/gazelle/print.go
+++ b/go/tools/gazelle/gazelle/print.go
@@ -18,11 +18,11 @@ package main
 import (
 	"os"
 
-	bzl "github.com/bazelbuild/buildtools/build"
+	bf "github.com/bazelbuild/buildtools/build"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/config"
 )
 
-func printFile(c *config.Config, f *bzl.File) error {
-	_, err := os.Stdout.Write(bzl.Format(f))
+func printFile(c *config.Config, f *bf.File) error {
+	_, err := os.Stdout.Write(bf.Format(f))
 	return err
 }

--- a/go/tools/gazelle/merger/merger.go
+++ b/go/tools/gazelle/merger/merger.go
@@ -22,7 +22,7 @@ import (
 	"sort"
 	"strings"
 
-	bzl "github.com/bazelbuild/buildtools/build"
+	bf "github.com/bazelbuild/buildtools/build"
 )
 
 const (
@@ -47,7 +47,7 @@ var (
 // If "oldFile" is nil, "genFile" will be returned. If "oldFile" contains
 // a "# gazelle:ignore" comment, nil will be returned. If an error occurs,
 // it will be logged, and nil will be returned.
-func MergeWithExisting(genFile, oldFile *bzl.File) *bzl.File {
+func MergeWithExisting(genFile, oldFile *bf.File) *bf.File {
 	if oldFile == nil {
 		return genFile
 	}
@@ -56,14 +56,14 @@ func MergeWithExisting(genFile, oldFile *bzl.File) *bzl.File {
 	}
 
 	mergedFile := *oldFile
-	mergedFile.Stmt = make([]bzl.Expr, len(oldFile.Stmt))
+	mergedFile.Stmt = make([]bf.Expr, len(oldFile.Stmt))
 	for i := range oldFile.Stmt {
 		mergedFile.Stmt[i] = oldFile.Stmt[i]
 	}
 
-	var newStmt []bzl.Expr
+	var newStmt []bf.Expr
 	for _, s := range genFile.Stmt {
-		genRule, ok := s.(*bzl.CallExpr)
+		genRule, ok := s.(*bf.CallExpr)
 		if !ok {
 			log.Panicf("got %v expected only CallExpr in %q", s, genFile.Path)
 		}
@@ -73,7 +73,7 @@ func MergeWithExisting(genFile, oldFile *bzl.File) *bzl.File {
 			continue
 		}
 
-		var mergedRule bzl.Expr
+		var mergedRule bf.Expr
 		if kind(oldRule) == "load" {
 			mergedRule = mergeLoad(genRule, oldRule, oldFile)
 		} else {
@@ -88,19 +88,19 @@ func MergeWithExisting(genFile, oldFile *bzl.File) *bzl.File {
 
 // merge combines information from gen and old and returns an updated rule.
 // Both rules must be non-nil and must have the same kind and same name.
-func mergeRule(gen, old *bzl.CallExpr) *bzl.CallExpr {
-	genRule := bzl.Rule{Call: gen}
-	oldRule := bzl.Rule{Call: old}
+func mergeRule(gen, old *bf.CallExpr) *bf.CallExpr {
+	genRule := bf.Rule{Call: gen}
+	oldRule := bf.Rule{Call: old}
 	merged := *old
 	merged.List = nil
-	mergedRule := bzl.Rule{Call: &merged}
+	mergedRule := bf.Rule{Call: &merged}
 
 	// Copy unnamed arguments from the old rule without merging. The only rule
 	// generated with unnamed arguments is go_prefix, which we currently
 	// leave in place.
 	// TODO: maybe gazelle should allow the prefix to be changed.
 	for _, a := range old.List {
-		if b, ok := a.(*bzl.BinaryExpr); ok && b.Op == "=" {
+		if b, ok := a.(*bf.BinaryExpr); ok && b.Op == "=" {
 			break
 		}
 		merged.List = append(merged.List, a)
@@ -152,8 +152,8 @@ func mergeRule(gen, old *bzl.CallExpr) *bzl.CallExpr {
 //
 // An error is returned if the expressions can't be merged, for example
 // because they are not in one of the above formats.
-func mergeExpr(gen, old bzl.Expr) (bzl.Expr, error) {
-	if _, ok := gen.(*bzl.StringExpr); ok {
+func mergeExpr(gen, old bf.Expr) (bf.Expr, error) {
+	if _, ok := gen.(*bf.StringExpr); ok {
 		if shouldKeep(old) {
 			return old, nil
 		}
@@ -175,11 +175,11 @@ func mergeExpr(gen, old bzl.Expr) (bzl.Expr, error) {
 		return nil, err
 	}
 
-	var mergedSelect bzl.Expr
+	var mergedSelect bf.Expr
 	if mergedDict != nil {
-		mergedSelect = &bzl.CallExpr{
-			X:    &bzl.LiteralExpr{Token: "select"},
-			List: []bzl.Expr{mergedDict},
+		mergedSelect = &bf.CallExpr{
+			X:    &bf.LiteralExpr{Token: "select"},
+			List: []bf.Expr{mergedDict},
 		}
 	}
 
@@ -190,7 +190,7 @@ func mergeExpr(gen, old bzl.Expr) (bzl.Expr, error) {
 		return mergedList, nil
 	}
 	mergedList.ForceMultiLine = true
-	return &bzl.BinaryExpr{
+	return &bf.BinaryExpr{
 		X:  mergedList,
 		Op: "+",
 		Y:  mergedSelect,
@@ -200,36 +200,36 @@ func mergeExpr(gen, old bzl.Expr) (bzl.Expr, error) {
 // exprListAndDict matches an expression and attempts to extract either a list
 // of expressions, a call to select with a dictionary, or both.
 // An error is returned if the expression could not be matched.
-func exprListAndDict(expr bzl.Expr) (*bzl.ListExpr, *bzl.DictExpr, error) {
+func exprListAndDict(expr bf.Expr) (*bf.ListExpr, *bf.DictExpr, error) {
 	if expr == nil {
 		return nil, nil, nil
 	}
 	switch expr := expr.(type) {
-	case *bzl.ListExpr:
+	case *bf.ListExpr:
 		return expr, nil, nil
-	case *bzl.CallExpr:
-		if x, ok := expr.X.(*bzl.LiteralExpr); ok && x.Token == "select" && len(expr.List) == 1 {
-			if d, ok := expr.List[0].(*bzl.DictExpr); ok {
+	case *bf.CallExpr:
+		if x, ok := expr.X.(*bf.LiteralExpr); ok && x.Token == "select" && len(expr.List) == 1 {
+			if d, ok := expr.List[0].(*bf.DictExpr); ok {
 				return nil, d, nil
 			}
 		}
-	case *bzl.BinaryExpr:
+	case *bf.BinaryExpr:
 		if expr.Op != "+" {
 			return nil, nil, fmt.Errorf("expression could not be matched: unknown operator: %s", expr.Op)
 		}
-		l, ok := expr.X.(*bzl.ListExpr)
+		l, ok := expr.X.(*bf.ListExpr)
 		if !ok {
 			return nil, nil, fmt.Errorf("expression could not be matched: left operand not a list")
 		}
-		call, ok := expr.Y.(*bzl.CallExpr)
+		call, ok := expr.Y.(*bf.CallExpr)
 		if !ok || len(call.List) != 1 {
 			return nil, nil, fmt.Errorf("expression could not be matched: right operand not a call with one argument")
 		}
-		x, ok := call.X.(*bzl.LiteralExpr)
+		x, ok := call.X.(*bf.LiteralExpr)
 		if !ok || x.Token != "select" {
 			return nil, nil, fmt.Errorf("expression could not be matched: right operand not a call to select")
 		}
-		d, ok := call.List[0].(*bzl.DictExpr)
+		d, ok := call.List[0].(*bf.DictExpr)
 		if !ok {
 			return nil, nil, fmt.Errorf("expression could not be matched: argument to right operand not a dict")
 		}
@@ -238,18 +238,18 @@ func exprListAndDict(expr bzl.Expr) (*bzl.ListExpr, *bzl.DictExpr, error) {
 	return nil, nil, fmt.Errorf("expression could not be matched")
 }
 
-func mergeList(gen, old *bzl.ListExpr) *bzl.ListExpr {
+func mergeList(gen, old *bf.ListExpr) *bf.ListExpr {
 	if old == nil {
 		return gen
 	}
 	if gen == nil {
-		gen = &bzl.ListExpr{List: []bzl.Expr{}}
+		gen = &bf.ListExpr{List: []bf.Expr{}}
 	}
 
 	// Build a list of elements from the old list with "# keep" comments. We
 	// must not duplicate these elements, since duplicate elements will be
 	// removed when we rewrite the AST.
-	var merged []bzl.Expr
+	var merged []bf.Expr
 	kept := make(map[string]bool)
 	for _, v := range old.List {
 		if shouldKeep(v) {
@@ -270,15 +270,15 @@ func mergeList(gen, old *bzl.ListExpr) *bzl.ListExpr {
 	if len(merged) == 0 {
 		return nil
 	}
-	return &bzl.ListExpr{List: merged}
+	return &bf.ListExpr{List: merged}
 }
 
-func mergeDict(gen, old *bzl.DictExpr) (*bzl.DictExpr, error) {
+func mergeDict(gen, old *bf.DictExpr) (*bf.DictExpr, error) {
 	if old == nil {
 		return gen, nil
 	}
 	if gen == nil {
-		gen = &bzl.DictExpr{List: []bzl.Expr{}}
+		gen = &bf.DictExpr{List: []bf.Expr{}}
 	}
 
 	var entries []*dictEntry
@@ -319,7 +319,7 @@ func mergeDict(gen, old *bzl.DictExpr) (*bzl.DictExpr, error) {
 			// Keep the default case, even if it's empty.
 			haveDefault = true
 			if e.mergedValue == nil {
-				e.mergedValue = &bzl.ListExpr{}
+				e.mergedValue = &bf.ListExpr{}
 			}
 		} else if e.mergedValue != nil {
 			keys = append(keys, e.key)
@@ -334,41 +334,41 @@ func mergeDict(gen, old *bzl.DictExpr) (*bzl.DictExpr, error) {
 		keys = append(keys, "//conditions:default")
 	}
 
-	mergedEntries := make([]bzl.Expr, len(keys))
+	mergedEntries := make([]bf.Expr, len(keys))
 	for i, k := range keys {
 		e := entryMap[k]
-		mergedEntries[i] = &bzl.KeyValueExpr{
-			Key:   &bzl.StringExpr{Value: e.key},
+		mergedEntries[i] = &bf.KeyValueExpr{
+			Key:   &bf.StringExpr{Value: e.key},
 			Value: e.mergedValue,
 		}
 	}
 
-	return &bzl.DictExpr{List: mergedEntries, ForceMultiLine: true}, nil
+	return &bf.DictExpr{List: mergedEntries, ForceMultiLine: true}, nil
 }
 
 type dictEntry struct {
 	key                             string
-	oldValue, genValue, mergedValue *bzl.ListExpr
+	oldValue, genValue, mergedValue *bf.ListExpr
 }
 
-func dictEntryKeyValue(e bzl.Expr) (string, *bzl.ListExpr, error) {
-	kv, ok := e.(*bzl.KeyValueExpr)
+func dictEntryKeyValue(e bf.Expr) (string, *bf.ListExpr, error) {
+	kv, ok := e.(*bf.KeyValueExpr)
 	if !ok {
 		return "", nil, fmt.Errorf("dict entry was not a key-value pair: %#v", e)
 	}
-	k, ok := kv.Key.(*bzl.StringExpr)
+	k, ok := kv.Key.(*bf.StringExpr)
 	if !ok {
 		return "", nil, fmt.Errorf("dict key was not string: %#v", kv.Key)
 	}
-	v, ok := kv.Value.(*bzl.ListExpr)
+	v, ok := kv.Value.(*bf.ListExpr)
 	if !ok {
 		return "", nil, fmt.Errorf("dict value was not list: %#v", kv.Value)
 	}
 	return k.Value, v, nil
 }
 
-func mergeLoad(gen, old *bzl.CallExpr, oldfile *bzl.File) *bzl.CallExpr {
-	vals := make(map[string]bzl.Expr)
+func mergeLoad(gen, old *bf.CallExpr, oldfile *bf.File) *bf.CallExpr {
+	vals := make(map[string]bf.Expr)
 	for _, v := range gen.List[1:] {
 		vals[stringValue(v)] = v
 	}
@@ -394,7 +394,7 @@ func mergeLoad(gen, old *bzl.CallExpr, oldfile *bzl.File) *bzl.CallExpr {
 
 // shouldIgnore checks whether "gazelle:ignore" appears at the beginning of
 // a comment before or after any top-level statement in the file.
-func shouldIgnore(oldFile *bzl.File) bool {
+func shouldIgnore(oldFile *bf.File) bool {
 	for _, s := range oldFile.Stmt {
 		for _, c := range s.Comment().After {
 			if strings.HasPrefix(c.Token, gazelleIgnore) {
@@ -412,12 +412,12 @@ func shouldIgnore(oldFile *bzl.File) bool {
 
 // shouldKeep returns whether an expression from the original file should be
 // preserved. This is true if it has a trailing comment that starts with "keep".
-func shouldKeep(e bzl.Expr) bool {
+func shouldKeep(e bf.Expr) bool {
 	c := e.Comment()
 	return len(c.Suffix) > 0 && strings.HasPrefix(c.Suffix[0].Token, keep)
 }
 
-func ruleUsed(rule string, oldfile *bzl.File) bool {
+func ruleUsed(rule string, oldfile *bf.File) bool {
 	return len(oldfile.Rules(rule)) != 0
 }
 
@@ -425,7 +425,7 @@ func ruleUsed(rule string, oldfile *bzl.File) bool {
 // i.e. two 'go_library(name = "foo", ...)' are considered matches
 // despite the values of the other fields.
 // exception: if c is a 'load' statement, the match is done on the first value.
-func match(f *bzl.File, c *bzl.CallExpr) (int, *bzl.CallExpr) {
+func match(f *bf.File, c *bf.CallExpr) (int, *bf.CallExpr) {
 	var m matcher
 	if kind := kind(c); kind == "load" {
 		if len(c.List) == 0 {
@@ -436,7 +436,7 @@ func match(f *bzl.File, c *bzl.CallExpr) (int, *bzl.CallExpr) {
 		m = &nameMatcher{kind, name(c)}
 	}
 	for i, s := range f.Stmt {
-		other, ok := s.(*bzl.CallExpr)
+		other, ok := s.(*bf.CallExpr)
 		if !ok {
 			continue
 		}
@@ -448,14 +448,14 @@ func match(f *bzl.File, c *bzl.CallExpr) (int, *bzl.CallExpr) {
 }
 
 type matcher interface {
-	match(c *bzl.CallExpr) bool
+	match(c *bf.CallExpr) bool
 }
 
 type nameMatcher struct {
 	kind, name string
 }
 
-func (m *nameMatcher) match(c *bzl.CallExpr) bool {
+func (m *nameMatcher) match(c *bf.CallExpr) bool {
 	return m.kind == kind(c) && m.name == name(c)
 }
 
@@ -463,20 +463,20 @@ type loadMatcher struct {
 	load string
 }
 
-func (m *loadMatcher) match(c *bzl.CallExpr) bool {
+func (m *loadMatcher) match(c *bf.CallExpr) bool {
 	return kind(c) == "load" && len(c.List) > 0 && m.load == stringValue(c.List[0])
 }
 
-func kind(c *bzl.CallExpr) string {
-	return (&bzl.Rule{c}).Kind()
+func kind(c *bf.CallExpr) string {
+	return (&bf.Rule{c}).Kind()
 }
 
-func name(c *bzl.CallExpr) string {
-	return (&bzl.Rule{c}).Name()
+func name(c *bf.CallExpr) string {
+	return (&bf.Rule{c}).Name()
 }
 
-func stringValue(e bzl.Expr) string {
-	s, ok := e.(*bzl.StringExpr)
+func stringValue(e bf.Expr) string {
+	s, ok := e.(*bf.StringExpr)
 	if !ok {
 		return ""
 	}

--- a/go/tools/gazelle/merger/merger_test.go
+++ b/go/tools/gazelle/merger/merger_test.go
@@ -3,7 +3,7 @@ package merger
 import (
 	"testing"
 
-	bzl "github.com/bazelbuild/buildtools/build"
+	bf "github.com/bazelbuild/buildtools/build"
 )
 
 // should fix
@@ -428,12 +428,12 @@ go_library(
 
 func TestMergeWithExisting(t *testing.T) {
 	for _, tc := range testCases {
-		genFile, err := bzl.Parse("current", []byte(tc.current))
+		genFile, err := bf.Parse("current", []byte(tc.current))
 		if err != nil {
 			t.Errorf("%s: %v", tc.desc, err)
 			continue
 		}
-		oldFile, err := bzl.Parse("previous", []byte(tc.previous))
+		oldFile, err := bf.Parse("previous", []byte(tc.previous))
 		if err != nil {
 			t.Errorf("%s: %v", tc.desc, err)
 			continue
@@ -455,15 +455,15 @@ func TestMergeWithExisting(t *testing.T) {
 			want = want[1:]
 		}
 
-		if got := string(bzl.Format(mergedFile)); got != want {
+		if got := string(bf.Format(mergedFile)); got != want {
 			t.Errorf("%s: got %s; want %s", tc.desc, got, want)
 		}
 	}
 }
 
 func TestMergeWithExistingDifferentName(t *testing.T) {
-	oldFile := &bzl.File{Path: "BUILD"}
-	genFile := &bzl.File{Path: "BUILD.bazel"}
+	oldFile := &bf.File{Path: "BUILD"}
+	genFile := &bf.File{Path: "BUILD.bazel"}
 	mergedFile := MergeWithExisting(genFile, oldFile)
 	if got, want := mergedFile.Path, oldFile.Path; got != want {
 		t.Errorf("got %q; want %q", got, want)

--- a/go/tools/gazelle/packages/walk.go
+++ b/go/tools/gazelle/packages/walk.go
@@ -25,12 +25,12 @@ import (
 	"sort"
 	"strings"
 
-	bzl "github.com/bazelbuild/buildtools/build"
+	bf "github.com/bazelbuild/buildtools/build"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/config"
 )
 
 // A WalkFunc is a callback called by Walk for each package.
-type WalkFunc func(pkg *Package, oldFile *bzl.File)
+type WalkFunc func(pkg *Package, oldFile *bf.File)
 
 // Walk walks through directories under "root".
 // It calls back "f" for each package. If an existing BUILD file is present
@@ -56,7 +56,7 @@ func Walk(c *config.Config, dir string, f WalkFunc) {
 	visit = func(path string) bool {
 		// Look for an existing BUILD file. Directives in this file may influence
 		// the rest of the process.
-		var oldFile *bzl.File
+		var oldFile *bf.File
 		haveError := false
 		for _, base := range c.ValidBuildFileNames {
 			oldPath := filepath.Join(path, base)
@@ -76,7 +76,7 @@ func Walk(c *config.Config, dir string, f WalkFunc) {
 				haveError = true
 				continue
 			}
-			oldFile, err = bzl.Parse(oldPath, oldData)
+			oldFile, err = bf.Parse(oldPath, oldData)
 			if err != nil {
 				log.Print(err)
 				haveError = true
@@ -154,7 +154,7 @@ func Walk(c *config.Config, dir string, f WalkFunc) {
 // name matches the directory base name will be returned. If there is no such
 // package or if an error occurs, an error will be logged, and nil will be
 // returned.
-func buildPackage(c *config.Config, dir string, oldFile *bzl.File, goFiles, genGoFiles, otherFiles []string, hasTestdata bool) *Package {
+func buildPackage(c *config.Config, dir string, oldFile *bf.File, goFiles, genGoFiles, otherFiles []string, hasTestdata bool) *Package {
 	rel, err := filepath.Rel(c.RepoRoot, dir)
 	if err != nil {
 		log.Print(err)
@@ -282,16 +282,16 @@ func defaultPackageName(c *config.Config, dir string) string {
 	return name
 }
 
-func findGenGoFiles(f *bzl.File, excluded map[string]bool) []string {
+func findGenGoFiles(f *bf.File, excluded map[string]bool) []string {
 	var strs []string
 	for _, r := range f.Rules("") {
 		for _, key := range []string{"out", "outs"} {
 			switch e := r.Attr(key).(type) {
-			case *bzl.StringExpr:
+			case *bf.StringExpr:
 				strs = append(strs, e.Value)
-			case *bzl.ListExpr:
+			case *bf.ListExpr:
 				for _, elem := range e.List {
-					if s, ok := elem.(*bzl.StringExpr); ok {
+					if s, ok := elem.(*bf.StringExpr); ok {
 						strs = append(strs, s.Value)
 					}
 				}
@@ -310,7 +310,7 @@ func findGenGoFiles(f *bzl.File, excluded map[string]bool) []string {
 
 const gazelleExclude = "# gazelle:exclude " // marker in a BUILD file to exclude source files.
 
-func findExcludedFiles(f *bzl.File) map[string]bool {
+func findExcludedFiles(f *bf.File) map[string]bool {
 	excluded := make(map[string]bool)
 	for _, s := range f.Stmt {
 		comments := append(s.Comment().Before, s.Comment().After...)

--- a/go/tools/gazelle/packages/walk_test.go
+++ b/go/tools/gazelle/packages/walk_test.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"testing"
 
-	bzl "github.com/bazelbuild/buildtools/build"
+	bf "github.com/bazelbuild/buildtools/build"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/config"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/packages"
 )
@@ -81,7 +81,7 @@ func walkPackages(repoRoot, goPrefix, dir string) []*packages.Package {
 		ValidBuildFileNames: config.DefaultValidBuildFileNames,
 	}
 	var pkgs []*packages.Package
-	packages.Walk(c, dir, func(pkg *packages.Package, _ *bzl.File) {
+	packages.Walk(c, dir, func(pkg *packages.Package, _ *bf.File) {
 		pkgs = append(pkgs, pkg)
 	})
 	return pkgs

--- a/go/tools/gazelle/rules/generator_test.go
+++ b/go/tools/gazelle/rules/generator_test.go
@@ -20,7 +20,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	bzl "github.com/bazelbuild/buildtools/build"
+	bf "github.com/bazelbuild/buildtools/build"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/config"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/packages"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/rules"
@@ -41,7 +41,7 @@ func testConfig(repoRoot, goPrefix string) *config.Config {
 
 func packageFromDir(c *config.Config, dir string) *packages.Package {
 	var pkg *packages.Package
-	packages.Walk(c, dir, func(p *packages.Package, _ *bzl.File) {
+	packages.Walk(c, dir, func(p *packages.Package, _ *bf.File) {
 		if p.Dir == dir {
 			pkg = p
 		}
@@ -71,7 +71,7 @@ func TestGenerator(t *testing.T) {
 		dir := filepath.Join(repoRoot, filepath.FromSlash(rel))
 		pkg := packageFromDir(c, dir)
 		f := g.Generate(pkg)
-		got := string(bzl.Format(f))
+		got := string(bf.Format(f))
 
 		wantPath := filepath.Join(pkg.Dir, "BUILD.want")
 		wantBytes, err := ioutil.ReadFile(wantPath)
@@ -113,18 +113,18 @@ func TestGeneratorGoPrefixRoot(t *testing.T) {
 	}
 }
 
-func findGoPrefix(f *bzl.File) string {
+func findGoPrefix(f *bf.File) string {
 	for _, s := range f.Stmt {
-		c, ok := s.(*bzl.CallExpr)
+		c, ok := s.(*bf.CallExpr)
 		if !ok {
 			continue
 		}
-		x, ok := c.X.(*bzl.LiteralExpr)
+		x, ok := c.X.(*bf.LiteralExpr)
 		if !ok {
 			continue
 		}
 		if x.Token == "go_prefix" {
-			return bzl.FormatString(s)
+			return bf.FormatString(s)
 		}
 	}
 	return ""

--- a/go/tools/wtool/main.go
+++ b/go/tools/wtool/main.go
@@ -26,7 +26,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	bzl "github.com/bazelbuild/buildtools/build"
+	bf "github.com/bazelbuild/buildtools/build"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/rules"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/wspace"
 	"golang.org/x/tools/go/vcs"
@@ -63,7 +63,7 @@ func run(args []string) error {
 	if err != nil {
 		return err
 	}
-	f, err := bzl.Parse(p, b)
+	f, err := bf.Parse(p, b)
 	if err != nil {
 		return err
 	}
@@ -75,8 +75,8 @@ func run(args []string) error {
 		// TODO(pmbethe09): ignore or maybe update sha1 if already defined in workspace.
 		f.Stmt = append(f.Stmt, imp)
 	}
-	bzl.Rewrite(f, nil)
-	return ioutil.WriteFile(f.Path, bzl.Format(f), 0644)
+	bf.Rewrite(f, nil)
+	return ioutil.WriteFile(f.Path, bf.Format(f), 0644)
 }
 
 func nameAndImportpath(name string) (string, string, error) {
@@ -96,7 +96,7 @@ func nameAndImportpath(name string) (string, string, error) {
 	return name, strings.Join([]string{s[1] + "." + s[0], s[2], rest}, "/"), nil
 }
 
-func findImport(nameIn string) (bzl.Expr, error) {
+func findImport(nameIn string) (bf.Expr, error) {
 	name, importpath, err := nameAndImportpath(nameIn)
 	if err != nil {
 		return nil, err
@@ -116,9 +116,9 @@ func findImport(nameIn string) (bzl.Expr, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &bzl.CallExpr{
-		X: &bzl.LiteralExpr{Token: "new_go_repository"},
-		List: []bzl.Expr{
+	return &bf.CallExpr{
+		X: &bf.LiteralExpr{Token: "new_go_repository"},
+		List: []bf.Expr{
 			attr("name", name),
 			attr("importpath", importpath),
 			attr("commit", commit),
@@ -126,11 +126,11 @@ func findImport(nameIn string) (bzl.Expr, error) {
 	}, nil
 }
 
-func attr(key, val string) *bzl.BinaryExpr {
-	return &bzl.BinaryExpr{
-		X:  &bzl.LiteralExpr{Token: key},
+func attr(key, val string) *bf.BinaryExpr {
+	return &bf.BinaryExpr{
+		X:  &bf.LiteralExpr{Token: key},
 		Op: "=",
-		Y:  &bzl.StringExpr{Value: val},
+		Y:  &bf.StringExpr{Value: val},
 	}
 }
 


### PR DESCRIPTION
This is in response to a review comment on an earlier Gazelle PR. The
package is "github.com/bazelbuild/buildtools/build", but "build" is
easy to confuse with "go/build". "bzl" is the suffix for Skylark files
(containing rule and macro definitions), so it doesn't seem
appropriate. "bf" can stand for "BUILD file" or "Bazel format".