### PR TITLE
Gazelle: initial support for generalized directive comments

### DIFF
--- a/go/tools/gazelle/config/BUILD.bazel
+++ b/go/tools/gazelle/config/BUILD.bazel
@@ -5,13 +5,18 @@ go_library(
     srcs = [
         "config.go",
         "constants.go",
+        "directives.go",
     ],
+    deps = ["@com_github_bazelbuild_buildtools//build:go_default_library"],
     visibility = ["//visibility:public"],
 )
 
 go_test(
     name = "go_default_test",
     size = "small",
-    srcs = ["config_test.go"],
+    srcs = [
+        "config_test.go",
+        "directives_test.go",
+    ],
     library = ":go_default_library",
 )

--- a/go/tools/gazelle/config/directives.go
+++ b/go/tools/gazelle/config/directives.go
@@ -1,0 +1,81 @@
+/* Copyright 2017 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"log"
+	"regexp"
+	"strings"
+
+	bf "github.com/bazelbuild/buildtools/build"
+)
+
+// Directive is a key-value pair extracted from a top-level comment in
+// a build file. Directives have the following format:
+//
+//     # gazelle:key value
+//
+// Keys may not contain spaces. Values may be empty and may contain spaces,
+// but surrounding space is trimmed.
+type Directive struct {
+	Key, Value string
+}
+
+// ParseDirectives scans f for Gazelle directives. Directives related to
+// the configuration will be applied to a copy of c, which is returned.
+// c may be nil, in which case changes are applied to the default configuration.
+// The full list of directives is returned in either case.
+//
+// The following configuration directives are recognized:
+//
+// * build_tags - comma-separated list of build tags that will be considered
+//   true on all platforms. Sets GenericTags.
+// * build_file_name - comma-separated list of build file names. Sets
+//   ValidBuildFileNames.
+//
+// TODO(jayconrod): support GoPrefix, and DepMode at least.
+func ParseDirectives(f *bf.File, c *Config) (*Config, []Directive) {
+	var modified Config
+	if c != nil {
+		modified = *c
+	}
+
+	var directives []Directive
+	for _, s := range f.Stmt {
+		comments := append(s.Comment().Before, s.Comment().After...)
+		for _, com := range comments {
+			match := directiveRe.FindStringSubmatch(com.Token)
+			if match == nil {
+				continue
+			}
+			d := Directive{match[1], match[2]}
+			directives = append(directives, d)
+
+			switch d.Key {
+			case "build_tags":
+				if err := modified.SetBuildTags(d.Value); err != nil {
+					log.Print(err)
+				}
+				modified.PreprocessTags()
+			case "build_file_name":
+				modified.ValidBuildFileNames = strings.Split(d.Value, ",")
+			}
+		}
+	}
+	return &modified, directives
+}
+
+var directiveRe = regexp.MustCompile(`^#\s*gazelle:(\w+)\s*(.*?)\s*$`)

--- a/go/tools/gazelle/config/directives_test.go
+++ b/go/tools/gazelle/config/directives_test.go
@@ -1,0 +1,83 @@
+/* Copyright 2017 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	bf "github.com/bazelbuild/buildtools/build"
+)
+
+func TestDirectives(t *testing.T) {
+	for _, tc := range []struct {
+		desc, content  string
+		wantConfig     Config
+		wantDirectives []Directive
+	}{
+		{
+			desc: "empty file",
+		}, {
+			desc: "locations",
+			content: `# gazelle:top
+
+#gazelle:before
+foo(
+   "foo",  # gazelle:inside
+) # gazelle:suffix
+#gazelle:after
+
+# gazelle: bottom`,
+			wantDirectives: []Directive{
+				{Key: "top"},
+				{Key: "before"},
+				{Key: "after"},
+			},
+		}, {
+			desc:           "empty build_tags",
+			content:        `# gazelle:build_tags`,
+			wantDirectives: []Directive{{"build_tags", ""}},
+		}, {
+			desc:           "build_tags",
+			content:        `# gazelle:build_tags  foo,bar  `,
+			wantConfig:     Config{GenericTags: BuildTags{"foo": true, "bar": true}},
+			wantDirectives: []Directive{{"build_tags", "foo,bar"}},
+		}, {
+			desc:           "build_file_name",
+			content:        `# gazelle:build_file_name foo,bar`,
+			wantConfig:     Config{ValidBuildFileNames: []string{"foo", "bar"}},
+			wantDirectives: []Directive{{"build_file_name", "foo,bar"}},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			f, err := bf.Parse("test.bazel", []byte(tc.content))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			c := &Config{}
+			c.PreprocessTags()
+			gotConfig, gotDirectives := ParseDirectives(f, c)
+			tc.wantConfig.PreprocessTags()
+			if !reflect.DeepEqual(*gotConfig, tc.wantConfig) {
+				t.Errorf("bad configuration. got %#v ; want %#v", *gotConfig, tc.wantConfig)
+			}
+			if !reflect.DeepEqual(gotDirectives, tc.wantDirectives) {
+				t.Errorf("bad directives. got %#v ; want %#v", gotDirectives, tc.wantDirectives)
+			}
+		})
+	}
+}

--- a/go/tools/gazelle/merger/merger.go
+++ b/go/tools/gazelle/merger/merger.go
@@ -23,12 +23,10 @@ import (
 	"strings"
 
 	bf "github.com/bazelbuild/buildtools/build"
+	"github.com/bazelbuild/rules_go/go/tools/gazelle/config"
 )
 
-const (
-	gazelleIgnore = "# gazelle:ignore" // marker in a BUILD file to ignore it.
-	keep          = "# keep"           // marker in srcs or deps to tell gazelle to preserve.
-)
+const keep = "# keep" // marker in srcs or deps to tell gazelle to preserve.
 
 var (
 	mergeableFields = map[string]bool{
@@ -429,16 +427,10 @@ func mergeLoad(gen, old *bf.CallExpr, oldfile *bf.File) *bf.CallExpr {
 // shouldIgnore checks whether "gazelle:ignore" appears at the beginning of
 // a comment before or after any top-level statement in the file.
 func shouldIgnore(oldFile *bf.File) bool {
-	for _, s := range oldFile.Stmt {
-		for _, c := range s.Comment().After {
-			if strings.HasPrefix(c.Token, gazelleIgnore) {
-				return true
-			}
-		}
-		for _, c := range s.Comment().Before {
-			if strings.HasPrefix(c.Token, gazelleIgnore) {
-				return true
-			}
+	_, directives := config.ParseDirectives(oldFile, nil)
+	for _, d := range directives {
+		if d.Key == "ignore" {
+			return true
 		}
 	}
 	return false

--- a/go/tools/gazelle/merger/merger.go
+++ b/go/tools/gazelle/merger/merger.go
@@ -427,7 +427,7 @@ func mergeLoad(gen, old *bf.CallExpr, oldfile *bf.File) *bf.CallExpr {
 // shouldIgnore checks whether "gazelle:ignore" appears at the beginning of
 // a comment before or after any top-level statement in the file.
 func shouldIgnore(oldFile *bf.File) bool {
-	_, directives := config.ParseDirectives(oldFile, nil)
+	directives := config.ParseDirectives(oldFile)
 	for _, d := range directives {
 		if d.Key == "ignore" {
 			return true

--- a/go/tools/gazelle/merger/merger_test.go
+++ b/go/tools/gazelle/merger/merger_test.go
@@ -114,7 +114,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 		previous: `
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 # gazelle:ignore`,
-		ignore: true,
+		ignore: false,
 	}, {
 		desc: "merge dicts",
 		previous: `

--- a/go/tools/gazelle/packages/walk.go
+++ b/go/tools/gazelle/packages/walk.go
@@ -29,7 +29,7 @@ import (
 )
 
 // A WalkFunc is a callback called by Walk for each package.
-type WalkFunc func(pkg *Package, oldFile *bf.File)
+type WalkFunc func(c *config.Config, pkg *Package, oldFile *bf.File)
 
 // Walk walks through directories under "root".
 // It calls back "f" for each package. If an existing BUILD file is present
@@ -53,8 +53,7 @@ func Walk(c *config.Config, dir string, f WalkFunc) {
 	// data dependencies.
 	var visit func(string) bool
 	visit = func(path string) bool {
-		// Look for an existing BUILD file. Directives in this file may influence
-		// the rest of the process.
+		// Look for an existing BUILD file.
 		var oldFile *bf.File
 		haveError := false
 		for _, base := range c.ValidBuildFileNames {
@@ -83,9 +82,16 @@ func Walk(c *config.Config, dir string, f WalkFunc) {
 			}
 		}
 
-		var excluded map[string]bool
+		// Process directives in the build file.
+		excluded := make(map[string]bool)
 		if oldFile != nil {
-			excluded = findExcludedFiles(oldFile)
+			var directives []config.Directive
+			c, directives = config.ParseDirectives(oldFile, c)
+			for _, d := range directives {
+				if d.Key == "exclude" {
+					excluded[d.Value] = true
+				}
+			}
 		}
 
 		// List files and subdirectories.
@@ -138,7 +144,7 @@ func Walk(c *config.Config, dir string, f WalkFunc) {
 		}
 		pkg := buildPackage(c, path, goFiles, otherFiles, genFiles, hasTestdata)
 		if pkg != nil {
-			f(pkg, oldFile)
+			f(c, pkg, oldFile)
 			hasPackage = true
 		}
 		return hasPackage
@@ -312,20 +318,4 @@ func findGenFiles(f *bf.File, excluded map[string]bool) []string {
 		}
 	}
 	return genFiles
-}
-
-const gazelleExclude = "# gazelle:exclude " // marker in a BUILD file to exclude source files.
-
-func findExcludedFiles(f *bf.File) map[string]bool {
-	excluded := make(map[string]bool)
-	for _, s := range f.Stmt {
-		comments := append(s.Comment().Before, s.Comment().After...)
-		for _, c := range comments {
-			if strings.HasPrefix(c.Token, gazelleExclude) {
-				f := strings.TrimSpace(c.Token[len(gazelleExclude):])
-				excluded[f] = true
-			}
-		}
-	}
-	return excluded
 }

--- a/go/tools/gazelle/packages/walk.go
+++ b/go/tools/gazelle/packages/walk.go
@@ -85,8 +85,8 @@ func Walk(c *config.Config, dir string, f WalkFunc) {
 		// Process directives in the build file.
 		excluded := make(map[string]bool)
 		if oldFile != nil {
-			var directives []config.Directive
-			c, directives = config.ParseDirectives(oldFile, c)
+			directives := config.ParseDirectives(oldFile)
+			c = config.ApplyDirectives(c, directives)
 			for _, d := range directives {
 				if d.Key == "exclude" {
 					excluded[d.Value] = true

--- a/go/tools/gazelle/packages/walk_test.go
+++ b/go/tools/gazelle/packages/walk_test.go
@@ -81,7 +81,7 @@ func walkPackages(repoRoot, goPrefix, dir string) []*packages.Package {
 		ValidBuildFileNames: config.DefaultValidBuildFileNames,
 	}
 	var pkgs []*packages.Package
-	packages.Walk(c, dir, func(pkg *packages.Package, _ *bf.File) {
+	packages.Walk(c, dir, func(_ *config.Config, pkg *packages.Package, _ *bf.File) {
 		pkgs = append(pkgs, pkg)
 	})
 	return pkgs
@@ -505,7 +505,7 @@ func TestVendor(t *testing.T) {
 				DepMode:             tc.mode,
 			}
 			var got []*packages.Package
-			packages.Walk(c, dir, func(pkg *packages.Package, _ *bf.File) {
+			packages.Walk(c, dir, func(_ *config.Config, pkg *packages.Package, _ *bf.File) {
 				got = append(got, pkg)
 			})
 

--- a/go/tools/gazelle/packages/walk_test.go
+++ b/go/tools/gazelle/packages/walk_test.go
@@ -407,7 +407,6 @@ func TestExcluded(t *testing.T) {
 # gazelle:exclude do.go
 
 # gazelle:exclude not.go
-x = 0
 # gazelle:exclude build.go
 
 genrule(

--- a/go/tools/gazelle/rules/generator_test.go
+++ b/go/tools/gazelle/rules/generator_test.go
@@ -45,7 +45,7 @@ func testConfig(repoRoot, goPrefix string) *config.Config {
 func packageFromDir(c *config.Config, dir string) (*packages.Package, *bf.File) {
 	var pkg *packages.Package
 	var oldFile *bf.File
-	packages.Walk(c, dir, func(p *packages.Package, f *bf.File) {
+	packages.Walk(c, dir, func(_ *config.Config, p *packages.Package, f *bf.File) {
 		if p.Dir == dir {
 			pkg = p
 			oldFile = f


### PR DESCRIPTION
Added config.ParseDirectives, which looks for comments of the form

    # gazelle:key value

Directives related to the configuration will be applied to a copy of
the current configuration, which is returned. This is passed down
through subdirectories by packages.Walk.

A full list of directives is returned. These may be processed by other
packages, for example gazelle:ignore and gazelle:exclude.