### PR TITLE
Adding info command

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "gazelle", "go_prefix", "go_path", "go_vet_test")
 load("@io_bazel_rules_go//go/private:lines_sorted_test.bzl", "lines_sorted_test")
+load("@io_bazel_rules_go//go/private:info.bzl", "go_info")
 load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_google_protobuf")
 
 go_prefix("github.com/bazelbuild/rules_go")
@@ -50,3 +51,5 @@ go_vet_test(
     name = "vet",
     data = [":all_srcs"]
 )
+
+go_info()

--- a/go/private/info.bzl
+++ b/go/private/info.bzl
@@ -1,0 +1,29 @@
+def _go_info_script_impl(ctx):
+  go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:toolchain"]
+  script_content = '\n'.join(['export {}="{}"'.format(key,go_toolchain.env[key]) for key in go_toolchain.env] + [
+    go_toolchain.go.path + " version",
+    go_toolchain.go.path + " env",
+  ])
+  script_file = ctx.new_file(ctx.label.name+".bash")
+  ctx.file_action(output=script_file, executable=True, content=script_content)
+  return struct(
+    files = depset([script_file]),
+    runfiles = ctx.runfiles([go_toolchain.go])
+  )
+
+_go_info_script = rule(
+    _go_info_script_impl,
+    attrs = {},
+    toolchains = ["@io_bazel_rules_go//go:toolchain"],
+)
+
+def go_info():
+  _go_info_script(
+      name = "go_info_script",
+      tags = ["manual"],
+  )
+  native.sh_binary(
+      name = "go_info",
+      srcs = ["go_info_script"],
+      tags = ["manual"],
+  )


### PR DESCRIPTION
This adds a special target so that

`bazel run @io_bazel_rules_go//:go_info`

Will tell you information about the go toolchain being used by the rules.
This is useful for debugging, checking cross compile platform settings or just
replicatiing the internal commands for normal shell use.