### PR TITLE
Gazelle: Split LabelResolver into Labeler and Resolver

### DIFF
--- a/go/tools/gazelle/config/config.go
+++ b/go/tools/gazelle/config/config.go
@@ -48,8 +48,11 @@ type Config struct {
 	// DepMode determines how imports outside of GoPrefix are resolved.
 	DepMode DependencyMode
 
-	// KnownImports is a list of imports to add to the external resolver cache
+	// KnownImports is a list of imports to add to the external resolver cache.
 	KnownImports []string
+
+	// StructureMode determines how build files are organized within a project.
+	StructureMode StructureMode
 }
 
 var DefaultValidBuildFileNames = []string{"BUILD.bazel", "BUILD"}
@@ -128,3 +131,17 @@ func DependencyModeFromString(s string) (DependencyMode, error) {
 		return 0, fmt.Errorf("unrecognized dependency mode: %q", s)
 	}
 }
+
+// StructureMode determines how build files are organized within a project.
+type StructureMode int
+
+const (
+	// In HierarchicalMode, one build file is generated per directory. This is
+	// the default mode.
+	HierarchicalMode StructureMode = iota
+
+	// In FlatMode, one build file is generated for the entire repository.
+	// FlatMode build files can be used with new_git_repository or
+	// new_http_archive.
+	FlatMode
+)

--- a/go/tools/gazelle/gazelle/main.go
+++ b/go/tools/gazelle/gazelle/main.go
@@ -57,7 +57,8 @@ var commandFromName = map[string]command{
 }
 
 func run(c *config.Config, cmd command, emit emitFunc) {
-	r := resolve.NewLabelResolver(c)
+	l := resolve.NewLabeler(c)
+	r := resolve.NewResolver(c, l)
 	shouldProcessRoot := false
 	didProcessRoot := false
 	shouldFix := cmd == fixCmd
@@ -69,7 +70,7 @@ func run(c *config.Config, cmd command, emit emitFunc) {
 			if pkg.Rel == "" {
 				didProcessRoot = true
 			}
-			processPackage(c, r, shouldFix, emit, pkg, oldFile)
+			processPackage(c, r, l, shouldFix, emit, pkg, oldFile)
 		})
 	}
 	if shouldProcessRoot && !didProcessRoot {
@@ -98,12 +99,12 @@ func run(c *config.Config, cmd command, emit emitFunc) {
 		}
 
 	processRoot:
-		processPackage(c, r, shouldFix, emit, pkg, oldFile)
+		processPackage(c, r, l, shouldFix, emit, pkg, oldFile)
 	}
 }
 
-func processPackage(c *config.Config, r resolve.LabelResolver, shouldFix bool, emit emitFunc, pkg *packages.Package, oldFile *bf.File) {
-	g := rules.NewGenerator(c, r, oldFile)
+func processPackage(c *config.Config, r resolve.Resolver, l resolve.Labeler, shouldFix bool, emit emitFunc, pkg *packages.Package, oldFile *bf.File) {
+	g := rules.NewGenerator(c, r, l, oldFile)
 	genFile := g.Generate(pkg)
 
 	if oldFile == nil {

--- a/go/tools/gazelle/resolve/BUILD
+++ b/go/tools/gazelle/resolve/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "labeler.go",
         "resolve.go",
         "resolve_external.go",
         "resolve_structured.go",
@@ -18,6 +19,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "labeler_test.go",
         "resolve_external_test.go",
         "resolve_structured_test.go",
         "resolve_test.go",

--- a/go/tools/gazelle/resolve/labeler.go
+++ b/go/tools/gazelle/resolve/labeler.go
@@ -1,0 +1,107 @@
+/* Copyright 2017 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolve
+
+import (
+	"path"
+	"path/filepath"
+
+	"github.com/bazelbuild/rules_go/go/tools/gazelle/config"
+)
+
+// Labeler generates Bazel labels for rules, based on their locations
+// within the repository.
+type Labeler interface {
+	LibraryLabel(rel string) Label
+	TestLabel(rel string, isXTest bool) Label
+	BinaryLabel(rel string) Label
+}
+
+func NewLabeler(c *config.Config) Labeler {
+	if c.StructureMode == config.FlatMode {
+		return &flatLabeler{c}
+	}
+	return &hierarchicalLabeler{c}
+}
+
+type hierarchicalLabeler struct {
+	c *config.Config
+}
+
+func (l *hierarchicalLabeler) LibraryLabel(rel string) Label {
+	return Label{Pkg: rel, Name: config.DefaultLibName}
+}
+
+func (l *hierarchicalLabeler) TestLabel(rel string, isXTest bool) Label {
+	var name string
+	if isXTest {
+		name = config.DefaultXTestName
+	} else {
+		name = config.DefaultTestName
+	}
+	return Label{Pkg: rel, Name: name}
+}
+
+func (l *hierarchicalLabeler) BinaryLabel(rel string) Label {
+	name := relBaseName(l.c, rel)
+	return Label{Pkg: rel, Name: name}
+}
+
+type flatLabeler struct {
+	c *config.Config
+}
+
+func (l *flatLabeler) LibraryLabel(rel string) Label {
+	if rel == "" {
+		return Label{Name: relBaseName(l.c, rel)}
+	}
+	return Label{Name: rel}
+}
+
+func (l *flatLabeler) TestLabel(rel string, isXTest bool) Label {
+	var suffix string
+	if isXTest {
+		suffix = "_xtest"
+	} else {
+		suffix = "_test"
+	}
+	if rel == "" {
+		return Label{Name: relBaseName(l.c, rel) + suffix}
+	}
+	return Label{Name: rel + suffix}
+}
+
+func (l *flatLabeler) BinaryLabel(rel string) Label {
+	suffix := "_cmd"
+	if rel == "" {
+		return Label{Name: relBaseName(l.c, rel) + suffix}
+	}
+	return Label{Name: rel + suffix}
+}
+
+func relBaseName(c *config.Config, rel string) string {
+	base := path.Base(rel)
+	if base == "." || base == "/" {
+		base = path.Base(c.GoPrefix)
+	}
+	if base == "." || base == "/" {
+		base = filepath.Base(c.RepoRoot)
+	}
+	if base == "." || base == "/" {
+		base = "root"
+	}
+	return base
+}

--- a/go/tools/gazelle/resolve/labeler_test.go
+++ b/go/tools/gazelle/resolve/labeler_test.go
@@ -1,0 +1,90 @@
+/* Copyright 2017 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolve
+
+import (
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/gazelle/config"
+)
+
+func TestLabeler(t *testing.T) {
+	for _, tc := range []struct {
+		name, rel                             string
+		mode                                  config.StructureMode
+		wantLib, wantBin, wantTest, wantXTest string
+	}{
+		{
+			name:      "root_hierarchical",
+			rel:       "",
+			mode:      config.HierarchicalMode,
+			wantLib:   "//:go_default_library",
+			wantBin:   "//:root",
+			wantTest:  "//:go_default_test",
+			wantXTest: "//:go_default_xtest",
+		}, {
+			name:      "sub_hierarchical",
+			rel:       "sub",
+			mode:      config.HierarchicalMode,
+			wantLib:   "//sub:go_default_library",
+			wantBin:   "//sub",
+			wantTest:  "//sub:go_default_test",
+			wantXTest: "//sub:go_default_xtest",
+		}, {
+			name:      "root_flat",
+			rel:       "",
+			mode:      config.FlatMode,
+			wantLib:   "//:root",
+			wantBin:   "//:root_cmd",
+			wantTest:  "//:root_test",
+			wantXTest: "//:root_xtest",
+		}, {
+			name:      "sub_flat",
+			rel:       "sub",
+			mode:      config.FlatMode,
+			wantLib:   "//:sub",
+			wantBin:   "//:sub_cmd",
+			wantTest:  "//:sub_test",
+			wantXTest: "//:sub_xtest",
+		}, {
+			name:      "deep_flat",
+			rel:       "sub/deep",
+			mode:      config.FlatMode,
+			wantLib:   "//:sub/deep",
+			wantBin:   "//:sub/deep_cmd",
+			wantTest:  "//:sub/deep_test",
+			wantXTest: "//:sub/deep_xtest",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &config.Config{StructureMode: tc.mode}
+			l := NewLabeler(c)
+
+			if got := l.LibraryLabel(tc.rel).String(); got != tc.wantLib {
+				t.Errorf("for library in %s: got %q ; want %q", tc.rel, got, tc.wantLib)
+			}
+			if got := l.BinaryLabel(tc.rel).String(); got != tc.wantBin {
+				t.Errorf("for binary in %s: got %q ; want %q", tc.rel, got, tc.wantBin)
+			}
+			if got := l.TestLabel(tc.rel, false).String(); got != tc.wantTest {
+				t.Errorf("for test in %s: got %q ; want %q", tc.rel, got, tc.wantTest)
+			}
+			if got := l.TestLabel(tc.rel, true).String(); got != tc.wantXTest {
+				t.Errorf("for test in %s: got %q ; want %q", tc.rel, got, tc.wantXTest)
+			}
+		})
+	}
+}

--- a/go/tools/gazelle/resolve/resolve_external_test.go
+++ b/go/tools/gazelle/resolve/resolve_external_test.go
@@ -101,7 +101,7 @@ func TestExternalResolver(t *testing.T) {
 			},
 		},
 	} {
-		l, err := r.Resolve(spec.importpath, "some/package")
+		l, err := r.Resolve(spec.importpath)
 		if err != nil {
 			t.Errorf("r.Resolve(%q) failed with %v; want success", spec.importpath, err)
 			continue
@@ -113,7 +113,8 @@ func TestExternalResolver(t *testing.T) {
 }
 
 func newStubExternalResolver(extraKnown []string) *externalResolver {
-	r := newExternalResolver(extraKnown)
+	l := NewLabeler(&config.Config{})
+	r := newExternalResolver(l, extraKnown)
 	r.repoRootForImportPath = stubRepoRootForImportPath
 	return r
 }

--- a/go/tools/gazelle/resolve/resolve_vendored.go
+++ b/go/tools/gazelle/resolve/resolve_vendored.go
@@ -15,14 +15,17 @@ limitations under the License.
 
 package resolve
 
-import "github.com/bazelbuild/rules_go/go/tools/gazelle/config"
-
 // vendoredResolver resolves external packages as packages in vendor/.
-type vendoredResolver struct{}
+type vendoredResolver struct {
+	l Labeler
+}
 
-func (v vendoredResolver) Resolve(importpath, dir string) (Label, error) {
-	return Label{
-		Pkg:  "vendor/" + importpath,
-		Name: config.DefaultLibName,
-	}, nil
+var _ Resolver = (*vendoredResolver)(nil)
+
+func newVendoredResolver(l Labeler) *vendoredResolver {
+	return &vendoredResolver{l}
+}
+
+func (v *vendoredResolver) Resolve(importpath string) (Label, error) {
+	return v.l.LibraryLabel("vendor/" + importpath), nil
 }

--- a/go/tools/gazelle/rules/generator_test.go
+++ b/go/tools/gazelle/rules/generator_test.go
@@ -24,8 +24,8 @@ import (
 	bf "github.com/bazelbuild/buildtools/build"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/config"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/packages"
-	"github.com/bazelbuild/rules_go/go/tools/gazelle/rules"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/resolve"
+	"github.com/bazelbuild/rules_go/go/tools/gazelle/rules"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/testdata"
 )
 
@@ -57,7 +57,8 @@ func TestGenerator(t *testing.T) {
 	repoRoot := filepath.Join(testdata.Dir(), "repo")
 	goPrefix := "example.com/repo"
 	c := testConfig(repoRoot, goPrefix)
-	r := resolve.NewLabelResolver(c)
+	l := resolve.NewLabeler(c)
+	r := resolve.NewResolver(c, l)
 
 	var dirs []string
 	err := filepath.Walk(repoRoot, func(path string, info os.FileInfo, err error) error {
@@ -80,7 +81,7 @@ func TestGenerator(t *testing.T) {
 		}
 
 		pkg, oldFile := packageFromDir(c, dir)
-		g := rules.NewGenerator(c, r, oldFile)
+		g := rules.NewGenerator(c, r, l, oldFile)
 		f := g.Generate(pkg)
 		got := string(bf.Format(f))
 
@@ -102,8 +103,9 @@ func TestGeneratorGoPrefixLib(t *testing.T) {
 	repoRoot := filepath.Join(testdata.Dir(), "repo", "lib")
 	goPrefix := "example.com/repo/lib"
 	c := testConfig(repoRoot, goPrefix)
-	r := resolve.NewLabelResolver(c)
-	g := rules.NewGenerator(c, r, nil)
+	l := resolve.NewLabeler(c)
+	r := resolve.NewResolver(c, l)
+	g := rules.NewGenerator(c, r, l, nil)
 	pkg, _ := packageFromDir(c, repoRoot)
 	f := g.Generate(pkg)
 
@@ -116,8 +118,9 @@ func TestGeneratorGoPrefixRoot(t *testing.T) {
 	repoRoot := filepath.Join(testdata.Dir(), "repo")
 	goPrefix := "example.com/repo"
 	c := testConfig(repoRoot, goPrefix)
-	r := resolve.NewLabelResolver(c)
-	g := rules.NewGenerator(c, r, nil)
+	l := resolve.NewLabeler(c)
+	r := resolve.NewResolver(c, l)
+	g := rules.NewGenerator(c, r, l, nil)
 	pkg := &packages.Package{Dir: repoRoot}
 	f := g.Generate(pkg)
 
@@ -152,8 +155,9 @@ func testGeneratedFileName(t *testing.T, buildFileName string) {
 	c := &config.Config{
 		ValidBuildFileNames: []string{buildFileName},
 	}
-	r := resolve.NewLabelResolver(c)
-	g := rules.NewGenerator(c, r, nil)
+	l := resolve.NewLabeler(c)
+	r := resolve.NewResolver(c, l)
+	g := rules.NewGenerator(c, r, l, nil)
 	pkg := &packages.Package{}
 	f := g.Generate(pkg)
 	if f.Path != buildFileName {


### PR DESCRIPTION
This is a prerequisite for flat mode.

* Labeler is responsible for generating names for library, binary, and
  test rules in a directory described by a relative path from the
  repository root.
* Labeler has two implementations: hierarchicalLabeler is the current,
  default behavior. flatLabeler will be used in flat mode.
* Resolver resolves absolute import paths to labels. It uses Labeler
  in its implementation. The caller is now responsible for cleaning
  relative import paths.