### PR TITLE
Consistently apply visibility to toolchain implementations.

### DIFF
--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -163,6 +163,7 @@ def go_toolchain(name, target, host=None, constraints=[], **kwargs):
       goarch = goarch,
       bootstrap = False,
       tags = ["manual"],
+      visibility = ["//visibility:public"],
       **kwargs
   )
   native.toolchain(


### PR DESCRIPTION
This was causing errors when building with custom toolchains.