### PR TITLE
Make gopkg.in's resolution logic aware of multiple path levels.

### DIFF
--- a/go/tools/gazelle/resolve/resolve_external_test.go
+++ b/go/tools/gazelle/resolve/resolve_external_test.go
@@ -39,6 +39,7 @@ func TestSpecialCases(t *testing.T) {
 		{in: "github.com/foo/bar", want: "github.com/foo/bar"},
 		{in: "github.com/foo/bar/baz", want: "github.com/foo/bar"},
 		{in: "gopkg.in/yaml.v2", want: "gopkg.in/yaml.v2"},
+		{in: "gopkg.in/src-d/go-git.v4", want: "gopkg.in/src-d/go-git.v4"},
 		{in: "unsupported.org/x/net/context", wantError: true},
 		{
 			in:         "private.com/my/repo/package/path",


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_go/issues/998