### PR TITLE
Temporary directory handling

### DIFF
--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -22,6 +22,7 @@ load("@io_bazel_rules_go//go/private:actions/link.bzl", "emit_link")
 load("@io_bazel_rules_go//go/private:actions/pack.bzl", "emit_pack")
 
 def _go_toolchain_impl(ctx):
+  tmp = ctx.attr._root.path + "/tmp"
   return [platform_common.ToolchainInfo(
       name = ctx.label.name,
       sdk = ctx.attr.sdk,
@@ -29,6 +30,7 @@ def _go_toolchain_impl(ctx):
           "GOROOT": ctx.attr._root.path,
           "GOOS": ctx.attr.goos,
           "GOARCH": ctx.attr.goarch,
+          "TMP": tmp,
       },
       actions = struct(
           asm = emit_asm,
@@ -40,6 +42,7 @@ def _go_toolchain_impl(ctx):
       ),
       paths = struct(
           root = ctx.attr._root,
+          tmp = tmp,
       ),
       tools = struct(
           go = ctx.executable._go,

--- a/go/private/repository_tools.bzl
+++ b/go/private/repository_tools.bzl
@@ -56,6 +56,12 @@ def _go_repository_tools_impl(ctx):
       type = "zip",
   )
 
+  if "TMP" in ctx.os.environ:
+    tmp = ctx.os.environ["TMP"]
+  else:
+    ctx.file("tmp/ignore", content="") # make a file to force the directory to exist
+    tmp = str(ctx.path("tmp").realpath)
+
   # Build something that looks like a normal GOPATH so go install will work
   ctx.symlink(x_tools_path, "src/golang.org/x/tools")
   ctx.symlink(buildtools_path, "src/github.com/bazelbuild/buildtools")
@@ -63,7 +69,7 @@ def _go_repository_tools_impl(ctx):
   env = {
     'GOROOT': str(go_tool.dirname.dirname),
     'GOPATH': str(ctx.path('')),
-    'TMP': ctx.os.environ['TMP'],
+    'TMP': tmp,
   }
 
   # build gazelle and fetch_repo

--- a/go/private/repository_tools.bzl
+++ b/go/private/repository_tools.bzl
@@ -63,6 +63,7 @@ def _go_repository_tools_impl(ctx):
   env = {
     'GOROOT': str(go_tool.dirname.dirname),
     'GOPATH': str(ctx.path('')),
+    'TMP': ctx.os.environ['TMP'],
   }
 
   # build gazelle and fetch_repo
@@ -92,4 +93,5 @@ go_repository_tools = repository_rule(
             single_file = True,
         ),
     },
+    environ = ["TMP"],
 )

--- a/go/private/toolchain.bzl
+++ b/go/private/toolchain.bzl
@@ -34,11 +34,15 @@ def _go_sdk_impl(ctx):
     _sdk_build_file(ctx, path)
     _local_sdk(ctx, path)
     
+  if "TMP" in ctx.os.environ:
+    tmp = ctx.os.environ["TMP"]
+    ctx.symlink(tmp, "tmp")
+  else:
+    ctx.file("tmp/ignore", content="") # make a file to force the directory to exist
+    tmp = str(ctx.path("tmp").realpath)
+  
   # Build the standard library for valid cross compile platforms
   #TODO: fix standard library cross compilation
-  tmp = ctx.os.environ['TMP']
-  ctx.symlink(tmp, "tmp")
-  
   if ctx.name.endswith("linux_amd64") and ctx.os.name == "linux":
     _cross_compile_stdlib(ctx, "windows", "amd64", tmp)
   if ctx.name.endswith("darwin_amd64") and ctx.os.name == "mac os x":

--- a/go/private/toolchain.bzl
+++ b/go/private/toolchain.bzl
@@ -36,10 +36,13 @@ def _go_sdk_impl(ctx):
     
   # Build the standard library for valid cross compile platforms
   #TODO: fix standard library cross compilation
+  tmp = ctx.os.environ['TMP']
+  ctx.symlink(tmp, "tmp")
+  
   if ctx.name.endswith("linux_amd64") and ctx.os.name == "linux":
-    _cross_compile_stdlib(ctx, "windows", "amd64")
+    _cross_compile_stdlib(ctx, "windows", "amd64", tmp)
   if ctx.name.endswith("darwin_amd64") and ctx.os.name == "mac os x":
-    _cross_compile_stdlib(ctx, "linux", "amd64")
+    _cross_compile_stdlib(ctx, "linux", "amd64", tmp)
 
 go_sdk = repository_rule(
     implementation = _go_sdk_impl, 
@@ -74,12 +77,13 @@ def _sdk_build_file(ctx, goroot):
       executable = False,
   )
 
-def _cross_compile_stdlib(ctx, goos, goarch):
+def _cross_compile_stdlib(ctx, goos, goarch, tmp):
   env = {
       "CGO_ENABLED": "0",
       "GOROOT": str(ctx.path(".")),
       "GOOS": goos,
       "GOARCH": goarch,
+      "TMP": tmp,
   }
   res = ctx.execute(
       ["bin/go", "install", "-v", "std"], 

--- a/go/private/tools/go_tool_binary.bzl
+++ b/go/private/tools/go_tool_binary.bzl
@@ -29,6 +29,7 @@ def _go_tool_binary_impl(ctx):
       mnemonic = "GoBuildTool",
       env = {
           "GOROOT": toolchain.paths.root.path,
+          "TMP": toolchain.paths.tmp,
       },
   )
   return [


### PR DESCRIPTION
The go toolchain on windows requires TMP to be a place it can work in.

Based on the work by Jannis Andrija Schnitzer (@xjs) in #821
The original approach did not quite work, and had some conflicts over TMP vs TMPDIR.
I am not really happy with this approach either, but it does seem to work.