### PR TITLE
Gazelle: fix how squashCgoLibrary deals with library attributes

### DIFF
--- a/go/tools/gazelle/merger/fix_test.go
+++ b/go/tools/gazelle/merger/fix_test.go
@@ -57,25 +57,23 @@ cgo_library(
 `,
 		},
 		{
-			desc: "unlinked cgo_library not removed",
+			desc: "unlinked cgo_library removed",
 			old: `load("@io_bazel_rules_go//go:def.bzl", "cgo_library", "go_library")
 
 go_library(
     name = "go_default_library",
+    library = ":something_else",
 )
 
 cgo_library(
     name = "cgo_default_library",
 )
 `,
-			want: `load("@io_bazel_rules_go//go:def.bzl", "cgo_library", "go_library")
+			want: `load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-)
-
-cgo_library(
-    name = "cgo_default_library",
+    cgo = True,
 )
 `,
 		},


### PR DESCRIPTION
squashCgoLibrary will no longer be as careful around library
attributes. It will squash go_library and cgo_library (with default
names) even if they were not linked.