### PR TITLE
Gazelle: don't skip files with errors

### DIFF
--- a/go/tools/gazelle/packages/walk_test.go
+++ b/go/tools/gazelle/packages/walk_test.go
@@ -543,7 +543,7 @@ func TestMalformedGoFile(t *testing.T) {
 			Name: "foo",
 			Library: packages.Target{
 				Sources: packages.PlatformStrings{
-					Generic: []string{"b.go"},
+					Generic: []string{"b.go", "a.go"},
 				},
 			},
 		},


### PR DESCRIPTION
Gazelle reads source files to extract package names, imports, build
tags, and other information. If an error is encountered when reading
this information, Gazelle will log a message and include the file in
the srcs list with as much information as is available. Previously,
Gazelle skipped these files.

Fixes #835