### PR TITLE
Don't apply coverage to go_binary or go_test sources

### DIFF
--- a/go/private/binary.bzl
+++ b/go/private/binary.bzl
@@ -23,6 +23,7 @@ def _go_binary_impl(ctx):
       deps = ctx.attr.deps,
       cgo_object = None,
       library = ctx.attr.library,
+      want_coverage = False,
   )
 
   # Default (dynamic) linking

--- a/go/private/library.bzl
+++ b/go/private/library.bzl
@@ -16,7 +16,7 @@ load("@io_bazel_rules_go//go/private:common.bzl", "get_go_toolchain", "DEFAULT_L
 load("@io_bazel_rules_go//go/private:asm.bzl", "emit_go_asm_action")
 load("@io_bazel_rules_go//go/private:providers.bzl", "GoLibrary", "GoSource")
 
-def emit_library_actions(ctx, sources, deps, cgo_object, library):
+def emit_library_actions(ctx, sources, deps, cgo_object, library, want_coverage):
   go_toolchain = get_go_toolchain(ctx)
 
   go_srcs = depset([s for s in sources if s.basename.endswith('.go')])
@@ -72,7 +72,10 @@ def emit_library_actions(ctx, sources, deps, cgo_object, library):
     transitive_cgo_deps += golib.transitive_cgo_deps
     transitive_go_library_paths += golib.transitive_go_library_paths
 
-  go_srcs = emit_go_compile_action(ctx,
+  if want_coverage:
+    go_srcs = _emit_go_cover_action(ctx, out_object, go_srcs)
+
+  emit_go_compile_action(ctx,
       sources = go_srcs,
       libs = direct_go_library_deps,
       lib_paths = direct_search_paths,
@@ -118,6 +121,7 @@ def _go_library_impl(ctx):
       deps = ctx.attr.deps,
       cgo_object = cgo_object,
       library = ctx.attr.library,
+      want_coverage = ctx.coverage_instrumented(),
   )
 
   return [
@@ -211,8 +215,6 @@ def emit_go_compile_action(ctx, sources, libs, lib_paths, direct_paths, out_obje
     gc_goopts: additional flags to pass to the compiler.
   """
   go_toolchain = get_go_toolchain(ctx)
-  if ctx.coverage_instrumented():
-    sources = _emit_go_cover_action(ctx, out_object, sources)
   gc_goopts = [ctx.expand_make_variables("gc_goopts", f, {}) for f in gc_goopts]
   inputs = depset([go_toolchain.go]) + sources + libs
   go_sources = [s.path for s in sources if not s.basename.startswith("_cgo")]
@@ -234,8 +236,6 @@ def emit_go_compile_action(ctx, sources, libs, lib_paths, direct_paths, out_obje
       arguments = args,
       env = go_toolchain.env,
   )
-
-  return sources
 
 def emit_go_pack_action(ctx, out_lib, objects):
   """Construct the command line for packing objects together.
@@ -260,6 +260,8 @@ def _emit_go_cover_action(ctx, out_object, sources):
 
   Args:
     ctx: The skylark Context.
+    out_object: the object file for the library being compiled. Used to name
+      cover files.
     sources: an iterable of Go source files.
 
   Returns:

--- a/go/private/test.bzl
+++ b/go/private/test.bzl
@@ -29,6 +29,7 @@ def _go_test_impl(ctx):
       deps = ctx.attr.deps,
       cgo_object = None,
       library = ctx.attr.library,
+      want_coverage = False,
   )
   main_go = ctx.new_file(ctx.label.name + "_main_test.go")
   main_object = ctx.new_file(ctx.label.name + "_main_test.o")

--- a/tests/coverage/BUILD
+++ b/tests/coverage/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test", "go_prefix")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test", "go_prefix")
 load("@io_bazel_rules_go//tests:bazel_tests.bzl", "bazel_test")
 
 go_prefix("github.com/bazelbuild/rules_go/tests/coverage")
@@ -27,3 +27,29 @@ if ! grep -q '^coverage: 50.0% of statements' "bazel-testlogs/go_default_test/te
 fi
     """
 )
+
+go_binary(
+    name = "bin",
+    srcs = ["bin.go"],
+    library = ":bin_lib",
+)
+
+go_library(
+    name = "bin_lib",
+    srcs = ["bin_lib.go"],
+)
+
+bazel_test(
+    name = "bin_coverage",
+    command = "coverage",
+    target = "//:bin",
+    check = """
+no_tests_found=4
+if [ "$result" -ne "$no_tests_found" ]; then
+  echo "error: unexpected bazel exit code: want $no_tests_found, got $result" >&2
+  exit 1
+fi
+result=0
+""",
+)
+

--- a/tests/coverage/bin.go
+++ b/tests/coverage/bin.go
@@ -1,0 +1,8 @@
+package main
+
+func main() {
+	if false {
+		panic("can't happen!")
+	}
+	live()
+}

--- a/tests/coverage/bin_lib.go
+++ b/tests/coverage/bin_lib.go
@@ -1,0 +1,9 @@
+package main
+
+func live() string {
+	return "live"
+}
+
+func dead() string {
+	return "dead"
+}


### PR DESCRIPTION
Coverage is now applied in emit_library_actions instead of
emit_go_compile_action. emit_library_actions accepts a want_coverage
parameter, which is only true for go_library. go_test and go_binary
should not apply coverage to their own sources, but will continue to
apply coverage to sources from the library attribute.

In the future, we may want to apply coverage before running cgo
(#641), so this provides an easy way to prevent coverage being applied
a second time in go_library.

Fixes #629