### PR TITLE
Update gRPC-related dependencies

### DIFF
--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -158,13 +158,24 @@ def go_rules_dependencies():
   # GRPC dependancies
   _maybe(go_repository,
       name = "org_golang_x_net",
-      commit = "4971afdc2f162e82d185353533d3cf16188a9f4e",
+      commit = "a04bdaca5b32abe1c069418fb7088ae607de5bd0",  # master as of 2017-10-10
       importpath = "golang.org/x/net",
   )
   _maybe(go_repository,
+      name = "org_golang_x_text",
+      commit = "ab5ac5f9a8deb4855a60fab02bc61a4ec770bd49",  # v0.1.0, latest as of 2017-10-10
+      importpath = "golang.org/x/text",
+  )
+  _maybe(go_repository,
       name = "org_golang_google_grpc",
-      tag = "v1.0.4",
+      commit = "f92cdcd7dcdc69e81b2d7b338479a19a8723cfa3",  # v1.6.0, latest as of 2017-10-10
       importpath = "google.golang.org/grpc",
+      build_file_proto_mode = "disable",  # use existing generated code
+  )
+  _maybe(go_repository,
+      name = "org_golang_google_genproto",
+      commit = "f676e0f3ac6395ff1a529ae59a6670878a8371a6",  # master on 2017-10-10
+      importpath = "google.golang.org/genproto",
   )
 
   # Needed for examples

--- a/go/workspace.rst
+++ b/go/workspace.rst
@@ -3,8 +3,10 @@ Go workspace rules
 
 .. _github.com/google/protobuf: https://github.com/google/protobuf/
 .. _github.com/golang/protobuf: https://github.com/golang/protobuf/
+.. _google.golang.org/genproto: https://github.com/google/go-genproto
 .. _google.golang.org/grpc: https://github.com/grpc/grpc-go
 .. _golang.org/x/net: https://github.com/golang/net/
+.. _golang.org/x/text: https://github.com/golang/text/
 .. _golang.org/x/tools: https://github.com/golang/tools/
 .. _go_library: core.rst#go_library
 .. _toolchains: toolchains.rst
@@ -67,8 +69,10 @@ likely to want to know about and override, but it is by no means a complete list
 
 * :value:`com_google_protobuf` : An http_archive for `github.com/google/protobuf`_
 * :value:`com_github_golang_protobuf` : A go_repository for `github.com/golang/protobuf`_
+* :value:`org_golang_google_genproto` : A go_repository for `google.golang.org/genproto`_
 * :value:`org_golang_google_grpc` : A go_repository for `google.golang.org/grpc`_
 * :value:`org_golang_x_net` : A go_repository for `golang.org/x/net`_
+* :value:`org_golang_x_text` : A go_repository for `golang.org/x/text`_
 * :value:`org_golang_x_tools` : A go_repository for `golang.org/x/tools`_
 
 


### PR DESCRIPTION
* org_golang_google_grpc is updated to v1.6.0
* org_golang_x_net is updated to master.
* org_golang_x_text is added.
* org_golang_google_genproto is added.

Fixes #892