### PR TITLE
Add `build_external` option to `go_repository`.

### DIFF
--- a/go/private/go_repository.bzl
+++ b/go/private/go_repository.bzl
@@ -82,6 +82,7 @@ def _go_repository_impl(ctx):
     cmds = [gazelle, '--go_prefix', ctx.attr.importpath, '--mode', 'fix',
             '--repo_root', ctx.path(''),
             "--build_tags", ",".join(ctx.attr.build_tags),
+            "--external", ctx.attr.build_external,
             "--proto", ctx.attr.build_file_proto_mode]
     if ctx.attr.build_file_name:
         cmds += ["--build_file_name", ctx.attr.build_file_name]
@@ -111,6 +112,7 @@ go_repository = repository_rule(
         "sha256": attr.string(),
 
         # Attributes for a repository that needs automatic build file generation
+        "build_external": attr.string(default="external", values=["external", "vendored"]),
         "build_file_name": attr.string(default="BUILD.bazel,BUILD"),
         "build_file_generation": attr.string(default="auto", values=["on", "auto", "off"]),
         "build_tags": attr.string_list(),


### PR DESCRIPTION
This attribute can be used to enable building a depended-on repository
with its own vendored dependencies, instead of workspace dependencies.

This PR is a reduced version of https://github.com/bazelbuild/rules_go/pull/601 that doesn't allow custom vendor prefixes.