### PR TITLE
Gazelle: prepare rules.Generator for flat mode

### DIFF
--- a/go/tools/gazelle/gazelle/main.go
+++ b/go/tools/gazelle/gazelle/main.go
@@ -104,7 +104,7 @@ func run(c *config.Config, cmd command, emit emitFunc) {
 }
 
 func processPackage(c *config.Config, r resolve.Resolver, l resolve.Labeler, shouldFix bool, emit emitFunc, pkg *packages.Package, oldFile *bf.File) {
-	g := rules.NewGenerator(c, r, l, oldFile)
+	g := rules.NewGenerator(c, r, l, pkg.Rel, oldFile)
 	genFile := g.Generate(pkg)
 
 	if oldFile == nil {

--- a/go/tools/gazelle/resolve/resolve_structured.go
+++ b/go/tools/gazelle/resolve/resolve_structured.go
@@ -18,8 +18,6 @@ package resolve
 import (
 	"fmt"
 	"strings"
-
-	"github.com/bazelbuild/rules_go/go/tools/gazelle/config"
 )
 
 // structuredResolver resolves go_library labels within the same repository as
@@ -34,15 +32,13 @@ var _ Resolver = (*structuredResolver)(nil)
 // Resolve takes a Go importpath within the same respository as r.goPrefix
 // and resolves it into a label in Bazel.
 func (r *structuredResolver) Resolve(importpath string) (Label, error) {
-	if importpath == r.goPrefix {
-		return Label{Name: config.DefaultLibName}, nil
+	relImportpath := ""
+	if importpath != r.goPrefix {
+		prefix := r.goPrefix + "/"
+		relImportpath = strings.TrimPrefix(importpath, prefix)
+		if relImportpath == importpath {
+			return Label{}, fmt.Errorf("importpath %q does not start with goPrefix %q", importpath, r.goPrefix)
+		}
 	}
-
-	prefix := r.goPrefix + "/"
-	relImportpath := strings.TrimPrefix(importpath, prefix)
-	if relImportpath == importpath {
-		return Label{}, fmt.Errorf("importpath %q does not start with goPrefix %q", importpath, r.goPrefix)
-	}
-
 	return r.l.LibraryLabel(relImportpath), nil
 }

--- a/go/tools/gazelle/rules/construct.go
+++ b/go/tools/gazelle/rules/construct.go
@@ -35,7 +35,7 @@ type globvalue struct {
 	excludes []string
 }
 
-func newRule(kind string, args []interface{}, kwargs []keyvalue) *bf.Rule {
+func newRule(kind string, args []interface{}, kwargs []keyvalue) *bf.CallExpr {
 	var list []bf.Expr
 	for _, arg := range args {
 		list = append(list, newValue(arg))
@@ -49,11 +49,9 @@ func newRule(kind string, args []interface{}, kwargs []keyvalue) *bf.Rule {
 		})
 	}
 
-	return &bf.Rule{
-		Call: &bf.CallExpr{
-			X:    &bf.LiteralExpr{Token: kind},
-			List: list,
-		},
+	return &bf.CallExpr{
+		X:    &bf.LiteralExpr{Token: kind},
+		List: list,
 	}
 }
 

--- a/go/tools/gazelle/rules/generator.go
+++ b/go/tools/gazelle/rules/generator.go
@@ -34,19 +34,36 @@ type Generator interface {
 	// contains rules for each non-empty target in "pkg". It also contains
 	// "load" statements necessary for the rule constructors. If this is the
 	// top-level package in the repository, the file will contain a
-	// "go_prefix" rule.
+	// "go_prefix" rule. This is a convenience method for the other methods
+	// in this interface.
 	Generate(pkg *packages.Package) *bf.File
+
+	// GeneratePrefix generates a go_prefix rule. This should be in the
+	// top-level build file for the repository.
+	GeneratePrefix() bf.Expr
+
+	// GenerateRules generates a list of rules for targets in "pkg".
+	GenerateRules(pkg *packages.Package) []bf.Expr
+
+	// GenerateLoad generates a load statement for the symbols referenced
+	// in "stmts". Returns nil if rules is empty.
+	GenerateLoad(stmts []bf.Expr) bf.Expr
 }
 
-func NewGenerator(c *config.Config, r resolve.Resolver, l resolve.Labeler, oldFile *bf.File) Generator {
+// NewGenerator returns a new instance of Generator.
+// "buildRel" is a slash-separated path to the directory containing the
+// build file being generated, relative to the repository root.
+// "oldFile" is the existing build file. May be nil.
+func NewGenerator(c *config.Config, r resolve.Resolver, l resolve.Labeler, buildRel string, oldFile *bf.File) Generator {
 	shouldSetVisibility := oldFile == nil || !hasDefaultVisibility(oldFile)
-	return &generator{c: c, r: r, l: l, shouldSetVisibility: shouldSetVisibility}
+	return &generator{c: c, r: r, l: l, buildRel: buildRel, shouldSetVisibility: shouldSetVisibility}
 }
 
 type generator struct {
 	c                   *config.Config
 	r                   resolve.Resolver
 	l                   resolve.Labeler
+	buildRel            string
 	shouldSetVisibility bool
 }
 
@@ -54,22 +71,21 @@ func (g *generator) Generate(pkg *packages.Package) *bf.File {
 	f := &bf.File{
 		Path: filepath.Join(pkg.Dir, g.c.DefaultBuildFileName()),
 	}
-	rs := g.generateRules(pkg)
-	if load := g.generateLoad(rs); load != nil {
-		f.Stmt = append(f.Stmt, load)
+	f.Stmt = append(f.Stmt, nil) // reserve space for load
+	if pkg.Rel == "" {
+		f.Stmt = append(f.Stmt, g.GeneratePrefix())
 	}
-	for _, r := range rs {
-		f.Stmt = append(f.Stmt, r.Call)
-	}
+	f.Stmt = append(f.Stmt, g.GenerateRules(pkg)...)
+	f.Stmt[0] = g.GenerateLoad(f.Stmt[1:])
 	return f
 }
 
-func (g *generator) generateRules(pkg *packages.Package) []*bf.Rule {
-	var rules []*bf.Rule
-	if pkg.Rel == "" {
-		rules = append(rules, newRule("go_prefix", []interface{}{g.c.GoPrefix}, nil))
-	}
+func (g *generator) GeneratePrefix() bf.Expr {
+	return newRule("go_prefix", []interface{}{g.c.GoPrefix}, nil)
+}
 
+func (g *generator) GenerateRules(pkg *packages.Package) []bf.Expr {
+	var rules []bf.Expr
 	library, r := g.generateLib(pkg)
 	if r != nil {
 		rules = append(rules, r)
@@ -94,7 +110,40 @@ func (g *generator) generateRules(pkg *packages.Package) []*bf.Rule {
 	return rules
 }
 
-func (g *generator) generateBin(pkg *packages.Package, library string) *bf.Rule {
+func (g *generator) GenerateLoad(stmts []bf.Expr) bf.Expr {
+	loadableKinds := []string{
+		// keep sorted
+		"go_binary",
+		"go_library",
+		"go_prefix",
+		"go_test",
+	}
+
+	kinds := make(map[string]bool)
+	for _, s := range stmts {
+		if c, ok := s.(*bf.CallExpr); ok {
+			r := bf.Rule{c}
+			kinds[r.Kind()] = true
+		}
+	}
+	args := make([]bf.Expr, 0, len(kinds)+1)
+	args = append(args, &bf.StringExpr{Value: config.RulesGoDefBzlLabel})
+	for _, k := range loadableKinds {
+		if kinds[k] {
+			args = append(args, &bf.StringExpr{Value: k})
+		}
+	}
+	if len(args) == 1 {
+		return nil
+	}
+	return &bf.CallExpr{
+		X:            &bf.LiteralExpr{Token: "load"},
+		List:         args,
+		ForceCompact: true,
+	}
+}
+
+func (g *generator) generateBin(pkg *packages.Package, library string) bf.Expr {
 	if !pkg.IsCommand() || pkg.Binary.Sources.IsEmpty() && library == "" {
 		return nil
 	}
@@ -103,7 +152,7 @@ func (g *generator) generateBin(pkg *packages.Package, library string) *bf.Rule 
 	return g.generateRule(pkg.Rel, "go_binary", name, visibility, library, false, pkg.Binary)
 }
 
-func (g *generator) generateLib(pkg *packages.Package) (string, *bf.Rule) {
+func (g *generator) generateLib(pkg *packages.Package) (string, bf.Expr) {
 	if !pkg.Library.HasGo() {
 		return "", nil
 	}
@@ -152,7 +201,7 @@ func checkInternalVisibility(rel, visibility string) string {
 // filegroup is a small hack for directories with pre-generated .pb.go files
 // and also source .proto files.  This creates a filegroup for the .proto in
 // addition to the usual go_library for the .pb.go files.
-func (g *generator) filegroup(pkg *packages.Package) *bf.Rule {
+func (g *generator) filegroup(pkg *packages.Package) bf.Expr {
 	if !pkg.HasPbGo || len(pkg.Protos) == 0 {
 		return nil
 	}
@@ -163,7 +212,7 @@ func (g *generator) filegroup(pkg *packages.Package) *bf.Rule {
 	})
 }
 
-func (g *generator) generateTest(pkg *packages.Package, library string) *bf.Rule {
+func (g *generator) generateTest(pkg *packages.Package, library string) bf.Expr {
 	if !pkg.Test.HasGo() {
 		return nil
 	}
@@ -172,7 +221,7 @@ func (g *generator) generateTest(pkg *packages.Package, library string) *bf.Rule
 	return g.generateRule(pkg.Rel, "go_test", name, "", library, pkg.HasTestdata, pkg.Test)
 }
 
-func (g *generator) generateXTest(pkg *packages.Package, library string) *bf.Rule {
+func (g *generator) generateXTest(pkg *packages.Package, library string) bf.Expr {
 	if !pkg.XTest.HasGo() {
 		return nil
 	}
@@ -181,26 +230,27 @@ func (g *generator) generateXTest(pkg *packages.Package, library string) *bf.Rul
 	return g.generateRule(pkg.Rel, "go_test", name, "", "", pkg.HasTestdata, pkg.XTest)
 }
 
-func (g *generator) generateRule(rel, kind, name, visibility, library string, hasTestdata bool, target packages.Target) *bf.Rule {
+func (g *generator) generateRule(pkgRel, kind, name, visibility, library string, hasTestdata bool, target packages.Target) bf.Expr {
 	// Construct attrs in the same order that bf.Rewrite uses. See
 	// namePriority in github.com/bazelbuild/buildtools/build/rewrite.go.
 	attrs := []keyvalue{
 		{"name", name},
 	}
 	if !target.Sources.IsEmpty() {
-		attrs = append(attrs, keyvalue{"srcs", target.Sources})
+		attrs = append(attrs, keyvalue{"srcs", g.sources(target.Sources, pkgRel)})
 	}
 	if !target.CLinkOpts.IsEmpty() {
-		attrs = append(attrs, keyvalue{"clinkopts", target.CLinkOpts})
+		attrs = append(attrs, keyvalue{"clinkopts", g.options(target.CLinkOpts, pkgRel)})
 	}
 	if !target.COpts.IsEmpty() {
-		attrs = append(attrs, keyvalue{"copts", target.COpts})
+		attrs = append(attrs, keyvalue{"copts", g.options(target.COpts, pkgRel)})
 	}
 	if target.Cgo {
 		attrs = append(attrs, keyvalue{"cgo", true})
 	}
 	if hasTestdata {
-		glob := globvalue{patterns: []string{"testdata/**"}}
+		rel := g.buildPkgRel(pkgRel)
+		glob := globvalue{patterns: []string{path.Join(rel, "testdata/**")}}
 		attrs = append(attrs, keyvalue{"data", glob})
 	}
 	if library != "" {
@@ -210,52 +260,54 @@ func (g *generator) generateRule(rel, kind, name, visibility, library string, ha
 		attrs = append(attrs, keyvalue{"visibility", []string{visibility}})
 	}
 	if !target.Imports.IsEmpty() {
-		deps := g.dependencies(target.Imports, rel)
+		deps := g.dependencies(target.Imports, pkgRel)
 		attrs = append(attrs, keyvalue{"deps", deps})
 	}
 	return newRule(kind, nil, attrs)
 }
 
-func (g *generator) generateLoad(rs []*bf.Rule) bf.Expr {
-	loadableKinds := []string{
-		// keep sorted
-		"go_binary",
-		"go_library",
-		"go_prefix",
-		"go_test",
+// sources converts paths in "srcs" which are relative to the Go package
+// directory ("pkgRel") into relative paths to the build file
+// being generated ("g.buildRel").
+func (g *generator) sources(srcs packages.PlatformStrings, pkgRel string) packages.PlatformStrings {
+	if g.buildRel == pkgRel {
+		return srcs
 	}
-
-	kinds := make(map[string]bool)
-	for _, r := range rs {
-		kinds[r.Kind()] = true
-	}
-	args := make([]bf.Expr, 0, len(kinds)+1)
-	args = append(args, &bf.StringExpr{Value: config.RulesGoDefBzlLabel})
-	for _, k := range loadableKinds {
-		if kinds[k] {
-			args = append(args, &bf.StringExpr{Value: k})
-		}
-	}
-	if len(args) == 1 {
-		return nil
-	}
-	return &bf.CallExpr{
-		X:            &bf.LiteralExpr{Token: "load"},
-		List:         args,
-		ForceCompact: true,
-	}
+	rel := g.buildPkgRel(pkgRel)
+	srcs, _ = srcs.Map(func(s string) (string, error) {
+		return path.Join(rel, s), nil
+	})
+	return srcs
 }
 
-func (g *generator) dependencies(imports packages.PlatformStrings, dir string) packages.PlatformStrings {
+// buildPkgRel returns the relative slash-separated path from the directory
+// containing the build file (g.buildRel) to the Go package directory (pkgRel).
+// pkgRel must start with g.buildRel.
+func (g *generator) buildPkgRel(pkgRel string) string {
+	if g.buildRel == pkgRel {
+		return ""
+	}
+	if g.buildRel == "" {
+		return pkgRel
+	}
+	rel := strings.TrimPrefix(pkgRel, g.buildRel+"/")
+	if rel == pkgRel {
+		log.Panicf("relative path to go package %s must start with relative path to Bazel package %s", pkgRel, g.buildRel)
+	}
+	return rel
+}
+
+// dependencies converts import paths in "imports" into Bazel labels.
+func (g *generator) dependencies(imports packages.PlatformStrings, pkgRel string) packages.PlatformStrings {
 	resolve := func(imp string) (string, error) {
 		if strings.HasPrefix(imp, "./") || strings.HasPrefix(imp, "..") {
-			imp = path.Clean(path.Join(g.c.GoPrefix, dir, imp))
+			imp = path.Clean(path.Join(g.c.GoPrefix, pkgRel, imp))
 		}
 		label, err := g.r.Resolve(imp)
 		if err != nil {
-			return "", fmt.Errorf("in dir %q, could not resolve import path %q: %v", dir, imp, err)
+			return "", fmt.Errorf("in dir %q, could not resolve import path %q: %v", pkgRel, imp, err)
 		}
-		label.Relative = label.Repo == "" && label.Pkg == dir
+		label.Relative = label.Repo == "" && label.Pkg == g.buildRel
 		return label.String(), nil
 	}
 
@@ -265,4 +317,12 @@ func (g *generator) dependencies(imports packages.PlatformStrings, dir string) p
 	}
 	deps.Clean()
 	return deps
+}
+
+func (g *generator) options(opts packages.PlatformStrings, rel string) packages.PlatformStrings {
+	// TODO(jayconrod): paths in options (for example, include directories) should
+	// be interpreted relative to the Go package. If the Go package is different
+	// than the Bazel package (as it may be in flat mode), these paths will not
+	// be correct. We should adjust them here, but they are difficult to identify.
+	return opts
 }

--- a/go/tools/gazelle/rules/generator_test.go
+++ b/go/tools/gazelle/rules/generator_test.go
@@ -81,7 +81,7 @@ func TestGenerator(t *testing.T) {
 		}
 
 		pkg, oldFile := packageFromDir(c, dir)
-		g := rules.NewGenerator(c, r, l, oldFile)
+		g := rules.NewGenerator(c, r, l, rel, oldFile)
 		f := g.Generate(pkg)
 		got := string(bf.Format(f))
 
@@ -105,7 +105,7 @@ func TestGeneratorGoPrefixLib(t *testing.T) {
 	c := testConfig(repoRoot, goPrefix)
 	l := resolve.NewLabeler(c)
 	r := resolve.NewResolver(c, l)
-	g := rules.NewGenerator(c, r, l, nil)
+	g := rules.NewGenerator(c, r, l, "", nil)
 	pkg, _ := packageFromDir(c, repoRoot)
 	f := g.Generate(pkg)
 
@@ -120,7 +120,7 @@ func TestGeneratorGoPrefixRoot(t *testing.T) {
 	c := testConfig(repoRoot, goPrefix)
 	l := resolve.NewLabeler(c)
 	r := resolve.NewResolver(c, l)
-	g := rules.NewGenerator(c, r, l, nil)
+	g := rules.NewGenerator(c, r, l, "", nil)
 	pkg := &packages.Package{Dir: repoRoot}
 	f := g.Generate(pkg)
 
@@ -157,7 +157,7 @@ func testGeneratedFileName(t *testing.T, buildFileName string) {
 	}
 	l := resolve.NewLabeler(c)
 	r := resolve.NewResolver(c, l)
-	g := rules.NewGenerator(c, r, l, nil)
+	g := rules.NewGenerator(c, r, l, "", nil)
 	pkg := &packages.Package{}
 	f := g.Generate(pkg)
 	if f.Path != buildFileName {


### PR DESCRIPTION
* GeneratePrefix, GenerateRules, and GenerateLoad are now separate
  methods. Generate is a convenience method that calls them together.
* generator has a new property, buildRel, the path from the repository
  root to the directory containing the build file. In flat mode, this
  will be different from pkg.Rel.

This is a prerequisite for flat mode.