### PR TITLE
Preparing actions for future changes

### DIFF
--- a/go/private/actions/asm.bzl
+++ b/go/private/actions/asm.bzl
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-def emit_asm(ctx, go_toolchain, source, hdrs, out_obj):
+def emit_asm(ctx, go_toolchain,
+    source = None,
+    hdrs = [],
+    out_obj = None):
   """Construct the command line for compiling Go Assembly code.
   Constructs a symlink tree to accomodate for workspace name.
   Args:
@@ -21,6 +24,8 @@ def emit_asm(ctx, go_toolchain, source, hdrs, out_obj):
     hdrs: list of .h files that may be included
     out_obj: the artifact (configured target?) that should be produced
   """
+  if source == None: fail("source is a required parameter")
+  if out_obj == None: fail("out_obj is a required parameter")
   includes = depset()
   includes += [f.dirname for f in hdrs]
   includes += [f.dirname for f in go_toolchain.data.headers.cc.transitive_headers]

--- a/go/private/actions/compile.bzl
+++ b/go/private/actions/compile.bzl
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_go//go/private:common.bzl", 
+load("@io_bazel_rules_go//go/private:common.bzl",
+    "NORMAL_MODE",
     "RACE_MODE",
 )
 load("@io_bazel_rules_go//go/private:providers.bzl",
@@ -20,7 +21,13 @@ load("@io_bazel_rules_go//go/private:providers.bzl",
     "get_searchpath",
 )
 
-def emit_compile(ctx, go_toolchain, sources, importpath, golibs, mode, out_lib, gc_goopts):
+def emit_compile(ctx, go_toolchain,
+    sources = None,
+    importpath = "",
+    golibs = [],
+    mode = NORMAL_MODE,
+    out_lib = None,
+    gc_goopts = []):
   """Construct the command line for compiling Go code.
 
   Args:
@@ -32,6 +39,9 @@ def emit_compile(ctx, go_toolchain, sources, importpath, golibs, mode, out_lib, 
     out_lib: the archive file that should be produced
     gc_goopts: additional flags to pass to the compiler.
   """
+
+  if sources == None: fail("sources is a required parameter")
+  if out_lib == None: fail("out_lib is a required parameter")
 
   # Add in any mode specific behaviours
   if mode == RACE_MODE:

--- a/go/private/actions/cover.bzl
+++ b/go/private/actions/cover.bzl
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-def emit_cover(ctx, go_toolchain, sources):
+def emit_cover(ctx, go_toolchain,
+               sources = []):
   """Construct the command line for test coverage instrument.
 
   Args:
@@ -29,8 +30,8 @@ def emit_cover(ctx, go_toolchain, sources):
   cover_vars = []
 
   for src in sources:
-    if (not src.basename.endswith(".go") or 
-        src.basename.endswith("_test.go") or 
+    if (not src.basename.endswith(".go") or
+        src.basename.endswith("_test.go") or
         src.basename.endswith(".cover.go")):
       outputs += [src]
       continue

--- a/go/private/actions/library.bzl
+++ b/go/private/actions/library.bzl
@@ -12,24 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_go//go/private:common.bzl", 
+load("@io_bazel_rules_go//go/private:common.bzl",
     "dict_of",
     "split_srcs",
     "join_srcs",
     "compile_modes",
 )
-load("@io_bazel_rules_go//go/private:providers.bzl", 
+load("@io_bazel_rules_go//go/private:providers.bzl",
     "CgoInfo",
-    "GoLibrary", 
+    "GoLibrary",
     "GoEmbed",
     "library_attr",
     "searchpath_attr",
 )
 
-def emit_library(
-    ctx,
-    go_toolchain,
-    importpath,
+def emit_library(ctx, go_toolchain,
+    importpath = "",
     srcs = (),
     deps = (),
     cgo_info = None,
@@ -59,7 +57,7 @@ def emit_library(
         other libraries.
     golibs: an iterable of GoLibrary objects. Used to pass in
         synthetic dependencies.
-       
+
   Returns:
     A tuple of GoLibrary and GoEmbed.
   """

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@io_bazel_rules_go//go/private:common.bzl",
+    "NORMAL_MODE",
     "RACE_MODE",
 )
 load("@io_bazel_rules_go//go/private:providers.bzl",
@@ -20,7 +21,12 @@ load("@io_bazel_rules_go//go/private:providers.bzl",
     "get_searchpath",
 )
 
-def emit_link(ctx, go_toolchain, library, mode, executable, gc_linkopts, x_defs):
+def emit_link(ctx, go_toolchain,
+    library = None,
+    mode = NORMAL_MODE,
+    executable = None,
+    gc_linkopts = [],
+    x_defs = {}):
   """Adds an action to link the supplied library in the given mode, producing the executable.
   Args:
     ctx: The skylark Context.
@@ -31,6 +37,9 @@ def emit_link(ctx, go_toolchain, library, mode, executable, gc_linkopts, x_defs)
     gc_linkopts: basic link options, these may be adjusted by the mode.
     x_defs: link defines, including build stamping ones
   """
+
+  if library == None: fail("library is a required parameter")
+  if executable == None: fail("executable is a required parameter")
 
   # Add in any mode specific behaviours
   if mode == RACE_MODE:
@@ -73,7 +82,7 @@ def emit_link(ctx, go_toolchain, library, mode, executable, gc_linkopts, x_defs)
       link_opts += ["-X", "%s=%s" % (k, v)]
 
   link_opts += go_toolchain.flags.link
-  if ld: 
+  if ld:
     link_opts += [
         "-extld", ld,
         "-extldflags", " ".join(extldflags),

--- a/go/private/actions/pack.bzl
+++ b/go/private/actions/pack.bzl
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-def emit_pack(ctx, go_toolchain, in_lib, out_lib, objects = (), archive = None):
+def emit_pack(ctx, go_toolchain,
+    in_lib = None,
+    out_lib = None,
+    objects = (),
+    archive = None):
   """Construct the command line for packing objects together.
 
   Args:
@@ -23,8 +27,11 @@ def emit_pack(ctx, go_toolchain, in_lib, out_lib, objects = (), archive = None):
     archive: an optional archive file to be concatenated with the output
         archive file.
   """
+  if in_lib == None: fail("in_lib is a required parameter")
+  if out_lib == None: fail("out_lib is a required parameter")
+
   inputs = [in_lib] + go_toolchain.data.tools
-    
+
   arguments = [
       "-gotool", go_toolchain.tools.go.path,
       "-in", in_lib.path,

--- a/go/toolchain/toolchains.bzl
+++ b/go/toolchain/toolchains.bzl
@@ -40,7 +40,7 @@ def _generate_toolchains():
           hosts = ["darwin_amd64", "linux_amd64"],
       ),
   ]
-  
+
   # The set of allowed cross compilations
   cross_targets = {
       "linux_amd64": ["windows_amd64"],


### PR DESCRIPTION
All action parameters have default values, so they are forced to be passed by
name.
This will allow us to deprecate them and add new ones safely.