### PR TITLE
Compatability shims

### DIFF
--- a/go/def.bzl
+++ b/go/def.bzl
@@ -18,10 +18,9 @@ load("@io_bazel_rules_go//go/private:providers.bzl",
     _GoBinary = "GoBinary",
 )
 load("@io_bazel_rules_go//go/private:repositories.bzl", "go_repositories")
-load("@io_bazel_rules_go//go/private:go_repository.bzl", "go_repository", "new_go_repository")
+load("@io_bazel_rules_go//go/private:go_repository.bzl", "go_repository")
 load("@io_bazel_rules_go//go/private:go_prefix.bzl", "go_prefix")
 load("@io_bazel_rules_go//go/private:embed_data.bzl", "go_embed_data")
-load("@io_bazel_rules_go//go/private:cgo.bzl", "cgo_library", "cgo_genrule")
 load("@io_bazel_rules_go//go/private:gazelle.bzl", "gazelle")
 load("@io_bazel_rules_go//go/private:wrappers.bzl",
     _go_library_macro = "go_library_macro",
@@ -123,3 +122,18 @@ go_test = _go_test_macro
         "copts": attr.string_list(), # Options for the the c compiler
         "clinkopts": attr.string_list(), # Options for the linker
 """
+
+
+# Compatability shims
+def cgo_genrule(name, tags=[], **kwargs):
+  print("DEPRECATED: {0} : cgo_genrule is deprecated. Please migrate to go_library with cgo=True.".format(name))
+  return go_library(name=name, tags=tags+["manual"], cgo=True, **kwargs)
+
+def cgo_library(name, **kwargs):
+  print("DEPRECATED: {0} : cgo_library is deprecated. Please migrate to go_library with cgo=True.".format(name))
+  return go_library(name=name, cgo=True, **kwargs)
+
+def new_go_repository(name, **kwargs):
+  print("DEPRECATED: {0} : new_go_repository is deprecated. Please migrate to go_repository soon.".format(name))
+  return go_repository(name=name, **kwargs)
+

--- a/go/private/cgo.bzl
+++ b/go/private/cgo.bzl
@@ -16,64 +16,6 @@ load("@io_bazel_rules_go//go/private:common.bzl", "get_go_toolchain", "go_exts",
 load("@io_bazel_rules_go//go/private:library.bzl", "go_library")
 load("@io_bazel_rules_go//go/private:binary.bzl", "c_linker_options")
 
-def cgo_genrule(tags=[], **kwargs):
-  return cgo_library(tags=tags+["manual"], **kwargs)
-
-def cgo_library(name, srcs,
-                go_toolchain=None,
-                go_tool=None,
-                copts=[],
-                clinkopts=[],
-                cdeps=[],
-                **kwargs):
-  """Builds a cgo-enabled go library.
-
-  Args:
-    name: A unique name for this rule.
-    srcs: List of Go, C and C++ files that are processed to build a Go library.
-      Those Go files must contain `import "C"`.
-      C and C++ files can be anything allowed in `srcs` attribute of
-      `cc_library`.
-    copts: Add these flags to the C++ compiler.
-    clinkopts: Add these flags to the C++ linker.
-    cdeps: List of C/C++ libraries to be linked into the binary target.
-      They must be `cc_library` rules.
-    deps: List of other libraries to be linked to this library target.
-    data: List of files needed by this rule at runtime.
-
-  NOTE:
-    `srcs` cannot contain pure-Go files, which do not have `import "C"`.
-    So you need to define another `go_library` when you build a go package with
-    both cgo-enabled and pure-Go sources.
-
-    ```
-    cgo_library(
-        name = "cgo_enabled",
-        srcs = ["cgo-enabled.go", "foo.cc", "bar.S", "baz.a"],
-    )
-
-    go_library(
-        name = "go_default_library",
-        srcs = ["pure-go.go"],
-        library = ":cgo_enabled",
-    )
-    ```
-  """
-  cgogen = setup_cgo_library(
-      name = name,
-      srcs = srcs,
-      cdeps = cdeps,
-      copts = copts,
-      clinkopts = clinkopts,
-  )
-
-  go_library(
-      name = name,
-      srcs = cgogen.go_srcs,
-      cgo_object = cgogen.cgo_object,
-      **kwargs
-  )
-
 def _cgo_select_go_files_impl(ctx):
   return struct(files = ctx.attr.dep.go_files)
 

--- a/go/private/go_repository.bzl
+++ b/go/private/go_repository.bzl
@@ -128,12 +128,6 @@ go_repository = repository_rule(
     },
 )
 
-# This is for legacy compatability
-# Originally this was the only rule that triggered BUILD file generation.
-def new_go_repository(name, **kwargs):
-  print("{0}: new_go_repository is deprecated. Please migrate to go_repository soon.".format(name))
-  return go_repository(name=name, **kwargs)
-
 def env_execute(ctx, arguments, environment = None, **kwargs):
   """env_execute prepends "env -i" to "arguments" before passing it to
   ctx.execute.


### PR DESCRIPTION
This adds the compatability shims to def.bzl written in terms of the correct
rules, with deprecation warnings, and removes the deprecated implementations.