### PR TITLE
Isolate access to the cpp fragment

### DIFF
--- a/go/private/cgo.bzl
+++ b/go/private/cgo.bzl
@@ -32,12 +32,8 @@ def _mangle(ctx, src):
     return mangled_stem, src_ext 
 
 def _c_filter_options(options, blacklist):
-  filtered = []
-  for opt in options:
-    if any([opt.startswith(prefix) for prefix in blacklist]):
-      continue
-    filtered.append(opt)
-  return filtered
+  return [opt for opt in options
+        if not any([opt.startswith(prefix) for prefix in blacklist])]
 
 def _cgo_codegen_impl(ctx):
   go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:toolchain"]

--- a/go/private/cgo.bzl
+++ b/go/private/cgo.bzl
@@ -14,7 +14,6 @@
 
 load("@io_bazel_rules_go//go/private:common.bzl", "dict_of", "split_srcs", "join_srcs", "pkg_dir")
 load("@io_bazel_rules_go//go/private:library.bzl", "go_library")
-load("@io_bazel_rules_go//go/private:binary.bzl", "c_linker_options")
 load("@io_bazel_rules_go//go/private:providers.bzl", "GoLibrary")
 
 def _cgo_select_go_files_impl(ctx):
@@ -32,10 +31,20 @@ def _mangle(ctx, src):
     mangled_stem = ctx.attr.out_dir + "/" + src_stem.replace('/', '_')
     return mangled_stem, src_ext 
 
+def _c_filter_options(options, blacklist):
+  filtered = []
+  for opt in options:
+    if any([opt.startswith(prefix) for prefix in blacklist]):
+      continue
+    filtered.append(opt)
+  return filtered
+
 def _cgo_codegen_impl(ctx):
   go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:toolchain"]
+  if not go_toolchain.external_linker:
+    fail("Go toolchain does not support cgo")
   linkopts = ctx.attr.linkopts[:]
-  copts = ctx.fragments.cpp.c_options + ctx.attr.copts
+  copts = go_toolchain.external_linker.c_options + ctx.attr.copts
   deps = depset([], order="topological")
   cgo_export_h = ctx.new_file(ctx.attr.out_dir + "/_cgo_export.h")
   cgo_export_c = ctx.new_file(ctx.attr.out_dir + "/_cgo_export.c")
@@ -43,7 +52,7 @@ def _cgo_codegen_impl(ctx):
   cgo_types = ctx.new_file(ctx.attr.out_dir + "/_cgo_gotypes.go")
   out_dir = cgo_main.dirname
 
-  cc = ctx.fragments.cpp.compiler_executable
+  cc = go_toolchain.external_linker.compiler_executable
   args = [go_toolchain.go.path, "-cc", str(cc), "-objdir", out_dir]
 
   c_outs = depset([cgo_export_h, cgo_export_c])
@@ -123,7 +132,6 @@ _cgo_codegen_rule = rule(
         "linkopts": attr.string_list(),
         "out_dir": attr.string(mandatory = True),
     },
-    fragments = ["cpp"],
     toolchains = ["@io_bazel_rules_go//go:toolchain"],
 )
 
@@ -162,7 +170,6 @@ _cgo_import = rule(
             mandatory = True,
         ),
     },
-    fragments = ["cpp"],
     toolchains = ["@io_bazel_rules_go//go:toolchain"],
 )
 
@@ -177,7 +184,10 @@ Args:
 
 def _cgo_object_impl(ctx):
   go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:toolchain"]
-  arguments = c_linker_options(ctx, blacklist=[
+  if not go_toolchain.external_linker:
+    fail("Go toolchain does not support cgo")
+  options = go_toolchain.external_linker.options
+  arguments = _c_filter_options(options, blacklist=[
       # never link any dependency libraries
       "-l", "-L",
       # manage flags to ld(1) by ourselves
@@ -196,11 +206,12 @@ def _cgo_object_impl(ctx):
       outputs = [ctx.outputs.out],
       mnemonic = "CGoObject",
       progress_message = "Linking %s" % ctx.outputs.out.short_path,
-      executable = ctx.fragments.cpp.compiler_executable,
+      executable = go_toolchain.external_linker.compiler_executable,
       arguments = arguments,
   )
   runfiles = ctx.runfiles(collect_data = True)
   runfiles = runfiles.merge(ctx.attr.src.data_runfiles)
+
   return struct(
       files = depset([ctx.outputs.out]),
       cgo_obj = ctx.outputs.out,
@@ -223,7 +234,6 @@ _cgo_object = rule(
             mandatory = True,
         ),
     },
-    fragments = ["cpp"],
     toolchains = ["@io_bazel_rules_go//go:toolchain"],
 )
 

--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -105,10 +105,10 @@ go_toolchain_flags = rule(
 def _external_linker_impl(ctx):
   cpp = ctx.fragments.cpp
   features = ctx.features
-  options = cpp.compiler_options(features)
-  options += cpp.unfiltered_compiler_options(features)
-  options += cpp.link_options
-  options += cpp.mostly_static_link_options(ctx.features, False)
+  options = (cpp.compiler_options(features) +
+        cpp.unfiltered_compiler_options(features) +
+        cpp.link_options +
+        cpp.mostly_static_link_options(features, False))
   return struct(
       compiler_executable = cpp.compiler_executable,
       options = options,

--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -44,7 +44,13 @@ def _go_toolchain_impl(ctx):
       link_flags = ctx.attr.link_flags,
       cgo_link_flags = ctx.attr.cgo_link_flags,
       crosstool = ctx.files.crosstool,
+      external_linker = ctx.attr._external_linker,
   )]
+
+def _get_linker():
+  # TODO: return None if there is no cpp fragment available
+  # This is not possible right now, we need a new bazel feature
+  return Label("//go/toolchain:external_linker")
 
 go_toolchain_core_attrs = {
     "sdk": attr.string(mandatory = True),
@@ -57,6 +63,7 @@ go_toolchain_core_attrs = {
     "cgo_link_flags": attr.string_list(default=[]),
     "goos": attr.string(mandatory = True),
     "goarch": attr.string(mandatory = True),
+    "_external_linker": attr.label(default=_get_linker),
 }
 
 go_toolchain_attrs = go_toolchain_core_attrs + {
@@ -94,3 +101,25 @@ go_toolchain_flags = rule(
         "compile_flags": attr.string_list(mandatory=True),
     },
 )
+
+def _external_linker_impl(ctx):
+  cpp = ctx.fragments.cpp
+  features = ctx.features
+  options = cpp.compiler_options(features)
+  options += cpp.unfiltered_compiler_options(features)
+  options += cpp.link_options
+  options += cpp.mostly_static_link_options(ctx.features, False)
+  return struct(
+      compiler_executable = cpp.compiler_executable,
+      options = options,
+      c_options = cpp.c_options,
+  )
+
+_external_linker = rule(
+    _external_linker_impl,
+    attrs = {},
+    fragments = ["cpp"],
+)
+
+def external_linker():
+    _external_linker(name="external_linker")

--- a/go/private/test.bzl
+++ b/go/private/test.bzl
@@ -140,7 +140,6 @@ go_test = rule(
         "_go_prefix": attr.label(default = go_prefix_default),
     },
     executable = True,
-    fragments = ["cpp"],
     test = True,
     toolchains = ["@io_bazel_rules_go//go:toolchain"],
 )

--- a/go/toolchain/toolchains.bzl
+++ b/go/toolchain/toolchains.bzl
@@ -1,4 +1,4 @@
-load('//go/private:go_toolchain.bzl', 'go_toolchain')
+load('//go/private:go_toolchain.bzl', 'go_toolchain', "external_linker")
 load('//go/private:go_tool_binary.bzl', 'go_bootstrap_toolchain')
 
 def _generate_toolchains():
@@ -162,6 +162,7 @@ def register_go_toolchains():
     native.register_toolchains(_label_prefix + toolchain["name"])
 
 def declare_toolchains():
+  external_linker()
   # Use the final dictionaries to create all the toolchains
   for toolchain in _toolchains:
     if "declare" in toolchain:

--- a/go/toolchain/toolchains.bzl
+++ b/go/toolchain/toolchains.bzl
@@ -1,4 +1,4 @@
-load('//go/private:go_toolchain.bzl', 'go_toolchain', "external_linker")
+load('//go/private:go_toolchain.bzl', 'external_linker', 'go_toolchain')
 load('//go/private:go_tool_binary.bzl', 'go_bootstrap_toolchain')
 
 def _generate_toolchains():


### PR DESCRIPTION
This collects the information needed into the go toolchain, rather than
accessing the cpp fragment all over the place.
Theoretically this would make pure go cross compilation easier, in practice you
still have to set --cpu correctly, and bazel still sulks if it has no valid cc
toolchain for that cpu.