### PR TITLE
Mention Windows compatibility in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,7 @@ They currently do not support (in order of importance):
 * C/C++ interoperation except cgo (swig etc.)
 * coverage
 * test sharding
+* building on Windows
 
 :Note: The latest version of these rules (0.7.0) require Bazel ≥ 0.6.0 to
   work.


### PR DESCRIPTION
Learned the hard way, and later through filed issues, that Go rules do not yet work on Windows.
Can hopefully save time for others if listed explicitly.