### PR TITLE
Make .bzl files compatible with future versions of Bazel

### DIFF
--- a/go/private/cgo.bzl
+++ b/go/private/cgo.bzl
@@ -34,7 +34,7 @@ def _mangle(ctx, src):
 
 def _cgo_codegen_impl(ctx):
   go_toolchain = get_go_toolchain(ctx)
-  linkopts = ctx.attr.linkopts
+  linkopts = ctx.attr.linkopts[:]
   copts = ctx.fragments.cpp.c_options + ctx.attr.copts
   deps = depset([], order="topological")
   cgo_export_h = ctx.new_file(ctx.attr.out_dir + "/_cgo_export.h")
@@ -256,7 +256,7 @@ def setup_cgo_library(name, srcs, cdeps, copts, clinkopts):
   base_dir = pkg_dir(
       "external/" + REPOSITORY_NAME[1:] if len(REPOSITORY_NAME) > 1 else "",
       PACKAGE_NAME)
-  copts += ["-I", base_dir]
+  copts = copts + ["-I", base_dir]
 
   cgo_codegen_name = name + ".cgo_codegen"
   _cgo_codegen_rule(

--- a/proto/go_proto_library.bzl
+++ b/proto/go_proto_library.bzl
@@ -331,9 +331,9 @@ def go_proto_repositories(shared = 1):
     # if using multiple *_proto_library, allows caller to skip this.
     native.http_archive(
         name = "com_github_google_protobuf",
-        url = "https://github.com/google/protobuf/archive/v3.3.0.tar.gz",
-        strip_prefix = "protobuf-3.3.0",
-        sha256 = "94c414775f275d876e5e0e4a276527d155ab2d0da45eed6b7734301c330be36e",
+        url = "https://github.com/google/protobuf/archive/v3.4.0.tar.gz",
+        strip_prefix = "protobuf-3.4.0",
+        sha256 = "cd55ee08e64a86cf12aaadd4672961813f592c194ed0c9ad94da0ec75acf219f",
     )
 
   # Needed for gRPC, only loaded by bazel if used


### PR DESCRIPTION
In Bazel 0.6 the `+=` operator on lists will have mutating semantics instead of copying. Some .bzl files have to be updated to be compatible with both semantics.

Protobuf is updated for the same reason.