### PR TITLE
Gazelle: don't merge or delete rules with keep comments

### DIFF
--- a/go/tools/gazelle/merger/merger_test.go
+++ b/go/tools/gazelle/merger/merger_test.go
@@ -623,6 +623,55 @@ go_library(
 )
 `,
 	}, {
+		desc: "keep prevents delete",
+		previous: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+# keep
+go_library(
+    name = "go_default_library",
+    srcs = ["lib.go"],
+)
+`,
+		empty: `
+go_library(name = "go_default_library")
+`,
+		expected: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+# keep
+go_library(
+    name = "go_default_library",
+    srcs = ["lib.go"],
+)
+`,
+	}, {
+		desc: "keep prevents merge",
+		previous: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+# keep
+go_library(
+    name = "go_default_library",
+    srcs = ["old.go"],
+)
+`,
+		current: `
+go_library(
+    name = "go_default_library",
+    srcs = ["new.go"],
+)
+`,
+		expected: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+# keep
+go_library(
+    name = "go_default_library",
+    srcs = ["old.go"],
+)
+`,
+	}, {
 		desc: "delete empty rule",
 		previous: `
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")


### PR DESCRIPTION
* '# keep' can now be used on an entire rule.
* Gazelle no longer recognizes comments that start with keep but
  contain other words.
* '# keep' may be used in an earlier line comment, not just a suffix
  comment.

Also:

* mergeLoad and ruleUsed are removed. Load statements are no longer
  generated and don't need to be merged. FixLoads takes care of this.

Fixes #884