### PR TITLE
Only pass direct targets to compile

### DIFF
--- a/go/private/library.bzl
+++ b/go/private/library.bzl
@@ -53,22 +53,26 @@ def emit_library_actions(ctx, sources, deps, cgo_object, library):
   lib_name = importpath + ".a"
   out_lib = ctx.new_file(lib_name)
   out_object = ctx.new_file(ctx.label.name + ".o")
-  search_path = out_lib.path[:-len(lib_name)]
+  searchpath = out_lib.path[:-len(lib_name)]
   gc_goopts = get_gc_goopts(ctx)
-  direct_go_library_paths = []
+  direct_go_library_deps = []
+  direct_search_paths = []
+  direct_import_paths = []
   transitive_go_library_deps = depset()
-  transitive_go_library_paths = depset([search_path])
+  transitive_go_library_paths = depset([searchpath])
   for dep in deps:
-    direct_go_library_paths += [dep.importpath]
+    direct_go_library_deps += [dep.library]
+    direct_search_paths += [dep.searchpath]
+    direct_import_paths += [dep.importpath]
     transitive_go_library_deps += dep.transitive_go_libraries
     transitive_cgo_deps += dep.transitive_cgo_deps
     transitive_go_library_paths += dep.transitive_go_library_paths
 
   go_srcs = emit_go_compile_action(ctx,
       sources = go_srcs,
-      libs = transitive_go_library_deps,
-      lib_paths = transitive_go_library_paths,
-      direct_paths = direct_go_library_paths,                                   
+      libs = direct_go_library_deps,
+      lib_paths = direct_search_paths,
+      direct_paths = direct_import_paths,
       out_object = out_object,
       gc_goopts = gc_goopts,
   )
@@ -85,6 +89,8 @@ def emit_library_actions(ctx, sources, deps, cgo_object, library):
   return struct(
     label = ctx.label,
     files = depset([out_lib]),
+    library = out_lib,
+    searchpath = searchpath,
     runfiles = runfiles,
     go_sources = go_srcs,
     asm_sources = asm_srcs,
@@ -113,6 +119,8 @@ def _go_library_impl(ctx):
   return struct(
     label = ctx.label,
     files = lib_result.files,
+    library = lib_result.library,
+    searchpath = lib_result.searchpath,
     runfiles = lib_result.runfiles,
     go_sources = lib_result.go_sources,
     asm_sources = lib_result.asm_sources,
@@ -218,7 +226,7 @@ def emit_go_compile_action(ctx, sources, libs, lib_paths, direct_paths, out_obje
     args += ["-src", src]
   for dep in direct_paths:
     args += ["-dep", dep]
-  args += ["--", "-o", out_object.path, "-trimpath", ".", "-I", "."]
+  args += ["-o", out_object.path, "-trimpath", ".", "-I", "."]
   for path in lib_paths:
     args += ["-I", path]
   args += gc_goopts + cgo_sources

--- a/go/private/library.bzl
+++ b/go/private/library.bzl
@@ -229,7 +229,7 @@ def emit_go_compile_action(ctx, sources, libs, lib_paths, direct_paths, out_obje
   args += ["-o", out_object.path, "-trimpath", ".", "-I", "."]
   for path in lib_paths:
     args += ["-I", path]
-  args += gc_goopts + cgo_sources
+  args += ["--"] + gc_goopts + cgo_sources
   ctx.action(
       inputs = list(inputs),
       outputs = [out_object],

--- a/go/private/test.bzl
+++ b/go/private/test.bzl
@@ -32,7 +32,6 @@ def _go_test_impl(ctx):
   main_go = ctx.new_file(ctx.label.name + "_main_test.go")
   main_object = ctx.new_file(ctx.label.name + "_main_test.o")
   main_lib = ctx.new_file(ctx.label.name + "_main_test.a")
-  go_import = go_importpath(ctx)
   run_dir = pkg_dir(ctx.label.workspace_root, ctx.label.package)
 
   ctx.action(
@@ -42,7 +41,7 @@ def _go_test_impl(ctx):
       executable = go_toolchain.test_generator,
       arguments = [
           '--package',
-          go_import,
+          lib_result.importpath,
           '--rundir',
           run_dir,
           '--output',
@@ -54,9 +53,9 @@ def _go_test_impl(ctx):
   emit_go_compile_action(
     ctx,
     sources=depset([main_go]),
-    libs=lib_result.transitive_go_libraries,
-    lib_paths=lib_result.transitive_go_library_paths,
-    direct_paths=[go_import],
+    libs=[lib_result.library],
+    lib_paths=[lib_result.searchpath],
+    direct_paths=[lib_result.importpath],
     out_object=main_object,
     gc_goopts=get_gc_goopts(ctx),
   )


### PR DESCRIPTION
They have all the transitive data they need inside them.
This should make complex builds considerably faster, although we have no useful
benchmark to prove it.
Also cleaned up the compile argument handling while I was in there.