### PR TITLE
Make go_prefix optional

### DIFF
--- a/go/private/binary.bzl
+++ b/go/private/binary.bzl
@@ -13,13 +13,19 @@
 # limitations under the License.
 
 load("@io_bazel_rules_go//go/private:common.bzl",
-  "get_go_toolchain",
-  "go_filetype",
-  "compile_modes",
-  "NORMAL_MODE",
-  "RACE_MODE",
+    "NORMAL_MODE",
+    "RACE_MODE",
+    "compile_modes",
+    "get_go_toolchain",
+    "go_filetype",
 )
-load("@io_bazel_rules_go//go/private:library.bzl", "emit_library_actions", "go_importpath", "get_library", "get_searchpath")
+load("@io_bazel_rules_go//go/private:library.bzl",
+    "emit_library_actions",
+    "get_library",
+    "get_searchpath",
+    "go_importpath",
+    "go_prefix_default",
+)
 load("@io_bazel_rules_go//go/private:providers.bzl", "GoLibrary", "GoBinary")
 
 def _go_binary_impl(ctx):
@@ -97,10 +103,7 @@ go_binary = rule(
         "x_defs": attr.string_dict(),
         #TODO(toolchains): Remove _toolchain attribute when real toolchains arrive
         "_go_toolchain": attr.label(default = Label("@io_bazel_rules_go_toolchain//:go_toolchain")),
-        "_go_prefix": attr.label(default = Label(
-            "//:go_prefix",
-            relative_to_caller_repository = True,
-        )),
+        "_go_prefix": attr.label(default = go_prefix_default),
     },
     executable = True,
     fragments = ["cpp"],

--- a/go/private/library.bzl
+++ b/go/private/library.bzl
@@ -160,6 +160,11 @@ def _go_library_impl(ctx):
       ),
   ]
 
+def go_prefix_default(importpath):
+  return (None
+          if importpath
+          else Label("//:go_prefix", relative_to_caller_repository = True))
+
 go_library = rule(
     _go_library_impl,
     attrs = {
@@ -177,7 +182,7 @@ go_library = rule(
         ),
         #TODO(toolchains): Remove _toolchain attribute when real toolchains arrive
         "_go_toolchain": attr.label(default = Label("@io_bazel_rules_go_toolchain//:go_toolchain")),
-        "_go_prefix": attr.label(default=Label("//:go_prefix", relative_to_caller_repository = True)),
+        "_go_prefix": attr.label(default = go_prefix_default),
     },
     fragments = ["cpp"],
 )

--- a/go/private/test.bzl
+++ b/go/private/test.bzl
@@ -20,7 +20,13 @@ load("@io_bazel_rules_go//go/private:common.bzl",
     "NORMAL_MODE",
     "RACE_MODE",
 )
-load("@io_bazel_rules_go//go/private:library.bzl", "emit_library_actions", "go_importpath", "emit_go_compile_action", "emit_go_pack_action")
+load("@io_bazel_rules_go//go/private:library.bzl",
+    "emit_go_compile_action",
+    "emit_go_pack_action",
+    "emit_library_actions",
+    "go_importpath",
+    "go_prefix_default",
+)
 load("@io_bazel_rules_go//go/private:binary.bzl", "emit_go_link_action", "gc_linkopts")
 load("@io_bazel_rules_go//go/private:providers.bzl", "GoLibrary", "GoBinary")
 
@@ -131,10 +137,7 @@ go_test = rule(
         "x_defs": attr.string_dict(),
         #TODO(toolchains): Remove _toolchain attribute when real toolchains arrive
         "_go_toolchain": attr.label(default = Label("@io_bazel_rules_go_toolchain//:go_toolchain")),
-        "_go_prefix": attr.label(default = Label(
-            "//:go_prefix",
-            relative_to_caller_repository = True,
-        )),
+        "_go_prefix": attr.label(default = go_prefix_default),
     },
     executable = True,
     fragments = ["cpp"],

--- a/tests/no_prefix/BUILD
+++ b/tests/no_prefix/BUILD
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@io_bazel_rules_go//tests:bazel_tests.bzl", "bazel_test")
+
+bazel_test(
+    name = "no_prefix",
+    command = "build",
+    target = "//:go_default_library //:go_default_xtest //:cmd",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["no_prefix.go"],
+    importpath = "github.com/bazelbuild/rules_go/tests/no_prefix",
+)
+
+go_test(
+    name = "go_default_xtest",
+    srcs = ["no_prefix_test.go"],
+    deps = [":go_default_library"],
+    importpath = "github.com/bazelbuild/rules_go/tests/no_prefix_test",
+)
+
+go_binary(
+    name = "cmd",
+    srcs = ["cmd.go"],
+    deps = [":go_default_library"],
+    importpath = "github.com/bazelbuild/rules_go/tests/no_prefix/cmd",
+)

--- a/tests/no_prefix/cmd.go
+++ b/tests/no_prefix/cmd.go
@@ -1,0 +1,6 @@
+package main
+
+import _ "github.com/bazelbuild/rules_go/tests/no_prefix"
+
+func main() {
+}

--- a/tests/no_prefix/no_prefix.go
+++ b/tests/no_prefix/no_prefix.go
@@ -1,0 +1,1 @@
+package no_prefix

--- a/tests/no_prefix/no_prefix_test.go
+++ b/tests/no_prefix/no_prefix_test.go
@@ -1,0 +1,3 @@
+package no_prefix_test
+
+import _ "github.com/bazelbuild/rules_go/tests/no_prefix"


### PR DESCRIPTION
go_prefix is used to generate Go import paths from Bazel labels. Until
now, it has been mandatory, since there's an implicit dependency from
all go_library, go_binary, and go_test rules on //:go_prefix. With
this change, that dependency is not present when the importpath
attribute is specified. This means that if all of the Go rules in a
repository specify importpath, there's no need to define a go_prefix
rule in the repository root.

Fixes #720
Related #721