### PR TITLE
Get directories from parsed FlagSet

### DIFF
--- a/go/tools/gazelle/gazelle/main.go
+++ b/go/tools/gazelle/gazelle/main.go
@@ -175,7 +175,7 @@ func newConfiguration(args []string) (*config.Config, emitFunc, error) {
 	var c config.Config
 	var err error
 
-	c.Dirs = flag.Args()
+	c.Dirs = fs.Args()
 	if len(c.Dirs) == 0 {
 		c.Dirs = []string{"."}
 	}


### PR DESCRIPTION
The directories here should come from the flagSet we have parsed from the passed in args and not from the global Flag.args()