### PR TITLE
README: clarify sample bazel test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -816,8 +816,8 @@ go_test(name, srcs, deps, data, library, gc_goopts, gc_linkopts)
 contain sources for internal tests or external tests, but not both (see example
 below).
 
-To run all tests in a given directory, and print output on failure (the
-equivalent of "go test ./..."), run
+To run all tests in the workspace, and print output on failure (the
+equivalent of "go test ./..." from `go_prefix` in a `GOPATH` tree), run
 
 ```
 bazel test --test_output=errors //...


### PR DESCRIPTION
bazel test //... runs all tests in the entire workspace, not just under
the current working directory, as "go test ./..." implies. Note that and
clarify that "go test ./..." is only equivalent if it were run from the
go_prefix directory inside GOPATH.

bazel test ...:all could be used to run all tests under the CWD, but in
my experience it is more common to remain at workspace root anyways, and
specify packages you care about (//pkg/...) rather than changing to that
directory.

@kevinburke @jayconrod 