### PR TITLE
Abstract the environment setting

### DIFF
--- a/go/private/actions/action.bzl
+++ b/go/private/actions/action.bzl
@@ -1,3 +1,17 @@
+# Copyright 2014 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 def action_with_go_env(ctx, go_toolchain, env=None, **kwargs):
   fullenv = dict(go_toolchain.env)
   if env:

--- a/go/private/actions/action.bzl
+++ b/go/private/actions/action.bzl
@@ -1,0 +1,5 @@
+def action_with_go_env(ctx, go_toolchain, env=None, **kwargs):
+  fullenv = dict(go_toolchain.env)
+  if env:
+    fullenv.update(env)
+  ctx.action(env=fullenv, **kwargs)

--- a/go/private/actions/asm.bzl
+++ b/go/private/actions/asm.bzl
@@ -27,11 +27,10 @@ def emit_asm(ctx, go_toolchain,
   asm_args = [go_toolchain.tools.go.path, source.path, "--", "-o", out_obj.path]
   for inc in includes:
     asm_args += ["-I", inc]
-  ctx.action(
+  go_toolchain.actions.env(ctx, go_toolchain,
       inputs = list(inputs),
       outputs = [out_obj],
       mnemonic = "GoAsmCompile",
       executable = go_toolchain.tools.asm,
       arguments = asm_args,
-      env = go_toolchain.env,
   )

--- a/go/private/actions/compile.bzl
+++ b/go/private/actions/compile.bzl
@@ -57,13 +57,12 @@ def emit_compile(ctx, go_toolchain,
   if ctx.attr._go_toolchain_flags.compilation_mode == "debug":
     args.extend(["-N", "-l"])
   args.extend(cgo_sources)
-  ctx.action(
+  go_toolchain.actions.env(ctx, go_toolchain,
       inputs = list(inputs),
       outputs = [out_lib],
       mnemonic = "GoCompile",
       executable = go_toolchain.tools.compile,
       arguments = args,
-      env = go_toolchain.env,
   )
 
 
@@ -82,11 +81,10 @@ def bootstrap_compile(ctx, go_toolchain,
 
   inputs = depset([go_toolchain.tools.go]) + sources
   args = ["tool", "compile", "-o", out_lib.path] + list(gc_goopts) + [s.path for s in sources]
-  ctx.action(
+  go_toolchain.actions.env(ctx, go_toolchain,
       inputs = list(inputs),
       outputs = [out_lib],
       mnemonic = "GoCompile",
       executable = go_toolchain.tools.go,
       arguments = args,
-      env = go_toolchain.env,
   )

--- a/go/private/actions/cover.bzl
+++ b/go/private/actions/cover.bzl
@@ -30,13 +30,12 @@ def emit_cover(ctx, go_toolchain,
     cover_vars += ["{}={}".format(cover_var,src.short_path)]
     out = ctx.new_file(cover_var + '.cover.go')
     outputs += [out]
-    ctx.action(
+    go_toolchain.actions.env(ctx, go_toolchain,
         inputs = [src] + go_toolchain.data.tools,
         outputs = [out],
         mnemonic = "GoCover",
         executable = go_toolchain.tools.go,
         arguments = ["tool", "cover", "--mode=set", "-var=%s" % cover_var, "-o", out.path, src.path],
-        env = go_toolchain.env,
     )
 
   return outputs, tuple(cover_vars)

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -109,14 +109,13 @@ def emit_link(ctx, go_toolchain,
 
   link_args += ["--"] + link_opts
 
-  ctx.action(
+  go_toolchain.actions.env(ctx, go_toolchain,
       inputs = list(libs + cgo_deps +
                 go_toolchain.data.tools + go_toolchain.data.crosstool + stamp_inputs),
       outputs = [executable],
       mnemonic = "GoLink",
       executable = go_toolchain.tools.link,
       arguments = link_args,
-      env = go_toolchain.env,
   )
 
 def bootstrap_link(ctx, go_toolchain,
@@ -135,13 +134,12 @@ def bootstrap_link(ctx, go_toolchain,
   lib = get_library(library, NORMAL_MODE)
   inputs = depset([go_toolchain.tools.go]) + [lib]
   args = ["tool", "link", "-o", executable.path] + list(gc_linkopts) + [lib.path]
-  ctx.action(
+  go_toolchain.actions.env(ctx, go_toolchain,
       inputs = list(inputs),
       outputs = [executable],
       mnemonic = "GoCompile",
       executable = go_toolchain.tools.go,
       arguments = args,
-      env = go_toolchain.env,
   )
 
 def _extract_extldflags(gc_linkopts, extldflags):

--- a/go/private/actions/pack.bzl
+++ b/go/private/actions/pack.bzl
@@ -37,11 +37,10 @@ def emit_pack(ctx, go_toolchain,
     inputs.append(archive)
     arguments.extend(["-arc", archive.path])
 
-  ctx.action(
+  go_toolchain.actions.env(ctx, go_toolchain,
       inputs = inputs,
       outputs = [out_lib],
       mnemonic = "GoPack",
       executable = go_toolchain.tools.pack,
       arguments = arguments,
-      env = go_toolchain.env,
   )

--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -14,6 +14,7 @@
 """
 Toolchain rules used by go.
 """
+load("@io_bazel_rules_go//go/private:actions/action.bzl", "action_with_go_env")
 load("@io_bazel_rules_go//go/private:actions/asm.bzl", "emit_asm")
 load("@io_bazel_rules_go//go/private:actions/binary.bzl", "emit_binary")
 load("@io_bazel_rules_go//go/private:actions/compile.bzl", "emit_compile", "bootstrap_compile")
@@ -33,6 +34,7 @@ def _go_toolchain_impl(ctx):
           "TMP": tmp,
       },
       actions = struct(
+          env = action_with_go_env,
           asm = emit_asm,
           binary = emit_binary,
           compile = emit_compile if ctx.executable._compile else bootstrap_compile,

--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -20,7 +20,7 @@ _CgoCodegen = provider()
 def _mangle(ctx, src):
     src_stem, _, src_ext = src.path.rpartition('.')
     mangled_stem = ctx.attr.out_dir + "/" + src_stem.replace('/', '_')
-    return mangled_stem, src_ext 
+    return mangled_stem, src_ext
 
 def _c_filter_options(options, blacklist):
   return [opt for opt in options
@@ -104,18 +104,18 @@ def _cgo_codegen_impl(ctx):
   # The first -- below is to stop the cgo from processing args, the
   # second is an actual arg to forward to the underlying go tool
   args += ["--", "--"] + copts
-  ctx.action(
+  go_toolchain.actions.env(ctx, go_toolchain,
       inputs = inputs,
       outputs = list(c_outs + go_outs + [cgo_main]),
       mnemonic = "CGoCodeGen",
       progress_message = "CGoCodeGen %s" % ctx.label,
       executable = go_toolchain.tools.cgo,
       arguments = args,
-      env = go_toolchain.env + {
+      env = {
           "CGO_LDFLAGS": " ".join(linkopts),
       },
   )
-  
+
   return [
       _CgoCodegen(
           go_files = go_outs,
@@ -159,14 +159,13 @@ def _cgo_import_impl(ctx):
       " -dynpackage $(%s %s)"  % (go_toolchain.tools.extract_package.path,
                                   ctx.files.sample_go_srcs[0].path)
   )
-  ctx.action(
+  go_toolchain.actions.env(ctx, go_toolchain,
       inputs = (go_toolchain.data.tools +
                 [go_toolchain.tools.go, go_toolchain.tools.extract_package,
                  ctx.file.cgo_o, ctx.files.sample_go_srcs[0]]),
       outputs = [ctx.outputs.out],
       command = command,
       mnemonic = "CGoImportGen",
-      env = go_toolchain.env,
   )
   return struct(
       files = depset([ctx.outputs.out]),
@@ -199,7 +198,7 @@ def _cgo_collect_info_impl(ctx):
   codegen = ctx.attr.codegen[_CgoCodegen]
   runfiles = ctx.runfiles(collect_data = True)
   runfiles = runfiles.merge(ctx.attr.codegen.data_runfiles)
-  
+
   return [
       DefaultInfo(files = depset(), runfiles = runfiles),
       CgoInfo(
@@ -227,7 +226,7 @@ def setup_cgo_library(name, srcs, cdeps, copts, clinkopts):
 
   # Apply build constraints to source files (both Go and C) but not to header
   # files. Separate filtered Go and C sources.
-  
+
   # Run cgo on the filtered Go files. This will split them into pure Go files
   # and pure C files, plus a few other glue files.
   base_dir = pkg_dir(

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -81,13 +81,15 @@ def _go_test_impl(ctx):
       for var in g.cover_vars:
         arguments += ["-cover", "{}={}".format(var, g.importpath)]
 
-  ctx.action(
+  go_toolchain.actions.env(ctx, go_toolchain,
       inputs = go_srcs,
       outputs = [main_go],
       mnemonic = "GoTestGenTest",
       executable = go_toolchain.tools.test_generator,
       arguments = arguments + [src.path for src in go_srcs],
-      env = dict(go_toolchain.env, RUNDIR=ctx.label.package)
+      env = {
+          "RUNDIR" : ctx.label.package,
+      },
   )
 
   # Now compile the test binary itself


### PR DESCRIPTION
The go toolchain now provides a helper for running a command with the correct go
environment.
This is a neccesary isolation for future improvements where we no longer hard
code the GOROOT and the GOOS and GOARCH can vary per rule.