### PR TITLE
don't ignore raw arguments passed to gazelle

### DIFF
--- a/go/private/gazelle.bzl
+++ b/go/private/gazelle.bzl
@@ -21,7 +21,7 @@ $BASE/{gazelle} {args} $@
 
 def _gazelle_script_impl(ctx):
   args = ctx.attr.args
-  args = [
+  args += [
       "-repo_root", "$WORKSPACE",
       "-go_prefix", ctx.attr._go_prefix.go_prefix,
       "-external", ctx.attr.external,


### PR DESCRIPTION
Args coming from the naked `args` parameter were overridden immediately, making it for example impossible to override the `build_file_name` option.