### PR TITLE
examples/proto: fix rule names and run buildifier

### DIFF
--- a/examples/proto/BUILD.bazel
+++ b/examples/proto/BUILD.bazel
@@ -3,19 +3,21 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["gs.go"],
-    deps = [
-        "//examples/proto/gostyle:go_default_library",
-        "//examples/proto/lib:go_default_library",
-    ],
+    importpath = "github.com/bazelbuild/rules_go/examples/proto",
     visibility = ["//visibility:public"],
+    deps = [
+        "//examples/proto/gostyle:gostyle_go_proto",
+        "//examples/proto/lib:lib_go_proto",
+    ],
 )
 
 go_test(
     name = "proto_test",
     size = "small",
     srcs = ["proto_test.go"],
+    importpath = "github.com/bazelbuild/rules_go/examples/proto",
     deps = [
         "//examples/proto/embed:go_default_library",
-        "//examples/proto/lib:go_default_library",
+        "//examples/proto/lib:lib_go_proto",
     ],
 )

--- a/examples/proto/dep/BUILD.bazel
+++ b/examples/proto/dep/BUILD.bazel
@@ -4,17 +4,18 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "useful_proto",
     srcs = ["useful.proto"],
+    visibility = ["//visibility:public"],
     deps = [
         "@com_google_protobuf//:duration_proto",
     ],
-    visibility = ["//visibility:public"],
 )
 
 go_proto_library(
-    name = "go_default_library",
+    name = "useful_go_proto",
+    importpath = "github.com/bazelbuild/rules_go/examples/proto/dep",
     proto = ":useful_proto",
+    visibility = ["//visibility:public"],
     deps = [
         "@com_github_golang_protobuf//ptypes/duration:go_default_library",
     ],
-    visibility = ["//visibility:public"],
 )

--- a/examples/proto/embed/BUILD.bazel
+++ b/examples/proto/embed/BUILD.bazel
@@ -2,25 +2,25 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
-    name = "proto_library",
+    name = "embed_proto",
     srcs = ["embed.proto"],
     visibility = ["//visibility:public"],
 )
 
 go_proto_library(
-    name = "go_proto_library",
-    proto = ":proto_library",
+    name = "embed_go_proto",
+    # Note that if you forget the importpath everything will break horribly.
+    importpath = "github.com/bazelbuild/rules_go/examples/proto/embed",
+    proto = ":embed_proto",
     deps = [
         "@com_github_golang_protobuf//ptypes/any:go_default_library",
     ],
-    # Note that if you forget the importpath everything will break horribly.
-    importpath = "github.com/bazelbuild/rules_go/examples/proto/embed",
 )
 
 go_library(
     name = "go_default_library",
     srcs = ["embed.go"],
-    embed = [":go_proto_library"],
+    embed = [":embed_go_proto"],
     importpath = "github.com/bazelbuild/rules_go/examples/proto/embed",
     visibility = ["//visibility:public"],
 )

--- a/examples/proto/gostyle/BUILD.bazel
+++ b/examples/proto/gostyle/BUILD.bazel
@@ -9,19 +9,20 @@ genrule(
 )
 
 proto_library(
-    name = "gostyle",
+    name = "gostyle_proto",
     srcs = [":copy"],
+    visibility = ["//visibility:public"],
     deps = [
         "@com_google_protobuf//:any_proto",
     ],
-    visibility = ["//visibility:public"],
 )
 
 go_proto_library(
-    name = "go_default_library",
-    proto = ":gostyle",
+    name = "gostyle_go_proto",
+    importpath = "github.com/bazelbuild/rules_go/examples/proto/gostyle",
+    proto = ":gostyle_proto",
+    visibility = ["//visibility:public"],
     deps = [
         "@com_github_golang_protobuf//ptypes/any:go_default_library",
     ],
-    visibility = ["//visibility:public"],
 )

--- a/examples/proto/grpc/BUILD.bazel
+++ b/examples/proto/grpc/BUILD.bazel
@@ -13,21 +13,21 @@ proto_library(
 
 go_proto_library(
     name = "not_grpc",
-    proto = ":my_svc_proto",
     importpath = "github.com/bazelbuild/rules_go/examples/proto/grpc/my_svc_proto",
+    proto = ":my_svc_proto",
     deps = [
-        "//examples/proto/lib:go_default_library",
+        "//examples/proto/lib:lib_go_proto",
         "@com_github_golang_protobuf//ptypes/any:go_default_library",
         "@com_github_golang_protobuf//ptypes/empty:go_default_library",
     ],
 )
 
 go_grpc_library(
-    name = "go_default_library",
-    proto = ":my_svc_proto",
+    name = "my_svc_go_proto",
     importpath = "github.com/bazelbuild/rules_go/examples/proto/grpc/my_svc_proto",
+    proto = ":my_svc_proto",
     deps = [
-        "//examples/proto/lib:go_default_library",
+        "//examples/proto/lib:lib_go_proto",
         "@com_github_golang_protobuf//ptypes/any:go_default_library",
         "@com_github_golang_protobuf//ptypes/empty:go_default_library",
     ],
@@ -37,8 +37,8 @@ go_binary(
     name = "test_grpc",
     srcs = ["main.go"],
     deps = [
-        ":go_default_library",
-        "//examples/proto/lib:go_default_library",
+        ":my_svc_go_proto",
+        "//examples/proto/lib:lib_go_proto",
         "@com_github_golang_protobuf//ptypes/any:go_default_library",
         "@com_github_golang_protobuf//ptypes/empty:go_default_library",
         "@org_golang_google_grpc//:go_default_library",

--- a/examples/proto/lib/BUILD.bazel
+++ b/examples/proto/lib/BUILD.bazel
@@ -7,18 +7,18 @@ proto_library(
         "lib.proto",
         "lib2.proto",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "//examples/proto/dep:useful_proto",
     ],
-    visibility = ["//visibility:public"],
 )
 
 go_proto_library(
-    name = "go_default_library",
-    proto = ":lib_proto",
-    deps = [
-        "//examples/proto/dep:go_default_library",
-    ],
+    name = "lib_go_proto",
     importpath = "github.com/bazelbuild/rules_go/examples/proto/lib/lib_proto",
+    proto = ":lib_proto",
     visibility = ["//visibility:public"],
+    deps = [
+        "//examples/proto/dep:useful_go_proto",
+    ],
 )


### PR DESCRIPTION
* Renamed proto_library rules to follow "foo_proto" convention.
* Renamed go_proto_library and go_grpc_library to follow
  "foo_go_proto" convention.
* Ran buildifier on build files in examples/proto.