### PR TITLE
Add debug compile flags

### DIFF
--- a/go/private/BUILD
+++ b/go/private/BUILD
@@ -1,5 +1,32 @@
+load("@io_bazel_rules_go//go/private:go_toolchain.bzl", "go_toolchain_flags")
+
 filegroup(
     name = "all_rules",
     srcs = glob(["*.bzl"]) + ["//go/private/tools:all_rules"],
     visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "fastbuild",
+    values = {"compilation_mode": "fastbuild"}
+)
+
+config_setting(
+    name = "debug",
+    values = {"compilation_mode": "dbg"}
+)
+
+config_setting(
+    name = "optimized",
+    values = {"compilation_mode": "opt"}
+)
+
+go_toolchain_flags(
+    name = "go_toolchain_flags",
+    compile_flags = select({
+        "@io_bazel_rules_go//go/private:fastbuild": [],
+        "@io_bazel_rules_go//go/private:debug": ["-N", "-l"],
+        "@io_bazel_rules_go//go/private:optimized": [],
+    }),
+    visibility = ["@io_bazel_rules_go//go/toolchain:__subpackages__"],
 )

--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -70,6 +70,7 @@ def _go_toolchain_impl(ctx):
       cgo = ctx.executable.cgo,
       test_generator = ctx.executable.test_generator,
       extract_package = ctx.executable.extract_package,
+      compile_flags = ctx.attr._go_toolchain_flags.compile_flags,
       link_flags = ctx.attr.link_flags,
       cgo_link_flags = ctx.attr.cgo_link_flags,
       crosstool = ctx.files.crosstool,
@@ -100,6 +101,7 @@ go_toolchain_attrs = go_toolchain_core_attrs + {
     "link_flags": attr.string_list(default=[]),
     "cgo_link_flags": attr.string_list(default=[]),
     "crosstool": attr.label(default=Label("//tools/defaults:crosstool")),
+    "_go_toolchain_flags": attr.label(default=Label("@io_bazel_rules_go//go/private:go_toolchain_flags")),
 }
 
 go_toolchain = rule(
@@ -114,3 +116,15 @@ Args:
   target_compatible_with: The set of constraints for the outputs built with this toolchain.
   go: The location of the `go` binary.
 """
+
+def _go_toolchain_flags(ctx):
+    return struct(
+        compile_flags = ctx.attr.compile_flags,
+    )
+
+go_toolchain_flags = rule(
+    _go_toolchain_flags,
+    attrs = {
+        "compile_flags": attr.string_list(mandatory=True),
+    },
+)

--- a/go/private/library.bzl
+++ b/go/private/library.bzl
@@ -243,7 +243,7 @@ def emit_go_compile_action(ctx, sources, golibs, mode, out_object, gc_goopts):
     args += ["-dep", golib.importpath]
     args += ["-I", get_searchpath(golib,mode)]
   args += ["-o", out_object.path, "-trimpath", ".", "-I", "."]
-  args += ["--"] + gc_goopts + cgo_sources
+  args += ["--"] + gc_goopts + go_toolchain.compile_flags + cgo_sources
   ctx.action(
       inputs = list(inputs),
       outputs = [out_object],


### PR DESCRIPTION
Triggered when -c dbg is specified on the hazel command line.
Turns of inlining and optimizations
Fixes #741