### PR TITLE
Compile archives (not objects) and pack extra objects only when needed

### DIFF
--- a/go/private/actions/compile.bzl
+++ b/go/private/actions/compile.bzl
@@ -20,7 +20,7 @@ load("@io_bazel_rules_go//go/private:providers.bzl",
     "get_searchpath",
 )
 
-def emit_compile(ctx, go_toolchain, sources, golibs, mode, out_object, gc_goopts):
+def emit_compile(ctx, go_toolchain, sources, golibs, mode, out_lib, gc_goopts):
   """Construct the command line for compiling Go code.
 
   Args:
@@ -29,7 +29,7 @@ def emit_compile(ctx, go_toolchain, sources, golibs, mode, out_object, gc_goopts
     golibs: a depset of representing all imported libraries.
     mode: Controls the compilation setup affecting things like enabling profilers and sanitizers.
       This must be one of the values in common.bzl#compile_modes
-    out_object: the object file that should be produced
+    out_lib: the archive file that should be produced
     gc_goopts: additional flags to pass to the compiler.
   """
 
@@ -48,11 +48,11 @@ def emit_compile(ctx, go_toolchain, sources, golibs, mode, out_object, gc_goopts
     inputs += [get_library(golib, mode)]
     args += ["-dep", golib.importpath]
     args += ["-I", get_searchpath(golib,mode)]
-  args += ["-o", out_object.path, "-trimpath", ".", "-I", "."]
+  args += ["-o", out_lib.path, "-trimpath", ".", "-I", "."]
   args += ["--"] + gc_goopts + go_toolchain.flags.compile + cgo_sources
   ctx.action(
       inputs = list(inputs),
-      outputs = [out_object],
+      outputs = [out_lib],
       mnemonic = "GoCompile",
       executable = go_toolchain.tools.compile,
       arguments = args,

--- a/go/private/actions/pack.bzl
+++ b/go/private/actions/pack.bzl
@@ -12,20 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-def emit_pack(ctx, go_toolchain, out_lib, objects):
+def emit_pack(ctx, go_toolchain, in_lib, out_lib, objects):
   """Construct the command line for packing objects together.
 
   Args:
     ctx: The skylark Context.
+    in_lib: the archive that should be copied and appended to.
     out_lib: the archive that should be produced
     objects: an iterable of object files to be added to the output archive file.
   """
+  arguments = [
+      go_toolchain.tools.go.path,
+      in_lib.path,
+      out_lib.path,
+  ] + [obj.path for obj in objects]
   ctx.action(
-      inputs = objects + go_toolchain.data.tools,
+      inputs = [in_lib] + objects + go_toolchain.data.tools,
       outputs = [out_lib],
       mnemonic = "GoPack",
-      executable = go_toolchain.tools.go,
-      arguments = ["tool", "pack", "c", out_lib.path] + [a.path for a in objects],
+      executable = go_toolchain.tools.pack,
+      arguments = arguments,
       env = go_toolchain.env,
   )
-

--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -39,27 +39,28 @@ def _go_toolchain_impl(ctx):
           pack = emit_pack,
       ),
       paths = struct(
-        root = ctx.attr.root,
+          root = ctx.attr.root,
       ),
       tools = struct(
-        go = ctx.executable.go,
-        asm = ctx.executable._asm,
-        compile = ctx.executable._compile,
-        link = ctx.executable._link,
-        cgo = ctx.executable._cgo,
-        test_generator = ctx.executable._test_generator,
-        extract_package = ctx.executable._extract_package,
+          go = ctx.executable.go,
+          asm = ctx.executable._asm,
+          compile = ctx.executable._compile,
+          pack = ctx.executable._pack,
+          link = ctx.executable._link,
+          cgo = ctx.executable._cgo,
+          test_generator = ctx.executable._test_generator,
+          extract_package = ctx.executable._extract_package,
       ),
       flags = struct(
-        compile = ctx.attr._go_toolchain_flags.compile_flags,
-        link = ctx.attr.link_flags,
-        link_cgo = ctx.attr.cgo_link_flags,
+          compile = ctx.attr._go_toolchain_flags.compile_flags,
+          link = ctx.attr.link_flags,
+          link_cgo = ctx.attr.cgo_link_flags,
       ),
       data = struct(
-        tools = ctx.files.tools,
-        stdlib = ctx.files.stdlib,
-        headers = ctx.attr.headers,
-        crosstool = ctx.files._crosstool,
+          tools = ctx.files.tools,
+          stdlib = ctx.files.stdlib,
+          headers = ctx.attr.headers,
+          crosstool = ctx.files._crosstool,
       ),
       external_linker = ctx.attr._external_linker,
   )]
@@ -78,6 +79,11 @@ def _compile(bootstrap):
   if bootstrap:
     return None
   return Label("//go/tools/builders:compile")
+
+def _pack(bootstrap):
+  if bootstrap:
+    return None
+  return Label("//go/tools/builders:pack")
 
 def _link(bootstrap):
   if bootstrap:
@@ -116,6 +122,7 @@ go_toolchain = rule(
         # Tools, missing from bootstrap toolchains
         "_asm": attr.label(allow_files = True, single_file = True, executable = True, cfg = "host", default = _asm),
         "_compile": attr.label(allow_files = True, single_file = True, executable = True, cfg = "host", default = _compile),
+        "_pack": attr.label(allow_files = True, single_file = True, executable = True, cfg = "host", default = _pack),
         "_link": attr.label(allow_files = True, single_file = True, executable = True, cfg = "host", default = _link),
         "_cgo": attr.label(allow_files = True, single_file = True, executable = True, cfg = "host", default = _cgo),
         "_test_generator": attr.label(allow_files = True, single_file = True, executable = True, cfg = "host", default = _test_generator),

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -71,3 +71,9 @@ go_tool_binary(
     ],
     visibility = ["//visibility:public"],
 )
+
+go_tool_binary(
+    name = "pack",
+    srcs = ["pack.go"],
+    visibility = ["//visibility:public"],
+)

--- a/go/tools/builders/compile.go
+++ b/go/tools/builders/compile.go
@@ -79,7 +79,7 @@ func run(args []string) error {
 	for _, path := range search {
 		goargs = append(goargs, "-I", abs(path))
 	}
-	goargs = append(goargs, "-o", *output)
+	goargs = append(goargs, "-pack", "-o", *output)
 	goargs = append(goargs, flags.Args()...)
 	goargs = append(goargs, sources...)
 	cmd := exec.Command(gotool, goargs...)

--- a/go/tools/builders/pack.go
+++ b/go/tools/builders/pack.go
@@ -1,0 +1,63 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// pack copies an .a file and appends a list of .o files to the copy using
+// go tool pack. It is invoked by the Go rules as an action.
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+)
+
+func run(args []string) error {
+	if len(args) < 4 {
+		return fmt.Errorf("Usage: pack gotool in.a out.a obj.o...")
+	}
+	gotool := args[0]
+	inArchive := args[1]
+	outArchive := args[2]
+	objects := args[3:]
+
+	if err := copyFile(inArchive, outArchive); err != nil {
+		return err
+	}
+	packArgs := append([]string{"tool", "pack", "r", outArchive}, objects...)
+	cmd := exec.Command(gotool, packArgs...)
+	return cmd.Run()
+}
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func copyFile(inPath, outPath string) error {
+	inFile, err := os.Open(inPath)
+	if err != nil {
+		return err
+	}
+	defer inFile.Close()
+	outFile, err := os.Create(outPath)
+	if err != nil {
+		return err
+	}
+	defer outFile.Close()
+	_, err = io.Copy(outFile, inFile)
+	return err
+}


### PR DESCRIPTION
The Go compiler can produce either an .a file (with -pack; contains
export data and compiled code) or an .o file (embeds export data and
compiled code). Additional .o files may be packed into an .a file.

The Go rules have not previously used -pack. We used "go tool pack c"
whether we had extra objects or not to simplify our logic. This is not
safe, since the Go compiler does not embed export data in .o files in
a format that can safely be extracted.

With this change, we always pass -pack to the compiler to produce an
.a file directly. If we have extra objects, we copy it, then append to
the copy. This is what "go build" does (minus the copy).

Fixes #769