### PR TITLE
Report coverage metrics using original source filenames.

### DIFF
--- a/go/private/test.bzl
+++ b/go/private/test.bzl
@@ -42,6 +42,13 @@ def _go_test_impl(ctx):
   else:
     run_dir = pkg_dir(ctx.label.workspace_root, ctx.label.package)
 
+  coverage_args = []
+  if ctx.attr.library:
+    coverage_filename_map = ctx.attr.library[GoLibrary].coverage_filename_map
+    if coverage_filename_map:
+      coverage_json = struct(**coverage_filename_map).to_json()
+      coverage_args = ["--coverage_filename_map", coverage_json]
+
   go_srcs = list(split_srcs(golib.srcs).go)
   ctx.action(
       inputs = go_srcs,
@@ -55,7 +62,7 @@ def _go_test_impl(ctx):
           run_dir,
           '--output',
           main_go.path,
-      ] + [src.path for src in go_srcs],
+      ] + coverage_args + [src.path for src in go_srcs],
       env = dict(go_toolchain.env, RUNDIR=ctx.label.package)
   )
 

--- a/tests/coverage/BUILD
+++ b/tests/coverage/BUILD
@@ -21,6 +21,14 @@ bazel_test(
     command = "coverage",
     target = "//:go_default_test",
     check = """
+if grep -q 'GoCover_0.cover.go' 'bazel-out/local-fastbuild/bin/go_default_test_main_test.go'; then
+  echo "error: coverage output should reference original source files" >&2
+  exit 1
+fi
+if ! grep -q 'coverRegisterFile("lib.go",' 'bazel-out/local-fastbuild/bin/go_default_test_main_test.go'; then
+  echo "error: coverage output should reference original source files" >&2
+  exit 1
+fi
 if ! grep -q '^coverage: 50.0% of statements' "bazel-testlogs/go_default_test/test.log"; then
   echo "error: no coverage output found in test log file" >&2
   exit 1


### PR DESCRIPTION
Currently, the metrics are being emitted for the generated
coverage-instrumented file, which makes `go tool cover` unable to render
the coverage HTML correctly. Reporting coverage with the original source
filename lets `go tool cover` work.