### PR TITLE
Gazelle: represent lists of cgo options as single strings

### DIFF
--- a/go/tools/gazelle/packages/fileinfo.go
+++ b/go/tools/gazelle/packages/fileinfo.go
@@ -76,10 +76,11 @@ type fileInfo struct {
 }
 
 // taggedOpts a list of compile or link options which should only be applied
-// if the given set of build tags are satisfied.
+// if the given set of build tags are satisfied. The list is represented as
+// a single string. Bazel will apply Bourne shell tokenization to split it.
 type taggedOpts struct {
 	tags string
-	opts []string
+	opts string
 }
 
 // extCategory indicates how a file should be treated, based on extension.
@@ -281,9 +282,9 @@ func saveCgo(info *fileInfo, cg *ast.CommentGroup) error {
 		// Add tags to appropriate list.
 		switch verb {
 		case "CFLAGS", "CPPFLAGS", "CXXFLAGS":
-			info.copts = append(info.copts, taggedOpts{tags, opts})
+			info.copts = append(info.copts, taggedOpts{tags, strings.Join(opts, " ")})
 		case "LDFLAGS":
-			info.clinkopts = append(info.clinkopts, taggedOpts{tags, opts})
+			info.clinkopts = append(info.clinkopts, taggedOpts{tags, strings.Join(opts, " ")})
 		case "pkg-config":
 			return fmt.Errorf("%s: pkg-config not supported: %s", info.path, orig)
 		default:

--- a/go/tools/gazelle/packages/fileinfo_test.go
+++ b/go/tools/gazelle/packages/fileinfo_test.go
@@ -540,12 +540,12 @@ import "C"
 			fileInfo{
 				isCgo: true,
 				copts: []taggedOpts{
-					{opts: []string{"-O0"}},
-					{opts: []string{"-O1"}},
-					{opts: []string{"-O2"}},
+					{opts: "-O0"},
+					{opts: "-O1"},
+					{opts: "-O2"},
 				},
 				clinkopts: []taggedOpts{
-					{opts: []string{"-O3", "-O4"}},
+					{opts: "-O3 -O4"},
 				},
 			},
 		},
@@ -561,7 +561,7 @@ import "C"
 			fileInfo{
 				isCgo: true,
 				copts: []taggedOpts{
-					{tags: "foo bar,!baz", opts: []string{"-O0"}},
+					{tags: "foo bar,!baz", opts: "-O0"},
 				},
 			},
 		},
@@ -576,8 +576,8 @@ import "C"
 			fileInfo{
 				isCgo: true,
 				copts: []taggedOpts{
-					{opts: []string{"-O0"}},
-					{opts: []string{"-O1"}},
+					{opts: "-O0"},
+					{opts: "-O1"},
 				},
 			},
 		},
@@ -593,7 +593,7 @@ import ("C")
 			fileInfo{
 				isCgo: true,
 				copts: []taggedOpts{
-					{opts: []string{"-O0"}},
+					{opts: "-O0"},
 				},
 			},
 		},

--- a/go/tools/gazelle/packages/package.go
+++ b/go/tools/gazelle/packages/package.go
@@ -198,7 +198,7 @@ func (ps *PlatformStrings) addGenericStrings(ss ...string) {
 func (ps *PlatformStrings) addGenericOpts(platforms config.PlatformTags, opts []taggedOpts) {
 	for _, t := range opts {
 		if t.tags == "" {
-			ps.Generic = append(ps.Generic, t.opts...)
+			ps.Generic = append(ps.Generic, t.opts)
 			continue
 		}
 
@@ -207,7 +207,7 @@ func (ps *PlatformStrings) addGenericOpts(platforms config.PlatformTags, opts []
 				if ps.Platform == nil {
 					ps.Platform = make(map[string][]string)
 				}
-				ps.Platform[name] = append(ps.Platform[name], t.opts...)
+				ps.Platform[name] = append(ps.Platform[name], t.opts)
 			}
 		}
 	}
@@ -226,7 +226,7 @@ func (ps *PlatformStrings) addTaggedOpts(name string, opts []taggedOpts, tags ma
 			if ps.Platform == nil {
 				ps.Platform = make(map[string][]string)
 			}
-			ps.Platform[name] = append(ps.Platform[name], t.opts...)
+			ps.Platform[name] = append(ps.Platform[name], t.opts)
 		}
 	}
 }


### PR DESCRIPTION
This allows groups of options like "-framework IOKit" to be passed to
Bazel in the same string. Bazel applies Bourne shell tokenization and
label expansion to cc_library opts and linkopts. The label expansion
causes problems for arguments like "IOKit", which are not labels.

Fixes #646