### PR TITLE
Clean up go sdk rules

### DIFF
--- a/go/def.bzl
+++ b/go/def.bzl
@@ -23,6 +23,9 @@ load("@io_bazel_rules_go//go/private:repositories.bzl",
     "go_rules_dependencies",
     "go_register_toolchains",
 )
+load("@io_bazel_rules_go//go/private:toolchain.bzl",
+    go_sdk = "go_sdk",
+)
 load("@io_bazel_rules_go//go/private:rules/prefix.bzl", 
     "go_prefix",
 )

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -14,7 +14,7 @@
 
 # Once nested repositories work, this file should cease to exist.
 
-load("@io_bazel_rules_go//go/private:toolchain.bzl", "go_sdk_repository", "go_host_sdk_repository")
+load("@io_bazel_rules_go//go/private:toolchain.bzl", "go_sdk", "go_host_sdk")
 load("@io_bazel_rules_go//go/private:repository_tools.bzl", "go_repository_tools")
 load("@io_bazel_rules_go//go/private:go_repository.bzl", "go_repository")
 load('@io_bazel_rules_go//go/toolchain:toolchains.bzl', "go_register_toolchains")
@@ -76,14 +76,14 @@ def go_rules_dependencies():
       if name.endswith(suffix):
         name = name[:-len(suffix)]
     name = name.replace("-", "_").replace(".", "_")
-    go_sdk_repository(
+    go_sdk(
         name = name,
         url = "https://storage.googleapis.com/golang/" + filename,
         sha256 = sha256,
         strip_prefix = "go",
     )
 
-  go_host_sdk_repository(
+  go_host_sdk(
       name = "go_host_sdk",
   )
   # Needed for gazelle and wtool

--- a/go/private/toolchain.bzl
+++ b/go/private/toolchain.bzl
@@ -12,23 +12,66 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-def _go_sdk_repository_impl(ctx):
-  goroot = ctx.path(".")
-  ctx.template("BUILD.bazel", 
-    Label("@io_bazel_rules_go//go/private:BUILD.sdk.bazel"),
-    substitutions = {"{goroot}": str(goroot)}, 
-    executable = False,
-  )
+def _go_host_sdk_impl(ctx):
+  root = _detect_host_sdk(ctx)
+  _local_sdk(ctx, root)
+  _skd_build_file(ctx, root)
+
+go_host_sdk = repository_rule(_go_host_sdk_impl, environ = ["GOROOT"])
+"""go_host_sdk is a specialization of go_sdk just to add the GOROOT dependancy"""
+
+def _go_sdk_impl(ctx):
+  _skd_build_file(ctx, str(ctx.path(".")))
+  if ctx.attr.url:
+    if ctx.attr.root:
+      fail("url and root cannot both be set on go_sdk, got {} and {}".format(ctx.attr.url, ctx.attr.root))
+    _remote_sdk(ctx, ctx.attr.url, ctx.attr.strip_prefix, ctx.attr.sha256)
+  elif ctx.attr.root:
+    _local_sdk(ctx, ctx.attr.root)
+    _skd_build_file(ctx, ctx.attr.root)
+  else:
+    root = _detect_host_sdk(ctx)
+    _local_sdk(ctx, root)
+    _skd_build_file(ctx, root)
+    
+  # Build the standard library for valid cross compile platforms
+  #TODO: fix standard library cross compilation
+  if ctx.name.endswith("linux_amd64") and ctx.os.name == "linux":
+    _cross_compile_stdlib(ctx, "windows", "amd64")
+  if ctx.name.endswith("darwin_amd64") and ctx.os.name == "mac os x":
+    _cross_compile_stdlib(ctx, "linux", "amd64")
+
+go_sdk = repository_rule(
+    implementation = _go_sdk_impl, 
+    attrs = {
+        "root" : attr.string(),
+        "url" : attr.string(),
+        "strip_prefix" : attr.string(default="go"),
+        "sha256" : attr.string(),
+    },
+)
+"""
+    go_sdk is a rule for adding a new go SDK to the available set.
+    This does not make the sdk available for use directly, it needs to be exposed through a toolchain.
+    If you do not specify url or path, then it will attempt to detect the installed version of go.
+"""
+
+def _remote_sdk(ctx, url, strip_prefix, sha256):
   ctx.download_and_extract(
       url = ctx.attr.url,
       stripPrefix = ctx.attr.strip_prefix,
       sha256 = ctx.attr.sha256)
 
-  # Build the standard library for valid cross compile platforms
-  if ctx.name.endswith("linux_amd64") and ctx.os.name == "linux":
-    _cross_compile_stdlib(ctx, "windows", "amd64")
-  if ctx.name.endswith("darwin_amd64") and ctx.os.name == "mac os x":
-    _cross_compile_stdlib(ctx, "linux", "amd64")
+def _local_sdk(ctx, root):
+  for entry in ["src", "pkg", "bin"]:
+    ctx.symlink(root+"/"+entry, entry)
+
+def _skd_build_file(ctx, goroot):
+  ctx.template("BUILD.bazel", 
+    Label("@io_bazel_rules_go//go/private:BUILD.sdk.bazel"),
+    substitutions = {"{goroot}": goroot},
+    executable = False,
+  )
 
 def _cross_compile_stdlib(ctx, goos, goarch):
   env = {
@@ -52,39 +95,15 @@ def _cross_compile_stdlib(ctx, goos, goarch):
     print("failed: ", res.stderr)
     fail("go runtime cgo cross compile %s to %s-%s failed" % (ctx.name, goos, goarch))
 
-go_sdk_repository = repository_rule(
-    implementation = _go_sdk_repository_impl, 
-    attrs = {
-        "url" : attr.string(),
-        "strip_prefix" : attr.string(),
-        "sha256" : attr.string(),
-    },
-)
-
-def _go_host_sdk_repository_impl(ctx):
+def _detect_host_sdk(ctx):
   root = "@invalid@"
   if "GOROOT" in ctx.os.environ:
-    root = ctx.os.environ["GOROOT"]
-  else:
-    res = ctx.execute(["go", "env", "GOROOT"])
-    if res.return_code:
-        fail("Could not detect host go version")
-    root = res.stdout.strip()
-    if not root:
-        fail("host go version failed to report it's GOROOT")
-  ctx.template("BUILD.bazel", 
-    Label("@io_bazel_rules_go//go/private:BUILD.sdk.bazel"),
-    substitutions = {"{goroot}": root}, 
-    executable = False,
-  )
-  for entry in ["src", "pkg", "bin"]:
-    ctx.symlink(root+"/"+entry, entry)
-
-go_host_sdk_repository = repository_rule(
-    implementation = _go_host_sdk_repository_impl, 
-    attrs = {},
-    environ = [
-      "GOROOT",
-    ],
-)
+    return ctx.os.environ["GOROOT"]
+  res = ctx.execute(["go", "env", "GOROOT"])
+  if res.return_code:
+      fail("Could not detect host go version")
+  root = res.stdout.strip()
+  if not root:
+      fail("host go version failed to report it's GOROOT")
+  return root
 


### PR DESCRIPTION
They are going to become part of the public interface to allow custom
toolchains.
This simplifies that interface, and then adds the ability to specify either an
archive or an already unpacked goroot