### PR TITLE
Fix the backwards-compatible go_repositories()

### DIFF
--- a/go/def.bzl
+++ b/go/def.bzl
@@ -155,7 +155,7 @@ def go_repositories(
 
   print("DEPRECATED: go_repositories has been deprecated. go_rules_dependencies installs dependencies the way nested workspaces should, and go_register_toolchains adds the toolchains")
   go_rules_dependencies()
-  if go_version is not None:
+  if go_version != None:
     go_register_toolchains(go_version=go_version)
   else:
     go_register_toolchains()

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -155,5 +155,8 @@ def go_repositories(
 
   print("DEPRECATED: go_repositories has been deprecated. go_rules_dependencies installs dependencies the way nested workspaces should, and go_register_toolchains adds the toolchains")
   go_rules_dependencies()
-  go_register_toolchains(go_version=go_version)
+  if go_version is not None:
+    go_register_toolchains(go_version=go_version)
+  else:
+    go_register_toolchains()
 


### PR DESCRIPTION
Currently if you call go_repositories(), it fails with "no matching
toolchains found", as calling go_register_toolchains(go_version=None)
overrides the default value.