### PR TITLE
Apply Bourne shell tokenization in cgo builder

### DIFF
--- a/tests/cgo_opts/BUILD.bazel
+++ b/tests/cgo_opts/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["cgo_opts.go"],
+    cgo = True,
+    copts = ["-DFOO=1 -DBAR=2 -g -O2"],
+    importpath = "github.com/bazelbuild/rules_go/tests/cgo_opts",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["cgo_opts_test.go"],
+    importpath = "github.com/bazelbuild/rules_go/tests/cgo_opts",
+    library = ":go_default_library",
+)

--- a/tests/cgo_opts/cgo_opts.go
+++ b/tests/cgo_opts/cgo_opts.go
@@ -1,0 +1,9 @@
+package cgo_opts
+
+/*
+#cgo CFLAGS: -DFOO=1 -DBAR=2 -g -O2
+int x = FOO + BAR;
+*/
+import "C"
+
+var x = int(C.x)

--- a/tests/cgo_opts/cgo_opts_test.go
+++ b/tests/cgo_opts/cgo_opts_test.go
@@ -1,0 +1,9 @@
+package cgo_opts
+
+import "testing"
+
+func TestCOpts(t *testing.T) {
+	if x != 3 {
+		t.Errorf("got %d; want 3", x)
+	}
+}


### PR DESCRIPTION
Bazel's cc_library and cc_binary automatically apply Bourne shell
tokenization to copts and linkopts. We keep groups of flags such as
"-framework CoreFoundation" together so that label resolution is not
applied to later arguments. However, this breaks cgo, since no
tokenization is performed there.

This change copies the splitQuoted method from go/build into the cgo
builder. This is applied to copts before passing them to cgo.

Related #646