### PR TITLE
Write go_binary in terms of a binary action generator

### DIFF
--- a/go/private/actions/binary.bzl
+++ b/go/private/actions/binary.bzl
@@ -1,0 +1,86 @@
+# Copyright 2014 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go/private:common.bzl",
+    "compile_modes",
+    "NORMAL_MODE",
+    "RACE_MODE",
+)
+load("@io_bazel_rules_go//go/private:providers.bzl",
+    "GoBinary",
+)
+
+def emit_binary(ctx, go_toolchain,
+    name="",
+    importpath = "",
+    srcs = (),
+    deps = (),
+    cgo_info = None,
+    embed = (),
+    gc_linkopts = (),
+    x_defs = {}):
+  """See go/toolchains.rst#binary for full documentation."""
+
+  if name == "": fail("name is a required parameter")
+
+  golib, _ = go_toolchain.actions.library(ctx,
+      go_toolchain = go_toolchain,
+      srcs = srcs,
+      deps = deps,
+      cgo_info = cgo_info,
+      embed = embed,
+      importpath = importpath,
+      importable = False,
+  )
+
+  # Default (dynamic) linking
+  race_executable = ctx.new_file(name + ".race")
+  for mode in compile_modes:
+    executable = ctx.outputs.executable
+    if mode == RACE_MODE:
+      executable = race_executable
+    go_toolchain.actions.link(
+        ctx,
+        go_toolchain = go_toolchain,
+        library=golib,
+        mode=mode,
+        executable=executable,
+        gc_linkopts=gc_linkopts,
+        x_defs=x_defs,
+    )
+
+  # Static linking (in the 'static' output group)
+  static_linkopts = [
+      "-linkmode", "external",
+      "-extldflags", "-static",
+  ]
+  static_executable = ctx.new_file(name + ".static")
+  go_toolchain.actions.link(
+      ctx,
+      go_toolchain = go_toolchain,
+      library=golib,
+      mode=NORMAL_MODE,
+      executable=static_executable,
+      gc_linkopts=gc_linkopts + static_linkopts,
+      x_defs=x_defs,
+  )
+
+  return [
+      golib,
+      GoBinary(
+          executable = ctx.outputs.executable,
+          static = static_executable,
+          race = race_executable,
+      ),
+  ]

--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -15,6 +15,7 @@
 Toolchain rules used by go.
 """
 load("@io_bazel_rules_go//go/private:actions/asm.bzl", "emit_asm")
+load("@io_bazel_rules_go//go/private:actions/binary.bzl", "emit_binary")
 load("@io_bazel_rules_go//go/private:actions/compile.bzl", "emit_compile")
 load("@io_bazel_rules_go//go/private:actions/cover.bzl", "emit_cover")
 load("@io_bazel_rules_go//go/private:actions/library.bzl", "emit_library")
@@ -34,6 +35,7 @@ def _go_toolchain_impl(ctx):
       },
       actions = struct(
           asm = emit_asm,
+          binary = emit_binary,
           compile = emit_compile,
           cover = emit_cover,
           library = emit_library,

--- a/go/toolchains.rst
+++ b/go/toolchains.rst
@@ -351,6 +351,7 @@ the stable public interface is
   * actions
 
     * asm_
+    * binary_
     * compile_
     * cover_
     * library_
@@ -401,6 +402,63 @@ It does not return anything.
 +--------------------------------+-----------------------------+-----------------------------------+
 | The output object file that should be built by the generated action.                             |
 +--------------------------------+-----------------------------+-----------------------------------+
+
+
+binary
+~~~~~~
+
+This emits actions to compile and link Go code into a binary.
+It supports embedding, cgo dependencies, coverage, and assembling and packing .s files.
+
+It returns a tuple of GoLibrary_ and GoBinary_.
+
++--------------------------------+-----------------------------+-----------------------------------+
+| **Name**                       | **Type**                    | **Default value**                 |
++--------------------------------+-----------------------------+-----------------------------------+
+| :param:`ctx`                   | :type:`string`              | |mandatory|                       |
++--------------------------------+-----------------------------+-----------------------------------+
+| The current rule context, used to generate the actions.                                          |
++--------------------------------+-----------------------------+-----------------------------------+
+| :param:`go_toolchain`          | :type:`the Go toolchain`    | |mandatory|                       |
++--------------------------------+-----------------------------+-----------------------------------+
+| This must be the same Go toolchain object you got this function from.                            |
++--------------------------------+-----------------------------+-----------------------------------+
+| :param:`name`                  | :type:`string`              | |mandatory|                       |
++--------------------------------+-----------------------------+-----------------------------------+
+| The base name of the generated binaries.                                                         |
++--------------------------------+-----------------------------+-----------------------------------+
+| :param:`srcs`                  | :type:`File iterable`       | :value:`[]`                       |
++--------------------------------+-----------------------------+-----------------------------------+
+| An iterable of Go source Files to be compiled.                                                   |
++--------------------------------+-----------------------------+-----------------------------------+
+| :param:`deps`                  | :type:`GoLibrary iterable`  | :value:`[]`                       |
++--------------------------------+-----------------------------+-----------------------------------+
+| The list of direct dependencies of this package.                                                 |
++--------------------------------+-----------------------------+-----------------------------------+
+| :param:`cgo_info`              | :type:`CgoInfo`             | :value:`None`                     |
++--------------------------------+-----------------------------+-----------------------------------+
+| An optional CgoInfo provider for this library.                                                   |
+| There may be at most one of these among the library and its embeds.                              |
++--------------------------------+-----------------------------+-----------------------------------+
+| :param:`embed`                 | :type:`GoEmbed iterable`    | :value:`[]`                       |
++--------------------------------+-----------------------------+-----------------------------------+
+| Sources, dependencies, and other information from these are combined with the package            |
+| being compiled.                                                                                  |
+| Used to build internal test packages.                                                            |
++--------------------------------+-----------------------------+-----------------------------------+
+| :param:`importpath`            | :type:`string`              | :value:`""`                       |
++--------------------------------+-----------------------------+-----------------------------------+
+| The import path this package represents.                                                         |
++--------------------------------+-----------------------------+-----------------------------------+
+| :param:`gc_linkopts`           | :type:`string_list`         | :value:`[]`                       |
++--------------------------------+-----------------------------+-----------------------------------+
+| Basic link options.                                                                              |
++--------------------------------+-----------------------------+-----------------------------------+
+| :param:`x_defs`                | :type:`map`                 | :value:`{}`                       |
++--------------------------------+-----------------------------+-----------------------------------+
+| Link defines, including build stamping ones.                                                     |
++--------------------------------+-----------------------------+-----------------------------------+
+
 
 compile
 ~~~~~~~
@@ -479,6 +537,7 @@ Note that this removes most comments, including cgo comments.
 | These Must be pure .go files that are ready to be passed to compile_, no assembly or cgo is      |
 | allowed.                                                                                         |
 +--------------------------------+-----------------------------+-----------------------------------+
+
 
 library
 ~~~~~~~


### PR DESCRIPTION
This will allow other rules that also want to build go binaries to do so in a
compatible way with the go_binary rule.

This is progress towards fixing #815