### PR TITLE
Gazelle: transform paths in cgo options

### DIFF
--- a/go/tools/gazelle/packages/fileinfo_test.go
+++ b/go/tools/gazelle/packages/fileinfo_test.go
@@ -540,12 +540,12 @@ import "C"
 			fileInfo{
 				isCgo: true,
 				copts: []taggedOpts{
-					{opts: "-O0"},
-					{opts: "-O1"},
-					{opts: "-O2"},
+					{opts: []string{"-O0"}},
+					{opts: []string{"-O1"}},
+					{opts: []string{"-O2"}},
 				},
 				clinkopts: []taggedOpts{
-					{opts: "-O3 -O4"},
+					{opts: []string{"-O3", "-O4"}},
 				},
 			},
 		},
@@ -561,7 +561,7 @@ import "C"
 			fileInfo{
 				isCgo: true,
 				copts: []taggedOpts{
-					{tags: "foo bar,!baz", opts: "-O0"},
+					{tags: "foo bar,!baz", opts: []string{"-O0"}},
 				},
 			},
 		},
@@ -576,8 +576,8 @@ import "C"
 			fileInfo{
 				isCgo: true,
 				copts: []taggedOpts{
-					{opts: "-O0"},
-					{opts: "-O1"},
+					{opts: []string{"-O0"}},
+					{opts: []string{"-O1"}},
 				},
 			},
 		},
@@ -593,7 +593,7 @@ import ("C")
 			fileInfo{
 				isCgo: true,
 				copts: []taggedOpts{
-					{opts: "-O0"},
+					{opts: []string{"-O0"}},
 				},
 			},
 		},
@@ -727,6 +727,30 @@ func TestShellSafety(t *testing.T) {
 		}
 		if output != test.expected {
 			t.Errorf("Expected %q while %q expands with SRCDIR=%q; got %q", test.expected, test.input, test.srcdir, output)
+		}
+	}
+}
+
+func TestJoinOptions(t *testing.T) {
+	for _, tc := range []struct {
+		opts, want []string
+	}{
+		{
+			opts: nil,
+			want: nil,
+		}, {
+			opts: []string{"a", "b", optSeparator},
+			want: []string{"a b"},
+		}, {
+			opts: []string{`a\`, `b'`, `c"`, `d `, optSeparator},
+			want: []string{`a\\ b\' c\" d\ `},
+		}, {
+			opts: []string{"a", "b", optSeparator, "c", optSeparator},
+			want: []string{"a b", "c"},
+		},
+	} {
+		if got := JoinOptions(tc.opts); !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("JoinOptions(%#v): got %#v ; want %#v", tc.opts, got, tc.want)
 		}
 	}
 }

--- a/go/tools/gazelle/testdata/repo/cgolib/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/cgolib/BUILD.want
@@ -11,7 +11,7 @@ go_library(
     ],
     cgo = True,
     clinkopts = ["-lweird"],
-    copts = ["-I/weird/path"],
+    copts = ["-I/weird/path -iquotecgolib/sub"],
     visibility = ["//visibility:public"],
     deps = [
         "//lib/deep:go_default_library",

--- a/go/tools/gazelle/testdata/repo/cgolib/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/cgolib/BUILD.want
@@ -11,7 +11,10 @@ go_library(
     ],
     cgo = True,
     clinkopts = ["-lweird"],
-    copts = ["-I/weird/path -iquotecgolib/sub"],
+    copts = [
+        "-I/weird/path -Icgolib/sub",
+        "-I cgolib/sub -iquote cgolib/sub",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "//lib/deep:go_default_library",

--- a/go/tools/gazelle/testdata/repo/cgolib/foo.go
+++ b/go/tools/gazelle/testdata/repo/cgolib/foo.go
@@ -16,7 +16,8 @@ limitations under the License.
 package cgolib
 
 /**
-#cgo CFLAGS: -I/weird/path -iquotesub/../sub
+#cgo CFLAGS: -I/weird/path -Isub/../sub
+#cgo CFLAGS: -I sub/../sub -iquote sub/../sub
 #cgo LDFLAGS: -lweird
 **/
 import "C"

--- a/go/tools/gazelle/testdata/repo/cgolib/foo.go
+++ b/go/tools/gazelle/testdata/repo/cgolib/foo.go
@@ -16,7 +16,7 @@ limitations under the License.
 package cgolib
 
 /**
-#cgo CFLAGS: -I/weird/path
+#cgo CFLAGS: -I/weird/path -iquotesub/../sub
 #cgo LDFLAGS: -lweird
 **/
 import "C"


### PR DESCRIPTION
generator.options now transforms package-relative paths in cgo options
into repo-root relative paths.