### PR TITLE
Adding a gofmt test

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -23,3 +23,4 @@ Justine Alexandra Roberts Tunney <jart@google.com>
 Kristina Chodorow <kchodorow@google.com>
 Lukacs Berki <lberki@google.com>
 Yuki Yugui Sonoda <yugui@yugui.jp>
+Dan Couture <mathyourlife@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,6 +12,7 @@
 Benjamin Staffin <benley@gmail.com>
 Brian Silverman <bsilver16384@gmail.com>
 Damien Martin-Guillerez <dmarting@google.com>
+Dan Couture <mathyourlife@gmail.com>
 David Chen <dzc@google.com>
 David Santiago <david.santiago@gmail.com>
 Han-Wen Nienhuys <hanwen@google.com>
@@ -23,4 +24,3 @@ Justine Alexandra Roberts Tunney <jart@google.com>
 Kristina Chodorow <kchodorow@google.com>
 Lukacs Berki <lberki@google.com>
 Yuki Yugui Sonoda <yugui@yugui.jp>
-Dan Couture <mathyourlife@gmail.com>

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -53,6 +53,9 @@ load("@io_bazel_rules_go//go/private:tools/path.bzl",
 load("@io_bazel_rules_go//go/private:tools/vet.bzl",
     _go_vet_test = "go_vet_test",
 )
+load("@io_bazel_rules_go//go/private:tools/gofmt.bzl",
+    _go_fmt_test = "go_fmt_test",
+)
 
 GoLibrary = _GoLibrary
 """See go/providers.rst#GoLibrary for full documentation."""
@@ -83,6 +86,11 @@ go_path = _go_path
 go_vet_test = _go_vet_test
 """
     go_vet_test
+"""
+
+go_fmt_test = _go_fmt_test
+"""
+    go_fmt_test
 """
 
 

--- a/go/private/rules/stdlib.bzl
+++ b/go/private/rules/stdlib.bzl
@@ -46,8 +46,9 @@ def _stdlib_impl(ctx):
   go = ctx.actions.declare_file("bin/go") # TODO: .exe
   src = ctx.actions.declare_directory("src")
   pkg = ctx.actions.declare_directory("pkg")
+  gofmt = ctx.actions.declare_file("bin/gofmt")
   root_file = ctx.actions.declare_file("ROOT")
-  files = [root_file, go, src, pkg]
+  files = [root_file, go, src, pkg, gofmt]
   goroot = root_file.path[:-(len(root_file.basename)+1)]
   sdk = ""
   for f in ctx.files._host_sdk:
@@ -85,12 +86,13 @@ def _stdlib_impl(ctx):
 
   ctx.actions.run_shell(
       inputs = inputs,
-      outputs = [go, src, pkg],
+      outputs = [go, src, pkg, gofmt],
       command = " && ".join([
           "export " + " ".join(["{}={}".format(key, value) for key, value in env.items()]),
           "mkdir -p {}".format(src.path),
           "mkdir -p {}".format(pkg.path),
           "cp {}/bin/{} {}".format(sdk, go.basename, go.path),
+          "cp {}/bin/{} {}".format(sdk, gofmt.basename, gofmt.path),
           "cp -rf {}/src/* {}/".format(sdk, src.path),
           "cp -rf {}/pkg/tool {}/".format(sdk, pkg.path),
           "cp -rf {}/pkg/include {}/".format(sdk, pkg.path),
@@ -100,10 +102,11 @@ def _stdlib_impl(ctx):
   )
   return [
       DefaultInfo(
-          files = depset([root_file, go, src, pkg]),
+          files = depset([root_file, go, src, pkg, gofmt]),
       ),
       GoStdLib(
           go = go,
+          gofmt = gofmt,
           root_file = root_file,
           goos = ctx.attr.goos,
           goarch = ctx.attr.goarch,

--- a/go/private/tools/gofmt.bzl
+++ b/go/private/tools/gofmt.bzl
@@ -1,0 +1,68 @@
+# Copyright 2014 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go/private:providers.bzl", "GoPath")
+
+def _go_fmt_generate_impl(ctx):
+  print("""
+EXPERIMENTAL: the go_fmt_test rule is still very experimental
+Please do not rely on it for production use, but feel free to use it and file issues
+""")
+  go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:toolchain"]
+  stdlib = go_toolchain.stdlib.get(ctx, go_toolchain)
+  script_file = ctx.new_file(ctx.label.name+".bash")
+  files = ctx.files.data + stdlib.files
+  packages = []
+  content="""
+STATUS=0
+"""
+  for data in ctx.attr.data:
+    entry = data[GoPath]
+    for package in entry.packages:
+      content += """
+if [[ $({gofmt} -d -e {package}/*.go | tee /dev/stderr) ]]; then STATUS=1; fi
+""".format(
+      gofmt=stdlib.gofmt.short_path,
+      package=package.dir,
+    )
+  content += """
+exit $STATUS
+"""
+  ctx.file_action(output=script_file, executable=True, content=content)
+  return struct(
+    files = depset([script_file]),
+    runfiles = ctx.runfiles(files, collect_data = True),
+  )
+
+_go_fmt_generate = rule(
+    _go_fmt_generate_impl,
+    attrs = {
+        "data": attr.label_list(providers=[GoPath], cfg = "data"),
+    },
+    toolchains = ["@io_bazel_rules_go//go:toolchain"],
+)
+
+def go_fmt_test(name, data, **kwargs):
+  script_name = "generate_"+name
+  _go_fmt_generate(
+    name=script_name,
+    data=data,
+    tags = ["manual"],
+  )
+  native.sh_test(
+    name=name,
+    srcs=[script_name],
+    data=data,
+    **kwargs
+  )


### PR DESCRIPTION
Based off the format of the `go vet` test.  Runs `gofmt -d -e` off the packages go source code.  If any output diff is produced, fail the test.