### PR TITLE
Don't expose the env action

### DIFF
--- a/go/private/actions/action.bzl
+++ b/go/private/actions/action.bzl
@@ -22,3 +22,6 @@ def action_with_go_env(ctx, go_toolchain, env=None, **kwargs):
   if env:
     fullenv.update(env)
   ctx.action(env=fullenv, **kwargs)
+
+def bootstrap_action(ctx, go_toolchain, **kwargs):
+  ctx.action(env={"GOROOT": go_toolchain.stdlib.root.path}, **kwargs)

--- a/go/private/actions/asm.bzl
+++ b/go/private/actions/asm.bzl
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@io_bazel_rules_go//go/private:actions/action.bzl",
+    "action_with_go_env",
+)
+
 def emit_asm(ctx, go_toolchain,
     source = None,
     hdrs = [],
@@ -27,7 +31,7 @@ def emit_asm(ctx, go_toolchain,
   asm_args = [go_toolchain.tools.go.path, source.path, "--", "-o", out_obj.path]
   for inc in includes:
     asm_args += ["-I", inc]
-  go_toolchain.actions.env(ctx, go_toolchain,
+  action_with_go_env(ctx, go_toolchain,
       inputs = list(inputs),
       outputs = [out_obj],
       mnemonic = "GoAsmCompile",

--- a/go/private/actions/compile.bzl
+++ b/go/private/actions/compile.bzl
@@ -20,6 +20,10 @@ load("@io_bazel_rules_go//go/private:providers.bzl",
     "get_library",
     "get_searchpath",
 )
+load("@io_bazel_rules_go//go/private:actions/action.bzl",
+    "action_with_go_env",
+    "bootstrap_action",
+)
 
 def emit_compile(ctx, go_toolchain,
     sources = None,
@@ -57,7 +61,7 @@ def emit_compile(ctx, go_toolchain,
   if ctx.attr._go_toolchain_flags.compilation_mode == "debug":
     args.extend(["-N", "-l"])
   args.extend(cgo_sources)
-  go_toolchain.actions.env(ctx, go_toolchain,
+  action_with_go_env(ctx, go_toolchain,
       inputs = list(inputs),
       outputs = [out_lib],
       mnemonic = "GoCompile",
@@ -81,7 +85,7 @@ def bootstrap_compile(ctx, go_toolchain,
 
   inputs = depset([go_toolchain.tools.go]) + sources
   args = ["tool", "compile", "-o", out_lib.path] + list(gc_goopts) + [s.path for s in sources]
-  go_toolchain.actions.env(ctx, go_toolchain,
+  bootstrap_action(ctx, go_toolchain,
       inputs = list(inputs),
       outputs = [out_lib],
       mnemonic = "GoCompile",

--- a/go/private/actions/cover.bzl
+++ b/go/private/actions/cover.bzl
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@io_bazel_rules_go//go/private:actions/action.bzl",
+    "action_with_go_env",
+)
+
 def emit_cover(ctx, go_toolchain,
                sources = []):
   """See go/toolchains.rst#cover for full documentation."""
@@ -30,7 +34,7 @@ def emit_cover(ctx, go_toolchain,
     cover_vars += ["{}={}".format(cover_var,src.short_path)]
     out = ctx.new_file(cover_var + '.cover.go')
     outputs += [out]
-    go_toolchain.actions.env(ctx, go_toolchain,
+    action_with_go_env(ctx, go_toolchain,
         inputs = [src] + go_toolchain.data.tools,
         outputs = [out],
         mnemonic = "GoCover",

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -21,6 +21,10 @@ load("@io_bazel_rules_go//go/private:providers.bzl",
     "get_library",
     "get_searchpath",
 )
+load("@io_bazel_rules_go//go/private:actions/action.bzl",
+    "action_with_go_env",
+    "bootstrap_action",
+)
 
 def emit_link(ctx, go_toolchain,
     library = None,
@@ -109,7 +113,7 @@ def emit_link(ctx, go_toolchain,
 
   link_args += ["--"] + link_opts
 
-  go_toolchain.actions.env(ctx, go_toolchain,
+  action_with_go_env(ctx, go_toolchain,
       inputs = list(libs + cgo_deps +
                 go_toolchain.data.tools + go_toolchain.data.crosstool + stamp_inputs),
       outputs = [executable],
@@ -134,7 +138,7 @@ def bootstrap_link(ctx, go_toolchain,
   lib = get_library(library, NORMAL_MODE)
   inputs = depset([go_toolchain.tools.go]) + [lib]
   args = ["tool", "link", "-o", executable.path] + list(gc_linkopts) + [lib.path]
-  go_toolchain.actions.env(ctx, go_toolchain,
+  bootstrap_action(ctx, go_toolchain,
       inputs = list(inputs),
       outputs = [executable],
       mnemonic = "GoCompile",

--- a/go/private/actions/pack.bzl
+++ b/go/private/actions/pack.bzl
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@io_bazel_rules_go//go/private:actions/action.bzl",
+    "action_with_go_env",
+)
+
 def emit_pack(ctx, go_toolchain,
     in_lib = None,
     out_lib = None,
@@ -37,7 +41,7 @@ def emit_pack(ctx, go_toolchain,
     inputs.append(archive)
     arguments.extend(["-arc", archive.path])
 
-  go_toolchain.actions.env(ctx, go_toolchain,
+  action_with_go_env(ctx, go_toolchain,
       inputs = inputs,
       outputs = [out_lib],
       mnemonic = "GoPack",

--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -14,7 +14,6 @@
 """
 Toolchain rules used by go.
 """
-load("@io_bazel_rules_go//go/private:actions/action.bzl", "action_with_go_env")
 load("@io_bazel_rules_go//go/private:actions/asm.bzl", "emit_asm")
 load("@io_bazel_rules_go//go/private:actions/binary.bzl", "emit_binary")
 load("@io_bazel_rules_go//go/private:actions/compile.bzl", "emit_compile", "bootstrap_compile")
@@ -31,7 +30,6 @@ def _go_toolchain_impl(ctx):
       name = ctx.label.name,
       stdlib = ctx.attr._stdlib[GoStdLib],
       actions = struct(
-          env = action_with_go_env,
           asm = emit_asm,
           binary = emit_binary,
           compile = emit_compile if ctx.executable._compile else bootstrap_compile,

--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -14,6 +14,9 @@
 
 load("@io_bazel_rules_go//go/private:common.bzl", "dict_of", "split_srcs", "join_srcs", "pkg_dir")
 load("@io_bazel_rules_go//go/private:providers.bzl", "CgoInfo", "GoLibrary")
+load("@io_bazel_rules_go//go/private:actions/action.bzl",
+    "action_with_go_env",
+)
 
 _CgoCodegen = provider()
 
@@ -104,7 +107,7 @@ def _cgo_codegen_impl(ctx):
   # The first -- below is to stop the cgo from processing args, the
   # second is an actual arg to forward to the underlying go tool
   args += ["--", "--"] + copts
-  go_toolchain.actions.env(ctx, go_toolchain,
+  action_with_go_env(ctx, go_toolchain,
       inputs = inputs,
       outputs = list(c_outs + go_outs + [cgo_main]),
       mnemonic = "CGoCodeGen",
@@ -158,7 +161,7 @@ def _cgo_import_impl(ctx):
       "-src", ctx.files.sample_go_srcs[0].path,
   ]
 
-  go_toolchain.actions.env(ctx, go_toolchain,
+  action_with_go_env(ctx, go_toolchain,
       inputs = go_toolchain.data.tools + [
           go_toolchain.tools.go,
           ctx.file.cgo_o,

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -30,6 +30,9 @@ load("@io_bazel_rules_go//go/private:providers.bzl",
     "GoBinary",
     "GoEmbed",
 )
+load("@io_bazel_rules_go//go/private:actions/action.bzl",
+    "action_with_go_env",
+)
 
 def _go_test_impl(ctx):
   """go_test_impl implements go testing.
@@ -81,7 +84,7 @@ def _go_test_impl(ctx):
       for var in g.cover_vars:
         arguments += ["-cover", "{}={}".format(var, g.importpath)]
 
-  go_toolchain.actions.env(ctx, go_toolchain,
+  action_with_go_env(ctx, go_toolchain,
       inputs = go_srcs,
       outputs = [main_go],
       mnemonic = "GoTestGenTest",


### PR DESCRIPTION
I thought about it a bit more and decided it should not even be public for now,
if we decide it should be it's easy to add it back, but for now we just invoke
it directly rather than through the toolchain.

Also bootstrap actions have to work differently.