### PR TITLE
Add go_path rule

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "gazelle", "go_prefix")
+load("@io_bazel_rules_go//go:def.bzl", "gazelle", "go_prefix", "go_path")
 load("@io_bazel_rules_go//go/private:lines_sorted_test.bzl", "lines_sorted_test")
 load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_google_protobuf")
 
@@ -28,3 +28,21 @@ gazelle(
 
 # This could be any file, used as an anchor point for the directory in tests
 exports_files(["README.md"])
+
+go_path(
+    name = "all_srcs",
+    deps = [
+        "//go/tools/builders:asm",
+        "//go/tools/builders:compile",
+        "//go/tools/builders:embed",
+        "//go/tools/builders:filter_tags",
+        "//go/tools/builders:generate_test_main",
+        "//go/tools/builders:link",
+        "//go/tools/builders:cgo",
+        "//go/tools/builders:md5sum",
+        "//go/tools/gazelle/gazelle:gazelle",
+        "//go/tools/fetch_repo:fetch_repo",
+        "//go/tools/wtool:wtool",
+    ],
+    tags = ["manual"],
+)

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -26,6 +26,9 @@ load("@io_bazel_rules_go//go/private:wrappers.bzl",
     _go_binary_macro = "go_binary_macro",
     _go_test_macro = "go_test_macro",
 )
+load("@io_bazel_rules_go//go/private:path.bzl", 
+  _go_path = "go_path",
+)
 
 GoLibrary = _GoLibrary
 """
@@ -113,6 +116,11 @@ go_test = _go_test_macro
         "cdeps": attr.label_list(), # TODO: Would be nicer to be able to filter deps instead
         "copts": attr.string_list(), # Options for the the c compiler
         "clinkopts": attr.string_list(), # Options for the linker
+"""
+
+go_path = _go_path
+"""
+    go_path 
 """
 
 

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -120,7 +120,10 @@ go_test = _go_test_macro
 
 go_path = _go_path
 """
-    go_path 
+    go_path is a rule for creating `go build` compatible file layouts from a set of Bazel.
+    targets.
+        "deps": attr.label_list(providers=[GoLibrary]), # The set of go libraries to include the export
+        "mode": attr.string(default="link", values=["link", "copy"]) # Whether to copy files or produce soft links
 """
 
 

--- a/go/private/go_tool_binary.bzl
+++ b/go/private/go_tool_binary.bzl
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 load('//go/private:go_toolchain.bzl', 'toolchain_type', 'ConstraintValueInfo', 'go_toolchain_core_attrs')
+load("@io_bazel_rules_go//go/private:providers.bzl", "GoLibrary")
+load("@io_bazel_rules_go//go/private:library.bzl", "go_importpath")
 
 go_bootstrap_toolchain_type = toolchain_type()
 
@@ -46,13 +48,23 @@ def _go_tool_binary_impl(ctx):
           "GOROOT": toolchain.root,
       },
   )
+  return [
+      GoLibrary(
+          label = ctx.label,
+          importpath = go_importpath(ctx),
+          srcs = depset(ctx.files.srcs),
+          transitive = (),
+      ),
+  ]
 
 go_tool_binary = rule(
     _go_tool_binary_impl,
     attrs = {
         "srcs": attr.label_list(allow_files = FileType([".go"])),
+        "importpath": attr.string(),
         #TODO(toolchains): Remove toolchain attribute when we switch to real toolchains
         "_go_toolchain": attr.label(default = Label("@io_bazel_rules_go_toolchain//:bootstrap_toolchain")),
+        "_go_prefix": attr.label(default=Label("//:go_prefix", relative_to_caller_repository = True)),
     },
     executable = True,
 )

--- a/go/private/library.bzl
+++ b/go/private/library.bzl
@@ -108,6 +108,7 @@ def emit_library_actions(ctx, srcs, deps, cgo_object, library, want_coverage, im
 
   return [
       GoLibrary(
+          label = ctx.label,
           importpath = importpath, # The import path for this library
           direct = direct, # The direct depencancies of the library
           transitive = transitive, # The transitive set of go libraries depended on

--- a/go/private/path.bzl
+++ b/go/private/path.bzl
@@ -1,0 +1,101 @@
+# Copyright 2014 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go/private:providers.bzl", "GoLibrary", "GoPath")
+
+def _go_path_impl(ctx):
+  print("""
+EXPERIMENTAL: the go_path rule is still very experimental
+Please do not rely on it for production use, but feel free to use it and file issues
+""")
+  # First gather all the library rules
+  golibs = depset()
+  for dep in ctx.attr.deps:
+    golib = dep[GoLibrary]
+    golibs += [golib]
+    golibs += golib.transitive
+  seen_libs = {}
+  seen_paths = {}
+
+  # Now scan them for sources
+  outputs = depset()
+  packages = []
+  for golib in golibs:
+    if golib.importpath in seen_libs:
+      # We found two different library rules that map to the same import path
+      # This is legal in bazel, but we can't build a valid go path for it.
+      # TODO: we might be able to ignore this if the content is identical
+      print("""Duplicate package
+Found {} in
+  {}
+and
+  {}
+""".format(golib.importpath, golib.label, seen_libs[golib.importpath].label))
+      # for now we don't fail if we see duplicate packages
+      # the most common case is the same source from two different workspaces
+      continue
+    seen_libs[golib.importpath] = golib
+    package_files = []
+    outdir = "{}/src/{}".format(ctx.label.name, golib.importpath)
+    for src in golib.srcs:
+      outpath = "{}/{}".format(outdir, src.basename)
+      if outpath in seen_paths:
+        # If we see the same path twice, it's a fatal error
+        fail("Duplicate path {}".format(outpath))
+      seen_paths[outpath] = True
+      out = ctx.new_file(outpath)
+      package_files += [out]
+      outputs += [out]
+      if ctx.attr.mode == "copy":
+        ctx.template_action(template=src, output=out, substitutions={})
+      elif ctx.attr.mode == "link":
+        ctx.action(
+            command="ln -s $(realpath $1) $2",
+            arguments=[src.path, out.path],
+            inputs=[src],
+            outputs=[out],
+        )
+      else:
+        fail("Invalid go path mode '{}'".format(ctx.attr.mode))
+    packages += [struct(
+      golib = golib,
+      dir = outdir,
+      files = package_files,
+    )]
+  envscript = ctx.new_file("{}/setenv.sh".format(ctx.label.name))
+  gopath = envscript.short_path[:-len(envscript.basename)]
+  #TODO: also set the GOROOT, need new toolchains first
+  ctx.file_action(envscript, content="""
+export GOPATH={gopath}
+""".format(
+  gopath = gopath,
+))
+  return [
+      DefaultInfo(
+          files = outputs + [envscript],
+      ),
+      GoPath(
+        gopath = gopath,
+        packages = packages,
+        srcs = outputs,
+      )
+  ]
+
+go_path = rule(
+  _go_path_impl,
+  attrs = {
+      "deps": attr.label_list(providers=[GoLibrary]),
+      "mode": attr.string(default="link", values=["link", "copy"])
+  },
+)

--- a/go/private/path.bzl
+++ b/go/private/path.bzl
@@ -13,22 +13,24 @@
 # limitations under the License.
 
 load("@io_bazel_rules_go//go/private:providers.bzl", "GoLibrary", "GoPath")
+load("@io_bazel_rules_go//go/private:common.bzl", "get_go_toolchain")
 
 def _go_path_impl(ctx):
   print("""
 EXPERIMENTAL: the go_path rule is still very experimental
 Please do not rely on it for production use, but feel free to use it and file issues
 """)
+  go_toolchain = get_go_toolchain(ctx)
   # First gather all the library rules
   golibs = depset()
   for dep in ctx.attr.deps:
     golib = dep[GoLibrary]
     golibs += [golib]
     golibs += golib.transitive
-  seen_libs = {}
-  seen_paths = {}
 
   # Now scan them for sources
+  seen_libs = {}
+  seen_paths = {}
   outputs = depset()
   packages = []
   for golib in golibs:
@@ -61,7 +63,7 @@ and
         ctx.template_action(template=src, output=out, substitutions={})
       elif ctx.attr.mode == "link":
         ctx.action(
-            command="ln -s $(realpath $1) $2",
+            command='ln -s $(realpath "$1") "$2"',
             arguments=[src.path, out.path],
             inputs=[src],
             outputs=[out],
@@ -74,13 +76,14 @@ and
       files = package_files,
     )]
   envscript = ctx.new_file("{}/setenv.sh".format(ctx.label.name))
-  gopath = envscript.short_path[:-len(envscript.basename)]
-  #TODO: also set the GOROOT, need new toolchains first
+  gopath, _, _ = envscript.short_path.rpartition("/")
   ctx.file_action(envscript, content="""
-export GOPATH={gopath}
+export GOROOT="{goroot}"
+export GOPATH=$(realpath "{gopath}")
 """.format(
-  gopath = gopath,
-))
+      goroot=go_toolchain.root.path,
+      gopath = gopath,
+  ))
   return [
       DefaultInfo(
           files = outputs + [envscript],
@@ -93,9 +96,10 @@ export GOPATH={gopath}
   ]
 
 go_path = rule(
-  _go_path_impl,
-  attrs = {
-      "deps": attr.label_list(providers=[GoLibrary]),
-      "mode": attr.string(default="link", values=["link", "copy"])
-  },
+    _go_path_impl,
+    attrs = {
+        "deps": attr.label_list(providers=[GoLibrary]),
+        "mode": attr.string(default="link", values=["link", "copy"]),
+        "_go_toolchain": attr.label(default = Label("@io_bazel_rules_go_toolchain//:go_toolchain")),
+    },
 )

--- a/go/private/providers.bzl
+++ b/go/private/providers.bzl
@@ -15,3 +15,4 @@
 GoLibrary = provider()
 GoBinary = provider()
 CgoLibrary = provider()
+GoPath = provider()

--- a/go/tools/fetch_repo/BUILD
+++ b/go/tools/fetch_repo/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 go_binary(
     name = "fetch_repo",
     library = ":go_default_library",
+    visibility = ["//visibility:public"],
 )
 
 go_library(


### PR DESCRIPTION
This is used to produce a GOPATH like export of the transitive set of sources
used to build specific targets.
You can run it in either copy or link mode.
Link mode allows tools that mutate the original source to run as well