### PR TITLE
Remove the GoSource provider

### DIFF
--- a/go/def.bzl
+++ b/go/def.bzl
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 load("@io_bazel_rules_go//go/private:providers.bzl",
-    _GoSource = "GoSource",
     _GoLibrary = "GoLibrary",
     _GoBinary = "GoBinary",
 )
@@ -27,13 +26,6 @@ load("@io_bazel_rules_go//go/private:wrappers.bzl",
     _go_binary_macro = "go_binary_macro",
     _go_test_macro = "go_test_macro",
 )
-
-GoSource = _GoSource
-"""
-This is the provider used to expose a go sources to other rules.
-It provides the following fields:
-  TODO: List all the provider fields here
-"""
 
 GoLibrary = _GoLibrary
 """
@@ -52,7 +44,7 @@ It provides the following fields:
 go_library = _go_library_macro
 """
     go_library is a macro for building go libraries.
-    It returns the GoSource and GoLibrary providers,
+    It returns the GoLibrary providers,
     and accepts the following attributes:
         "importpath": attr.string(),
         # inputs

--- a/go/private/asm.bzl
+++ b/go/private/asm.bzl
@@ -32,7 +32,7 @@ def emit_go_asm_action(ctx, source, hdrs, out_obj):
   for inc in includes:
     asm_args += ["-I", inc]
   ctx.action(
-      inputs = inputs,
+      inputs = list(inputs),
       outputs = [out_obj],
       mnemonic = "GoAsmCompile",
       executable = go_toolchain.asm,

--- a/go/private/binary.bzl
+++ b/go/private/binary.bzl
@@ -19,7 +19,7 @@ load("@io_bazel_rules_go//go/private:providers.bzl", "GoLibrary", "GoBinary")
 def _go_binary_impl(ctx):
   """go_binary_impl emits actions for compiling and linking a go executable."""
   lib_result = emit_library_actions(ctx,
-      sources = depset(ctx.files.srcs),
+      srcs = ctx.files.srcs,
       deps = ctx.attr.deps,
       cgo_object = None,
       library = ctx.attr.library,

--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -68,3 +68,39 @@ def pkg_dir(workspace_root, package_name):
   if package_name:
     return package_name
   return "."
+
+def dict_of(st):
+  """Converts struct objects into dictionaries."""
+  data = dict()
+  for key in dir(st):
+    value = getattr(st, key, None)
+    if value != None: # skip methods
+      data[key] = value
+  return data
+
+
+def split_srcs(srcs):
+  go = depset()
+  headers = depset()
+  asm = depset()
+  c = depset()
+  for src in srcs:
+    if any([src.basename.endswith(ext) for ext in go_exts]):
+      go += [src]
+    elif any([src.basename.endswith(ext) for ext in hdr_exts]):
+      headers += [src]
+    elif any([src.basename.endswith(ext) for ext in asm_exts]):
+      asm += [src]
+    elif any([src.basename.endswith(ext) for ext in c_exts]):
+      c += [src]
+    else:
+      fail("Unknown source type {0}".format(src.basename))
+  return struct(
+      go = go,
+      headers = headers,
+      asm = asm,
+      c = c,
+  )
+
+def join_srcs(source):
+  return depset() + source.go + source.headers + source.asm + source.c

--- a/go/private/providers.bzl
+++ b/go/private/providers.bzl
@@ -12,6 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-GoSource = provider()
 GoLibrary = provider()
 GoBinary = provider()


### PR DESCRIPTION
GoSource gets in the way more than it helps.
This removes it, and also rationalises all source list splitting and joining
into some helpers, and then always passes unified source lists across action
boundaries rather than exploded ones.
This is a preparatory step for cleaning up both the library attribute and the
cover rules.