### PR TITLE
Gazelle: check for ignored files before emitting

### DIFF
--- a/go/tools/gazelle/gazelle/main.go
+++ b/go/tools/gazelle/gazelle/main.go
@@ -102,6 +102,11 @@ func processPackage(c *config.Config, g rules.Generator, emit emitFunc, pkg *pac
 
 	// Existing file, so merge and replace the old one.
 	mergedFile := merger.MergeWithExisting(genFile, oldFile)
+	if mergedFile == nil {
+		// Ignored file. Don't emit.
+		return
+	}
+
 	bf.Rewrite(mergedFile, nil) // have buildifier 'format' our rules.
 	if err := emit(c, mergedFile); err != nil {
 		log.Print(err)


### PR DESCRIPTION
merger.MergeWithExisting returns nil when it finds a
"# gazelle:ignore" directive. run must check for this before
formatting and writing the file.