### PR TITLE
Separate GoArchive from GoLibrary

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -1,0 +1,82 @@
+# Copyright 2014 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go/private:common.bzl",
+    "split_srcs",
+)
+load("@io_bazel_rules_go//go/private:mode.bzl",
+    "mode_string",
+)
+load("@io_bazel_rules_go//go/private:providers.bzl",
+    "GoArchive",
+)
+
+def emit_archive(ctx, go_toolchain,
+    importpath = "",
+    srcs = (),
+    direct = (),
+    cgo_info = None,
+    importable = True,
+    mode = None,
+    gc_goopts = ()):
+  """See go/toolchains.rst#archive for full documentation."""
+
+  source = split_srcs(srcs)
+  lib_name = importpath + ".a"
+  compilepath = importpath if importable else None
+  out_dir = "~{}~{}~".format(mode_string(mode), ctx.label.name)
+  out_lib = ctx.new_file("{}/{}".format(out_dir, lib_name))
+  searchpath = out_lib.path[:-len(lib_name)]
+
+  extra_objects = []
+  for src in source.asm:
+    obj = ctx.new_file(src, "%s.dir/%s.o" % (ctx.label.name, src.basename[:-2]))
+    go_toolchain.actions.asm(ctx, go_toolchain, src, source.headers, obj)
+    extra_objects += [obj]
+  archive = cgo_info.archive if cgo_info else None
+
+  if len(extra_objects) == 0 and archive == None:
+    go_toolchain.actions.compile(ctx,
+        go_toolchain = go_toolchain,
+        sources = source.go,
+        importpath = compilepath,
+        golibs = direct,
+        mode = mode,
+        out_lib = out_lib,
+        gc_goopts = gc_goopts,
+    )
+  else:
+    partial_lib = ctx.new_file("{}/~partial.a".format(out_dir))
+    go_toolchain.actions.compile(ctx,
+        go_toolchain = go_toolchain,
+        sources = source.go,
+        importpath = compilepath,
+        golibs = direct,
+        mode = mode,
+        out_lib = partial_lib,
+        gc_goopts = gc_goopts,
+    )
+    go_toolchain.actions.pack(ctx,
+        go_toolchain = go_toolchain,
+        in_lib = partial_lib,
+        out_lib = out_lib,
+        objects = extra_objects,
+        archive = archive,
+    )
+
+  return GoArchive(
+      lib = out_lib,
+      mode = mode,
+      searchpath = searchpath,
+  )

--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -14,6 +14,7 @@
 """
 Toolchain rules used by go.
 """
+load("@io_bazel_rules_go//go/private:actions/archive.bzl", "emit_archive")
 load("@io_bazel_rules_go//go/private:actions/asm.bzl", "emit_asm")
 load("@io_bazel_rules_go//go/private:actions/binary.bzl", "emit_binary")
 load("@io_bazel_rules_go//go/private:actions/compile.bzl", "emit_compile", "bootstrap_compile")
@@ -44,6 +45,7 @@ def _go_toolchain_impl(ctx):
           get = _get_stdlib,
       ),
       actions = struct(
+          archive = emit_archive,
           asm = emit_asm,
           binary = emit_binary,
           compile = emit_compile if ctx.executable._compile else bootstrap_compile,

--- a/go/private/providers.bzl
+++ b/go/private/providers.bzl
@@ -25,15 +25,11 @@ GoPath = provider()
 GoEmbed = provider()
 """See go/providers.rst#GoEmbed for full documentation."""
 
+GoArchive = provider()
+"""See go/providers.rst#GoArchive for full documentation."""
+
 CgoInfo = provider()
 GoStdLib = provider()
-
-def library_attr(mode):
-  """Returns the attribute name for the library of the given mode.
-
-  mode must a struct returned by common.bzl#mode
-  """
-  return mode_string(mode)+"_library"
 
 def get_library(golib, mode):
   """Returns the compiled library for the given mode
@@ -41,14 +37,7 @@ def get_library(golib, mode):
   golib must be a GoLibrary
   mode must a struct returned by common.bzl#mode
   """
-  return getattr(golib, library_attr(mode))
-
-def searchpath_attr(mode):
-  """Returns the search path for the given mode
-
-  mode must a struct returned by common.bzl#mode
-  """
-  return mode_string(mode)+"_searchpath"
+  return getattr(golib, mode_string(mode)).lib
 
 def get_searchpath(golib, mode):
   """Returns the search path for the given mode
@@ -56,6 +45,5 @@ def get_searchpath(golib, mode):
   golib must be a GoLibrary
   mode must a struct returned by common.bzl#mode
   """
-  return getattr(golib, searchpath_attr(mode))
-
+  return getattr(golib, mode_string(mode)).searchpath
 

--- a/go/providers.rst
+++ b/go/providers.rst
@@ -79,21 +79,13 @@ binaries or tests.
 +--------------------------------+-----------------------------------------------------------------+
 | The files needed to run anything that includes this library.                                     |
 +--------------------------------+-----------------------------------------------------------------+
-| :param:`normal_library`        | :type:`File`                                                    |
+| :param:`normal`                | :type:`GoArchive`                                               |
 +--------------------------------+-----------------------------------------------------------------+
-| The archive file representing the library compiled with the default options.                     |
+| The GoArchive provider representing the library compiled with the default options.               |
 +--------------------------------+-----------------------------------------------------------------+
-| :param:`normal_searchpath`     | :type:`string`                                                  |
+| :param:`race`                  | :type:`GoArchive`                                               |
 +--------------------------------+-----------------------------------------------------------------+
-| The search path entry under which the :param:`normal_library` would be found.                    |
-+--------------------------------+-----------------------------------------------------------------+
-| :param:`race_library`          | :type:`File`                                                    |
-+--------------------------------+-----------------------------------------------------------------+
-| The archive file representing the library compiled with the race detector enabled.               |
-+--------------------------------+-----------------------------------------------------------------+
-| :param:`race_searchpath`       | :type:`string`                                                  |
-+--------------------------------+-----------------------------------------------------------------+
-| The search path entry under which the :param:`race_library` would be found.                      |
+| The GoArchive provider representing the library compiled with the race detector enabled.         |
 +--------------------------------+-----------------------------------------------------------------+
 
 
@@ -149,6 +141,29 @@ There are two main uses for this.
 +--------------------------------+-----------------------------------------------------------------+
 | Go compilation options that should be used when compiling these sources.                         |
 | In general these will be used for *all* sources of any library this provider is embedded into.   |
++--------------------------------+-----------------------------------------------------------------+
+
+
+GoArchive
+~~~~~~~~~
+
+GoArchive is a provider that exposes a compiled library.
+
++--------------------------------+-----------------------------------------------------------------+
+| **Name**                       | **Type**                                                        |
++--------------------------------+-----------------------------------------------------------------+
+| :param:`lib`                   | :type:`compiled archive file`                                   |
++--------------------------------+-----------------------------------------------------------------+
+| The archive file representing the library compiled in a specific :param:`mode` ready for linking |
+| into binaries.                                                                                   |
++--------------------------------+-----------------------------------------------------------------+
+| :param:`searchpath`            | :type:`string`                                                  |
++--------------------------------+-----------------------------------------------------------------+
+| The search path entry under which the :param:`lib` would be found.                               |
++--------------------------------+-----------------------------------------------------------------+
+| :param:`mode`                  | :type:`Mode`                                                    |
++--------------------------------+-----------------------------------------------------------------+
+| The mode the library was compiled in.                                                            |
 +--------------------------------+-----------------------------------------------------------------+
 
 


### PR DESCRIPTION
actions.library is now responsible for preparing a go_library, whereas
ations.archive is repsonsible for compiling a library to a linkable archive.
At the moment actions.archive is only called from inside actions.library, and
the behvaiour of the system has not changed.