### PR TITLE
Gazelle: fix spurious warnings in non-Go BUILD files

### DIFF
--- a/go/tools/gazelle/merger/fix.go
+++ b/go/tools/gazelle/merger/fix.go
@@ -284,7 +284,7 @@ func fixLoads(oldFile *bf.File) *bf.File {
 	var newFirstLoad *bf.CallExpr
 	if len(loads) == 0 {
 		newFirstLoad = fixLoad(nil, usedKinds)
-		changed = true
+		changed = newFirstLoad != nil
 	} else {
 		for i := 0; i < len(loads); i++ {
 			if i == 0 {
@@ -376,6 +376,10 @@ func fixLoad(load *bf.CallExpr, kinds map[string]bool) *bf.CallExpr {
 		}
 	}
 	if added == 0 && removed == 0 {
+		if load != nil && len(load.List) == 1 {
+			// Special case: delete existing empty load.
+			return nil
+		}
 		return load
 	}
 

--- a/go/tools/gazelle/merger/fix_test.go
+++ b/go/tools/gazelle/merger/fix_test.go
@@ -176,6 +176,31 @@ go_library(
 		},
 		// fixLoads tests
 		{
+			desc: "empty file",
+			old:  "",
+			want: "",
+		}, {
+			desc: "non-Go file",
+			old: `load("@io_bazel_rules_intercal//intercal:def.bzl", "intercal_library")
+
+intercal_library(
+    name = "intercal_default_library",
+    srcs = ["foo.ic"],
+)
+`,
+			want: `load("@io_bazel_rules_intercal//intercal:def.bzl", "intercal_library")
+
+intercal_library(
+    name = "intercal_default_library",
+    srcs = ["foo.ic"],
+)
+`,
+		}, {
+			desc: "empty Go load",
+			old: `load("@io_bazel_rules_go//go:def.bzl")
+`,
+			want: "",
+		}, {
 			desc: "add and remove loaded symbols",
 			old: `load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 


### PR DESCRIPTION
* We won't mark a file as changed if load statements if no Go symbols
  are used and no existing Go load statements were found.
* We will delete empty Go load statements in any case.