### PR TITLE
Gazelle: add importpath attributes to rules

### DIFF
--- a/go/tools/gazelle/merger/merger.go
+++ b/go/tools/gazelle/merger/merger.go
@@ -32,12 +32,13 @@ const (
 
 var (
 	mergeableFields = map[string]bool{
-		"cgo":       true,
-		"clinkopts": true,
-		"copts":     true,
-		"deps":      true,
-		"library":   true,
-		"srcs":      true,
+		"cgo":        true,
+		"clinkopts":  true,
+		"copts":      true,
+		"deps":       true,
+		"importpath": true,
+		"library":    true,
+		"srcs":       true,
 	}
 )
 

--- a/go/tools/gazelle/packages/package.go
+++ b/go/tools/gazelle/packages/package.go
@@ -81,8 +81,6 @@ func (p *Package) HasGo() bool {
 // ImportPath returns the inferred Go import path for this package. This
 // is determined as follows:
 //
-// * If there is no library target or if Name is "main", "" is returned.
-//   This indicates the library cannot be imported.
 // * If "vendor" is a component in p.Rel, everything after the last "vendor"
 //   component is returned.
 // * Otherwise, prefix joined with Rel is returned.
@@ -90,10 +88,6 @@ func (p *Package) HasGo() bool {
 // TODO(jayconrod): extract canonical import paths from comments on
 // package statements.
 func (p *Package) ImportPath(prefix string) string {
-	if !p.Library.HasGo() || p.IsCommand() {
-		return ""
-	}
-
 	components := strings.Split(p.Rel, "/")
 	for i := len(components) - 1; i >= 0; i-- {
 		if components[i] == "vendor" {

--- a/go/tools/gazelle/packages/package_test.go
+++ b/go/tools/gazelle/packages/package_test.go
@@ -67,8 +67,8 @@ func TestImportPathNoLib(t *testing.T) {
 		Name: "bar",
 		Rel:  "foo/bar",
 	}
-	if got := pkg.ImportPath("example.com/repo"); got != "" {
-		t.Errorf(`got %q; want ""`, got)
+	if got, want := pkg.ImportPath("example.com/repo"), "example.com/repo/foo/bar"; got != want {
+		t.Errorf(`got %q; want %q`, got, want)
 	}
 }
 
@@ -82,8 +82,8 @@ func TestImportPathCmd(t *testing.T) {
 			},
 		},
 	}
-	if got := pkg.ImportPath("example.com/repo"); got != "" {
-		t.Errorf(`got %q; want ""`, got)
+	if got, want := pkg.ImportPath("example.com/repo"), "example.com/repo/foo/bar"; got != want {
+		t.Errorf(`got %q; want %q`, got, want)
 	}
 }
 

--- a/go/tools/gazelle/rules/generator_test.go
+++ b/go/tools/gazelle/rules/generator_test.go
@@ -99,53 +99,6 @@ func TestGenerator(t *testing.T) {
 	}
 }
 
-func TestGeneratorGoPrefixLib(t *testing.T) {
-	repoRoot := filepath.Join(testdata.Dir(), "repo", "lib")
-	goPrefix := "example.com/repo/lib"
-	c := testConfig(repoRoot, goPrefix)
-	l := resolve.NewLabeler(c)
-	r := resolve.NewResolver(c, l)
-	g := rules.NewGenerator(c, r, l, "", nil)
-	pkg, _ := packageFromDir(c, repoRoot)
-	f := g.Generate(pkg)
-
-	if got, want := findGoPrefix(f), `go_prefix("example.com/repo/lib")`; got != want {
-		t.Errorf("got %q; want %q", got, want)
-	}
-}
-
-func TestGeneratorGoPrefixRoot(t *testing.T) {
-	repoRoot := filepath.Join(testdata.Dir(), "repo")
-	goPrefix := "example.com/repo"
-	c := testConfig(repoRoot, goPrefix)
-	l := resolve.NewLabeler(c)
-	r := resolve.NewResolver(c, l)
-	g := rules.NewGenerator(c, r, l, "", nil)
-	pkg := &packages.Package{Dir: repoRoot}
-	f := g.Generate(pkg)
-
-	if got, want := findGoPrefix(f), `go_prefix("example.com/repo")`; got != want {
-		t.Errorf("got %q; want %q", got, want)
-	}
-}
-
-func findGoPrefix(f *bf.File) string {
-	for _, s := range f.Stmt {
-		c, ok := s.(*bf.CallExpr)
-		if !ok {
-			continue
-		}
-		x, ok := c.X.(*bf.LiteralExpr)
-		if !ok {
-			continue
-		}
-		if x.Token == "go_prefix" {
-			return bf.FormatString(s)
-		}
-	}
-	return ""
-}
-
 func TestGeneratedFileName(t *testing.T) {
 	testGeneratedFileName(t, "BUILD")
 	testGeneratedFileName(t, "BUILD.bazel")

--- a/go/tools/gazelle/testdata/repo/allcgolib/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/allcgolib/BUILD.want
@@ -7,6 +7,7 @@ go_library(
         "foo.c",
     ],
     cgo = True,
+    importpath = "example.com/repo/allcgolib",
     visibility = ["//visibility:public"],
     deps = ["//lib:go_default_library"],
 )
@@ -14,5 +15,6 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["foo_test.go"],
+    importpath = "example.com/repo/allcgolib",
     library = ":go_default_library",
 )

--- a/go/tools/gazelle/testdata/repo/bin/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/bin/BUILD.want
@@ -3,12 +3,14 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
+    importpath = "example.com/repo/bin",
     visibility = ["//visibility:private"],
     deps = ["//lib:go_default_library"],
 )
 
 go_binary(
     name = "bin",
+    importpath = "example.com/repo/bin",
     library = ":go_default_library",
     visibility = ["//visibility:public"],
 )

--- a/go/tools/gazelle/testdata/repo/bin_with_tests/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/bin_with_tests/BUILD.want
@@ -3,12 +3,14 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
+    importpath = "example.com/repo/bin_with_tests",
     visibility = ["//visibility:private"],
     deps = ["//lib:go_default_library"],
 )
 
 go_binary(
     name = "bin_with_tests",
+    importpath = "example.com/repo/bin_with_tests",
     library = ":go_default_library",
     visibility = ["//visibility:public"],
 )
@@ -16,5 +18,6 @@ go_binary(
 go_test(
     name = "go_default_test",
     srcs = ["bin_test.go"],
+    importpath = "example.com/repo/bin_with_tests",
     library = ":go_default_library",
 )

--- a/go/tools/gazelle/testdata/repo/cgolib/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/cgolib/BUILD.want
@@ -15,6 +15,7 @@ go_library(
         "-I/weird/path -Icgolib/sub",
         "-I cgolib/sub -iquote cgolib/sub",
     ],
+    importpath = "example.com/repo/cgolib",
     visibility = ["//visibility:public"],
     deps = [
         "//lib/deep:go_default_library",
@@ -25,5 +26,6 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["foo_test.go"],
+    importpath = "example.com/repo/cgolib",
     library = ":go_default_library",
 )

--- a/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/BUILD.want
@@ -32,6 +32,7 @@ go_library(
         ],
         "//conditions:default": [],
     }),
+    importpath = "example.com/repo/cgolib_with_build_tags",
     visibility = ["//visibility:public"],
     deps = [
         "//lib/deep:go_default_library",
@@ -42,5 +43,6 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["foo_test.go"],
+    importpath = "example.com/repo/cgolib_with_build_tags",
     library = ":go_default_library",
 )

--- a/go/tools/gazelle/testdata/repo/default_visibility/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/default_visibility/BUILD.want
@@ -3,15 +3,18 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["lib.go"],
+    importpath = "example.com/repo/default_visibility",
 )
 
 go_binary(
     name = "default_visibility",
+    importpath = "example.com/repo/default_visibility",
     library = ":go_default_library",
 )
 
 go_test(
     name = "go_default_test",
     srcs = ["a_test.go"],
+    importpath = "example.com/repo/default_visibility",
     library = ":go_default_library",
 )

--- a/go/tools/gazelle/testdata/repo/gen_and_exclude/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/gen_and_exclude/BUILD.want
@@ -14,6 +14,7 @@ go_library(
         ],
         "//conditions:default": [],
     }),
+    importpath = "example.com/repo/gen_and_exclude",
     visibility = ["//visibility:public"],
     deps = select({
         "@io_bazel_rules_go//go/platform:darwin_amd64": [

--- a/go/tools/gazelle/testdata/repo/lib/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/lib/BUILD.want
@@ -8,6 +8,7 @@ go_library(
         "asm.h",
         "asm.s",
     ],
+    importpath = "example.com/repo/lib",
     visibility = ["//visibility:public"],
     deps = ["//lib/internal/deep:go_default_library"],
 )
@@ -15,11 +16,13 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["lib_test.go"],
+    importpath = "example.com/repo/lib",
     library = ":go_default_library",
 )
 
 go_test(
     name = "go_default_xtest",
     srcs = ["lib_external_test.go"],
+    importpath = "example.com/repo/lib_test",
     deps = [":go_default_library"],
 )

--- a/go/tools/gazelle/testdata/repo/lib/internal/deep/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/lib/internal/deep/BUILD.want
@@ -3,5 +3,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["thought.go"],
+    importpath = "example.com/repo/lib/internal/deep",
     visibility = ["//lib:__subpackages__"],
 )

--- a/go/tools/gazelle/testdata/repo/lib/relativeimporter/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/lib/relativeimporter/BUILD.want
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["importer.go"],
+    importpath = "example.com/repo/lib/relativeimporter",
     visibility = ["//visibility:public"],
     deps = ["//lib/internal/deep:go_default_library"],
 )

--- a/go/tools/gazelle/testdata/repo/main_test_only/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/main_test_only/BUILD.want
@@ -3,4 +3,5 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 go_test(
     name = "go_default_test",
     srcs = ["foo_test.go"],
+    importpath = "example.com/repo/main_test_only",
 )

--- a/go/tools/gazelle/testdata/repo/platforms/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/platforms/BUILD.want
@@ -37,6 +37,7 @@ go_library(
         ],
         "//conditions:default": [],
     }),
+    importpath = "example.com/repo/platforms",
     visibility = ["//visibility:public"],
     deps = [
         "//platforms/generic:go_default_library",
@@ -61,4 +62,5 @@ go_test(
         ],
         "//conditions:default": [],
     }),
+    importpath = "example.com/repo/platforms_test",
 )

--- a/go/tools/gazelle/testdata/repo/tests_import_testdata/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/tests_import_testdata/BUILD.want
@@ -3,11 +3,13 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 go_test(
     name = "go_default_test",
     srcs = ["internal_test.go"],
+    importpath = "example.com/repo/tests_import_testdata",
     deps = ["//tests_import_testdata/testdata:go_default_library"],
 )
 
 go_test(
     name = "go_default_xtest",
     srcs = ["external_test.go"],
+    importpath = "example.com/repo/tests_import_testdata_test",
     deps = ["//tests_import_testdata/testdata:go_default_library"],
 )

--- a/go/tools/gazelle/testdata/repo/tests_with_testdata/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/tests_with_testdata/BUILD.want
@@ -4,10 +4,12 @@ go_test(
     name = "go_default_test",
     srcs = ["internal_test.go"],
     data = glob(["testdata/**"]),
+    importpath = "example.com/repo/tests_with_testdata",
 )
 
 go_test(
     name = "go_default_xtest",
     srcs = ["external_test.go"],
     data = glob(["testdata/**"]),
+    importpath = "example.com/repo/tests_with_testdata_test",
 )


### PR DESCRIPTION
* go_prefix is no longer generated. In a future change, existing
  go_prefix rules will be removed in fix mode.
* All go_library, go_test, and go_binary rules are generated with an
  importpath attribute.
* importpath is now a mergeable attribute; Gazelle will replace
  existing importpath attributes unless they have a keep comment. This
  helps keep libraries up to date after they are moved to a new
  location.

Related #721