### PR TITLE
Library as source

### DIFF
--- a/go/def.bzl
+++ b/go/def.bzl
@@ -18,6 +18,7 @@ load("@io_bazel_rules_go//go/private:go_repository.bzl",
 load("@io_bazel_rules_go//go/private:providers.bzl",
     _GoLibrary = "GoLibrary",
     _GoBinary = "GoBinary",
+    _GoEmbed = "GoEmbed",
 )
 load("@io_bazel_rules_go//go/private:repositories.bzl",
     "go_rules_dependencies",
@@ -54,6 +55,14 @@ It provides the following fields:
 GoBinary = _GoBinary
 """
 This is the provider used to expose a go binary to other rules.
+It provides the following fields:
+  TODO: List all the provider fields here
+"""
+
+GoEmbed = _GoEmbed
+"""
+This is the provider used to provide paired source and deps to a go library.
+This should generally be the provider returned by code generators.
 It provides the following fields:
   TODO: List all the provider fields here
 """

--- a/go/private/actions/library.bzl
+++ b/go/private/actions/library.bzl
@@ -21,31 +21,32 @@ load("@io_bazel_rules_go//go/private:common.bzl",
 load("@io_bazel_rules_go//go/private:providers.bzl", 
     "GoLibrary", 
     "CgoLibrary",
+    "GoEmbed",
     "library_attr",
     "searchpath_attr",
 )
 
-def emit_library(ctx, go_toolchain, srcs, deps, cgo_object, library, want_coverage, importpath, golibs=[]):
+def emit_library(ctx, go_toolchain, srcs, deps, cgo_object, embed, want_coverage, importpath, golibs=[]):
   dep_runfiles = [d.data_runfiles for d in deps]
   direct = depset(golibs)
   gc_goopts = tuple(ctx.attr.gc_goopts)
   cgo_deps = depset()
   cover_vars = ()
-  if library:
-    golib = library[GoLibrary]
-    cgolib = library[CgoLibrary]
-    srcs = golib.transformed + srcs
-    cover_vars += golib.cover_vars
-    direct += golib.direct
-    dep_runfiles += [library.data_runfiles]
-    gc_goopts += golib.gc_goopts
-    cgo_deps += golib.cgo_deps
-    if cgolib.object:
-      if cgo_object:
-        fail("go_library %s cannot have cgo_object because the package " +
-             "already has cgo_object in %s" % (ctx.label.name,
-                                               golib.name))
-      cgo_object = cgolib.object
+  for t in embed:
+    goembed = t[GoEmbed]
+    srcs = getattr(goembed, "srcs", depset()) + srcs
+    cover_vars += getattr(goembed, "cover_vars", ())
+    direct += getattr(goembed, "deps", ())
+    dep_runfiles += [t.data_runfiles]
+    gc_goopts += getattr(goembed, "gc_goopts", ())
+    cgo_deps += getattr(goembed, "cgo_deps", ())
+    if CgoLibrary in t:
+      cgolib = t[CgoLibrary]
+      if cgolib.object:
+        if cgo_object:
+          fail("go_library %s cannot have cgo_object because the package " +
+               "already has cgo_object in %s" % (ctx.label.name, cgolib.object))
+        cgo_object = cgolib.object
   source = split_srcs(srcs)
   if source.c:
     fail("c sources in non cgo rule")
@@ -111,12 +112,17 @@ def emit_library(ctx, go_toolchain, srcs, deps, cgo_object, library, want_covera
           direct = direct, # The direct depencancies of the library
           transitive = transitive, # The transitive set of go libraries depended on
           srcs = depset(srcs), # The original sources
-          transformed = join_srcs(struct(**transformed)), # The transformed sources actually compiled
+          cover_vars = cover_vars, # The cover variables for this library
+          cgo_deps = cgo_deps, # The direct cgo dependencies of this library
+          runfiles = runfiles, # The runfiles needed for things including this library
+          **mode_fields
+      ),
+      GoEmbed(
+          srcs = join_srcs(struct(**transformed)), # The transformed sources actually compiled
+          deps = direct, # The direct depencancies of the library
+          cover_vars = cover_vars, # The cover variables for these sources
           cgo_deps = cgo_deps, # The direct cgo dependencies of this library
           gc_goopts = gc_goopts, # The options this library was compiled with
-          runfiles = runfiles, # The runfiles needed for things including this library
-          cover_vars = cover_vars, # The cover variables for this library
-          **mode_fields
       ),
       CgoLibrary(
           object = cgo_object,

--- a/go/private/providers.bzl
+++ b/go/private/providers.bzl
@@ -16,6 +16,7 @@ GoLibrary = provider()
 GoBinary = provider()
 CgoLibrary = provider()
 GoPath = provider()
+GoEmbed = provider()
 
 def library_attr(mode):
   """Returns the attribute name for the library of the given mode.

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -22,17 +22,20 @@ load("@io_bazel_rules_go//go/private:common.bzl",
 load("@io_bazel_rules_go//go/private:rules/prefix.bzl",
     "go_prefix_default",
 )
-load("@io_bazel_rules_go//go/private:providers.bzl", "GoLibrary", "GoBinary")
+load("@io_bazel_rules_go//go/private:providers.bzl", "GoLibrary", "GoBinary", "GoEmbed")
 
 def _go_binary_impl(ctx):
   """go_binary_impl emits actions for compiling and linking a go executable."""
   go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:toolchain"]
-  golib, _ = go_toolchain.actions.library(ctx,
+  embed = ctx.attr.embed
+  if ctx.attr.library:
+    embed = embed + [ctx.attr.library]
+  golib, _, _ = go_toolchain.actions.library(ctx,
       go_toolchain = go_toolchain,
       srcs = ctx.files.srcs,
       deps = ctx.attr.deps,
       cgo_object = None,
-      library = ctx.attr.library,
+      embed = embed,
       want_coverage = False,
       importpath = go_importpath(ctx),
   )
@@ -97,6 +100,7 @@ go_binary = rule(
         "deps": attr.label_list(providers = [GoLibrary]),
         "importpath": attr.string(),
         "library": attr.label(providers = [GoLibrary]),
+        "embed": attr.label_list(providers = [GoEmbed]),
         "gc_goopts": attr.string_list(),
         "gc_linkopts": attr.string_list(),
         "linkstamp": attr.string(),

--- a/go/private/rules/library.bzl
+++ b/go/private/rules/library.bzl
@@ -19,7 +19,8 @@ load("@io_bazel_rules_go//go/private:common.bzl",
     "NORMAL_MODE",
 )
 load("@io_bazel_rules_go//go/private:providers.bzl", 
-    "GoLibrary", 
+    "GoLibrary",
+    "GoEmbed",
     "get_library",
 )
 load("@io_bazel_rules_go//go/private:rules/prefix.bzl",
@@ -32,19 +33,21 @@ def _go_library_impl(ctx):
   cgo_object = None
   if hasattr(ctx.attr, "cgo_object"):
     cgo_object = ctx.attr.cgo_object
-  golib, cgolib = go_toolchain.actions.library(ctx,
+  embed = ctx.attr.embed
+  if ctx.attr.library:
+    embed = embed + [ctx.attr.library]
+  golib, goembed, cgolib = go_toolchain.actions.library(ctx,
       go_toolchain = go_toolchain,
       srcs = ctx.files.srcs,
       deps = ctx.attr.deps,
       cgo_object = cgo_object,
-      library = ctx.attr.library,
+      embed = embed,
       want_coverage = ctx.coverage_instrumented(),
       importpath = go_importpath(ctx),
   )
 
   return [
-      golib,
-      cgolib,
+      golib, goembed, cgolib,
       DefaultInfo(
           files = depset([get_library(golib, NORMAL_MODE)]),
           runfiles = golib.runfiles,
@@ -62,6 +65,7 @@ go_library = rule(
         "deps": attr.label_list(providers = [GoLibrary]),
         "importpath": attr.string(),
         "library": attr.label(providers = [GoLibrary]),
+        "embed": attr.label_list(providers = [GoEmbed]),
         "gc_goopts": attr.string_list(),
         "cgo_object": attr.label(
             providers = [


### PR DESCRIPTION
This removes the concept of the "library" at the action level, instead allowing GoLibrary providers to be used as source entries.
This enables all the features by library, whilst also allowing other uses (in particular, code generators can use this mechanism to provide source and deps pairs to go library rules easily, looking at you proto...)
I would like to deprecate the library attribute in favour of this. For example
```
go_test(
    name = "go_default_test",
    size = "small",
    srcs = ["bindata_test.go"],
    library = ":go_default_library",
)
```
would become
```
go_test(
    name = "go_default_test",
    size = "small",
    srcs = [
      "bindata_test.go",
      ":go_default_library",
    ],
)
```