### PR TITLE
Normalise go environment handling

### DIFF
--- a/go/private/actions/action.bzl
+++ b/go/private/actions/action.bzl
@@ -12,16 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-def action_with_go_env(ctx, go_toolchain, env=None, **kwargs):
-  fullenv = {
-      "GOROOT": go_toolchain.stdlib.root.path,
-      "GOOS": go_toolchain.stdlib.goos,
-      "GOARCH": go_toolchain.stdlib.goarch,
-      "TMP": go_toolchain.paths.tmp,
-  }
-  if env:
-    fullenv.update(env)
-  ctx.action(env=fullenv, **kwargs)
+def action_with_go_env(ctx, go_toolchain, executable = None, command=None, arguments = [], inputs = [], **kwargs):
+  if command:
+    fail("You cannot run action_with_go_env with a 'command', only an 'executable'")
+  args = [
+      "-go", go_toolchain.tools.go.path,
+      "-root", go_toolchain.stdlib.root.path,
+      "-goos", go_toolchain.stdlib.goos,
+      "-goarch", go_toolchain.stdlib.goarch,
+      "-cgo=" + ("1" if go_toolchain.stdlib.cgo else "0"),
+      "-tmp", go_toolchain.paths.tmp,
+  ] + arguments
+  ctx.action(
+      inputs = depset(inputs) + go_toolchain.data.tools,
+      executable = executable,
+      arguments = args,
+      **kwargs)
 
 def bootstrap_action(ctx, go_toolchain, **kwargs):
-  ctx.action(env={"GOROOT": go_toolchain.stdlib.root.path}, **kwargs)
+  ctx.action(executable = go_toolchain.tools.go, env={"GOROOT": go_toolchain.stdlib.root.path}, **kwargs)

--- a/go/private/actions/asm.bzl
+++ b/go/private/actions/asm.bzl
@@ -27,8 +27,8 @@ def emit_asm(ctx, go_toolchain,
   includes = depset()
   includes += [f.dirname for f in hdrs]
   includes += [f.dirname for f in go_toolchain.data.headers.cc.transitive_headers]
-  inputs = hdrs + list(go_toolchain.data.headers.cc.transitive_headers) + go_toolchain.data.tools + [source]
-  asm_args = [go_toolchain.tools.go.path, source.path, "--", "-o", out_obj.path]
+  inputs = hdrs + list(go_toolchain.data.headers.cc.transitive_headers) + [source]
+  asm_args = [source.path, "-o", out_obj.path]
   for inc in includes:
     asm_args += ["-I", inc]
   action_with_go_env(ctx, go_toolchain,

--- a/go/private/actions/compile.bzl
+++ b/go/private/actions/compile.bzl
@@ -42,10 +42,10 @@ def emit_compile(ctx, go_toolchain,
     gc_goopts = gc_goopts + ("-race",)
 
   gc_goopts = [ctx.expand_make_variables("gc_goopts", f, {}) for f in gc_goopts]
-  inputs = depset([go_toolchain.tools.go]) + sources
+  inputs = sources
   go_sources = [s.path for s in sources if not s.basename.startswith("_cgo")]
   cgo_sources = [s.path for s in sources if s.basename.startswith("_cgo")]
-  args = [go_toolchain.tools.go.path]
+  args = []
   for src in go_sources:
     args += ["-src", src]
   for golib in golibs:
@@ -83,12 +83,10 @@ def bootstrap_compile(ctx, go_toolchain,
   if out_lib == None: fail("out_lib is a required parameter")
   if golibs:  fail("compile does not accept deps in bootstrap mode")
 
-  inputs = depset([go_toolchain.tools.go]) + sources
   args = ["tool", "compile", "-o", out_lib.path] + list(gc_goopts) + [s.path for s in sources]
   bootstrap_action(ctx, go_toolchain,
-      inputs = list(inputs),
+      inputs = sources,
       outputs = [out_lib],
       mnemonic = "GoCompile",
-      executable = go_toolchain.tools.go,
       arguments = args,
   )

--- a/go/private/actions/cover.bzl
+++ b/go/private/actions/cover.bzl
@@ -35,11 +35,11 @@ def emit_cover(ctx, go_toolchain,
     out = ctx.new_file(cover_var + '.cover.go')
     outputs += [out]
     action_with_go_env(ctx, go_toolchain,
-        inputs = [src] + go_toolchain.data.tools,
+        inputs = [src],
         outputs = [out],
         mnemonic = "GoCover",
         executable = go_toolchain.tools.cover,
-        arguments = [go_toolchain.tools.go.path, "--", "--mode=set", "-var=%s" % cover_var, "-o", out.path, src.path],
+        arguments = ["--", "--mode=set", "-var=%s" % cover_var, "-o", out.path, src.path],
     )
 
   return outputs, tuple(cover_vars)

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -96,7 +96,7 @@ def emit_link(ctx, go_toolchain,
         "-extldflags", " ".join(extldflags),
     ]
   link_opts += [get_library(golib, libmode).path]
-  link_args = [go_toolchain.tools.go.path]
+  link_args = []
   # Stamping support
   stamp_inputs = []
   if stamp_x_defs or ctx.attr.linkstamp:
@@ -115,7 +115,7 @@ def emit_link(ctx, go_toolchain,
 
   action_with_go_env(ctx, go_toolchain,
       inputs = list(libs + cgo_deps +
-                go_toolchain.data.tools + go_toolchain.data.crosstool + stamp_inputs),
+                go_toolchain.data.crosstool + stamp_inputs),
       outputs = [executable],
       mnemonic = "GoLink",
       executable = go_toolchain.tools.link,
@@ -136,13 +136,12 @@ def bootstrap_link(ctx, go_toolchain,
   if x_defs:  fail("link does not accept x_defs in bootstrap mode")
 
   lib = get_library(library, NORMAL_MODE)
-  inputs = depset([go_toolchain.tools.go]) + [lib]
+  inputs = depset([lib])
   args = ["tool", "link", "-o", executable.path] + list(gc_linkopts) + [lib.path]
   bootstrap_action(ctx, go_toolchain,
       inputs = list(inputs),
       outputs = [executable],
       mnemonic = "GoCompile",
-      executable = go_toolchain.tools.go,
       arguments = args,
   )
 

--- a/go/private/actions/pack.bzl
+++ b/go/private/actions/pack.bzl
@@ -26,10 +26,9 @@ def emit_pack(ctx, go_toolchain,
   if in_lib == None: fail("in_lib is a required parameter")
   if out_lib == None: fail("out_lib is a required parameter")
 
-  inputs = [in_lib] + go_toolchain.data.tools
+  inputs = [in_lib]
 
   arguments = [
-      "-gotool", go_toolchain.tools.go.path,
       "-in", in_lib.path,
       "-out", out_lib.path,
   ]

--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -58,7 +58,7 @@ def _cgo_codegen_impl(ctx):
   out_dir = cgo_main.dirname
 
   cc = go_toolchain.external_linker.compiler_executable
-  args = [go_toolchain.tools.go.path, "-cc", str(cc), "-objdir", out_dir]
+  args = ["-cc", str(cc), "-objdir", out_dir]
 
   c_outs = depset([cgo_export_h, cgo_export_c])
   go_outs = depset([cgo_types])
@@ -84,7 +84,7 @@ def _cgo_codegen_impl(ctx):
     c_outs += [gen_file]
     args += ["-src", gen_file.path + "=" + src.path]
 
-  inputs = ctx.files.srcs + go_toolchain.data.tools + go_toolchain.data.crosstool
+  inputs = ctx.files.srcs + go_toolchain.data.crosstool
   runfiles = ctx.runfiles(collect_data = True)
   for d in ctx.attr.deps:
     inputs += list(d.cc.transitive_headers)
@@ -155,15 +155,13 @@ _cgo_codegen = rule(
 def _cgo_import_impl(ctx):
   go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:toolchain"]
   args = [
-      go_toolchain.tools.go.path,
       "-dynout", ctx.outputs.out.path,
       "-dynimport", ctx.file.cgo_o.path,
       "-src", ctx.files.sample_go_srcs[0].path,
   ]
 
   action_with_go_env(ctx, go_toolchain,
-      inputs = go_toolchain.data.tools + [
-          go_toolchain.tools.go,
+      inputs = [
           ctx.file.cgo_o,
           ctx.files.sample_go_srcs[0],
       ],

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -23,6 +23,7 @@ go_tool_binary(
     name = "asm",
     srcs = [
         "asm.go",
+        "env.go",
         "filter.go",
     ],
     visibility = ["//visibility:public"],
@@ -32,6 +33,7 @@ go_tool_binary(
     name = "compile",
     srcs = [
         "compile.go",
+        "env.go",
         "filter.go",
         "flags.go",
     ],
@@ -42,6 +44,7 @@ go_tool_binary(
     name = "cover",
     srcs = [
         "cover.go",
+        "env.go",
     ],
     visibility = ["//visibility:public"],
 )
@@ -55,6 +58,7 @@ go_tool_binary(
 go_tool_binary(
     name = "generate_test_main",
     srcs = [
+        "env.go",
         "filter.go",
         "flags.go",
         "generate_test_main.go",
@@ -65,6 +69,7 @@ go_tool_binary(
 go_tool_binary(
     name = "link",
     srcs = [
+        "env.go",
         "flags.go",
         "link.go",
     ],
@@ -75,6 +80,7 @@ go_tool_binary(
     name = "cgo",
     srcs = [
         "cgo.go",
+        "env.go",
         "extract.go",
         "filter.go",
         "flags.go",
@@ -93,6 +99,7 @@ go_tool_binary(
 go_tool_binary(
     name = "pack",
     srcs = [
+        "env.go",
         "flags.go",
         "pack.go",
     ],

--- a/go/tools/builders/cgo.go
+++ b/go/tools/builders/cgo.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"go/ast"
-	"go/build"
 	"go/parser"
 	"go/token"
 	"io/ioutil"
@@ -69,18 +68,14 @@ func run(args []string) error {
 	dynout := ""
 	dynimport := ""
 	flags := flag.NewFlagSet("cgo", flag.ContinueOnError)
+	goenv := envFlags(flags)
 	flags.Var(&sources, "src", "A source file to be filtered and compiled")
 	flags.StringVar(&cc, "cc", "", "Sets the c compiler to use")
 	flags.StringVar(&objdir, "objdir", "", "The output directory")
 	flags.StringVar(&dynout, "dynout", "", "The output directory")
 	flags.StringVar(&dynimport, "dynimport", "", "The output directory")
 	// process the args
-	if len(args) < 2 {
-		flags.Usage()
-		return fmt.Errorf("The go tool must be specified")
-	}
-	gotool := args[0]
-	if err := flags.Parse(args[1:]); err != nil {
+	if err := flags.Parse(args); err != nil {
 		return err
 	}
 
@@ -95,7 +90,7 @@ func run(args []string) error {
 			"-dynimport", dynimport,
 			"-dynpackage", dynpackage,
 		}
-		cmd := exec.Command(gotool, goargs...)
+		cmd := exec.Command(goenv.Go, goargs...)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
@@ -106,8 +101,7 @@ func run(args []string) error {
 
 	// apply build constraints to the source list
 	// also pick out the cgo sources
-	bctx := build.Default
-	bctx.CgoEnabled = true
+	bctx := goenv.BuildContext()
 	cgoSrcs := []string{}
 	pkgName := ""
 	for _, s := range sources {
@@ -183,6 +177,9 @@ func run(args []string) error {
 		}
 	}
 	if pkgName == "" {
+		fmt.Fprintf(os.Stderr, "\n\n")
+		fmt.Fprintf(os.Stderr, "Remains: %v\n", flags.Args())
+		fmt.Fprintf(os.Stderr, "Source: %v\n", sources)
 		return fmt.Errorf("no buildable Go source files found")
 	}
 
@@ -212,13 +209,14 @@ func run(args []string) error {
 		cc = abs
 	}
 	env := os.Environ()
+	env = append(env, goenv.Env()...)
 	env = append(env, fmt.Sprintf("CC=%s", cc))
 	env = append(env, fmt.Sprintf("CXX=%s", cc))
 
 	goargs := []string{"tool", "cgo", "-objdir", objdir}
 	goargs = append(goargs, copts...)
 	goargs = append(goargs, cgoSrcs...)
-	cmd := exec.Command(gotool, goargs...)
+	cmd := exec.Command(goenv.Go, goargs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Env = env

--- a/go/tools/builders/cgo.go
+++ b/go/tools/builders/cgo.go
@@ -177,9 +177,6 @@ func run(args []string) error {
 		}
 	}
 	if pkgName == "" {
-		fmt.Fprintf(os.Stderr, "\n\n")
-		fmt.Fprintf(os.Stderr, "Remains: %v\n", flags.Args())
-		fmt.Fprintf(os.Stderr, "Source: %v\n", sources)
 		return fmt.Errorf("no buildable Go source files found")
 	}
 

--- a/go/tools/builders/cover.go
+++ b/go/tools/builders/cover.go
@@ -25,16 +25,16 @@ import (
 )
 
 func run(args []string) error {
-	gotool := args[0]
-	args = args[1:]
 	flags := flag.NewFlagSet("cover", flag.ExitOnError)
+	goenv := envFlags(flags)
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
 	goargs := []string{"tool", "cover"}
 	goargs = append(goargs, flags.Args()...)
 	env := os.Environ()
-	cmd := exec.Command(gotool, goargs...)
+	env = append(env, goenv.Env()...)
+	cmd := exec.Command(goenv.Go, goargs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Env = env

--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 )
 
-// GoEnv hold the go environment as specified on the command line.
+// GoEnv holds the go environment as specified on the command line.
 type GoEnv struct {
 	// Go is the path to the go executable.
 	Go string

--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -1,0 +1,73 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/build"
+	"strings"
+)
+
+// GoEnv hold the go environment as specified on the command line.
+type GoEnv struct {
+	// Go is the path to the go executable.
+	Go string
+	// Verbose debugging print control
+	Verbose bool
+	root    string
+	tmp     string
+	cgo     bool
+	goos    string
+	goarch  string
+	tags    string
+}
+
+func envFlags(flags *flag.FlagSet) *GoEnv {
+	env := &GoEnv{}
+	flags.StringVar(&env.Go, "go", "", "The path to the go tool.")
+	flags.StringVar(&env.root, "root", "", "The go root to use.")
+	flags.StringVar(&env.tmp, "tmp", "", "The temp directory to use.")
+	flags.BoolVar(&env.cgo, "cgo", false, "The value for CGO_ENABLED.")
+	flags.StringVar(&env.goos, "goos", "", "The value for GOOS.")
+	flags.StringVar(&env.goarch, "goarch", "", "The value for GOARCH.")
+	flags.BoolVar(&env.Verbose, "v", false, "Enables verbose debugging prints.")
+	flags.StringVar(&env.tags, "tags", "", "Only pass through files that match these tags.")
+	return env
+}
+
+func (env *GoEnv) Env() []string {
+	cgoEnabled := "0"
+	if env.cgo {
+		cgoEnabled = "1"
+	}
+	return []string{
+		fmt.Sprintf("GOROOT=%s", env.root),
+		fmt.Sprintf("TMP=%s", env.tmp),
+		fmt.Sprintf("GOOS=%s", env.goos),
+		fmt.Sprintf("GOARCH=%s", env.goarch),
+		fmt.Sprintf("CGO_ENABLED=%s", cgoEnabled),
+	}
+}
+
+func (env *GoEnv) BuildContext() build.Context {
+	bctx := build.Default
+	bctx.GOROOT = env.root
+	bctx.GOOS = env.goos
+	bctx.GOARCH = env.goarch
+	bctx.CgoEnabled = env.cgo
+	bctx.BuildTags = strings.Split(env.tags, ",")
+	return bctx
+}

--- a/go/tools/builders/generate_test_main.go
+++ b/go/tools/builders/generate_test_main.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"go/ast"
-	"go/build"
 	"go/parser"
 	"go/token"
 	"log"
@@ -176,10 +175,10 @@ func run(args []string) error {
 	// Prepare our flags
 	cover := multiFlag{}
 	flags := flag.NewFlagSet("generate_test_main", flag.ExitOnError)
+	goenv := envFlags(flags)
 	pkg := flags.String("package", "", "package from which to import test methods.")
 	runDir := flags.String("rundir", ".", "Path to directory where tests should run.")
 	out := flags.String("output", "", "output file to write. Defaults to stdout.")
-	tags := flags.String("tags", "", "Only pass through files that match these tags.")
 	flags.Var(&cover, "cover", "Information about a coverage variable")
 	if err := flags.Parse(args); err != nil {
 		return err
@@ -188,9 +187,7 @@ func run(args []string) error {
 		return fmt.Errorf("must set --package.")
 	}
 	// filter our input file list
-	bctx := build.Default
-	bctx.CgoEnabled = true
-	bctx.BuildTags = strings.Split(*tags, ",")
+	bctx := goenv.BuildContext()
 	filenames, err := filterFiles(bctx, flags.Args())
 	if err != nil {
 		return err

--- a/go/tools/builders/pack.go
+++ b/go/tools/builders/pack.go
@@ -38,7 +38,7 @@ import (
 
 func run(args []string) error {
 	flags := flag.NewFlagSet("pack", flag.ContinueOnError)
-	gotool := flags.String("gotool", "", "Path to the go tool")
+	goenv := envFlags(flags)
 	inArchive := flags.String("in", "", "Path to input archive")
 	outArchive := flags.String("out", "", "Path to output archive")
 	objects := multiFlag{}
@@ -60,7 +60,7 @@ func run(args []string) error {
 		objects = append(objects, archiveObjects...)
 	}
 
-	return appendFiles(*gotool, *outArchive, objects)
+	return appendFiles(goenv.Go, *outArchive, objects)
 }
 
 func main() {


### PR DESCRIPTION
This pushes the handling of the environment into the helpers rather than
actually setting the environment in skylark.
This will allow us to do things like abs the paths during execution