### PR TITLE
Gazelle: simplify rule generation

### DIFF
--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -76,8 +76,10 @@ def go_repositories(
   # Needed for gazelle and wtool
   native.http_archive(
       name = "com_github_bazelbuild_buildtools",
-      url = "https://codeload.github.com/bazelbuild/buildtools/zip/d5dcc29f2304aa28c29ecb8337d52bb9de908e0c",
-      strip_prefix = "buildtools-d5dcc29f2304aa28c29ecb8337d52bb9de908e0c",
+      # master, as of 14 Aug 2017
+      url = "https://codeload.github.com/bazelbuild/buildtools/zip/799e530642bac55de7e76728fa0c3161484899f6",
+      strip_prefix = "buildtools-799e530642bac55de7e76728fa0c3161484899f6",
+      sha256 = "ea23bbec9e86205b71ef647e1755ae0ec400aa76aeb5d13913d3fc3a37afbb5f",
       type = "zip",
   )
 

--- a/go/tools/gazelle/rules/BUILD
+++ b/go/tools/gazelle/rules/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//go/tools/gazelle/packages:go_default_library",
         "//go/tools/gazelle/resolve:go_default_library",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
+        "@com_github_bazelbuild_buildtools//tables:go_default_library",
         "@org_golang_x_tools//go/vcs:go_default_library",
     ],
 )

--- a/go/tools/gazelle/rules/construct.go
+++ b/go/tools/gazelle/rules/construct.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 
 	bf "github.com/bazelbuild/buildtools/build"
+	bt "github.com/bazelbuild/buildtools/tables"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/packages"
 )
 
@@ -155,38 +156,8 @@ func (s byAttrName) Len() int {
 	return len(s)
 }
 
-// namePriority is the sort order for rule attributes.
-// Copied from github.com/bazelbuild/buildifier/build/rewrite.go
-var namePriority = map[string]int{
-	"name":              -99,
-	"gwt_name":          -98,
-	"package_name":      -97,
-	"visible_node_name": -96, // for boq_initial_css_modules and boq_jswire_test_suite
-	"size":              -95,
-	"timeout":           -94,
-	"testonly":          -93,
-	"src":               -92,
-	"srcdir":            -91,
-	"srcs":              -90,
-	"out":               -89,
-	"outs":              -88,
-	"hdrs":              -87,
-	"has_services":      -86, // before api versions, for proto
-	"include":           -85, // before exclude, for glob
-	"of":                -84, // for check_dependencies
-	"baseline":          -83, // for searchbox_library
-	// All others sort here, at 0.
-	"destdir":        1,
-	"exports":        2,
-	"runtime_deps":   3,
-	"deps":           4,
-	"implementation": 5,
-	"implements":     6,
-	"alwayslink":     7,
-}
-
 func (s byAttrName) Less(i, j int) bool {
-	if cmp := namePriority[s[i].key] - namePriority[s[j].key]; cmp != 0 {
+	if cmp := bt.NamePriority[s[i].key] - bt.NamePriority[s[j].key]; cmp != 0 {
 		return cmp < 0
 	}
 	return s[i].key < s[j].key

--- a/go/tools/gazelle/testdata/repo/cgolib/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/cgolib/BUILD.want
@@ -9,9 +9,9 @@ go_library(
         "foo.c",
         "foo.h",
     ],
+    cgo = True,
     clinkopts = ["-lweird"],
     copts = ["-I/weird/path"],
-    cgo = True,
     visibility = ["//visibility:public"],
     deps = [
         "//lib/deep:go_default_library",

--- a/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/BUILD.want
@@ -16,6 +16,7 @@ go_library(
         ],
         "//conditions:default": [],
     }),
+    cgo = True,
     clinkopts = ["-lweird"],
     copts = [
         "-I/weird/path",
@@ -31,7 +32,6 @@ go_library(
         ],
         "//conditions:default": [],
     }),
-    cgo = True,
     visibility = ["//visibility:public"],
     deps = [
         "//lib/deep:go_default_library",

--- a/go/tools/gazelle/testdata/repo/platforms/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/platforms/BUILD.want
@@ -28,6 +28,7 @@ go_library(
         ],
         "//conditions:default": [],
     }),
+    cgo = True,
     copts = [
         "-DGENERIC",
     ] + select({
@@ -36,7 +37,6 @@ go_library(
         ],
         "//conditions:default": [],
     }),
-    cgo = True,
     visibility = ["//visibility:public"],
     deps = [
         "//platforms/generic:go_default_library",


### PR DESCRIPTION
* Replace generator.generateRule with commonAttrs, which just returns
  []keyvalue containing attributes relevant for all rules. Other
  methods add kind-specific attributes to this, then call newRule
  directly.
* newRule sorts attributes using the same order as buildifier.