### PR TITLE
Cleaning up the GoSource provider usage

### DIFF
--- a/go/private/binary.bzl
+++ b/go/private/binary.bzl
@@ -19,7 +19,7 @@ load("@io_bazel_rules_go//go/private:providers.bzl", "GoLibrary", "GoBinary")
 def _go_binary_impl(ctx):
   """go_binary_impl emits actions for compiling and linking a go executable."""
   lib_result = emit_library_actions(ctx,
-      sources = depset(ctx.files.srcs),
+      srcs = ctx.files.srcs,
       deps = ctx.attr.deps,
       cgo_object = None,
       library = ctx.attr.library,

--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -68,3 +68,29 @@ def pkg_dir(workspace_root, package_name):
   if package_name:
     return package_name
   return "."
+
+def dict_of(st):
+  """Converts struct objects into dictionaries."""
+  data = dict()
+  for key in dir(st):
+    value = getattr(st, key, None)
+    if value != None: # skip methods
+      data[key] = value
+  return data
+
+def merge(a, b):
+  """Merges two structs by assuming that all fields present support +="""
+  data = dict_of(a)
+  for key, value in dict_of(b).items():
+    if key in data:
+      data[key] += value
+    else:
+      data[key] = value
+  return data
+
+def replace(a, b):
+  """Returns a dict where values from b are used when present in both a and b"""
+  data = dict_of(a)
+  for key, value in dict_of(b).items():
+    data[key] = value
+  return data

--- a/go/private/providers.bzl
+++ b/go/private/providers.bzl
@@ -12,6 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@io_bazel_rules_go//go/private:common.bzl", "go_exts", "hdr_exts", "asm_exts", "c_exts")
+
 GoSource = provider()
 GoLibrary = provider()
 GoBinary = provider()
+
+
+def split_srcs(ctx, srcs):
+  go = depset()
+  headers = depset()
+  asm = depset()
+  c = depset()
+  for src in srcs:
+    if any([src.basename.endswith(ext) for ext in go_exts]):
+      go += [src]
+    elif any([src.basename.endswith(ext) for ext in hdr_exts]):
+      headers += [src]
+    elif any([src.basename.endswith(ext) for ext in asm_exts]):
+      asm += [src]
+    elif any([src.basename.endswith(ext) for ext in c_exts]):
+      c += [src]
+    else:
+      fail("Unknown source type {0} in {1}".format(src.basename, ctx.label))
+  return GoSource(
+      input = srcs,
+      go = go,
+      headers = headers,
+      asm = asm,
+      c = c,
+  )

--- a/go/private/test.bzl
+++ b/go/private/test.bzl
@@ -25,7 +25,7 @@ def _go_test_impl(ctx):
 
   go_toolchain = get_go_toolchain(ctx)
   lib_result = emit_library_actions(ctx,
-      sources = depset(ctx.files.srcs),
+      srcs = ctx.files.srcs,
       deps = ctx.attr.deps,
       cgo_object = None,
       library = ctx.attr.library,
@@ -43,7 +43,7 @@ def _go_test_impl(ctx):
     run_dir = pkg_dir(ctx.label.workspace_root, ctx.label.package)
 
   ctx.action(
-      inputs = list(lib_result.go_sources),
+      inputs = list(lib_result.source.go),
       outputs = [main_go],
       mnemonic = "GoTestGenTest",
       executable = go_toolchain.test_generator,
@@ -54,7 +54,7 @@ def _go_test_impl(ctx):
           run_dir,
           '--output',
           main_go.path,
-      ] + [src.path for src in lib_result.go_sources],
+      ] + [src.path for src in lib_result.source.go],
       env = dict(go_toolchain.env, RUNDIR=ctx.label.package)
   )
 


### PR DESCRIPTION
We use it to manage all source lists, and propagate both original and modified
sources sets from rules.
This is a preparatory step for cleaning up both the library attribute and the
cover rules.