### PR TITLE
Remove sha256 from dependencies fetched from codeload.github.com

### DIFF
--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -79,7 +79,6 @@ def go_repositories(
       # master, as of 14 Aug 2017
       url = "https://codeload.github.com/bazelbuild/buildtools/zip/799e530642bac55de7e76728fa0c3161484899f6",
       strip_prefix = "buildtools-799e530642bac55de7e76728fa0c3161484899f6",
-      sha256 = "ea23bbec9e86205b71ef647e1755ae0ec400aa76aeb5d13913d3fc3a37afbb5f",
       type = "zip",
   )
 

--- a/proto/go_proto_library.bzl
+++ b/proto/go_proto_library.bzl
@@ -333,7 +333,6 @@ def go_proto_repositories(shared = 1):
         name = "com_github_google_protobuf",
         url = "https://github.com/google/protobuf/archive/v3.4.0.tar.gz",
         strip_prefix = "protobuf-3.4.0",
-        sha256 = "cd55ee08e64a86cf12aaadd4672961813f592c194ed0c9ad94da0ec75acf219f",
     )
 
   # Needed for gRPC, only loaded by bazel if used


### PR DESCRIPTION
This is a cherry-pick of #823 onto a new branch, release/0.5.5 which is
based on tag 0.5.4.

----

These archives are prepared on-the-fly by GitHub and are not
guaranteed to be the same every time (for example, the order of files
within the archive could change).

All archives are fetched over https; this should be as secure as
git_repository and still faster.

Related #820

[skip ci]
[ci skip]