### PR TITLE
Gazelle: don't recurse into vendor directories in external mode

### DIFF
--- a/go/tools/gazelle/packages/walk.go
+++ b/go/tools/gazelle/packages/walk.go
@@ -100,7 +100,9 @@ func Walk(c *config.Config, dir string, f WalkFunc) {
 		for _, f := range files {
 			base := f.Name()
 			switch {
-			case base == "" || base[0] == '.' || base[0] == '_' || excluded != nil && excluded[base]:
+			case base == "" || base[0] == '.' || base[0] == '_' ||
+				excluded != nil && excluded[base] ||
+				base == "vendor" && f.IsDir() && c.DepMode != config.VendorMode:
 				continue
 
 			case f.IsDir():


### PR DESCRIPTION
In external mode, nothing will depend on rules in vendor
directories. They are not likely to build.

Fixes #660