### PR TITLE
Travis CI: use xcode8.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 dist: trusty
 sudo: required
 # xcode8 has jdk8
-osx_image: xcode8
+osx_image: xcode8.3
 # Not technically required but suppresses 'Ruby' in Job status message.
 language: java
 


### PR DESCRIPTION
This will put us on macOS 10.12 instead of 10.11. I'm mostly changing
this experimentally to see if we can fix some flaky link warnings and
errors.