### PR TITLE
Fix up creation of GoLibrary providers

### DIFF
--- a/go/private/binary.bzl
+++ b/go/private/binary.bzl
@@ -18,7 +18,7 @@ load("@io_bazel_rules_go//go/private:providers.bzl", "GoLibrary", "GoBinary")
 
 def _go_binary_impl(ctx):
   """go_binary_impl emits actions for compiling and linking a go executable."""
-  lib_result = emit_library_actions(ctx,
+  golib, _ = emit_library_actions(ctx,
       srcs = ctx.files.srcs,
       deps = ctx.attr.deps,
       cgo_object = None,
@@ -29,10 +29,10 @@ def _go_binary_impl(ctx):
   # Default (dynamic) linking
   emit_go_link_action(
       ctx,
-      transitive_go_libraries=lib_result.transitive_go_libraries,
-      transitive_go_library_paths=lib_result.transitive_go_library_paths,
-      cgo_deps=lib_result.transitive_cgo_deps,
-      libs=depset([lib_result.library]),
+      transitive_go_libraries=golib.transitive_go_libraries,
+      transitive_go_library_paths=golib.transitive_go_library_paths,
+      cgo_deps=golib.transitive_cgo_deps,
+      libs=depset([golib.library]),
       executable=ctx.outputs.executable,
       gc_linkopts=gc_linkopts(ctx),
       x_defs=ctx.attr.x_defs,
@@ -46,10 +46,10 @@ def _go_binary_impl(ctx):
   static_executable = ctx.new_file(ctx.attr.name + ".static")
   emit_go_link_action(
       ctx,
-      transitive_go_libraries=lib_result.transitive_go_libraries,
-      transitive_go_library_paths=lib_result.transitive_go_library_paths,
-      cgo_deps=lib_result.transitive_cgo_deps,
-      libs=depset([lib_result.library]),
+      transitive_go_libraries=golib.transitive_go_libraries,
+      transitive_go_library_paths=golib.transitive_go_library_paths,
+      cgo_deps=golib.transitive_cgo_deps,
+      libs=depset([golib.library]),
       executable=static_executable,
       gc_linkopts=gc_linkopts(ctx) + static_linkopts,
       x_defs=ctx.attr.x_defs,
@@ -59,10 +59,10 @@ def _go_binary_impl(ctx):
   race_executable = ctx.new_file(ctx.attr.name + ".race")
   emit_go_link_action(
     ctx,
-    transitive_go_libraries=lib_result.transitive_go_libraries_race,
-    transitive_go_library_paths=lib_result.transitive_go_library_paths_race,
-    cgo_deps=lib_result.transitive_cgo_deps,
-    libs=depset([lib_result.race]),
+    transitive_go_libraries=golib.transitive_go_libraries_race,
+    transitive_go_library_paths=golib.transitive_go_library_paths_race,
+    cgo_deps=golib.transitive_cgo_deps,
+    libs=depset([golib.race]),
     executable=race_executable,
     gc_linkopts=gc_linkopts(ctx) + ["-race"],
     x_defs=ctx.attr.x_defs,
@@ -73,11 +73,10 @@ def _go_binary_impl(ctx):
           executable = ctx.outputs.executable,
           static = static_executable,
           race = race_executable,
-          cgo_object = lib_result.cgo_object,
       ),
       DefaultInfo(
           files = depset([ctx.outputs.executable]),
-          runfiles = lib_result.runfiles,
+          runfiles = golib.runfiles,
       ),
       OutputGroupInfo(
           static = depset([static_executable]),

--- a/go/private/library.bzl
+++ b/go/private/library.bzl
@@ -98,7 +98,7 @@ def emit_library_actions(ctx, srcs, deps, cgo_object, library, want_coverage):
       lib_paths = direct_search_paths_race,
       direct_paths = direct_import_paths,
       out_object = race_object,
-      gc_goopts = gc_goopts + ["-race"],
+      gc_goopts = gc_goopts + ("-race",),
   )
   emit_go_pack_action(ctx, race_lib, [race_object] + extra_objects)
 
@@ -115,7 +115,7 @@ def emit_library_actions(ctx, srcs, deps, cgo_object, library, want_coverage):
   transformed["go"] = go_srcs
 
   return [
-    GoLibrary(
+      GoLibrary(
           library = out_lib,
           race = race_lib,
           searchpath = searchpath,
@@ -148,8 +148,6 @@ def _go_library_impl(ctx):
       library = ctx.attr.library,
       want_coverage = ctx.coverage_instrumented(),
   )
-
-  depset([golib])
 
   return [
       golib,
@@ -211,7 +209,7 @@ def go_importpath(ctx):
   return path
 
 def get_gc_goopts(ctx):
-  gc_goopts = ctx.attr.gc_goopts
+  gc_goopts = tuple(ctx.attr.gc_goopts)
   if ctx.attr.library:
     gc_goopts += ctx.attr.library[GoLibrary].gc_goopts
   return gc_goopts

--- a/go/private/library.bzl
+++ b/go/private/library.bzl
@@ -14,22 +14,23 @@
 
 load("@io_bazel_rules_go//go/private:common.bzl", "get_go_toolchain", "DEFAULT_LIB", "VENDOR_PREFIX", "go_filetype", "dict_of", "split_srcs", "join_srcs")
 load("@io_bazel_rules_go//go/private:asm.bzl", "emit_go_asm_action")
-load("@io_bazel_rules_go//go/private:providers.bzl", "GoLibrary")
+load("@io_bazel_rules_go//go/private:providers.bzl", "GoLibrary", "CgoLibrary")
 
 def emit_library_actions(ctx, srcs, deps, cgo_object, library, want_coverage):
   go_toolchain = get_go_toolchain(ctx)
   dep_runfiles = [d.data_runfiles for d in deps]
   if library:
     golib = library[GoLibrary]
+    cgolib = library[CgoLibrary]
     srcs = golib.srcs + srcs
     deps += golib.direct_deps
     dep_runfiles += [library.data_runfiles]
-    if golib.cgo_object:
+    if cgolib.object:
       if cgo_object:
         fail("go_library %s cannot have cgo_object because the package " +
              "already has cgo_object in %s" % (ctx.label.name,
                                                golib.name))
-      cgo_object = golib.cgo_object
+      cgo_object = cgolib.object
   source = split_srcs(srcs)
   if source.c:
     fail("c sources in non cgo rule")
@@ -113,32 +114,34 @@ def emit_library_actions(ctx, srcs, deps, cgo_object, library, want_coverage):
   transformed = dict_of(source)
   transformed["go"] = go_srcs
 
-  return struct(
-    label = ctx.label,
-    files = depset([out_lib]),
-    library = out_lib,
-    race = race_lib,
-    searchpath = searchpath,
-    searchpath_race = searchpath_race,
-    runfiles = runfiles,
-    srcs = join_srcs(struct(**transformed)),
-    importpath = importpath,
-    cgo_object = cgo_object,
-    direct_deps = deps,
-    transitive_cgo_deps = transitive_cgo_deps,
-    transitive_go_libraries = transitive_go_library_deps + [out_lib],
-    transitive_go_libraries_race = transitive_go_library_deps_race + [race_lib],
-    transitive_go_library_paths = transitive_go_library_paths,
-    transitive_go_library_paths_race = transitive_go_library_paths_race,
-    gc_goopts = gc_goopts,
-  )
+  return [
+    GoLibrary(
+          library = out_lib,
+          race = race_lib,
+          searchpath = searchpath,
+          searchpath_race = searchpath_race,
+          srcs = join_srcs(struct(**transformed)),
+          importpath = importpath,
+          direct_deps = deps,
+          transitive_cgo_deps = transitive_cgo_deps,
+          transitive_go_libraries = transitive_go_library_deps + [out_lib],
+          transitive_go_libraries_race = transitive_go_library_deps_race + [race_lib],
+          transitive_go_library_paths = transitive_go_library_paths,
+          transitive_go_library_paths_race = transitive_go_library_paths_race,
+          gc_goopts = gc_goopts,
+          runfiles = runfiles,
+      ),
+      CgoLibrary(
+          object = cgo_object,
+      ),
+  ]
 
 def _go_library_impl(ctx):
   """Implements the go_library() rule."""
   cgo_object = None
   if hasattr(ctx.attr, "cgo_object"):
     cgo_object = ctx.attr.cgo_object
-  lib_result = emit_library_actions(ctx,
+  golib, cgolib = emit_library_actions(ctx,
       srcs = ctx.files.srcs,
       deps = ctx.attr.deps,
       cgo_object = cgo_object,
@@ -146,30 +149,17 @@ def _go_library_impl(ctx):
       want_coverage = ctx.coverage_instrumented(),
   )
 
+  depset([golib])
+
   return [
-      GoLibrary(
-          label = ctx.label,
-          library = lib_result.library,
-          race = lib_result.race,
-          searchpath = lib_result.searchpath,
-          searchpath_race = lib_result.searchpath_race,
-          importpath = lib_result.importpath,
-          cgo_object = lib_result.cgo_object,
-          direct_deps = lib_result.direct_deps,
-          transitive_cgo_deps = lib_result.transitive_cgo_deps,
-          transitive_go_libraries = lib_result.transitive_go_libraries,
-          transitive_go_libraries_race = lib_result.transitive_go_libraries_race,
-          transitive_go_library_paths = lib_result.transitive_go_library_paths,
-          transitive_go_library_paths_race = lib_result.transitive_go_library_paths_race,
-          gc_goopts = lib_result.gc_goopts,
-          srcs = lib_result.srcs,
-      ),
+      golib,
+      cgolib,
       DefaultInfo(
-          files = lib_result.files,
-          runfiles = lib_result.runfiles,
+          files = depset([golib.library]),
+          runfiles = golib.runfiles,
       ),
       OutputGroupInfo(
-          race = depset([lib_result.race]),
+          race = depset([golib.race]),
       ),
   ]
 

--- a/go/private/providers.bzl
+++ b/go/private/providers.bzl
@@ -14,3 +14,4 @@
 
 GoLibrary = provider()
 GoBinary = provider()
+CgoLibrary = provider()


### PR DESCRIPTION
We create them directly inside emit_library_actions now, so we dont have to do a
struct to provider field by field copy.
the cgo_object is now passed in it's own provider, this is partly to enable a
future clean up of the cgo chain, and partly because it contains mutable fields.
This leaves GoLibrary as something that can now be put in a depset.