### PR TITLE
Gazelle: merge copts and clinkopts

### DIFF
--- a/go/tools/gazelle/merger/merger.go
+++ b/go/tools/gazelle/merger/merger.go
@@ -32,9 +32,11 @@ const (
 
 var (
 	mergeableFields = map[string]bool{
-		"srcs":    true,
-		"deps":    true,
-		"library": true,
+		"srcs":      true,
+		"deps":      true,
+		"library":   true,
+		"copts":     true,
+		"clinkopts": true,
 	}
 )
 

--- a/go/tools/gazelle/merger/merger_test.go
+++ b/go/tools/gazelle/merger/merger_test.go
@@ -423,6 +423,47 @@ go_library(
     srcs = ["foo.go"],
 )
 `,
+	}, {
+		desc: "merge copts and clinkopts",
+		previous: `
+load("@io_bazel_rules_go//go:def.bzl", "cgo_library")
+
+cgo_library(
+    name = "cgo_default_library",
+    copts = [
+        "-O0",
+        "-g",  # keep
+    ],
+    clinkopts = [
+        "-lX11",
+    ],
+)
+`,
+		current: `
+load("@io_bazel_rules_go//go:def.bzl", "cgo_library")
+
+cgo_library(
+    name = "cgo_default_library",
+    copts = [
+        "-O2",
+    ],
+    clinkopts = [
+        "-lpng",
+    ],
+)
+`,
+		expected: `
+load("@io_bazel_rules_go//go:def.bzl", "cgo_library")
+
+cgo_library(
+    name = "cgo_default_library",
+    copts = [
+        "-g",  # keep
+        "-O2",
+    ],
+    clinkopts = ["-lpng"],
+)
+`,
 	},
 }
 


### PR DESCRIPTION
This change adds copts and clinkopts to the list of attributes Gazelle
will merge. Gazelle still won't merge data and visibility, since any
change in these normally implies user intent.

Fixes #525