### PR TITLE
Add -known_import flag

### DIFF
--- a/go/tools/gazelle/config/config.go
+++ b/go/tools/gazelle/config/config.go
@@ -47,6 +47,9 @@ type Config struct {
 
 	// DepMode determines how imports outside of GoPrefix are resolved.
 	DepMode DependencyMode
+
+	// KnownImports is a list of imports to add to the external resolver cache
+	KnownImports []string
 }
 
 var DefaultValidBuildFileNames = []string{"BUILD.bazel", "BUILD"}

--- a/go/tools/gazelle/gazelle/BUILD
+++ b/go/tools/gazelle/gazelle/BUILD
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "diff.go",
         "fix.go",
+        "flags.go",
         "main.go",
         "print.go",
     ],

--- a/go/tools/gazelle/gazelle/flags.go
+++ b/go/tools/gazelle/gazelle/flags.go
@@ -1,0 +1,32 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "fmt"
+
+// multiFlag allows repeated string flags to be collected into a slice
+type multiFlag []string
+
+func (m *multiFlag) String() string {
+	if len(*m) == 0 {
+		return ""
+	}
+	return fmt.Sprint(*m)
+}
+
+func (m *multiFlag) Set(v string) error {
+	(*m) = append(*m, v)
+	return nil
+}

--- a/go/tools/gazelle/gazelle/main.go
+++ b/go/tools/gazelle/gazelle/main.go
@@ -161,11 +161,13 @@ func newConfiguration(args []string) (*config.Config, emitFunc, error) {
 	// -h or -help were passed explicitly.
 	fs.Usage = func() {}
 
+	knownImports := multiFlag{}
 	buildFileName := fs.String("build_file_name", "BUILD.bazel,BUILD", "comma-separated list of valid build file names.\nThe first element of the list is the name of output build files to generate.")
 	buildTags := fs.String("build_tags", "", "comma-separated list of build tags. If not specified, Gazelle will not\n\tfilter sources with build constraints.")
 	external := fs.String("external", "external", "external: resolve external packages with go_repository\n\tvendored: resolve external packages as packages in vendor/")
 	goPrefix := fs.String("go_prefix", "", "go_prefix of the target workspace")
 	repoRoot := fs.String("repo_root", "", "path to a directory which corresponds to go_prefix, otherwise gazelle searches for it.")
+	fs.Var(&knownImports, "known_import", "import path for which external resolution is skipped (can specify multiple times)")
 	mode := fs.String("mode", "fix", "print: prints all of the updated BUILD files\n\tfix: rewrites all of the BUILD files in place\n\tdiff: computes the rewrite but then just does a diff")
 	if err := fs.Parse(args); err != nil {
 		if err == flag.ErrHelp {
@@ -246,6 +248,8 @@ func newConfiguration(args []string) (*config.Config, emitFunc, error) {
 	if !ok {
 		return nil, nil, fmt.Errorf("unrecognized emit mode: %q", *mode)
 	}
+
+	c.KnownImports = append(c.KnownImports, knownImports...)
 
 	return &c, emit, err
 }

--- a/go/tools/gazelle/resolve/resolve.go
+++ b/go/tools/gazelle/resolve/resolve.go
@@ -76,7 +76,7 @@ func NewLabelResolver(c *config.Config) LabelResolver {
 	var e LabelResolver
 	switch c.DepMode {
 	case config.ExternalMode:
-		e = newExternalResolver()
+		e = newExternalResolver(c.KnownImports)
 	case config.VendorMode:
 		e = vendoredResolver{}
 	}

--- a/go/tools/gazelle/resolve/resolve_external.go
+++ b/go/tools/gazelle/resolve/resolve_external.go
@@ -41,7 +41,7 @@ type externalResolver struct {
 
 var _ LabelResolver = (*externalResolver)(nil)
 
-func newExternalResolver() *externalResolver {
+func newExternalResolver(extraKnownImports []string) *externalResolver {
 	cache := make(map[string]repoRootCacheEntry)
 	for _, e := range []repoRootCacheEntry{
 		{prefix: "golang.org/x", missing: 1},
@@ -50,6 +50,10 @@ func newExternalResolver() *externalResolver {
 		{prefix: "github.com", missing: 2},
 	} {
 		cache[e.prefix] = e
+	}
+
+	for _, e := range extraKnownImports {
+		cache[e] = repoRootCacheEntry{prefix: e, missing: 0}
 	}
 
 	return &externalResolver{


### PR DESCRIPTION
Private repositories can take a long time to resolve, and if the repo
host does not properly support go-import meta tags then gazelle may not
be able to resolve them at all.

This change allows the author of WORKSPACE files to add specially
crafted comments which instruct gazelle to update the external
resolver's repo cache. As a result, gazelle can be instructed to skip
resolution of certain imports.