### PR TITLE
Adds go_repository options for using vendored code

### DIFF
--- a/go/private/go_repository.bzl
+++ b/go/private/go_repository.bzl
@@ -73,6 +73,10 @@ def _go_repository_impl(ctx):
             "--build_tags", ",".join(ctx.attr.build_tags)]
     if ctx.attr.build_file_name:
         cmds += ["--build_file_name", ctx.attr.build_file_name]
+    if ctx.attr.build_vendor:
+        cmds += ["--external", "vendored"]
+        if ctx.attr.build_vendor_prefix:
+            cmds += ["--vendor_prefix", ctx.attr.build_vendor_prefix]
     cmds += [ctx.path('')]
     result = env_execute(ctx, cmds)
     if result.return_code:
@@ -102,6 +106,11 @@ go_repository = repository_rule(
         "build_file_name": attr.string(default="BUILD.bazel,BUILD"),
         "build_file_generation": attr.string(default="auto", values=["on", "auto", "off"]),
         "build_tags": attr.string_list(),
+
+        # Attributes for a repository that uses build file generation with
+        # vendored dependencies.
+        "build_vendor": attr.bool(default=False),
+        "build_vendor_prefix": attr.string(default="vendor/"),
 
         # Hidden attributes for tool dependancies
         "_fetch_repo": attr.label(

--- a/go/tools/gazelle/config/config.go
+++ b/go/tools/gazelle/config/config.go
@@ -47,6 +47,10 @@ type Config struct {
 
 	// DepMode determines how imports outside of GoPrefix are resolved.
 	DepMode DependencyMode
+
+	// VendorPrefix is the import prefix for vendored dependencies. It will
+	// usually be "vendor/".
+	VendorPrefix string
 }
 
 var DefaultValidBuildFileNames = []string{"BUILD.bazel", "BUILD"}

--- a/go/tools/gazelle/gazelle/main.go
+++ b/go/tools/gazelle/gazelle/main.go
@@ -162,6 +162,7 @@ func newConfiguration(args []string) (*config.Config, emitFunc, error) {
 	external := fs.String("external", "external", "external: resolve external packages with go_repository\n\tvendored: resolve external packages as packages in vendor/")
 	goPrefix := fs.String("go_prefix", "", "go_prefix of the target workspace")
 	repoRoot := fs.String("repo_root", "", "path to a directory which corresponds to go_prefix, otherwise gazelle searches for it.")
+	vendorPrefix := fs.String("vendor_prefix", "vendor/", "import prefix for vendored dependencies.")
 	mode := fs.String("mode", "fix", "print: prints all of the updated BUILD files\n\tfix: rewrites all of the BUILD files in place\n\tdiff: computes the rewrite but then just does a diff")
 	if err := fs.Parse(args); err != nil {
 		if err == flag.ErrHelp {
@@ -232,6 +233,8 @@ func newConfiguration(args []string) (*config.Config, emitFunc, error) {
 			return nil, nil, fmt.Errorf("-go_prefix not set and not root BUILD file found")
 		}
 	}
+
+	c.VendorPrefix = *vendorPrefix
 
 	c.DepMode, err = config.DependencyModeFromString(*external)
 	if err != nil {

--- a/go/tools/gazelle/rules/generator.go
+++ b/go/tools/gazelle/rules/generator.go
@@ -68,7 +68,7 @@ func NewGenerator(c *config.Config) Generator {
 	case config.ExternalMode:
 		e = newExternalResolver()
 	case config.VendorMode:
-		e = vendoredResolver{}
+		e = newVendoredResolver(c)
 	default:
 		return nil
 	}

--- a/go/tools/gazelle/rules/resolve_vendored.go
+++ b/go/tools/gazelle/rules/resolve_vendored.go
@@ -1,11 +1,23 @@
 package rules
 
+import (
+	"github.com/bazelbuild/rules_go/go/tools/gazelle/config"
+)
+
 // vendoredResolver resolves external packages as packages in vendor/.
-type vendoredResolver struct{}
+type vendoredResolver struct {
+	prefix string
+}
+
+var _ labelResolver = (*vendoredResolver)(nil)
+
+func newVendoredResolver(c *config.Config) *vendoredResolver {
+	return &vendoredResolver{prefix: c.VendorPrefix}
+}
 
 func (v vendoredResolver) resolve(importpath, dir string) (label, error) {
 	return label{
-		pkg:  "vendor/" + importpath,
+		pkg:  v.prefix + importpath,
 		name: defaultLibName,
 	}, nil
 }


### PR DESCRIPTION
There are two commits here:

First, I've added a `--vendor_prefix` flag to Gazelle. Setting this flag lets the caller adjust where Gazelle looks for vendored dependencies, for cases where the repository owner didn't use the default `vendor/` location.

Second, I added attributes to the `go_repository()` rule to let Gazelle use vendored dependencies in external repositories. I understand this is not quite the preferred approach of having everything in `WORKSPACE`, but it makes life significantly easier when our build wants to depend on a single `go_binary()` that itself requires ~dozens of vendored dependencies.

The motivating use case for us is bundling a compiled-from-Git etcd (https://github.com/coreos/etcd) into some Docker images built with Bazel's docker rules. With these changes, it's possible to depend on the etcd binary from our build without having to maintain a permanent "etcd plus BUILD rules" fork.