### PR TITLE
Don't mix declared and old-style providers

### DIFF
--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -53,10 +53,7 @@ cgo_filetype = FileType([
 ])
 
 def get_go_toolchain(ctx):
-  #TODO(toolchains): Declared providers should be used for all targets
-  if go_toolchain_type in ctx.attr._go_toolchain:
-    return ctx.attr._go_toolchain[go_toolchain_type]
-  return ctx.attr._go_toolchain
+  return ctx.attr._go_toolchain[go_toolchain_type]
 
 def emit_generate_params_action(cmds, ctx, fn):
   cmds_all = [

--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -48,7 +48,7 @@ def constraint_value(name, setting):
 go_toolchain_type = toolchain_type()
 
 def _go_toolchain_impl(ctx):
-  return go_toolchain_type(
+  return [go_toolchain_type(
       exec_compatible_with = ctx.attr.exec_compatible_with,
       target_compatible_with = ctx.attr.target_compatible_with,
       env = {
@@ -72,7 +72,7 @@ def _go_toolchain_impl(ctx):
       link_flags = ctx.attr.link_flags,
       cgo_link_flags = ctx.attr.cgo_link_flags,
       crosstool = ctx.files.crosstool,
-  )
+  )]
 
 go_toolchain_core_attrs = {
     "exec_compatible_with": attr.label_list(providers = [ConstraintValueInfo]),

--- a/tests/bazel_tests.bzl
+++ b/tests/bazel_tests.bzl
@@ -25,10 +25,7 @@ def _bazel_test_script_impl(ctx):
     root = ext.label.workspace_root
     _,_,ws = root.rpartition("/")
     workspace_content += 'local_repository(name = "{0}", path = "{1}/{2}")\n'.format(ws, ctx.attr._execroot.path, root)
-  if go_toolchain_type in ctx.attr._go_toolchain:
-    go_toolchain = ctx.attr._go_toolchain[go_toolchain_type]  # Use a declared provider
-  else:
-    go_toolchain = ctx.attr._go_toolchain  # Use an old-style struct value
+  go_toolchain = ctx.attr._go_toolchain[go_toolchain_type]
   workspace_content += 'local_repository(name = "{0}", path = "{1}")\n'.format(go_toolchain.sdk, go_toolchain.root.path)
   # finalise the workspace file
   workspace_content += 'load("@io_bazel_rules_go//go:def.bzl", "go_repositories")\n'


### PR DESCRIPTION
Now declared providers are used for both go_bootstrap_toolchain and go_toolchain.

In the future it will be possible to return a single declare provider (not in a list), but now due to a bug such providers are treated like old-style structs, therefore both rule implementation functions return singleton lists now for compatibility.