### PR TITLE
Document the core rules

### DIFF
--- a/go/core.rst
+++ b/go/core.rst
@@ -1,0 +1,425 @@
+Core go rules
+=============
+
+.. _test_filter: https://bazel.build/versions/master/docs/bazel-user-manual.html#flag--test_filter
+.. _test_arg: https://bazel.build/versions/master/docs/bazel-user-manual.html#flag--test_arg
+.. _gazelle: tools/gazelle/README.md
+.. _build constraints: http://golang.org/pkg/go/build/
+.. _GoLibrary: providers.rst#GoLibrary
+.. _GoEmbed: providers.rst#GoEmbed
+.. _GoBinary: providers.rst#GoBinary
+.. _cgo: http://golang.org/cmd/cgo/
+.. _"Make variable": https://docs.bazel.build/versions/master/be/make-variables.html
+.. _Bourne shell tokenization: https://docs.bazel.build/versions/master/be/common-definitions.html#sh-tokenization
+.. _data dependencies: https://docs.bazel.build/versions/master/build-ref.html#data
+.. _static: modes.rst#using-the-race-detector
+.. _race: modes.rst#building-static-binaries
+
+.. role:: param(kbd)
+.. role:: type(emphasis)
+.. role:: value(code)
+.. |mandatory| replace:: **mandatory value**
+
+These are the core go rules, required for basic operation.
+The intent is that theses rules are sufficient to match the capabilities of the normal go tools.
+
+.. contents::
+
+-----
+
+Design
+------
+
+Defines and stamping
+~~~~~~~~~~~~~~~~~~~~
+
+**TODO**: More information
+
+Embedding
+~~~~~~~~~
+
+This is used for things like internal tests, where a library is recompiled with additional
+and also code generators where the generated source will be known to have extra dependancies.
+
+**TODO**: More information
+
+API
+---
+
+go_library
+~~~~~~~~~~
+
+This builds a Go library from a set of source files that are all part of
+the same package.
+
+Providers
+^^^^^^^^^
+
+* GoLibrary_
+* GoEmbed_
+
+Output groups
+^^^^^^^^^^^^^
+
+* default *: A library with the default build options.*
+* race_ *: The library build with race detection enabled.*
+
+Attributes
+^^^^^^^^^^
+
++----------------------------+-----------------------------+---------------------------------------+
+| **Name**                   | **Type**                    | **Default value**                     |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`name`              | :type:`string`              | |mandatory|                           |
++----------------------------+-----------------------------+---------------------------------------+
+| A unique name for this rule.                                                                     |
+|                                                                                                  |
+| To interoperated cleanly with gazelle_ right now this should be :value:`go_default_library`.     |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`importpath`        | :type:`string`              | :value:`""`                           |
++----------------------------+-----------------------------+---------------------------------------+
+| The import path of this library. If unspecified, the library will have an implicit               |
+| dependency on ``//:go_prefix``, and the import path will be derived from the prefix              |
+| and the library's label.                                                                         |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`srcs`              | :type:`label_list`          | :value:`None`                         |
++----------------------------+-----------------------------+---------------------------------------+
+| The list of Go source files that are compiled to create the package.                             |
+| Only :value:`.go` files are permitted, unless the cgo attribute is set, in which case the        |
+| following file types are permitted: :value:`.go, .c, .s, .S .h`.                                 |
+| The files may contain Go-style `build constraints`_.                                             |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`deps`              | :type:`label_list`          | :value:`None`                         |
++----------------------------+-----------------------------+---------------------------------------+
+| List of GoLibrary_ providers this library imports directly.                                      |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`embed`             | :type:`label_list`          | :value:`None`                         |
++----------------------------+-----------------------------+---------------------------------------+
+| List of GoEmbed_ providers this library embeds.                                                  |
+| These can provide both :param:`srcs` and param:`deps` to this library.                           |
+| See Embedding_ for more information about how and when to use this.                              |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`data`              | :type:`label_list`          | :value:`None`                         |
++----------------------------+-----------------------------+---------------------------------------+
+| The list of files needed by this rule at runtime. Targets named in the data attribute will       |
+| appear in the *.runfiles area of this rule, if it has one. This may include data files needed    |
+| by the binary, or other programs needed by it. See `data dependencies`_ for more information     |
+| about how to depend on and use data files.                                                       |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`gc_goopts`         | :type:`string_list`         | :value:`[]`                           |
++----------------------------+-----------------------------+---------------------------------------+
+| List of flags to add to the Go compilation command when using the gc compiler.                   |
+| Subject to `"Make variable"`_ substitution and `Bourne shell tokenization`_.                     |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`cgo`               | :type:`boolean`             | :value:`False`                        |
++----------------------------+-----------------------------+---------------------------------------+
+| If :value:`True`, the package uses cgo_.                                                         |
+| The cgo tool permits Go code to call C code and vice-versa.                                      |
+| This does not support calling C++.                                                               |
+| When cgo is set, :param:`srcs` may contain C or assembly files; these files are compiled with    |
+| the normal c compiler and included in the package.                                               |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`cdeps`             | :type:`label_list`          | :value:`None`                         |
++----------------------------+-----------------------------+---------------------------------------+
+| The list of other libraries that the c code depends on.                                          |
+| These should be names of C++ library rules.                                                      |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`copts`             | :type:`string_list`         | :value:`[]`                           |
++----------------------------+-----------------------------+---------------------------------------+
+| List of flags to add to the C compilation command.                                               |
+| Subject to `"Make variable"`_ substitution and `Bourne shell tokenization`_.                     |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`clinkopts`         | :type:`string_list`         | :value:`[]`                           |
++----------------------------+-----------------------------+---------------------------------------+
+| List of flags to add to the C link command.                                                      |
+| Subject to `"Make variable"`_ substitution and `Bourne shell tokenization`_.                     |
++----------------------------+-----------------------------+---------------------------------------+
+
+Example
+^^^^^^^
+
+.. code:: bzl
+
+  go_library(
+      name = "go_default_library",
+      srcs = [
+          "foo.go",
+          "bar.go",
+      ],
+      deps = [
+          "//tools:go_default_library",
+          "@org_golang_x_utils//stuff:go_default_library",
+      ],
+      importpath = "github.com/example/project/foo",
+      visibility = ["//visibility:public"],
+  )
+
+go_binary
+~~~~~~~~~
+
+This builds an executable from a set of source files, which must all be
+in the ``main`` package. You can run the binary with ``bazel run``, or you can
+build it with ``bazel build`` and run it directly.
+
+Providers
+^^^^^^^^^
+
+* GoLibrary_
+* GoBinary_
+* GoEmbed_
+
+Output groups
+^^^^^^^^^^^^^
+
+* default *: A binary with the default build options.*
+* static_ *: A statically linked binary.*
+* race_ *: The binary with race detection enabled.*
+
+Attributes
+^^^^^^^^^^
+
++----------------------------+-----------------------------+---------------------------------------+
+| **Name**                   | **Type**                    | **Default value**                     |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`name`              | :type:`string`              | |mandatory|                           |
++----------------------------+-----------------------------+---------------------------------------+
+| A unique name for this rule.                                                                     |
+|                                                                                                  |
+| This should be named the same as the desired name of the generated binary .                      |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`importpath`        | :type:`string`              | :value:`""`                           |
++----------------------------+-----------------------------+---------------------------------------+
+| The import path of this binary. If unspecified, the binary will have an implicit                 |
+| dependency on ``//:go_prefix``, and the import path will be derived from the prefix              |
+| and the binary's label.                                                                          |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`srcs`              | :type:`label_list`          | :value:`None`                         |
++----------------------------+-----------------------------+---------------------------------------+
+| The list of Go source files that are compiled to create the binary.                              |
+| Only :value:`.go` files are permitted, unless the cgo attribute is set, in which case the        |
+| following file types are permitted: :value:`.go, .c, .s, .S .h`.                                 |
+| The files may contain Go-style `build constraints`_.                                             |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`deps`              | :type:`label_list`          | :value:`None`                         |
++----------------------------+-----------------------------+---------------------------------------+
+| List of GoLibrary_ providers this binary imports directly.                                       |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`embed`             | :type:`label_list`          | :value:`None`                         |
++----------------------------+-----------------------------+---------------------------------------+
+| List of GoEmbed_ providers this binary embeds.                                                   |
+| These can provide both :param:`srcs` and param:`deps` to this library.                           |
+| See Embedding_ for more information about how and when to use this.                              |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`data`              | :type:`label_list`          | :value:`None`                         |
++----------------------------+-----------------------------+---------------------------------------+
+| The list of files needed by this rule at runtime. Targets named in the data attribute will       |
+| appear in the *.runfiles area of this rule, if it has one. This may include data files needed    |
+| by the binary, or other programs needed by it. See `data dependencies`_ for more information     |
+| about how to depend on and use data files.                                                       |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`gc_goopts`         | :type:`string_list`         | :value:`[]`                           |
++----------------------------+-----------------------------+---------------------------------------+
+| List of flags to add to the Go compilation command when using the gc compiler.                   |
+| Subject to `"Make variable"`_ substitution and `Bourne shell tokenization`_.                     |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`gc_linkopts`       | :type:`string_list`         | :value:`[]`                           |
++----------------------------+-----------------------------+---------------------------------------+
+| List of flags to add to the Go link command when using the gc compiler.                          |
+| Subject to `"Make variable"`_ substitution and `Bourne shell tokenization`_.                     |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`x_defs`            | :type:`string_dict`         | :value:`{}`                           |
++----------------------------+-----------------------------+---------------------------------------+
+| Map of defines to add to the go link command.                                                    |
+| See `Defines and stamping`_ for examples of how to use these.                                    |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`cgo`               | :type:`boolean`             | :value:`False`                        |
++----------------------------+-----------------------------+---------------------------------------+
+| If :value:`True`, the binary uses cgo_.                                                          |
+| The cgo tool permits Go code to call C code and vice-versa.                                      |
+| This does not support calling C++.                                                               |
+| When cgo is set, :param:`srcs` may contain C or assembly files; these files are compiled with    |
+| the normal c compiler and included in the package.                                               |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`cdeps`             | :type:`label_list`          | :value:`None`                         |
++----------------------------+-----------------------------+---------------------------------------+
+| The list of other libraries that the c code depends on.                                          |
+| These should be names of C++ library rules.                                                      |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`copts`             | :type:`string_list`         | :value:`[]`                           |
++----------------------------+-----------------------------+---------------------------------------+
+| List of flags to add to the C compilation command.                                               |
+| Subject to `"Make variable"`_ substitution and `Bourne shell tokenization`_.                     |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`clinkopts`         | :type:`string_list`         | :value:`[]`                           |
++----------------------------+-----------------------------+---------------------------------------+
+| List of flags to add to the C link command.                                                      |
+| Subject to `"Make variable"`_ substitution and `Bourne shell tokenization`_.                     |
++----------------------------+-----------------------------+---------------------------------------+
+
+go_test
+~~~~~~~
+
+This builds a set of tests that can be run with ``bazel test``. 
+
+To run all tests in the workspace, and print output on failure (the
+equivalent of ``go test ./...`` from ``go_prefix`` in a ``GOPATH`` tree), run
+
+::
+
+  bazel test --test_output=errors //...
+
+You can run specific tests by passing the `--test_filter=pattern <test_filter_>`_ argument to Bazel. 
+You can pass arguments to tests by passing `--test_arg=arg <test_arg_>`_ arguments to Bazel.
+
+Providers
+^^^^^^^^^
+
+* GoBinary_
+
+Output groups
+^^^^^^^^^^^^^
+
+* default *: The test binary.*
+
+Attributes
+^^^^^^^^^^
+
++----------------------------+-----------------------------+---------------------------------------+
+| **Name**                   | **Type**                    | **Default value**                     |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`name`              | :type:`string`              | |mandatory|                           |
++----------------------------+-----------------------------+---------------------------------------+
+| A unique name for this rule.                                                                     |
+|                                                                                                  |
+| To interoperated cleanly with gazelle_ right now this should be :value:`go_default_test` for     |
+| internal tests and :value:`go_default_xtest` for external tests.                                 |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`importpath`        | :type:`string`              | :value:`""`                           |
++----------------------------+-----------------------------+---------------------------------------+
+| The import path of this test. If unspecified, the test will have an implicit                     |
+| dependency on ``//:go_prefix``, and the import path will be derived from the prefix              |
+| and the test's label.                                                                            |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`srcs`              | :type:`label_list`          | :value:`None`                         |
++----------------------------+-----------------------------+---------------------------------------+
+| The list of Go source files that are compiled to create the test.                                |
+| Only :value:`.go` files are permitted, unless the cgo attribute is set, in which case the        |
+| following file types are permitted: :value:`.go, .c, .s, .S .h`.                                 |
+| The files may contain Go-style `build constraints`_.                                             |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`deps`              | :type:`label_list`          | :value:`None`                         |
++----------------------------+-----------------------------+---------------------------------------+
+| List of GoLibrary_ providers this test imports directly.                                         |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`embed`             | :type:`label_list`          | :value:`None`                         |
++----------------------------+-----------------------------+---------------------------------------+
+| List of GoEmbed_ providers this binary embeds.                                                   |
+| These can provide both :param:`srcs` and param:`deps` to this library.                           |
+| See Embedding_ for more information about how and when to use this.                              |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`data`              | :type:`label_list`          | :value:`None`                         |
++----------------------------+-----------------------------+---------------------------------------+
+| The list of files needed by this rule at runtime. Targets named in the data attribute will       |
+| appear in the *.runfiles area of this rule, if it has one. This may include data files needed    |
+| by the binary, or other programs needed by it. See `data dependencies`_ for more information     |
+| about how to depend on and use data files.                                                       |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`gc_goopts`         | :type:`string_list`         | :value:`[]`                           |
++----------------------------+-----------------------------+---------------------------------------+
+| List of flags to add to the Go compilation command when using the gc compiler.                   |
+| Subject to `"Make variable"`_ substitution and `Bourne shell tokenization`_.                     |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`gc_linkopts`       | :type:`string_list`         | :value:`[]`                           |
++----------------------------+-----------------------------+---------------------------------------+
+| List of flags to add to the Go link command when using the gc compiler.                          |
+| Subject to `"Make variable"`_ substitution and `Bourne shell tokenization`_.                     |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`x_defs`            | :type:`string_dict`         | :value:`{}`                           |
++----------------------------+-----------------------------+---------------------------------------+
+| Map of defines to add to the go link command.                                                    |
+| See `Defines and stamping`_ for examples of how to use these.                                    |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`cgo`               | :type:`boolean`             | :value:`False`                        |
++----------------------------+-----------------------------+---------------------------------------+
+| If :value:`True`, the binary uses cgo_.                                                          |
+| The cgo tool permits Go code to call C code and vice-versa.                                      |
+| This does not support calling C++.                                                               |
+| When cgo is set, :param:`srcs` may contain C or assembly files; these files are compiled with    |
+| the normal c compiler and included in the package.                                               |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`cdeps`             | :type:`label_list`          | :value:`None`                         |
++----------------------------+-----------------------------+---------------------------------------+
+| The list of other libraries that the c code depends on.                                          |
+| These should be names of C++ library rules.                                                      |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`copts`             | :type:`string_list`         | :value:`[]`                           |
++----------------------------+-----------------------------+---------------------------------------+
+| List of flags to add to the C compilation command.                                               |
+| Subject to `"Make variable"`_ substitution and `Bourne shell tokenization`_.                     |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`clinkopts`         | :type:`string_list`         | :value:`[]`                           |
++----------------------------+-----------------------------+---------------------------------------+
+| List of flags to add to the C link command.                                                      |
+| Subject to `"Make variable"`_ substitution and `Bourne shell tokenization`_.                     |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`rundir`            | :type:`string`              | The package path                      |
++----------------------------+-----------------------------+---------------------------------------+
+| A directory to cd to before the test is run.                                                     |
+| This should be a path relative to the execution dir of the test.                                 |
+|                                                                                                  |
+| The default behaviour is to change to the workspace relative path, this replicates the normal    |
+| behaviour of ``go test`` so it is easy to write compatible tests.                                |
+|                                                                                                  |
+| Setting it to :value:`.` makes the test behave the normal way for a bazel test.                  |
++----------------------------+-----------------------------+---------------------------------------+
+
+To write an internal test, reference the library being tested with the :param:`embed`
+instead of :param:`deps`. This will compile the test sources into the same package as the library
+sources.
+
+Internal test example
+^^^^^^^^^^^^^^^^^^^^^
+
+This builds a test that can use the internal interface of the package being tested.
+
+In the normal go toolchain this would be the kind of tests formed by adding writing 
+``<file>_test.go`` files in the same package.
+
+It references the library being tested with :param:`embed`.
+
+
+.. code:: bzl
+
+  go_library(
+      name = "go_default_library",
+      srcs = ["lib.go"],
+  )
+
+  go_test(
+      name = "go_default_test",
+      srcs = ["lib_test.go"],
+      embed = [":go_default_library"],
+  )
+
+External test example
+^^^^^^^^^^^^^^^^^^^^^
+
+This builds a test that can only use the public interface(s) of the packages being tested.
+
+In the normal go toolchain this would be the kind of tests formed by adding an ``<name>_test``
+package.
+
+It references the library(s) being tested with :param:`deps`.
+
+.. code:: bzl
+
+  go_library(
+      name = "go_default_library",
+      srcs = ["lib.go"],
+  )
+
+  go_test(
+      name = "go_default_xtest",
+      srcs = ["lib_x_test.go"],
+      deps = [":go_default_library"],
+  )

--- a/go/core.rst
+++ b/go/core.rst
@@ -12,8 +12,13 @@ Core go rules
 .. _"Make variable": https://docs.bazel.build/versions/master/be/make-variables.html
 .. _Bourne shell tokenization: https://docs.bazel.build/versions/master/be/common-definitions.html#sh-tokenization
 .. _data dependencies: https://docs.bazel.build/versions/master/build-ref.html#data
+.. _cc library deps: https://docs.bazel.build/versions/master/be/c-cpp.html#cc_library.deps
+
+.. |default| replace:: :code:`default`
 .. _static: modes.rst#using-the-race-detector
+.. |static| replace:: :code:`static`
 .. _race: modes.rst#building-static-binaries
+.. |race| replace:: :code:`race`
 
 .. role:: param(kbd)
 .. role:: type(emphasis)
@@ -23,7 +28,7 @@ Core go rules
 These are the core go rules, required for basic operation.
 The intent is that theses rules are sufficient to match the capabilities of the normal go tools.
 
-.. contents::
+.. contents:: :depth: 2
 
 -----
 
@@ -38,8 +43,8 @@ Defines and stamping
 Embedding
 ~~~~~~~~~
 
-This is used for things like internal tests, where a library is recompiled with additional
-and also code generators where the generated source will be known to have extra dependancies.
+This is used for things like internal tests, where a library is recompiled with additional sources
+and also code generators where the generated source will be known to have extra dependencies.
 
 **TODO**: More information
 
@@ -61,8 +66,8 @@ Providers
 Output groups
 ^^^^^^^^^^^^^
 
-* default *: A library with the default build options.*
-* race_ *: The library build with race detection enabled.*
+* |default| : A library with the default build options.
+* |race|_ : The library build with race detection enabled.
 
 Attributes
 ^^^^^^^^^^
@@ -91,11 +96,13 @@ Attributes
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`deps`              | :type:`label_list`          | :value:`None`                         |
 +----------------------------+-----------------------------+---------------------------------------+
-| List of GoLibrary_ providers this library imports directly.                                      |
+| List of Go libraries this library imports directly.                                              |
+| These may be go_library rules or compatible rules with the GoLibrary_ provider.                  |
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`embed`             | :type:`label_list`          | :value:`None`                         |
 +----------------------------+-----------------------------+---------------------------------------+
-| List of GoEmbed_ providers this library embeds.                                                  |
+| List of Go libraries this test library directly.                                                 |
+| These may be go_library rules or compatible rules with the GoEmbed_ provider.                    |
 | These can provide both :param:`srcs` and param:`deps` to this library.                           |
 | See Embedding_ for more information about how and when to use this.                              |
 +----------------------------+-----------------------------+---------------------------------------+
@@ -122,17 +129,20 @@ Attributes
 | :param:`cdeps`             | :type:`label_list`          | :value:`None`                         |
 +----------------------------+-----------------------------+---------------------------------------+
 | The list of other libraries that the c code depends on.                                          |
-| These should be names of C++ library rules.                                                      |
+| This can be anything that would be allowed in `cc library deps`_                                 |
+| Only valid if :param:`cgo` = :value:`True`.                                                      |
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`copts`             | :type:`string_list`         | :value:`[]`                           |
 +----------------------------+-----------------------------+---------------------------------------+
 | List of flags to add to the C compilation command.                                               |
 | Subject to `"Make variable"`_ substitution and `Bourne shell tokenization`_.                     |
+| Only valid if :param:`cgo` = :value:`True`.                                                      |
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`clinkopts`         | :type:`string_list`         | :value:`[]`                           |
 +----------------------------+-----------------------------+---------------------------------------+
 | List of flags to add to the C link command.                                                      |
 | Subject to `"Make variable"`_ substitution and `Bourne shell tokenization`_.                     |
+| Only valid if :param:`cgo` = :value:`True`.                                                      |
 +----------------------------+-----------------------------+---------------------------------------+
 
 Example
@@ -171,9 +181,9 @@ Providers
 Output groups
 ^^^^^^^^^^^^^
 
-* default *: A binary with the default build options.*
-* static_ *: A statically linked binary.*
-* race_ *: The binary with race detection enabled.*
+* |default| : A binary with the default build options.
+* |static|_ : A statically linked binary.
+* |race|_ : The binary with race detection enabled.
 
 Attributes
 ^^^^^^^^^^
@@ -202,12 +212,14 @@ Attributes
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`deps`              | :type:`label_list`          | :value:`None`                         |
 +----------------------------+-----------------------------+---------------------------------------+
-| List of GoLibrary_ providers this binary imports directly.                                       |
+| List of Go libraries this binary imports directly.                                               |
+| These may be go_library rules or compatible rules with the GoLibrary_ provider.                  |
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`embed`             | :type:`label_list`          | :value:`None`                         |
 +----------------------------+-----------------------------+---------------------------------------+
-| List of GoEmbed_ providers this binary embeds.                                                   |
-| These can provide both :param:`srcs` and param:`deps` to this library.                           |
+| List of Go libraries this binary embeds directly.                                                |
+| These may be go_library rules or compatible rules with the GoEmbed_ provider.                    |
+| These can provide both :param:`srcs` and param:`deps` to this binary.                            |
 | See Embedding_ for more information about how and when to use this.                              |
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`data`              | :type:`label_list`          | :value:`None`                         |
@@ -243,17 +255,20 @@ Attributes
 | :param:`cdeps`             | :type:`label_list`          | :value:`None`                         |
 +----------------------------+-----------------------------+---------------------------------------+
 | The list of other libraries that the c code depends on.                                          |
-| These should be names of C++ library rules.                                                      |
+| This can be anything that would be allowed in `cc library deps`_                                 |
+| Only valid if :param:`cgo` = :value:`True`.                                                      |
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`copts`             | :type:`string_list`         | :value:`[]`                           |
 +----------------------------+-----------------------------+---------------------------------------+
 | List of flags to add to the C compilation command.                                               |
 | Subject to `"Make variable"`_ substitution and `Bourne shell tokenization`_.                     |
+| Only valid if :param:`cgo` = :value:`True`.                                                      |
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`clinkopts`         | :type:`string_list`         | :value:`[]`                           |
 +----------------------------+-----------------------------+---------------------------------------+
 | List of flags to add to the C link command.                                                      |
 | Subject to `"Make variable"`_ substitution and `Bourne shell tokenization`_.                     |
+| Only valid if :param:`cgo` = :value:`True`.                                                      |
 +----------------------------+-----------------------------+---------------------------------------+
 
 go_test
@@ -279,7 +294,7 @@ Providers
 Output groups
 ^^^^^^^^^^^^^
 
-* default *: The test binary.*
+* |default| : The test binary.
 
 Attributes
 ^^^^^^^^^^
@@ -309,12 +324,14 @@ Attributes
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`deps`              | :type:`label_list`          | :value:`None`                         |
 +----------------------------+-----------------------------+---------------------------------------+
-| List of GoLibrary_ providers this test imports directly.                                         |
+| List of Go libraries this test imports directly.                                                 |
+| These may be go_library rules or compatible rules with the GoLibrary_ provider.                  |
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`embed`             | :type:`label_list`          | :value:`None`                         |
 +----------------------------+-----------------------------+---------------------------------------+
-| List of GoEmbed_ providers this binary embeds.                                                   |
-| These can provide both :param:`srcs` and param:`deps` to this library.                           |
+| List of Go libraries this test embeds directly.                                                  |
+| These may be go_library rules or compatible rules with the GoEmbed_ provider.                    |
+| These can provide both :param:`srcs` and param:`deps` to this test.                              |
 | See Embedding_ for more information about how and when to use this.                              |
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`data`              | :type:`label_list`          | :value:`None`                         |
@@ -350,17 +367,20 @@ Attributes
 | :param:`cdeps`             | :type:`label_list`          | :value:`None`                         |
 +----------------------------+-----------------------------+---------------------------------------+
 | The list of other libraries that the c code depends on.                                          |
-| These should be names of C++ library rules.                                                      |
+| This can be anything that would be allowed in `cc library deps`_                                 |
+| Only valid if :param:`cgo` = :value:`True`.                                                      |
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`copts`             | :type:`string_list`         | :value:`[]`                           |
 +----------------------------+-----------------------------+---------------------------------------+
 | List of flags to add to the C compilation command.                                               |
 | Subject to `"Make variable"`_ substitution and `Bourne shell tokenization`_.                     |
+| Only valid if :param:`cgo` = :value:`True`.                                                      |
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`clinkopts`         | :type:`string_list`         | :value:`[]`                           |
 +----------------------------+-----------------------------+---------------------------------------+
 | List of flags to add to the C link command.                                                      |
 | Subject to `"Make variable"`_ substitution and `Bourne shell tokenization`_.                     |
+| Only valid if :param:`cgo` = :value:`True`.                                                      |
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`rundir`            | :type:`string`              | The package path                      |
 +----------------------------+-----------------------------+---------------------------------------+


### PR DESCRIPTION
More for #810

Still need the x_ref section filled in, and some more about embedding and why we do it, but even without that it is strictly better and more accurate than what we have right now.

[skip ci]
[ci skip]