### PR TITLE
Cope with cgo=True when there is no cgo

### DIFF
--- a/go/tools/builders/cgo.go
+++ b/go/tools/builders/cgo.go
@@ -151,7 +151,7 @@ func run(args []string) error {
 		// This is so we can still run the cgo tool to build all the other outputs
 		nullCgo := filepath.Join(objdir, "_cgo_empty.go")
 		cgoSrcs = append(cgoSrcs, nullCgo)
-		if err := ioutil.WriteFile(nullCgo, []byte("package "+pkg+"\n/* const int ___no_cgo_present; */\nimport \"C\"\n"), 0644); err != nil {
+		if err := ioutil.WriteFile(nullCgo, []byte("package "+pkg+"\n/*\n*/\nimport \"C\"\n"), 0644); err != nil {
 			return err
 		}
 	}

--- a/go/tools/builders/cgo.go
+++ b/go/tools/builders/cgo.go
@@ -83,6 +83,7 @@ func run(args []string) error {
 	bctx := build.Default
 	bctx.CgoEnabled = true
 	cgoSrcs := []string{}
+	pkg := ""
 	for _, s := range sources {
 		bits := strings.SplitN(s, "=", 2)
 		if len(bits) != 2 {
@@ -118,7 +119,8 @@ func run(args []string) error {
 
 		// Go source, must produce both c and go outputs
 		cOut := strings.TrimSuffix(out, ".cgo1.go") + ".cgo2.c"
-		isCgo, pkg, err := testCgo(in, data)
+		isCgo := false
+		isCgo, pkg, err = testCgo(in, data)
 		if err != nil {
 			return err
 		}
@@ -141,6 +143,16 @@ func run(args []string) error {
 			if err := ioutil.WriteFile(cOut, []byte(""), 0644); err != nil {
 				return err
 			}
+		}
+	}
+
+	if len(cgoSrcs) == 0 {
+		// If there were no cgo sources present, generate a minimal cgo input
+		// This is so we can still run the cgo tool to build all the other outputs
+		nullCgo := filepath.Join(objdir, "_cgo_empty.go")
+		cgoSrcs = append(cgoSrcs, nullCgo)
+		if err := ioutil.WriteFile(nullCgo, []byte("package "+pkg+"\n/* const int ___no_cgo_present; */\nimport \"C\"\n"), 0644); err != nil {
+			return err
 		}
 	}
 

--- a/tests/cgo_filtered/BUILD
+++ b/tests/cgo_filtered/BUILD
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = ["pure_test.go"],
+    library = ":go_default_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["pure.go"],
+    cgo = True,
+)

--- a/tests/cgo_filtered/pure.go
+++ b/tests/cgo_filtered/pure.go
@@ -1,0 +1,3 @@
+package cgo_filtered
+
+var Value = 42

--- a/tests/cgo_filtered/pure_test.go
+++ b/tests/cgo_filtered/pure_test.go
@@ -1,0 +1,9 @@
+package cgo_filtered
+
+import "testing"
+
+func TestFoo(t *testing.T) {
+	if got, want := Value, 42; got != want {
+		t.Errorf("got %d; want %d", got, want)
+	}
+}


### PR DESCRIPTION
This happens when a go library has cgo files that are only present in some
configurations.

Fixes #678