### PR TITLE
Add a reference to the proto rules in the Setup section.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,6 +105,9 @@ Setup
     load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
     go_rules_dependencies()
     go_register_toolchains()
+    # The following are only needed if you have proto files in your repository.
+    load("@io_bazel_rules_go//proto:def.bzl", "proto_register_toolchains")
+    proto_register_toolchains()
 
   If you want to use a specific commit (for example, something close to
   ``master``), add the following instead:
@@ -119,6 +122,9 @@ Setup
     load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
     go_rules_dependencies()
     go_register_toolchains()
+    # The following are only needed if you have proto files in your repository.
+    load("@io_bazel_rules_go//proto:def.bzl", "proto_register_toolchains")
+    proto_register_toolchains()
 
   You can add more external dependencies to this file later (see go_repository_).
 

--- a/README.rst
+++ b/README.rst
@@ -105,9 +105,6 @@ Setup
     load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
     go_rules_dependencies()
     go_register_toolchains()
-    # The following are only needed if you have proto files in your repository.
-    load("@io_bazel_rules_go//proto:def.bzl", "proto_register_toolchains")
-    proto_register_toolchains()
 
   If you want to use a specific commit (for example, something close to
   ``master``), add the following instead:
@@ -122,7 +119,12 @@ Setup
     load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
     go_rules_dependencies()
     go_register_toolchains()
-    # The following are only needed if you have proto files in your repository.
+
+  If you plan to use the proto rules (``go_proto_library`` and
+  ``go_grpc_library``), add the following to WORKSPACE.
+
+  .. code:: bzl
+
     load("@io_bazel_rules_go//proto:def.bzl", "proto_register_toolchains")
     proto_register_toolchains()
 


### PR DESCRIPTION
Without this, `gazelle` will generate unbuildable targets when you have `.proto` files.