### PR TITLE
Gazelle: flat mode

### DIFF
--- a/go/tools/gazelle/gazelle/integration_test.go
+++ b/go/tools/gazelle/gazelle/integration_test.go
@@ -530,6 +530,190 @@ go_library(
 	})
 }
 
+func TestFlatExternal(t *testing.T) {
+	files := []fileSpec{
+		{path: "WORKSPACE"},
+		{
+			path:    "a.go",
+			content: `package foo`,
+		}, {
+			path:    "b/b.go",
+			content: `package b`,
+		}, {
+			path:    "b/b_test.go",
+			content: `package b`,
+		}, {
+			path: "b/b_x_test.go",
+			content: `package b_test
+
+import _ "example.com/foo/b"
+`,
+		}, {
+			path: "b/testdata/",
+		}, {
+			path:    "b/deep/deep.go",
+			content: `package deep`,
+		}, {
+			path: "c/c.go",
+			content: `package main
+
+import (
+  _ "example.com/foo"
+  _ "example.com/foo/b"
+  _ "example.com/foo/b/deep"
+  _ "golang.org/x/tools/go/ssa"
+)
+`,
+		},
+	}
+	dir, err := createFiles(files)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	args := []string{"-go_prefix", "example.com/foo", "-experimental_flat"}
+	if err := runGazelle(dir, args); err != nil {
+		t.Fatal(err)
+	}
+
+	checkFiles(t, dir, []fileSpec{
+		{
+			path: config.DefaultValidBuildFileNames[0],
+			content: `load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_prefix", "go_test")
+
+go_prefix("example.com/foo")
+
+go_library(
+    name = "foo",
+    srcs = ["a.go"],
+    importpath = "example.com/foo",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "b",
+    srcs = ["b/b.go"],
+    importpath = "example.com/foo/b",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "b_test",
+    srcs = ["b/b_test.go"],
+    data = glob(["b/testdata/**"]),
+    library = ":b",
+    rundir = "b",
+)
+
+go_test(
+    name = "b_xtest",
+    srcs = ["b/b_x_test.go"],
+    data = glob(["b/testdata/**"]),
+    rundir = "b",
+    deps = [":b"],
+)
+
+go_library(
+    name = "b/deep",
+    srcs = ["b/deep/deep.go"],
+    importpath = "example.com/foo/b/deep",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "c",
+    srcs = ["c/c.go"],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":b",
+        ":b/deep",
+        ":foo",
+        "@org_golang_x_tools//:go/ssa",
+    ],
+)
+
+go_binary(
+    name = "c_cmd",
+    library = ":c",
+    visibility = ["//visibility:public"],
+)
+`,
+		},
+	})
+}
+
+func TestFlatVendored(t *testing.T) {
+	files := []fileSpec{
+		{path: "WORKSPACE"},
+		{
+			path: "foo.go",
+			content: `package foo
+
+import (
+  _ "github.com/jr_hacker/stuff/a"
+  _ "github.com/jr_hacker/stuff/a/b"
+)
+`,
+		}, {
+			path: "vendor/github.com/jr_hacker/stuff/a/a.go",
+			content: `package a
+
+import _ "github.com/jr_hacker/stuff/a/b"
+`,
+		}, {
+			path:    "vendor/github.com/jr_hacker/stuff/a/b/b.go",
+			content: "package b",
+		},
+	}
+	dir, err := createFiles(files)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	args := []string{"-go_prefix", "example.com/foo", "-experimental_flat", "-external", "vendored"}
+	if err := runGazelle(dir, args); err != nil {
+		t.Fatal(err)
+	}
+
+	checkFiles(t, dir, []fileSpec{
+		{
+			path: config.DefaultValidBuildFileNames[0],
+			content: `load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_prefix")
+
+go_prefix("example.com/foo")
+
+go_library(
+    name = "foo",
+    srcs = ["foo.go"],
+    importpath = "example.com/foo",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":vendor/github.com/jr_hacker/stuff/a",
+        ":vendor/github.com/jr_hacker/stuff/a/b",
+    ],
+)
+
+go_library(
+    name = "vendor/github.com/jr_hacker/stuff/a",
+    srcs = ["vendor/github.com/jr_hacker/stuff/a/a.go"],
+    importpath = "github.com/jr_hacker/stuff/a",
+    visibility = ["//visibility:public"],
+    deps = [":vendor/github.com/jr_hacker/stuff/a/b"],
+)
+
+go_library(
+    name = "vendor/github.com/jr_hacker/stuff/a/b",
+    srcs = ["vendor/github.com/jr_hacker/stuff/a/b/b.go"],
+    importpath = "github.com/jr_hacker/stuff/a/b",
+    visibility = ["//visibility:public"],
+)
+`,
+		},
+	})
+}
+
 // TODO(jayconrod): more tests
 //   run in fix mode in testdata directories to create new files
 //   run in diff mode in testdata directories to update existing files (no change)


### PR DESCRIPTION
When given the -experimental_flat flag on the command line, Gazelle
will generate a single BUILD.bazel file at the top of the repository
that contains rules for everything in the repository.

This flag is intended to be used on external repositories. Files
generated with this flag may be checked in and used with
new_git_repository or new_http_archive. We hope to eventually remove
go_repository.

Related to #460