### PR TITLE
Stop testing Bazel HEAD in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ os:
   - osx
 
 env:
-  - V=HEAD
+  # TODO(bazelbuild/continuous-integration#95): re-enable HEAD builds with stable URL
+  # - V=HEAD
   - V=0.5.2
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Go rules for [Bazel](https://bazel.build/)
 
-Bazel ≥0.5.2 | linux-x86_64 | ubuntu_15.10-x86_64 | darwin-x86_64
-:---: | :---: | :---: | :---:
-[![Build Status](https://travis-ci.org/bazelbuild/rules_go.svg?branch=master)](https://travis-ci.org/bazelbuild/rules_go) | [![Build Status](http://ci.bazel.io/buildStatus/icon?job=rules_go/BAZEL_VERSION=latest,PLATFORM_NAME=linux-x86_64)](http://ci.bazel.io/job/rules_go/BAZEL_VERSION=latest,PLATFORM_NAME=linux-x86_64) | [![Build Status](http://ci.bazel.io/buildStatus/icon?job=rules_go/BAZEL_VERSION=latest,PLATFORM_NAME=ubuntu_15.10-x86_64)](http://ci.bazel.io/job/rules_go/BAZEL_VERSION=latest,PLATFORM_NAME=ubuntu_15.10-x86_64) | [![Build Status](http://ci.bazel.io/buildStatus/icon?job=rules_go/BAZEL_VERSION=latest,PLATFORM_NAME=darwin-x86_64)](http://ci.bazel.io/job/rules_go/BAZEL_VERSION=latest,PLATFORM_NAME=darwin-x86_64)
+Bazel 0.5.2 | Bazel HEAD
+:---: | :---:
+[![Build Status](https://travis-ci.org/bazelbuild/rules_go.svg?branch=master)](https://travis-ci.org/bazelbuild/rules_go) | [![Build Status](http://ci.bazel.io/buildStatus/icon?job=PR/rules_go)](http://ci.bazel.io/job/PR/rules_go)
 
 ## Announcements
 


### PR DESCRIPTION
The URL for the last successful build has changed a couple times in
the last week. We'll re-enable when
bazelbuild/continuous-integration#95 is resolved. We are still testing
at HEAD in Jenkins.

This change also fixes broken status icon links to Jenkins.

Related #649