### PR TITLE
Use go_library for go_test

### DIFF
--- a/go/private/actions/binary.bzl
+++ b/go/private/actions/binary.bzl
@@ -29,7 +29,6 @@ def emit_binary(ctx, go_toolchain,
     importpath = "",
     srcs = (),
     deps = (),
-    golibs = (),
     cgo_info = None,
     embed = (),
     gc_linkopts = (),
@@ -47,7 +46,6 @@ def emit_binary(ctx, go_toolchain,
       embed = embed,
       importpath = importpath,
       importable = False,
-      golibs = golibs,
   )
 
   executables = {}

--- a/go/private/actions/library.bzl
+++ b/go/private/actions/library.bzl
@@ -34,11 +34,10 @@ def emit_library(ctx, go_toolchain,
     cgo_info = None,
     embed = (),
     want_coverage = False,
-    importable = True,
-    golibs=()):
+    importable = True):
   """See go/toolchains.rst#library for full documentation."""
   dep_runfiles = [d.data_runfiles for d in deps]
-  direct = depset(golibs)
+  direct = depset()
   gc_goopts = tuple(ctx.attr.gc_goopts)
   cover_vars = ()
   if cgo_info:

--- a/go/private/rules/wrappers.bzl
+++ b/go/private/rules/wrappers.bzl
@@ -53,20 +53,24 @@ def go_binary_macro(name, srcs=None, cgo=False, cdeps=[], copts=[], clinkopts=[]
       **kwargs
   )
 
-def go_test_macro(name, srcs=None, cgo=False, cdeps=[], copts=[], clinkopts=[], **kwargs):
+def go_test_macro(name, srcs=None, deps=None, importpath="", library=None, embed=[], gc_goopts=[], cgo=False, cdeps=[], copts=[], clinkopts=[], **kwargs):
   """See go/core.rst#go_test for full documentation."""
-  cgo_info = None
-  if cgo:
-    cgo_info = setup_cgo_library(
-        name = name,
-        srcs = srcs,
-        cdeps = cdeps,
-        copts = copts,
-        clinkopts = clinkopts,
-    )
+  library_name = name + "~library~"
+  go_library(
+      name = library_name,
+      visibility = ["//visibility:private"],
+      srcs=srcs,
+      deps=deps,
+      importpath=importpath,
+      library=library,
+      embed=embed,
+      gc_goopts=gc_goopts,
+      testonly=True,
+      tags = ["manual"]
+  )
   return go_test(
       name = name,
-      srcs = srcs,
-      cgo_info = cgo_info,
+      library = library_name,
+      gc_goopts=gc_goopts,
       **kwargs
   )

--- a/go/private/rules/wrappers.bzl
+++ b/go/private/rules/wrappers.bzl
@@ -75,6 +75,7 @@ def go_test_macro(name, srcs=None, deps=None, importpath="", library=None, embed
   return go_test(
       name = name,
       library = library_name,
+      importpath = importpath,
       gc_goopts = gc_goopts,
       **kwargs
   )

--- a/go/private/rules/wrappers.bzl
+++ b/go/private/rules/wrappers.bzl
@@ -56,21 +56,25 @@ def go_binary_macro(name, srcs=None, cgo=False, cdeps=[], copts=[], clinkopts=[]
 def go_test_macro(name, srcs=None, deps=None, importpath="", library=None, embed=[], gc_goopts=[], cgo=False, cdeps=[], copts=[], clinkopts=[], **kwargs):
   """See go/core.rst#go_test for full documentation."""
   library_name = name + "~library~"
-  go_library(
+  go_library_macro(
       name = library_name,
       visibility = ["//visibility:private"],
-      srcs=srcs,
-      deps=deps,
-      importpath=importpath,
-      library=library,
-      embed=embed,
-      gc_goopts=gc_goopts,
-      testonly=True,
-      tags = ["manual"]
+      srcs = srcs,
+      deps = deps,
+      importpath = importpath,
+      library = library,
+      embed = embed,
+      gc_goopts = gc_goopts,
+      testonly = True,
+      tags = ["manual"],
+      cgo = False, 
+      cdeps = cdeps,
+      copts = copts,
+      clinkopts = clinkopts,
   )
   return go_test(
       name = name,
       library = library_name,
-      gc_goopts=gc_goopts,
+      gc_goopts = gc_goopts,
       **kwargs
   )

--- a/go/toolchains.rst
+++ b/go/toolchains.rst
@@ -504,11 +504,6 @@ It returns a tuple of GoLibrary_ and GoBinary_.
 +--------------------------------+-----------------------------+-----------------------------------+
 | Link defines, including build stamping ones.                                                     |
 +--------------------------------+-----------------------------+-----------------------------------+
-| :param:`golibs`                | :type:`GoLibrary iterable`  | :value:`[]`                       |
-+--------------------------------+-----------------------------+-----------------------------------+
-| An iterable of GoLibrary_ objects.                                                               |
-| Used to pass in synthetic dependencies.                                                          |
-+--------------------------------+-----------------------------+-----------------------------------+
 
 
 compile
@@ -639,11 +634,6 @@ It returns a tuple of GoLibrary_ and GoEmbed_.
 | :param:`importable`            | :type:`boolean`             | :value:`True`                     |
 +--------------------------------+-----------------------------+-----------------------------------+
 | A bool indicating whether the package can be imported by other libraries.                        |
-+--------------------------------+-----------------------------+-----------------------------------+
-| :param:`golibs`                | :type:`GoLibrary iterable`  | :value:`[]`                       |
-+--------------------------------+-----------------------------+-----------------------------------+
-| An iterable of GoLibrary_ objects.                                                               |
-| Used to pass in synthetic dependencies.                                                          |
 +--------------------------------+-----------------------------+-----------------------------------+
 
 


### PR DESCRIPTION
This makes the go_test macro build a go_library rule for the package under test,
and then a go_test rule to actually test it.
Makes sure that the library is built the same way it would be for real, and also
cleans up the need for the "synthetic" library parameter