### PR TITLE
Update README with details about `# gazelle:exclude`

### DIFF
--- a/go/tools/gazelle/README.md
+++ b/go/tools/gazelle/README.md
@@ -22,6 +22,13 @@ If you don't even have a WORKSPACE file yet, you also need to set -repo_root
 * `# keep` on an entry to a `deps` or `srcs` attribute will instruct gazelle to keep that element
 even if it thinks otherwise
 * `# gazelle:ignore` at the top level of a BUILD file will instruct gazelle to leave the file alone.
+* `# gazelle:exclude file-or-directory-name` at the top level of a BUILD file
+  will instruct gazelle to exclude the named file or directory from its
+  analysis. Gazelle won't recurse into excluded directories. This directive
+  may be used multiple times to exclude multiple files (one per line). Spaces
+  within the file name are significant, but leading and trailing spaces are
+  stripped.
+
 
 ## Known Shortcomings
 


### PR DESCRIPTION
`# gazelle:exclude` was added in #581 but the README wasn't updated.

I think this explanation is correct, but please correct me if I'm misunderstanding it.