### PR TITLE
Clean up default and boostrap toolchain declaration

### DIFF
--- a/go/def.bzl
+++ b/go/def.bzl
@@ -27,6 +27,9 @@ load("@io_bazel_rules_go//go/private:repositories.bzl",
 load("@io_bazel_rules_go//go/private:toolchain.bzl",
     go_sdk = "go_sdk",
 )
+load("@io_bazel_rules_go//go/private:go_toolchain.bzl",
+    go_toolchain = "go_toolchain",
+)
 load("@io_bazel_rules_go//go/private:rules/prefix.bzl", 
     "go_prefix",
 )

--- a/go/private/BUILD.bazel
+++ b/go/private/BUILD.bazel
@@ -31,5 +31,5 @@ go_toolchain_flags(
         ],
         "@io_bazel_rules_go//go/private:optimized": [],
     }),
-    visibility = ["@io_bazel_rules_go//go/toolchain:__subpackages__"],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Defaults and bootstraps are warts that I don't really want the user to have to
think about when declaring custom toolchains, so this hides them beneath the
go_toolchain macro.