### PR TITLE
Rationalise rules_go dependancies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,26 +1,9 @@
 workspace(name = "io_bazel_rules_go")
 
-load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains", "go_repository")
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
 go_rules_dependencies()
 go_register_toolchains()
 
-# Needed for examples
-go_repository(
-    name = "com_github_golang_glog",
-    commit = "23def4e6c14b4da8ac2ed8007337bc5eb5007998",
-    importpath = "github.com/golang/glog",
-)
-
-# Protocol buffers
-
-load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_proto_repositories")
-
-go_proto_repositories()
-
 # Needed for tests
-
 load("@io_bazel_rules_go//tests:bazel_tests.bzl", "test_environment")
 test_environment()
-
-load("@io_bazel_rules_go//examples/bindata:bindata.bzl", "bindata_repositories")
-bindata_repositories()

--- a/examples/bindata/bindata.bzl
+++ b/examples/bindata/bindata.bzl
@@ -33,10 +33,3 @@ bindata = rule(
         "_bindata":  attr.label(allow_files=True, single_file=True, default=Label("@com_github_jteeuwen_go_bindata//go-bindata:go-bindata")),
     },
 )
-
-def bindata_repositories():
-  go_repository(
-      name = "com_github_jteeuwen_go_bindata",
-      importpath = "github.com/jteeuwen/go-bindata",
-      commit = "a0ff2567cfb70903282db057e799fd826784d41d",
-  )

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -111,6 +111,44 @@ def go_rules_dependencies():
   )
 
 
+  # Proto dependancies
+  _maybe(go_repository,
+      name = "com_github_golang_protobuf",
+      importpath = "github.com/golang/protobuf",
+      commit = "8ee79997227bf9b34611aee7946ae64735e6fd93",
+  )
+  _maybe(native.http_archive,
+      name = "com_github_google_protobuf",
+      url = "https://github.com/google/protobuf/archive/v3.4.0.tar.gz",
+      strip_prefix = "protobuf-3.4.0",
+      sha256 = "cd55ee08e64a86cf12aaadd4672961813f592c194ed0c9ad94da0ec75acf219f",
+  )
+
+  # GRPC dependancies
+  _maybe(go_repository,
+      name = "org_golang_x_net",
+      commit = "4971afdc2f162e82d185353533d3cf16188a9f4e",
+      importpath = "golang.org/x/net",
+  )
+  _maybe(go_repository,
+      name = "org_golang_google_grpc",
+      tag = "v1.0.4",
+      importpath = "google.golang.org/grpc",
+  )
+
+  # Needed for examples
+  _maybe(go_repository,
+      name = "com_github_golang_glog",
+      commit = "23def4e6c14b4da8ac2ed8007337bc5eb5007998",
+      importpath = "github.com/golang/glog",
+  )
+  _maybe(go_repository,
+      name = "com_github_jteeuwen_go_bindata",
+      importpath = "github.com/jteeuwen/go-bindata",
+      commit = "a0ff2567cfb70903282db057e799fd826784d41d",
+  )
+
+
 def _maybe(repo_rule, name, **kwargs):
   if name not in native.existing_rules():
     repo_rule(name=name, **kwargs)

--- a/proto/go_proto_library.bzl
+++ b/proto/go_proto_library.bzl
@@ -20,12 +20,8 @@ Does not yet:
 Gets confused if local protos use 'option go_package'
 
 Usage:
-In WORKSPACE
-load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_proto_repositories")
 
-go_proto_repositories()
-
-Then in the BUILD file where protos are
+In the BUILD file where protos are
 
 load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_proto_library")
 
@@ -322,28 +318,4 @@ def go_google_protobuf(name = _GO_GOOGLE_PROTOBUF):
 
 def go_proto_repositories(shared = 1):
   """Add this to your WORKSPACE to pull in all of the needed dependencies."""
-  go_repository(
-      name = "com_github_golang_protobuf",
-      importpath = "github.com/golang/protobuf",
-      commit = "8ee79997227bf9b34611aee7946ae64735e6fd93",
-  )
-  if shared:
-    # if using multiple *_proto_library, allows caller to skip this.
-    native.http_archive(
-        name = "com_github_google_protobuf",
-        url = "https://github.com/google/protobuf/archive/v3.4.0.tar.gz",
-        strip_prefix = "protobuf-3.4.0",
-        sha256 = "cd55ee08e64a86cf12aaadd4672961813f592c194ed0c9ad94da0ec75acf219f",
-    )
-
-  # Needed for gRPC, only loaded by bazel if used
-  go_repository(
-      name = "org_golang_x_net",
-      commit = "4971afdc2f162e82d185353533d3cf16188a9f4e",
-      importpath = "golang.org/x/net",
-  )
-  go_repository(
-      name = "org_golang_google_grpc",
-      tag = "v1.0.4",
-      importpath = "google.golang.org/grpc",
-  )
+  print("DEPRECATED: go_proto_repositories is redundant and will be removed soon")


### PR DESCRIPTION
They are all installed in one place, using the same _maybe mechanism so that we
can move the whole function body back into the workspace when nested workspaces
arrive and it will behave identically.