### PR TITLE
Gazelle: refactor resolve_external.go to eliminate global state

### DIFF
--- a/go/tools/gazelle/rules/generator.go
+++ b/go/tools/gazelle/rules/generator.go
@@ -66,7 +66,7 @@ func NewGenerator(c *config.Config) Generator {
 	var e labelResolver
 	switch c.DepMode {
 	case config.ExternalMode:
-		e = externalResolver{}
+		e = newExternalResolver()
 	case config.VendorMode:
 		e = vendoredResolver{}
 	default:


### PR DESCRIPTION
The repo root cache and the repoRootForImportPath function pointer are
now fields of externalResolver instead of global. This reduces timing
dependencies between test cases.

Note that currently, only one instance of externalResolver is
created. If we go back to having multiple instances, we'll need to
find a way to share the cache.