### PR TITLE
Change direct deps standard library detection

### DIFF
--- a/go/private/actions/compile.bzl
+++ b/go/private/actions/compile.bzl
@@ -42,10 +42,10 @@ def emit_compile(ctx, go_toolchain,
     gc_goopts = gc_goopts + ("-race",)
 
   gc_goopts = [ctx.expand_make_variables("gc_goopts", f, {}) for f in gc_goopts]
-  inputs = sources
+  inputs = sources + [go_toolchain.data.package_list]
   go_sources = [s.path for s in sources if not s.basename.startswith("_cgo")]
   cgo_sources = [s.path for s in sources if s.basename.startswith("_cgo")]
-  args = []
+  args = ["-package_list", go_toolchain.data.package_list.path]
   for src in go_sources:
     args += ["-src", src]
   for golib in golibs:

--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -61,6 +61,7 @@ def _go_toolchain_impl(ctx):
           stdlib = ctx.files._stdlib,
           headers = ctx.attr._headers,
           crosstool = ctx.files._crosstool,
+          package_list = ctx.file._package_list,
       ),
       external_linker = ctx.attr._external_linker,
   )]
@@ -133,6 +134,7 @@ _go_toolchain = rule(
         "_headers": attr.label(default="@go_sdk//:headers"),
         "_root": attr.label(default="@go_sdk//:root"),
         "_crosstool": attr.label(default=Label("//tools/defaults:crosstool")),
+        "_package_list": attr.label(allow_files = True, single_file = True, default="@go_sdk//:packages.txt"),
         "_external_linker": attr.label(default=_get_linker),
     },
 )


### PR DESCRIPTION
Now uses the @go_sdk//:packages.txt file instead of stating the source tree
Statting the source tree does not work because compile actions are going to
loose visibility into the sdk source soon
Statting the package tree does not work because unsafe has no package