### PR TITLE
Allow configuring what type of protobuf generation to do in go_repository

### DIFF
--- a/go/private/go_repository.bzl
+++ b/go/private/go_repository.bzl
@@ -81,7 +81,8 @@ def _go_repository_impl(ctx):
     gazelle = ctx.path(Label(_gazelle))
     cmds = [gazelle, '--go_prefix', ctx.attr.importpath, '--mode', 'fix',
             '--repo_root', ctx.path(''),
-            "--build_tags", ",".join(ctx.attr.build_tags)]
+            "--build_tags", ",".join(ctx.attr.build_tags),
+            "--proto", ctx.attr.build_file_proto_mode]
     if ctx.attr.build_file_name:
         cmds += ["--build_file_name", ctx.attr.build_file_name]
     cmds += [ctx.path('')]
@@ -113,6 +114,7 @@ go_repository = repository_rule(
         "build_file_name": attr.string(default="BUILD.bazel,BUILD"),
         "build_file_generation": attr.string(default="auto", values=["on", "auto", "off"]),
         "build_tags": attr.string_list(),
+        "build_file_proto_mode": attr.string(default="default", values=["default", "disable", "legacy"]),
     },
 )
 """See go/workspace.rst#go-repository for full documentation."""

--- a/tests/popular_repos/WORKSPACE.in
+++ b/tests/popular_repos/WORKSPACE.in
@@ -39,6 +39,18 @@ go_repository(
 )
 
 go_repository(
+    name = "org_golang_google_grpc",
+    importpath = "google.golang.org/grpc",
+    commit = "3f10311ccf076b6b7cba28273df3290d42e60982",
+
+    # GRPC has already-generated protobuf definitions, and we don't currently
+    # register any protobuf toolchains in this WORKSPACE.  As such, the build
+    # should fail if we try to generate protobuf rules, but succeed if we
+    # disable generation.
+    build_file_proto_mode = "disable",
+)
+
+go_repository(
     name = "com_github_mattn_go_sqlite3",
     importpath = "github.com/mattn/go-sqlite3",
     commit = "83772a7051f5e30d8e59746a9e43dfa706b72f3b",

--- a/tests/popular_repos/popular_repos.bash
+++ b/tests/popular_repos/popular_repos.bash
@@ -41,6 +41,10 @@ targets=(
   @org_golang_x_text//...
   @org_golang_x_tools//...
   @com_github_mattn_go_sqlite3//...
+
+  # We don't need to build all of GRPC; just the components where we would
+  # otherwise generate a protobuf rule
+  @org_golang_google_grpc//grpclb/grpc_lb_v1/messages:go_default_library
 )
 
 excludes=(


### PR DESCRIPTION
This allows configuring what form of protobuf generation to do in a `go_repository` rule.

The main reason that I'd like this feature is that it allows us to use `grpc-gateway` (and, I'm sure, other projects) that have already-generated protobuf code in their repositories.  By default, when using `go_repository`, Gazelle will generate a BUILD file that attempts to build the protobufs; since importing external protobufs isn't yet supported, this fails.

With these changes, it's now possible to manually create the correct `go_repository` rules with `--proto disable`, which allows builds to succeed.

I've created a repository that demonstrates this problem here: https://github.com/andrew-d/rules_go-gateway-demo

If you check it out and run `bazel build //example:greeter`, you'll get the following error:

```
$ bazel build //example:greeter
INFO: Found 1 target...
ERROR: /private/var/tmp/_bazel_adunham/901306667fe55f4a3c8aee5008d8180a/external/com_github_grpc_ecosystem_grpc_gateway/runtime/internal/BUILD.bazel:10:1: Generating into bazel-out/darwin_x86_64-fastbuild/bin/external/com_github_grpc_ecosystem_grpc_gateway/runtime/internal/internal_go_proto/github.com/grpc-ecosystem/grpc-gateway/runtime/internal failed (Exit 1).
../com_github_grpc_ecosystem_grpc_gateway/runtime/internal/stream_chunk.proto: No such file or directory
Target //example:greeter failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 64.845s, Critical Path: 0.07s
```

If you uncomment the marked lines in the [`WORKSPACE` file](https://github.com/andrew-d/rules_go-gateway-demo/blob/master/WORKSPACE), which uses the features in this PR, then the build will succeed.

Thoughts and feedback appreciated!