### PR TITLE
Gazelle: add //vendor prefix to proto imports in vendor/

### DIFF
--- a/go/tools/gazelle/resolve/resolve.go
+++ b/go/tools/gazelle/resolve/resolve.go
@@ -89,7 +89,7 @@ const (
 
 // ResolveProto resolves an import statement in a .proto file to a label
 // for a proto_library rule.
-func (r *Resolver) ResolveProto(imp string) (Label, error) {
+func (r *Resolver) ResolveProto(imp, pkgRel string) (Label, error) {
 	if !strings.HasSuffix(imp, ".proto") {
 		return Label{}, fmt.Errorf("can't import non-proto: %q", imp)
 	}
@@ -103,8 +103,12 @@ func (r *Resolver) ResolveProto(imp string) (Label, error) {
 
 	// Temporary hack: guess the label based on the proto file name. We assume
 	// all proto files in a directory belong to the same package, and the
-	// package name matches the directory base name.
+	// package name matches the directory base name. We also assume that protos
+	// in the vendor directory must refer to something else in vendor.
 	// TODO(#859): use dependency table to resolve once it exists.
+	if pkgRel == "vendor" || strings.HasPrefix(pkgRel, "vendor/") {
+		imp = path.Join("vendor", imp)
+	}
 	rel := path.Dir(imp)
 	if rel == "." {
 		rel = ""
@@ -115,7 +119,7 @@ func (r *Resolver) ResolveProto(imp string) (Label, error) {
 
 // ResolveGoProto resolves an import statement in a .proto file to a
 // label for a go_library rule that embeds the corresponding go_proto_library.
-func (r *Resolver) ResolveGoProto(imp string) (Label, error) {
+func (r *Resolver) ResolveGoProto(imp, pkgRel string) (Label, error) {
 	if !strings.HasSuffix(imp, ".proto") {
 		return Label{}, fmt.Errorf("can't import non-proto: %q", imp)
 	}
@@ -133,8 +137,12 @@ func (r *Resolver) ResolveGoProto(imp string) (Label, error) {
 
 	// Temporary hack: guess the label based on the proto file name. We assume
 	// all proto files in a directory belong to the same package, and the
-	// package name matches the directory base name.
+	// package name matches the directory base name. We also assume that protos
+	// in the vendor directory must refer to something else in vendor.
 	// TODO(#859): use dependency table to resolve once it exists.
+	if pkgRel == "vendor" || strings.HasPrefix(pkgRel, "vendor/") {
+		imp = path.Join("vendor", imp)
+	}
 	rel := path.Dir(imp)
 	if rel == "." {
 		rel = ""

--- a/go/tools/gazelle/rules/generator.go
+++ b/go/tools/gazelle/rules/generator.go
@@ -111,7 +111,10 @@ func (g *Generator) generateProto(pkg *packages.Package) (string, []bf.Expr) {
 		{"srcs", g.sources(pkg.Proto.Sources, pkg.Rel)},
 		{"visibility", visibility},
 	}
-	protoDeps := g.dependencies(pkg.Proto.Imports, g.r.ResolveProto)
+	resolveProto := func(imp string) (resolve.Label, error) {
+		return g.r.ResolveProto(imp, pkg.Rel)
+	}
+	protoDeps := g.dependencies(pkg.Proto.Imports, resolveProto)
 	if !protoDeps.IsEmpty() {
 		protoAttrs = append(protoAttrs, keyvalue{"deps", protoDeps})
 	}
@@ -123,7 +126,10 @@ func (g *Generator) generateProto(pkg *packages.Package) (string, []bf.Expr) {
 		{"importpath", pkg.ImportPath(g.c.GoPrefix)},
 		{"visibility", visibility},
 	}
-	goProtoDeps := g.dependencies(pkg.Proto.Imports, g.r.ResolveGoProto)
+	resolveGoProto := func(imp string) (resolve.Label, error) {
+		return g.r.ResolveGoProto(imp, pkg.Rel)
+	}
+	goProtoDeps := g.dependencies(pkg.Proto.Imports, resolveGoProto)
 	if !goProtoDeps.IsEmpty() {
 		goProtoAttrs = append(goProtoAttrs, keyvalue{"deps", goProtoDeps})
 	}


### PR DESCRIPTION
This is a temporary hack until we have indexed proto import
resolution. It doesn't make sense for protos in vendor to import
protos outside of vendor, and protos can't import anything from
external repositories, so this seems reasonable for now.

Fixes #900