### PR TITLE
Clean up transitive information

### DIFF
--- a/go/private/binary.bzl
+++ b/go/private/binary.bzl
@@ -30,10 +30,8 @@ def _go_binary_impl(ctx):
   # Default (dynamic) linking
   emit_go_link_action(
       ctx,
-      transitive_go_libraries=golib.transitive_go_libraries,
-      transitive_go_library_paths=golib.transitive_go_library_paths,
-      cgo_deps=golib.transitive_cgo_deps,
-      libs=depset([golib.library]),
+      library=golib,
+      mode="",
       executable=ctx.outputs.executable,
       gc_linkopts=gc_linkopts(ctx),
       x_defs=ctx.attr.x_defs,
@@ -47,10 +45,8 @@ def _go_binary_impl(ctx):
   static_executable = ctx.new_file(ctx.attr.name + ".static")
   emit_go_link_action(
       ctx,
-      transitive_go_libraries=golib.transitive_go_libraries,
-      transitive_go_library_paths=golib.transitive_go_library_paths,
-      cgo_deps=golib.transitive_cgo_deps,
-      libs=depset([golib.library]),
+      library=golib,
+      mode="",
       executable=static_executable,
       gc_linkopts=gc_linkopts(ctx) + static_linkopts,
       x_defs=ctx.attr.x_defs,
@@ -60,10 +56,8 @@ def _go_binary_impl(ctx):
   race_executable = ctx.new_file(ctx.attr.name + ".race")
   emit_go_link_action(
     ctx,
-    transitive_go_libraries=golib.transitive_go_libraries_race,
-    transitive_go_library_paths=golib.transitive_go_library_paths_race,
-    cgo_deps=golib.transitive_cgo_deps,
-    libs=depset([golib.race]),
+    library=golib,
+    mode="_race",
     executable=race_executable,
     gc_linkopts=gc_linkopts(ctx) + ["-race"],
     x_defs=ctx.attr.x_defs,
@@ -164,8 +158,7 @@ def _extract_extldflags(gc_linkopts, extldflags):
       filtered_gc_linkopts += [opt]
   return filtered_gc_linkopts, extldflags
 
-def emit_go_link_action(ctx, transitive_go_library_paths, transitive_go_libraries, cgo_deps, libs,
-                         executable, gc_linkopts, x_defs):
+def emit_go_link_action(ctx, library, mode, executable, gc_linkopts, x_defs):
   """Sets up a symlink tree to libraries to link together."""
   go_toolchain = get_go_toolchain(ctx)
   config_strip = len(ctx.configuration.bin_dir.path) + 1
@@ -175,18 +168,24 @@ def emit_go_link_action(ctx, transitive_go_library_paths, transitive_go_librarie
   extldflags = c_linker_options(ctx) + [
       "-Wl,-rpath,$ORIGIN/" + ("../" * pkg_depth),
   ]
-  for d in cgo_deps:
-    if d.basename.endswith('.so'):
-      short_dir = d.dirname[len(d.root.path):]
-      extldflags += ["-Wl,-rpath,$ORIGIN/" + ("../" * pkg_depth) + short_dir]
 
   gc_linkopts, extldflags = _extract_extldflags(gc_linkopts, extldflags)
 
   link_opts = [
       "-L", "."
   ]
-  for path in transitive_go_library_paths:
-    link_opts += ["-L", path]
+  libs = depset()
+  cgo_deps = depset()
+  for golib in depset([library]) + library.transitive:
+    libs += [getattr(golib, "library" + mode)]
+    link_opts += ["-L", getattr(golib, "searchpath" + mode)]
+    cgo_deps += golib.cgo_deps
+
+  for d in cgo_deps:
+    if d.basename.endswith('.so'):
+      short_dir = d.dirname[len(d.root.path):]
+      extldflags += ["-Wl,-rpath,$ORIGIN/" + ("../" * pkg_depth) + short_dir]
+
   link_opts += [
       "-o", executable.path,
   ] + gc_linkopts
@@ -203,7 +202,7 @@ def emit_go_link_action(ctx, transitive_go_library_paths, transitive_go_librarie
   link_opts += go_toolchain.link_flags + [
       "-extld", ld,
       "-extldflags", " ".join(extldflags),
-  ] + [lib.path for lib in libs]
+  ] + [getattr(golib, "library" + mode).path]
 
   link_args = [go_toolchain.go.path]
   # Stamping support
@@ -223,7 +222,7 @@ def emit_go_link_action(ctx, transitive_go_library_paths, transitive_go_librarie
   link_args += ["--"] + link_opts
 
   ctx.action(
-      inputs = list(transitive_go_libraries + [lib] + cgo_deps +
+      inputs = list(libs + cgo_deps +
                 go_toolchain.tools + go_toolchain.crosstool + stamp_inputs),
       outputs = [executable],
       mnemonic = "GoLink",

--- a/go/private/binary.bzl
+++ b/go/private/binary.bzl
@@ -159,7 +159,16 @@ def _extract_extldflags(gc_linkopts, extldflags):
   return filtered_gc_linkopts, extldflags
 
 def emit_go_link_action(ctx, library, mode, executable, gc_linkopts, x_defs):
-  """Sets up a symlink tree to libraries to link together."""
+  """Adds an action to link the supplied library in the given mode, producing the executable.
+  Args:
+    ctx: The skylark Context.
+    library: The library to link.
+    mode: Controls the linking setup affecting things like enabling profilers and sanitizers.
+      (TODO: more detail when we switch to mode constants)
+    executable: The binary to produce.
+    gc_linkopts: basic link options, these may be adjusted by the mode.
+    x_defs: link defines, including build stamping ones
+  """
   go_toolchain = get_go_toolchain(ctx)
   config_strip = len(ctx.configuration.bin_dir.path) + 1
   pkg_depth = executable.dirname[config_strip:].count('/') + 1

--- a/go/private/library.bzl
+++ b/go/private/library.bzl
@@ -19,12 +19,17 @@ load("@io_bazel_rules_go//go/private:providers.bzl", "GoLibrary", "CgoLibrary")
 def emit_library_actions(ctx, srcs, deps, cgo_object, library, want_coverage, importpath, golibs=[]):
   go_toolchain = get_go_toolchain(ctx)
   dep_runfiles = [d.data_runfiles for d in deps]
+  direct = depset(golibs)
+  gc_goopts = tuple(ctx.attr.gc_goopts)
+  cgo_deps = depset()
   if library:
     golib = library[GoLibrary]
     cgolib = library[CgoLibrary]
-    srcs = golib.srcs + srcs
-    deps += golib.direct_deps
+    srcs = golib.transformed + srcs
+    direct += golib.direct
     dep_runfiles += [library.data_runfiles]
+    gc_goopts += golib.gc_goopts
+    cgo_deps += golib.cgo_deps
     if cgolib.object:
       if cgo_object:
         fail("go_library %s cannot have cgo_object because the package " +
@@ -37,10 +42,9 @@ def emit_library_actions(ctx, srcs, deps, cgo_object, library, want_coverage, im
   if not source.go:
     fail("no go sources")
 
-  transitive_cgo_deps = depset([], order="link")
   if cgo_object:
     dep_runfiles += [cgo_object.data_runfiles]
-    transitive_cgo_deps += cgo_object.cgo_deps
+    cgo_deps += cgo_object.cgo_deps
 
   extra_objects = [cgo_object.cgo_obj] if cgo_object else []
   for src in source.asm:
@@ -55,29 +59,14 @@ def emit_library_actions(ctx, srcs, deps, cgo_object, library, want_coverage, im
   race_lib =  ctx.new_file("~race~/"+lib_name)
   race_object = ctx.new_file("~race~/" + importpath + ".o")
   searchpath_race = race_lib.path[:-len(lib_name)]
-  gc_goopts = get_gc_goopts(ctx)
-  direct_go_library_deps = []
-  direct_go_library_deps_race = []
-  direct_search_paths = []
-  direct_search_paths_race = []
-  direct_import_paths = []
-  transitive_go_library_deps = depset()
-  transitive_go_library_deps_race = depset()
-  transitive_go_library_paths = depset([searchpath])
-  transitive_go_library_paths_race = depset([searchpath_race])
+
   for dep in deps:
-    golibs += [dep[GoLibrary]]
-  for golib in golibs:
-    direct_go_library_deps += [golib.library]
-    direct_go_library_deps_race += [golib.race]
-    direct_search_paths += [golib.searchpath]
-    direct_search_paths_race += [golib.searchpath_race]
-    direct_import_paths += [golib.importpath]
-    transitive_go_library_deps += golib.transitive_go_libraries
-    transitive_go_library_deps_race += golib.transitive_go_libraries_race
-    transitive_cgo_deps += golib.transitive_cgo_deps
-    transitive_go_library_paths += golib.transitive_go_library_paths
-    transitive_go_library_paths_race += golib.transitive_go_library_paths_race
+    direct += [dep[GoLibrary]]
+
+  transitive = depset()
+  for golib in direct:
+    transitive += [golib]
+    transitive += golib.transitive
 
   go_srcs = source.go
   if want_coverage:
@@ -85,18 +74,16 @@ def emit_library_actions(ctx, srcs, deps, cgo_object, library, want_coverage, im
 
   emit_go_compile_action(ctx,
       sources = go_srcs,
-      libs = direct_go_library_deps,
-      lib_paths = direct_search_paths,
-      direct_paths = direct_import_paths,
+      golibs = direct,
+      mode = "",
       out_object = out_object,
       gc_goopts = gc_goopts,
   )
   emit_go_pack_action(ctx, out_lib, [out_object] + extra_objects)
   emit_go_compile_action(ctx,
       sources = go_srcs,
-      libs = direct_go_library_deps_race,
-      lib_paths = direct_search_paths_race,
-      direct_paths = direct_import_paths,
+      golibs = direct,
+      mode = "_race",
       out_object = race_object,
       gc_goopts = gc_goopts + ("-race",),
   )
@@ -110,26 +97,23 @@ def emit_library_actions(ctx, srcs, deps, cgo_object, library, want_coverage, im
   for d in dep_runfiles:
     runfiles = runfiles.merge(d)
 
-  #TODO: for now, we return transformed sources, this will change
   transformed = dict_of(source)
   transformed["go"] = go_srcs
 
   return [
       GoLibrary(
-          library = out_lib,
-          race = race_lib,
-          searchpath = searchpath,
-          searchpath_race = searchpath_race,
-          srcs = join_srcs(struct(**transformed)),
-          importpath = importpath,
-          direct_deps = deps,
-          transitive_cgo_deps = transitive_cgo_deps,
-          transitive_go_libraries = transitive_go_library_deps + [out_lib],
-          transitive_go_libraries_race = transitive_go_library_deps_race + [race_lib],
-          transitive_go_library_paths = transitive_go_library_paths,
-          transitive_go_library_paths_race = transitive_go_library_paths_race,
-          gc_goopts = gc_goopts,
-          runfiles = runfiles,
+          importpath = importpath, # The import path for this library
+          library = out_lib, # The normal library
+          searchpath = searchpath, # The searchpath for the normal library
+          library_race = race_lib, # The library compiled for race detection
+          searchpath_race = searchpath_race, # The searchpath for the race library
+          direct = direct, # The direct depencancies of the library
+          transitive = transitive, # The transitive set of go libraries depended on
+          srcs = depset(srcs), # The original sources
+          transformed = join_srcs(struct(**transformed)), # The transformed sources actually compiled
+          cgo_deps = cgo_deps, # The direct cgo dependancies of this library
+          gc_goopts = gc_goopts, # The options this library was compiled with
+          runfiles = runfiles, # The runfiles needed for things including this library
       ),
       CgoLibrary(
           object = cgo_object,
@@ -158,7 +142,7 @@ def _go_library_impl(ctx):
           runfiles = golib.runfiles,
       ),
       OutputGroupInfo(
-          race = depset([golib.race]),
+          race = depset([golib.library_race]),
       ),
   ]
 
@@ -209,38 +193,31 @@ def go_importpath(ctx):
     path = path[1:]
   return path
 
-def get_gc_goopts(ctx):
-  gc_goopts = tuple(ctx.attr.gc_goopts)
-  if ctx.attr.library:
-    gc_goopts += ctx.attr.library[GoLibrary].gc_goopts
-  return gc_goopts
-
-def emit_go_compile_action(ctx, sources, libs, lib_paths, direct_paths, out_object, gc_goopts):
+def emit_go_compile_action(ctx, sources, golibs, mode, out_object, gc_goopts):
   """Construct the command line for compiling Go code.
 
   Args:
     ctx: The skylark Context.
     sources: an iterable of source code artifacts (or CTs? or labels?)
-    libs: a depset of representing all imported libraries.
-    lib_paths: the set of paths to search for imported libraries.
-    direct_paths: iterable of of import paths for the package's direct deps,
-      including those in the library attribute. Used for strict dep checking.
+    golibs: a depset of representing all imported libraries.
     out_object: the object file that should be produced
     gc_goopts: additional flags to pass to the compiler.
   """
   go_toolchain = get_go_toolchain(ctx)
   gc_goopts = [ctx.expand_make_variables("gc_goopts", f, {}) for f in gc_goopts]
-  inputs = depset([go_toolchain.go]) + sources + libs
+  inputs = depset([go_toolchain.go]) + sources
   go_sources = [s.path for s in sources if not s.basename.startswith("_cgo")]
   cgo_sources = [s.path for s in sources if s.basename.startswith("_cgo")]
   args = [go_toolchain.go.path]
   for src in go_sources:
     args += ["-src", src]
-  for dep in direct_paths:
-    args += ["-dep", dep]
+  for golib in golibs:
+    library = getattr(golib, "library" + mode)
+    searchpath = getattr(golib, "searchpath" + mode)
+    inputs += [library]
+    args += ["-dep", golib.importpath]
+    args += ["-I", searchpath]
   args += ["-o", out_object.path, "-trimpath", ".", "-I", "."]
-  for path in lib_paths:
-    args += ["-I", path]
   args += ["--"] + gc_goopts + cgo_sources
   ctx.action(
       inputs = list(inputs),

--- a/go/private/library.bzl
+++ b/go/private/library.bzl
@@ -200,6 +200,8 @@ def emit_go_compile_action(ctx, sources, golibs, mode, out_object, gc_goopts):
     ctx: The skylark Context.
     sources: an iterable of source code artifacts (or CTs? or labels?)
     golibs: a depset of representing all imported libraries.
+    mode: Controls the compilation setup affecting things like enabling profilers and sanitizers.
+      (TODO: more detail when we switch to mode constants)
     out_object: the object file that should be produced
     gc_goopts: additional flags to pass to the compiler.
   """


### PR DESCRIPTION
Instead of having the GoLibrary provider have lots of transitive fields, we now
have one transitive field full of GoLibrary providers.
This cleans up a lot of code, and also allows much more powerful tools to be
written on top of the new collated GoLibrary set.