### PR TITLE
Race detector

### DIFF
--- a/tests/race/BUILD.bazel
+++ b/tests/race/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test", "go_binary")
+
+go_library(
+    name="go_default_library",
+    srcs = ["race.go"],
+    deps = ["//tests/race/racy:go_default_library"],
+)
+
+go_binary(
+    name = "race",
+    srcs = ["race_main.go"],
+    deps = [":go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["race_test.go"],
+    library = ":go_default_library",
+    size = "small",
+    tags = ["manual"],
+)

--- a/tests/race/race.go
+++ b/tests/race/race.go
@@ -1,0 +1,9 @@
+package race
+
+import (
+	"github.com/bazelbuild/rules_go/tests/race/racy"
+)
+
+func TriggerRace() {
+	racy.Race()
+}

--- a/tests/race/race_main.go
+++ b/tests/race/race_main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/bazelbuild/rules_go/tests/race"
+)
+
+func main() {
+	race.TriggerRace()
+}

--- a/tests/race/race_test.go
+++ b/tests/race/race_test.go
@@ -1,0 +1,9 @@
+package race
+
+import (
+	"testing"
+)
+
+func TestRace(t *testing.T) {
+	TriggerRace()
+}

--- a/tests/race/racy/BUILD.bazel
+++ b/tests/race/racy/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name="go_default_library",
+    srcs = ["racy.go"],
+    visibility = ["//visibility:public"],
+)

--- a/tests/race/racy/racy.go
+++ b/tests/race/racy/racy.go
@@ -1,0 +1,15 @@
+package racy
+
+import "fmt"
+
+func Race() {
+	done := make(chan bool)
+	m := make(map[string]string)
+	m["name"] = "world"
+	go func() {
+		m["name"] = "data race"
+		done <- true
+	}()
+	fmt.Println("Hello,", m["name"])
+	<-done
+}


### PR DESCRIPTION
This is stacked on top of #633 and #634, putting it up now so you can review it while I am afk.

This is the full implementation of race detector, without using toolchains.
From the commit message..

Tests:
Without race detector
    bazel test //tests/race:go_default_test
will pass, but with it turned on
    bazel test —features race //tests/race:go_default_test

Binares:
Without race detector
    bazel build //tests/race
builds bazel-bin/tests/race/race
With race detector
    bazel build //tests/race --output_groups=race
builds bazel-bin/tests/race/race.race