### PR TITLE
Gazelle: generate consolidated go_library rules with cgo

### DIFF
--- a/go/tools/gazelle/merger/merger.go
+++ b/go/tools/gazelle/merger/merger.go
@@ -32,11 +32,12 @@ const (
 
 var (
 	mergeableFields = map[string]bool{
-		"srcs":      true,
+		"cgo":       true,
+		"clinkopts": true,
+		"copts":     true,
 		"deps":      true,
 		"library":   true,
-		"copts":     true,
-		"clinkopts": true,
+		"srcs":      true,
 	}
 )
 
@@ -155,7 +156,16 @@ func mergeRule(gen, old *bf.CallExpr) *bf.CallExpr {
 // An error is returned if the expressions can't be merged, for example
 // because they are not in one of the above formats.
 func mergeExpr(gen, old bf.Expr) (bf.Expr, error) {
-	if _, ok := gen.(*bf.StringExpr); ok {
+	if gen == nil {
+		if shouldKeep(old) {
+			return old, nil
+		}
+		return nil, nil
+	}
+
+	switch gen.(type) {
+	case *bf.StringExpr:
+	case *bf.LiteralExpr:
 		if shouldKeep(old) {
 			return old, nil
 		}

--- a/go/tools/gazelle/rules/construct.go
+++ b/go/tools/gazelle/rules/construct.go
@@ -61,6 +61,13 @@ func newRule(kind string, args []interface{}, kwargs []keyvalue) *bf.Rule {
 func newValue(val interface{}) bf.Expr {
 	rv := reflect.ValueOf(val)
 	switch rv.Kind() {
+	case reflect.Bool:
+		tok := "False"
+		if rv.Bool() {
+			tok = "True"
+		}
+		return &bf.LiteralExpr{Token: tok}
+
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
 		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		return &bf.LiteralExpr{Token: fmt.Sprintf("%d", val)}

--- a/go/tools/gazelle/testdata/repo/allcgolib/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/allcgolib/BUILD.want
@@ -1,19 +1,14 @@
-load("@io_bazel_rules_go//go:def.bzl", "cgo_library", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
-cgo_library(
-    name = "cgo_default_library",
+go_library(
+    name = "go_default_library",
     srcs = [
         "foo.go",
         "foo.c",
     ],
-    visibility = ["//visibility:private"],
-    deps = ["//lib:go_default_library"],
-)
-
-go_library(
-    name = "go_default_library",
-    library = ":cgo_default_library",
+    cgo = True,
     visibility = ["//visibility:public"],
+    deps = ["//lib:go_default_library"],
 )
 
 go_test(

--- a/go/tools/gazelle/testdata/repo/cgolib/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/cgolib/BUILD.want
@@ -1,23 +1,17 @@
-load("@io_bazel_rules_go//go:def.bzl", "cgo_library", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
-cgo_library(
-    name = "cgo_default_library",
+go_library(
+    name = "go_default_library",
     srcs = [
         "foo.go",
+        "pure.go",
         "asm.S",
         "foo.c",
         "foo.h",
     ],
     clinkopts = ["-lweird"],
     copts = ["-I/weird/path"],
-    visibility = ["//visibility:private"],
-    deps = ["//lib:go_default_library"],
-)
-
-go_library(
-    name = "go_default_library",
-    srcs = ["pure.go"],
-    library = ":cgo_default_library",
+    cgo = True,
     visibility = ["//visibility:public"],
     deps = [
         "//lib/deep:go_default_library",

--- a/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/BUILD.want
@@ -1,14 +1,16 @@
-load("@io_bazel_rules_go//go:def.bzl", "cgo_library", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
-cgo_library(
-    name = "cgo_default_library",
+go_library(
+    name = "go_default_library",
     srcs = [
         "foo.go",
+        "pure_other.go",
         "asm_other.S",
         "foo.h",
         "foo_other.c",
     ] + select({
         "@io_bazel_rules_go//go/platform:linux_amd64": [
+            "pure_linux.go",
             "asm_linux.S",
             "foo_linux.c",
         ],
@@ -29,21 +31,7 @@ cgo_library(
         ],
         "//conditions:default": [],
     }),
-    visibility = ["//visibility:private"],
-    deps = ["//lib:go_default_library"],
-)
-
-go_library(
-    name = "go_default_library",
-    srcs = [
-        "pure_other.go",
-    ] + select({
-        "@io_bazel_rules_go//go/platform:linux_amd64": [
-            "pure_linux.go",
-        ],
-        "//conditions:default": [],
-    }),
-    library = ":cgo_default_library",
+    cgo = True,
     visibility = ["//visibility:public"],
     deps = [
         "//lib/deep:go_default_library",

--- a/go/tools/gazelle/testdata/repo/platforms/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/platforms/BUILD.want
@@ -1,14 +1,30 @@
-load("@io_bazel_rules_go//go:def.bzl", "cgo_library", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
-cgo_library(
-    name = "cgo_default_library",
+go_library(
+    name = "go_default_library",
     srcs = [
         "cgo_generic.go",
+        "generic.go",
+        "release.go",
         "cgo_generic.c",
     ] + select({
+        "@io_bazel_rules_go//go/platform:darwin_amd64": [
+            "suffix_amd64.go",
+            "suffix_darwin.go",
+            "tag_a.go",
+            "tag_d.go",
+        ],
         "@io_bazel_rules_go//go/platform:linux_amd64": [
             "cgo_linux.go",
+            "suffix_amd64.go",
+            "suffix_linux.go",
+            "tag_a.go",
+            "tag_l.go",
             "cgo_linux.c",
+        ],
+        "@io_bazel_rules_go//go/platform:windows_amd64": [
+            "suffix_amd64.go",
+            "tag_a.go",
         ],
         "//conditions:default": [],
     }),
@@ -20,34 +36,7 @@ cgo_library(
         ],
         "//conditions:default": [],
     }),
-    visibility = ["//visibility:private"],
-)
-
-go_library(
-    name = "go_default_library",
-    srcs = [
-        "generic.go",
-        "release.go",
-    ] + select({
-        "@io_bazel_rules_go//go/platform:darwin_amd64": [
-            "suffix_amd64.go",
-            "suffix_darwin.go",
-            "tag_a.go",
-            "tag_d.go",
-        ],
-        "@io_bazel_rules_go//go/platform:linux_amd64": [
-            "suffix_amd64.go",
-            "suffix_linux.go",
-            "tag_a.go",
-            "tag_l.go",
-        ],
-        "@io_bazel_rules_go//go/platform:windows_amd64": [
-            "suffix_amd64.go",
-            "tag_a.go",
-        ],
-        "//conditions:default": [],
-    }),
-    library = ":cgo_default_library",
+    cgo = True,
     visibility = ["//visibility:public"],
     deps = [
         "//platforms/generic:go_default_library",


### PR DESCRIPTION
Gazelle will no longer generate new cgo_library rules. cgo sources,
deps, and options will be placed in a combined go_library with
cgo = True.

There will be another change soon to squash existing cgo_library rules
into go_library.