### PR TITLE
Switching coverage to a better mechanism

### DIFF
--- a/go/private/library.bzl
+++ b/go/private/library.bzl
@@ -22,10 +22,12 @@ def emit_library_actions(ctx, srcs, deps, cgo_object, library, want_coverage, im
   direct = depset(golibs)
   gc_goopts = tuple(ctx.attr.gc_goopts)
   cgo_deps = depset()
+  cover_vars = ()
   if library:
     golib = library[GoLibrary]
     cgolib = library[CgoLibrary]
     srcs = golib.transformed + srcs
+    cover_vars += golib.cover_vars
     direct += golib.direct
     dep_runfiles += [library.data_runfiles]
     gc_goopts += golib.gc_goopts
@@ -69,10 +71,10 @@ def emit_library_actions(ctx, srcs, deps, cgo_object, library, want_coverage, im
     transitive += golib.transitive
 
   go_srcs = source.go
-  cover_vars = ()
   if want_coverage:
-    go_srcs, cover_vars = _emit_go_cover_action(ctx, go_toolchain, go_srcs)
-    
+    go_srcs, cvars = _emit_go_cover_action(ctx, go_toolchain, go_srcs)
+    cover_vars += cvars
+
   emit_go_compile_action(ctx,
       sources = go_srcs,
       golibs = direct,

--- a/go/private/library.bzl
+++ b/go/private/library.bzl
@@ -69,9 +69,10 @@ def emit_library_actions(ctx, srcs, deps, cgo_object, library, want_coverage, im
     transitive += golib.transitive
 
   go_srcs = source.go
+  cover_vars = ()
   if want_coverage:
-    go_srcs = _emit_go_cover_action(ctx, out_object, go_srcs)
-
+    go_srcs, cover_vars = _emit_go_cover_action(ctx, go_toolchain, go_srcs)
+    
   emit_go_compile_action(ctx,
       sources = go_srcs,
       golibs = direct,
@@ -114,6 +115,7 @@ def emit_library_actions(ctx, srcs, deps, cgo_object, library, want_coverage, im
           cgo_deps = cgo_deps, # The direct cgo dependancies of this library
           gc_goopts = gc_goopts, # The options this library was compiled with
           runfiles = runfiles, # The runfiles needed for things including this library
+          cover_vars = cover_vars, # The cover variables for this library
       ),
       CgoLibrary(
           object = cgo_object,
@@ -248,7 +250,7 @@ def emit_go_pack_action(ctx, out_lib, objects):
       env = go_toolchain.env,
   )
 
-def _emit_go_cover_action(ctx, out_object, sources):
+def _emit_go_cover_action(ctx, go_toolchain, sources):
   """Construct the command line for test coverage instrument.
 
   Args:
@@ -260,10 +262,9 @@ def _emit_go_cover_action(ctx, out_object, sources):
   Returns:
     A list of Go source code files which might be coverage instrumented.
   """
-  go_toolchain = get_go_toolchain(ctx)
   outputs = []
   # TODO(linuxerwang): make the mode configurable.
-  count = 0
+  cover_vars = []
 
   for src in sources:
     if (not src.basename.endswith(".go") or 
@@ -272,8 +273,9 @@ def _emit_go_cover_action(ctx, out_object, sources):
       outputs += [src]
       continue
 
-    cover_var = "GoCover_%d" % count
-    out = ctx.new_file(out_object, out_object.basename + '_' + src.basename[:-3] + '_' + cover_var + '.cover.go')
+    cover_var = "Cover_" + src.basename[:-3].replace("-", "_").replace(".", "_")
+    cover_vars += ["{}={}".format(cover_var,src.short_path)]
+    out = ctx.new_file(cover_var + '.cover.go')
     outputs += [out]
     ctx.action(
         inputs = [src] + go_toolchain.tools,
@@ -283,6 +285,5 @@ def _emit_go_cover_action(ctx, out_object, sources):
         arguments = ["tool", "cover", "--mode=set", "-var=%s" % cover_var, "-o", out.path, src.path],
         env = go_toolchain.env,
     )
-    count += 1
 
-  return outputs
+  return outputs, tuple(cover_vars)

--- a/go/private/test.bzl
+++ b/go/private/test.bzl
@@ -41,21 +41,30 @@ def _go_test_impl(ctx):
   else:
     run_dir = pkg_dir(ctx.label.workspace_root, ctx.label.package)
 
-  go_srcs = list(split_srcs(golib.transformed).go)
+  go_srcs = list(split_srcs(golib.srcs).go)
   main_go = ctx.new_file(ctx.label.name + "_main_test.go")
+  arguments = [
+      '--package',
+      golib.importpath,
+      '--rundir',
+      run_dir,
+      '--output',
+      main_go.path,
+  ]
+  cover_vars = []
+  covered_libs = []
+  for golib in depset([golib]) + golib.transitive:
+    if golib.cover_vars:
+        covered_libs += [golib]
+        for var in golib.cover_vars:
+            arguments += ["-cover", "{}={}".format(var, golib.importpath)]
+
   ctx.action(
       inputs = go_srcs,
       outputs = [main_go],
       mnemonic = "GoTestGenTest",
       executable = go_toolchain.test_generator,
-      arguments = [
-          '--package',
-          golib.importpath,
-          '--rundir',
-          run_dir,
-          '--output',
-          main_go.path,
-      ] + [src.path for src in go_srcs],
+      arguments = arguments + [src.path for src in go_srcs],
       env = dict(go_toolchain.env, RUNDIR=ctx.label.package)
   )
 
@@ -66,7 +75,7 @@ def _go_test_impl(ctx):
       library = None,
       want_coverage = False,
       importpath = ctx.label.name + "~testmain~",
-      golibs = [golib],
+      golibs = [golib] + covered_libs,
   )
 
   mode = ""

--- a/go/private/test.bzl
+++ b/go/private/test.bzl
@@ -55,9 +55,9 @@ def _go_test_impl(ctx):
   covered_libs = []
   for golib in depset([golib]) + golib.transitive:
     if golib.cover_vars:
-        covered_libs += [golib]
-        for var in golib.cover_vars:
-            arguments += ["-cover", "{}={}".format(var, golib.importpath)]
+      covered_libs += [golib]
+      for var in golib.cover_vars:
+        arguments += ["-cover", "{}={}".format(var, golib.importpath)]
 
   ctx.action(
       inputs = go_srcs,

--- a/go/tools/builders/BUILD
+++ b/go/tools/builders/BUILD
@@ -48,6 +48,7 @@ go_tool_binary(
     name = "generate_test_main",
     srcs = [
         "filter.go",
+        "flags.go",
         "generate_test_main.go",
     ],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
This works by tracking all coverage variables from the full transitive dependacy
set, which allows multiple packages to be covered at once.
This also normalises the names of cover variables so that two separate covers of
the same file will produce actions that merge.
It also tracks the cover variables directly, rather than inferring them from the
file names, which also means the test generator does not need to process the
generated files.

@linuxerwang you might want to check these changes, as it's based heavily on the work you did.