### PR TITLE
go_test: add rundir attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -810,7 +810,7 @@ directly.
 ### `go_test`
 
 ```bzl
-go_test(name, srcs, deps, data, library, gc_goopts, gc_linkopts)
+go_test(name, srcs, deps, data, library, gc_goopts, gc_linkopts, rundir)
 ```
 
 `go_test` builds a set of tests that can be run with `bazel test`. This can
@@ -899,6 +899,16 @@ arguments to Bazel.
         variable substitution</a> and
         <a href="https://bazel.build/versions/master/docs/be/common-definitions.html#sh-tokenization">Bourne
         shell tokenization</a>.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>rundir</code></td>
+      <td>
+        <code>String, optional</code>
+        <p>Path to the directory the test should run in. This should be relative
+        to the root of the repository the test is defined in. By default, the
+        test will run in the directory of the BUILD file that defines it.
+        Use "." to run the test at the repository root.</p>
       </td>
     </tr>
   </tbody>

--- a/go/private/test.bzl
+++ b/go/private/test.bzl
@@ -34,7 +34,13 @@ def _go_test_impl(ctx):
   main_go = ctx.new_file(ctx.label.name + "_main_test.go")
   main_object = ctx.new_file(ctx.label.name + "_main_test.o")
   main_lib = ctx.new_file(ctx.label.name + "_main_test.a")
-  run_dir = pkg_dir(ctx.label.workspace_root, ctx.label.package)
+  if ctx.attr.rundir:
+    if ctx.attr.rundir.startswith("/"):
+      run_dir = ctx.attr.rundir
+    else:
+      run_dir = pkg_dir(ctx.label.workspace_root, ctx.attr.rundir)
+  else:
+    run_dir = pkg_dir(ctx.label.workspace_root, ctx.label.package)
 
   ctx.action(
       inputs = list(lib_result.go_sources),
@@ -122,6 +128,7 @@ go_test = rule(
         "gc_goopts": attr.string_list(),
         "gc_linkopts": attr.string_list(),
         "linkstamp": attr.string(),
+        "rundir": attr.string(),
         "x_defs": attr.string_dict(),
         #TODO(toolchains): Remove _toolchain attribute when real toolchains arrive
         "_go_toolchain": attr.label(default = Label("@io_bazel_rules_go_toolchain//:go_toolchain")),

--- a/tests/test_rundir/BUILD
+++ b/tests/test_rundir/BUILD
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = ["rundir_test.go"],
+    data = ["//:README.md"],
+    rundir = ".",
+)

--- a/tests/test_rundir/rundir_test.go
+++ b/tests/test_rundir/rundir_test.go
@@ -1,0 +1,12 @@
+package test_rundir
+
+import (
+	"os"
+	"testing"
+)
+
+func TestRunDir(t *testing.T) {
+	if _, err := os.Stat("README.md"); err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
This lets developers specify the directory where a test will run.

Fixes #670