### PR TITLE
Make test_environment rule depend on environment variables it uses

### DIFF
--- a/tests/bazel_tests.bzl
+++ b/tests/bazel_tests.bzl
@@ -157,6 +157,11 @@ execroot(
 _test_environment = repository_rule(
     implementation = _test_environment_impl,
     attrs = {},
+    environ = [
+      "BAZEL",
+      "BAZEL_VERSION",
+      "HOME",
+    ],
 )
 
 def test_environment():


### PR DESCRIPTION
Fix
http://ci.bazel.io/blue/organizations/jenkins/Global%2Frules_go/detail/rules_go/52/pipeline/21

@dslomov 