### PR TITLE
Only download SDK once

### DIFF
--- a/go/private/repository_tools.bzl
+++ b/go/private/repository_tools.bzl
@@ -29,15 +29,6 @@ filegroup(
 """
 
 def _go_repository_tools_impl(ctx):
-  # We have to download this directly because the normal version is based on go_repository
-  # and thus requires the gazelle we build in here to generate it's BUILD files
-  # The commit used here should match the one in repositories.bzl
-  x_tools_commit = "3d92dd60033c312e3ae7cac319c792271cf67e37"
-  ctx.download_and_extract(
-      url = "https://codeload.github.com/golang/tools/zip/" + x_tools_commit,
-      type = "zip",
-  )
-
   # We work this out here because you can't use a toolchain from a repository rule
   if ctx.os.name == 'linux':
     go_tool = ctx.path(Label("@go1_8_3_linux_amd64//:bin/go"))
@@ -46,9 +37,18 @@ def _go_repository_tools_impl(ctx):
   else:
     fail("Unsupported operating system: " + ctx.os.name)
 
+  x_tools_commit = "3d92dd60033c312e3ae7cac319c792271cf67e37"
   x_tools_path = ctx.path('tools-' + x_tools_commit)
   buildtools_path = ctx.path(ctx.attr._buildtools).dirname
   go_tools_path = ctx.path(ctx.attr._tools).dirname
+
+  # We have to download this directly because the normal version is based on go_repository
+  # and thus requires the gazelle we build in here to generate it's BUILD files
+  # The commit used here should match the one in repositories.bzl
+  ctx.download_and_extract(
+      url = "https://codeload.github.com/golang/tools/zip/" + x_tools_commit,
+      type = "zip",
+  )
 
   # Build something that looks like a normal GOPATH so go install will work
   ctx.symlink(x_tools_path, "src/golang.org/x/tools")

--- a/go/private/toolchain.bzl
+++ b/go/private/toolchain.bzl
@@ -29,16 +29,16 @@ alias(
 """
 
 def _go_sdk_repository_impl(ctx):
-  ctx.download_and_extract(
-      url = ctx.attr.url,
-      stripPrefix = ctx.attr.strip_prefix,
-      sha256 = ctx.attr.sha256)
   goroot = ctx.path(".")
   ctx.template("BUILD.bazel", 
     Label("@io_bazel_rules_go//go/private:BUILD.sdk.bazel"),
     substitutions = {"{goroot}": str(goroot)}, 
     executable = False,
   )
+  ctx.download_and_extract(
+      url = ctx.attr.url,
+      stripPrefix = ctx.attr.strip_prefix,
+      sha256 = ctx.attr.sha256)
 
 go_sdk_repository = repository_rule(
     implementation = _go_sdk_repository_impl, 


### PR DESCRIPTION
Bazel repository rules may be restarted if they depend on a file that
isn't available yet using a Label. If a download has already occurred,
this means the download will happen again (unless
--experimental_repository_cache is in use).

We should download archives after Labels have been resolved.

Fixes #671