### PR TITLE
Make bzl files compatible with mutating behavior of += on lists

### DIFF
--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -43,7 +43,7 @@ def emit_link(ctx, go_toolchain, library, mode, executable, gc_linkopts, x_defs)
   extldflags = []
   if go_toolchain.external_linker:
     ld = go_toolchain.external_linker.compiler_executable
-    extldflags = go_toolchain.external_linker.options[:]
+    extldflags = list(go_toolchain.external_linker.options)
   extldflags += ["-Wl,-rpath,$ORIGIN/" + ("../" * pkg_depth)]
 
   gc_linkopts, extldflags = _extract_extldflags(gc_linkopts, extldflags)

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -43,7 +43,7 @@ def emit_link(ctx, go_toolchain, library, mode, executable, gc_linkopts, x_defs)
   extldflags = []
   if go_toolchain.external_linker:
     ld = go_toolchain.external_linker.compiler_executable
-    extldflags = go_toolchain.external_linker.options
+    extldflags = go_toolchain.external_linker.options[:]
   extldflags += ["-Wl,-rpath,$ORIGIN/" + ("../" * pkg_depth)]
 
   gc_linkopts, extldflags = _extract_extldflags(gc_linkopts, extldflags)


### PR DESCRIPTION
In the future versions of Bazel += will mutate lists instead of copying them. Because of that lists in the left-hand side can't be frozen, if they are they should be copied in the current mutability scope first.