### PR TITLE
Temporary directory handling

### DIFF
--- a/go/private/actions/action.bzl
+++ b/go/private/actions/action.bzl
@@ -21,7 +21,6 @@ def action_with_go_env(ctx, go_toolchain, executable = None, command=None, argum
       "-goos", go_toolchain.stdlib.goos,
       "-goarch", go_toolchain.stdlib.goarch,
       "-cgo=" + ("1" if go_toolchain.stdlib.cgo else "0"),
-      "-tmp", go_toolchain.paths.tmp,
   ] + arguments
   ctx.action(
       inputs = depset(inputs) + go_toolchain.data.tools,

--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -25,7 +25,6 @@ load("@io_bazel_rules_go//go/private:providers.bzl", "GoStdLib")
 
 
 def _go_toolchain_impl(ctx):
-  tmp = ctx.attr._root.path + "/tmp"
   return [platform_common.ToolchainInfo(
       name = ctx.label.name,
       stdlib = ctx.attr._stdlib[GoStdLib],
@@ -37,9 +36,6 @@ def _go_toolchain_impl(ctx):
           library = emit_library,
           link = emit_link if ctx.executable._link else bootstrap_link,
           pack = emit_pack,
-      ),
-      paths = struct(
-          tmp = tmp,
       ),
       tools = struct(
           go = ctx.executable._go,

--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -28,7 +28,6 @@ type GoEnv struct {
 	// Verbose debugging print control
 	Verbose bool
 	root    string
-	tmp     string
 	cgo     bool
 	goos    string
 	goarch  string
@@ -39,7 +38,6 @@ func envFlags(flags *flag.FlagSet) *GoEnv {
 	env := &GoEnv{}
 	flags.StringVar(&env.Go, "go", "", "The path to the go tool.")
 	flags.StringVar(&env.root, "root", "", "The go root to use.")
-	flags.StringVar(&env.tmp, "tmp", "", "The temp directory to use.")
 	flags.BoolVar(&env.cgo, "cgo", false, "The value for CGO_ENABLED.")
 	flags.StringVar(&env.goos, "goos", "", "The value for GOOS.")
 	flags.StringVar(&env.goarch, "goarch", "", "The value for GOARCH.")
@@ -55,7 +53,7 @@ func (env *GoEnv) Env() []string {
 	}
 	return []string{
 		fmt.Sprintf("GOROOT=%s", env.root),
-		fmt.Sprintf("TMP=%s", env.tmp),
+		fmt.Sprintf("TMP=%s", "/tmp"), // TODO: may need to be different on windows
 		fmt.Sprintf("GOOS=%s", env.goos),
 		fmt.Sprintf("GOARCH=%s", env.goarch),
 		fmt.Sprintf("CGO_ENABLED=%s", cgoEnabled),


### PR DESCRIPTION
Now everyone uses the same wrapper handling, we can normalise the TMP
environment variable handling to the wrapper.
This probably needs to be fixed up on windows in another PR