### PR TITLE
Gazelle: add fix and update commands

### DIFF
--- a/go/private/gazelle.bzl
+++ b/go/private/gazelle.bzl
@@ -20,7 +20,7 @@ $BASE/{gazelle} {args} $@
 """
 
 def _gazelle_script_impl(ctx):
-  args = ctx.attr.args
+  args = [ctx.attr.command] + ctx.attr.args
   args += [
       "-repo_root", "$WORKSPACE",
       "-go_prefix", ctx.attr._go_prefix.go_prefix,
@@ -40,10 +40,11 @@ def _gazelle_script_impl(ctx):
 _gazelle_script = rule(
     _gazelle_script_impl,
     attrs = {
-        "mode": attr.string(mandatory=True, values=["print", "fix", "diff"]),
-        "external": attr.string(mandatory=True, values=["external", "vendored"]),
-        "build_tags": attr.string_list(mandatory=True),
-        "args": attr.string_list(mandatory=True),
+        "command": attr.string(values=["update", "fix"], default="update"),
+        "mode": attr.string(values=["print", "fix", "diff"], default="fix"),
+        "external": attr.string(values=["external", "vendored"], default="external"),
+        "build_tags": attr.string_list(),
+        "args": attr.string_list(),
         "_gazelle": attr.label(
             default = Label("@io_bazel_rules_go//go/tools/gazelle/gazelle:gazelle"),
             allow_files = True,
@@ -58,15 +59,12 @@ _gazelle_script = rule(
     }
 )
 
-def gazelle(name, mode = "fix", external="external", build_tags=[], args = []):
+def gazelle(name, **kwargs):
   script_name = name+"_script"
   _gazelle_script(
       name = script_name,
-      mode = mode,
-      external = external,
-      build_tags = build_tags,
-      args = args,
       tags = ["manual"],
+      **kwargs
   )
   native.sh_binary(
       name = name,

--- a/go/tools/gazelle/gazelle/fix_test.go
+++ b/go/tools/gazelle/gazelle/fix_test.go
@@ -100,7 +100,7 @@ func TestCreateFile(t *testing.T) {
 
 	// Check that Gazelle creates a new file named "BUILD.bazel".
 	c := defaultConfig(dir)
-	run(c, fixFile)
+	run(c, updateCmd, fixFile)
 
 	buildFile := filepath.Join(dir, "BUILD.bazel")
 	if _, err = os.Stat(buildFile); err != nil {
@@ -129,7 +129,7 @@ func TestUpdateFile(t *testing.T) {
 
 	// Check that Gazelle updates the BUILD file in place.
 	c := defaultConfig(dir)
-	run(c, fixFile)
+	run(c, updateCmd, fixFile)
 	if st, err := os.Stat(buildFile); err != nil {
 		t.Errorf("could not stat BUILD: %v", err)
 	} else if st.Size() == 0 {


### PR DESCRIPTION
Gazelle will now accept a command verb as a first argument, which will
determine what should be done. Currently, two commands are supported:

  update - Gazelle will create new BUILD files or update existing
    BUILD files. This is the default; if Gazelle is run without a
    command, it will do this.
  fix - in addition to the changes made in update, Gazelle will make
    potentially breaking changes. Currently, it will squash
    cgo_library and consolidate load statements.

More commands will be added in the future, for example for managing
dependencies.