### PR TITLE
Gazelle: Fix substitution of ${SRCDIR} in cgo directives

### DIFF
--- a/go/tools/gazelle/packages/walk.go
+++ b/go/tools/gazelle/packages/walk.go
@@ -171,7 +171,7 @@ func buildPackage(c *config.Config, dir string, oldFile *bf.File, goFiles, genGo
 	packageMap := make(map[string]*Package)
 	cgo := false
 	for _, goFile := range goFiles {
-		info, err := goFileInfo(c, dir, goFile)
+		info, err := goFileInfo(c, dir, rel, goFile)
 		if err != nil {
 			log.Print(err)
 			continue
@@ -215,7 +215,7 @@ func buildPackage(c *config.Config, dir string, oldFile *bf.File, goFiles, genGo
 			// Explicitly excluded or found a static file with the same name.
 			continue
 		}
-		info := fileNameInfo(dir, goFile)
+		info := fileNameInfo(dir, rel, goFile)
 		err := pkg.addFile(c, info, false)
 		if err != nil {
 			log.Print(err)
@@ -224,7 +224,7 @@ func buildPackage(c *config.Config, dir string, oldFile *bf.File, goFiles, genGo
 
 	// Process the other files.
 	for _, file := range otherFiles {
-		info, err := otherFileInfo(dir, file)
+		info, err := otherFileInfo(dir, rel, file)
 		if err != nil {
 			log.Print(err)
 			continue


### PR DESCRIPTION
"go build replaces ${SRCDIR} in cgo directives with the absolute
path of the source directory. Gazelle did the same thing when
extracting copts from source files. This caused builds to be
non-hermetic when the path was used in defines.

With this change, ${SRCDIR} is replaced with the relative path from
the repo root. This will probably break some projects, requiring some
manual tweaking of BUILD files, but hermeticity is more important.

Fixes #704