### PR TITLE
Fix proto path

### DIFF
--- a/proto/toolchain.bzl
+++ b/proto/toolchain.bzl
@@ -18,7 +18,7 @@ def _emit_proto_compile(ctx, proto_toolchain, go_proto_toolchain, lib, importpat
       "--descriptor_set_in", ":".join(
           [s.path for s in lib.proto.transitive_descriptor_sets])
   ]
-  args += [proto.short_path for proto in lib.proto.direct_sources]
+  args += [proto_path(proto) for proto in lib.proto.direct_sources]
   ctx.action(
       inputs = [
           proto_toolchain.protoc,
@@ -29,8 +29,19 @@ def _emit_proto_compile(ctx, proto_toolchain, go_proto_toolchain, lib, importpat
       mnemonic = "GoProtocGen",
       executable = proto_toolchain.protoc,
       arguments = args,
+      #command = "tree",
   )
   return go_srcs
+
+def proto_path(proto):
+  path = proto.path
+  root = proto.root.path
+  ws = proto.owner.workspace_root
+  if path.startswith(root): path = path[len(root):]
+  if path.startswith("/"): path = path[1:]
+  if path.startswith(ws): path = path[len(ws):]
+  if path.startswith("/"): path = path[1:]
+  return path
 
 def _proto_toolchain_impl(ctx):
   return [platform_common.ToolchainInfo(

--- a/proto/toolchain.bzl
+++ b/proto/toolchain.bzl
@@ -18,7 +18,7 @@ def _emit_proto_compile(ctx, proto_toolchain, go_proto_toolchain, lib, importpat
       "--descriptor_set_in", ":".join(
           [s.path for s in lib.proto.transitive_descriptor_sets])
   ]
-  args += [proto_path(proto) for proto in lib.proto.direct_sources]
+  args += [_proto_path(proto) for proto in lib.proto.direct_sources]
   ctx.action(
       inputs = [
           proto_toolchain.protoc,
@@ -29,11 +29,14 @@ def _emit_proto_compile(ctx, proto_toolchain, go_proto_toolchain, lib, importpat
       mnemonic = "GoProtocGen",
       executable = proto_toolchain.protoc,
       arguments = args,
-      #command = "tree",
   )
   return go_srcs
 
-def proto_path(proto):
+def _proto_path(proto):
+  """
+  The proto path is not really a file path
+  It's the path to the proto that was seen when the descriptor file was generated.
+  """
   path = proto.path
   root = proto.root.path
   ws = proto.owner.workspace_root


### PR DESCRIPTION
The proto path is not really a file path, it's the path to the proto that was seen when the descriptor file was generated, which is suprisingly hard to work out after the fact.

Fixes #909