### PR TITLE
importpath for binaries

### DIFF
--- a/go/private/binary.bzl
+++ b/go/private/binary.bzl
@@ -19,7 +19,7 @@ load("@io_bazel_rules_go//go/private:common.bzl",
   "NORMAL_MODE",
   "RACE_MODE",
 )
-load("@io_bazel_rules_go//go/private:library.bzl", "emit_library_actions", "get_library", "get_searchpath")
+load("@io_bazel_rules_go//go/private:library.bzl", "emit_library_actions", "go_importpath", "get_library", "get_searchpath")
 load("@io_bazel_rules_go//go/private:providers.bzl", "GoLibrary", "GoBinary")
 
 def _go_binary_impl(ctx):
@@ -30,7 +30,7 @@ def _go_binary_impl(ctx):
       cgo_object = None,
       library = ctx.attr.library,
       want_coverage = False,
-      importpath = ctx.label.name + "~main~",
+      importpath = go_importpath(ctx),
   )
 
   # Default (dynamic) linking
@@ -64,6 +64,7 @@ def _go_binary_impl(ctx):
   )
 
   return [
+      golib,
       GoBinary(
           executable = ctx.outputs.executable,
           static = static_executable,

--- a/go/private/library.bzl
+++ b/go/private/library.bzl
@@ -81,8 +81,8 @@ def emit_library_actions(ctx, srcs, deps, cgo_object, library, want_coverage, im
   lib_name = importpath + ".a"
   mode_fields = {} # These are added to the GoLibrary provider directly
   for mode in compile_modes:
-    out_lib = ctx.new_file("~{}~/{}".format(mode, lib_name))
-    out_object = ctx.new_file("~{}~/{}.o".format(mode, importpath))
+    out_lib = ctx.new_file("~{}~{}~/{}".format(mode, ctx.label.name, lib_name))
+    out_object = ctx.new_file("~{}~{}~/{}.o".format(mode, ctx.label.name, importpath))
     searchpath = out_lib.path[:-len(lib_name)]
     mode_fields[mode+"_library"] = out_lib
     mode_fields[mode+"_searchpath"] = searchpath
@@ -199,7 +199,7 @@ def go_importpath(ctx):
     path = path[:-1]
   if ctx.label.package:
     path += "/" + ctx.label.package
-  if ctx.label.name != DEFAULT_LIB:
+  if ctx.label.name != DEFAULT_LIB and not path.endswith(ctx.label.name):
     path += "/" + ctx.label.name
   if path.rfind(VENDOR_PREFIX) != -1:
     path = path[len(VENDOR_PREFIX) + path.rfind(VENDOR_PREFIX):]


### PR DESCRIPTION
This produces a better fake import path for binaries.
This becomes important because I am using the import path when building the fake GOPATH