### PR TITLE
Simplify os_arch declarations

### DIFF
--- a/go/toolchain/toolchains.bzl
+++ b/go/toolchain/toolchains.bzl
@@ -58,7 +58,6 @@ def _generate_toolchains():
         full_name += ".0"
     version_constraints = [":go"+".".join(semver[:index+1]) for index, _ in  enumerate(semver)]
     for host in version.hosts:
-      "{}_{}".format(name, host)
       if hasattr(version, "sdk"):
         distribution = version.sdk
       else:
@@ -134,7 +133,11 @@ def declare_toolchains():
           "@io_bazel_rules_go//go/toolchain:" + goos,
           "@io_bazel_rules_go//go/toolchain:" + goarch,
       ]
-      exec_constraints = ["@io_bazel_rules_go//go/toolchain:" + part for part in toolchain["host"].split("_")]
+      host_goos, _, host_goarch = toolchain["host"].partition("_")
+      exec_constraints = [
+          "@io_bazel_rules_go//go/toolchain:" + host_goos,
+          "@io_bazel_rules_go//go/toolchain:" + host_goarch,
+      ]
       go_toolchain(
           name = toolchain["impl"],
           sdk = toolchain["sdk"],

--- a/go/toolchain/toolchains.bzl
+++ b/go/toolchain/toolchains.bzl
@@ -3,81 +3,48 @@ load('//go/private:go_toolchain.bzl', 'external_linker', 'go_toolchain')
 DEFAULT_VERSION = "1.9"
 
 def _generate_toolchains():
-  # The full set of allowed os and arch combinations for the go toolchain
-  # This is the set of targets allowed, of which the set of hosts is a strict subset
-  android_arm = struct(os="android", arch="arm")
-  darwin_386 = struct(os="darwin", arch="386")
-  darwin_amd64 = struct(os="darwin", arch="amd64")
-  darwin_arm = struct(os="darwin", arch="arm")
-  darwin_arm64 = struct(os="darwin", arch="arm64")
-  dragonfly_amd64 = struct(os="dragonfly", arch="amd64")
-  freebsd_386 = struct(os="freebsd", arch="386")
-  freebsd_amd64 = struct(os="freebsd", arch="amd64")
-  freebsd_arm = struct(os="freebsd", arch="arm")
-  linux_386 = struct(os="linux", arch="386")
-  linux_amd64 = struct(os="linux", arch="amd64")
-  linux_arm = struct(os="linux", arch="arm")
-  linux_arm64 = struct(os="linux", arch="arm64")
-  linux_ppc64 = struct(os="linux", arch="ppc64")
-  linux_ppc64le = struct(os="linux", arch="ppc64le")
-  linux_mips = struct(os="linux", arch="mips")
-  linux_mipsle = struct(os="linux", arch="mipsle")
-  linux_mips64 = struct(os="linux", arch="mips64")
-  linux_mips64le = struct(os="linux", arch="mips64le")
-  netbsd_386 = struct(os="netbsd", arch="386")
-  netbsd_amd64 = struct(os="netbsd", arch="amd64")
-  netbsd_arm = struct(os="netbsd", arch="arm")
-  openbsd_386 = struct(os="openbsd", arch="386")
-  openbsd_amd64 = struct(os="openbsd", arch="amd64")
-  openbsd_arm = struct(os="openbsd", arch="arm")
-  plan9_386 = struct(os="plan9", arch="386")
-  plan9_amd64 = struct(os="plan9", arch="amd64")
-  solaris_amd64 = struct(os="solaris", arch="amd64")
-  windows_386 = struct(os="windows", arch="386")
-  windows_amd64 = struct(os="windows", arch="amd64")
-  
   # The set of acceptable hosts for each of the go versions, this is essentially the
   # set of sdk's we know how to fetch
   versions = [
       struct(
           name = "host",
           sdk = "@go_host_sdk",
-          hosts = [darwin_amd64, linux_386, linux_amd64, windows_386, windows_amd64, freebsd_386, freebsd_amd64],
+          hosts = ["darwin_amd64", "linux_386", "linux_amd64", "windows_386", "windows_amd64", "freebsd_386", "freebsd_amd64"],
       ),
       struct(
           name = "1.9",
-          hosts = [darwin_amd64, linux_386, linux_amd64, windows_386, windows_amd64, freebsd_386, freebsd_amd64],
+          hosts = ["darwin_amd64", "linux_386", "linux_amd64", "windows_386", "windows_amd64", "freebsd_386", "freebsd_amd64"],
       ),
       struct(
           name = "1.8.3",
-          hosts = [darwin_amd64, linux_386, linux_amd64, windows_386, windows_amd64, freebsd_386, freebsd_amd64],
+          hosts = ["darwin_amd64", "linux_386", "linux_amd64", "windows_386", "windows_amd64", "freebsd_386", "freebsd_amd64"],
       ),
       struct(
           name = "1.8.2",
-          hosts = [darwin_amd64, linux_amd64],
+          hosts = ["darwin_amd64", "linux_amd64"],
       ),
       struct(
           name = "1.8.1",
-          hosts = [darwin_amd64, linux_amd64],
+          hosts = ["darwin_amd64", "linux_amd64"],
       ),
       struct(
           name = "1.8",
-          hosts = [darwin_amd64, linux_amd64],
+          hosts = ["darwin_amd64", "linux_amd64"],
       ),
       struct(
           name = "1.7.6",
-          hosts = [darwin_amd64, linux_386, linux_amd64, windows_386, windows_amd64, freebsd_386, freebsd_amd64]
+          hosts = ["darwin_amd64", "linux_386", "linux_amd64", "windows_386", "windows_amd64", "freebsd_386", "freebsd_amd64"]
       ),
       struct(
           name = "1.7.5",
-          hosts = [darwin_amd64, linux_amd64],
+          hosts = ["darwin_amd64", "linux_amd64"],
       ),
   ]
   
   # The set of allowed cross compilations
   cross_targets = {
-      linux_amd64: [windows_amd64],
-      darwin_amd64: [linux_amd64],
+      "linux_amd64": ["windows_amd64"],
+      "darwin_amd64": ["linux_amd64"],
   }
 
   # Use all the above information to generate all the possible toolchains we might support
@@ -91,16 +58,15 @@ def _generate_toolchains():
         full_name += ".0"
     version_constraints = [":go"+".".join(semver[:index+1]) for index, _ in  enumerate(semver)]
     for host in version.hosts:
-      "{}_{}_{}".format(name, host.os, host.arch)
+      "{}_{}".format(name, host)
       if hasattr(version, "sdk"):
         distribution = version.sdk
       else:
-        distribution = "@go{}_{}_{}".format(name, host.os, host.arch)
+        distribution = "@go{}_{}".format(name, host)
       for target in [host] + cross_targets.get(host, []):
-        toolchain_name = "{}_{}_{}".format(full_name, host.os, host.arch)
-        is_cross = host != target
-        if is_cross:
-          toolchain_name += "_cross_" + target.os + "_" + target.arch
+        toolchain_name = "{}_{}".format(full_name, host)
+        if host != target:
+          toolchain_name += "_cross_" + target
         base = dict(
             name = toolchain_name,
             impl = toolchain_name + "-impl",
@@ -108,9 +74,6 @@ def _generate_toolchains():
             target = target,
             typ = "@io_bazel_rules_go//go:toolchain",
             sdk = distribution[1:], # We have to strip off the @
-            is_cross = is_cross,
-            exec_constraints = [":"+host.os, ":"+host.arch],
-            target_constraints = [":"+target.os, ":"+target.arch],
             version_constraints = version_constraints,
             link_flags = [],
             cgo_link_flags = [],
@@ -123,14 +86,14 @@ def _generate_toolchains():
 
   # Now we go through the generated toolchains, adding exceptions, and removing invalid combinations.
   for toolchain in toolchains:
-    if toolchain["host"].os == "darwin":
+    if "darwin" in toolchain["host"]:
       # workaround for a bug in ld(1) on Mac OS X.
       # http://lists.apple.com/archives/Darwin-dev/2006/Sep/msg00084.html
       # TODO(yugui) Remove this workaround once rules_go stops supporting XCode 7.2
       # or earlier.
       toolchain["link_flags"] += ["-s"]
       toolchain["cgo_link_flags"] += ["-shared", "-Wl,-all_load"]
-    if toolchain["host"].os == "linux":
+    if "linux" in toolchain["host"]:
       toolchain["cgo_link_flags"] += ["-Wl,-whole-archive"]
 
   return toolchains
@@ -166,20 +129,26 @@ def declare_toolchains():
   # Use the final dictionaries to create all the toolchains
   for toolchain in _toolchains:
     if "default" not in toolchain:
+      goos, _, goarch = toolchain["target"].partition("_")
+      target_constraints = [
+          "@io_bazel_rules_go//go/toolchain:" + goos,
+          "@io_bazel_rules_go//go/toolchain:" + goarch,
+      ]
+      exec_constraints = ["@io_bazel_rules_go//go/toolchain:" + part for part in toolchain["host"].split("_")]
       go_toolchain(
           name = toolchain["impl"],
           sdk = toolchain["sdk"],
           link_flags = toolchain["link_flags"],
           cgo_link_flags = toolchain["cgo_link_flags"],
-          goos = toolchain["target"].os,
-          goarch = toolchain["target"].arch,
+          goos = goos,
+          goarch = goarch,
           bootstrap = toolchain["bootstrap"],
           tags = ["manual"],
       )
     native.toolchain(
         name = toolchain["name"],
         toolchain_type = toolchain["typ"],
-        exec_compatible_with = toolchain["exec_constraints"],
-        target_compatible_with = toolchain["target_constraints"]+toolchain["version_constraints"],
+        exec_compatible_with = exec_constraints,
+        target_compatible_with = target_constraints+toolchain["version_constraints"],
         toolchain = _label_prefix + toolchain["impl"],
     )


### PR DESCRIPTION
The structs were more hassle than help, and can't be used in BUILD files where
you want to declare custom toolchains.