### PR TITLE
Using ctx.actions.args

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ os:
 env:
   # TODO(bazelbuild/continuous-integration#95): re-enable HEAD builds with stable URL
   # - V=HEAD
-  - V=0.6.0
+  - V=0.7.0
 
 before_install:
   - |

--- a/examples/bindata/bindata.bzl
+++ b/examples/bindata/bindata.bzl
@@ -2,20 +2,22 @@ load("@io_bazel_rules_go//go/private:go_repository.bzl", "go_repository")
 
 def _bindata_impl(ctx):
   out = ctx.actions.declare_file(ctx.label.name + ".go")
-  arguments = [
+  arguments = ctx.actions.args()
+  arguments.add([
       "-o", out.path,
       "-pkg", ctx.attr.package,
       "-prefix", ctx.label.package,
-  ]
+  ])
   if not ctx.attr.compress:
-    arguments += ["-nocompress"]
+    arguments.add("-nocompress")
   if not ctx.attr.metadata:
-    arguments += ["-nometadata"]
+    arguments.add("-nometadata")
+  arguments.add(ctx.files.srcs)
   ctx.actions.run(
     inputs = ctx.files.srcs,
     outputs = [out],
     executable = ctx.file._bindata,
-    arguments = arguments + [src.path for src in ctx.files.srcs],
+    arguments = [arguments],
   )
   return [
     DefaultInfo(

--- a/go/private/actions/action.bzl
+++ b/go/private/actions/action.bzl
@@ -12,22 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-def action_with_go_env(ctx, go_toolchain, mode, executable = None, command=None, arguments = [], inputs = [], **kwargs):
-  if command:
-    fail("You cannot run action_with_go_env with a 'command', only an 'executable'")
-  stdlib = go_toolchain.stdlib.get(ctx, go_toolchain, mode)
-  args = [
-      "-go", stdlib.go.path,
-      "-root_file", stdlib.root_file.path,
+
+def add_go_env(args, stdlib, mode):
+  args.add([
+      "-go", stdlib.go,
+      "-root_file", stdlib.root_file,
       "-goos", stdlib.goos,
       "-goarch", stdlib.goarch,
       "-cgo=" + ("0" if mode.pure else "1"),
-  ] + arguments
-  ctx.actions.run(
-      inputs = depset(inputs) + stdlib.files,
-      executable = executable,
-      arguments = args,
-      **kwargs)
+  ])
 
 def bootstrap_action(ctx, go_toolchain, inputs, outputs, mnemonic, arguments):
   stdlib = go_toolchain.stdlib.cgo

--- a/go/private/rules/info.bzl
+++ b/go/private/rules/info.bzl
@@ -16,19 +16,23 @@ load("@io_bazel_rules_go//go/private:mode.bzl",
     "get_mode",
 )
 load("@io_bazel_rules_go//go/private:actions/action.bzl",
-    "action_with_go_env",
+    "add_go_env",
 )
 
 def _go_info_script_impl(ctx):
   go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:toolchain"]
   mode = get_mode(ctx, ctx.attr._go_toolchain_flags)
+  stdlib = go_toolchain.stdlib.get(ctx, go_toolchain, mode)
   out = ctx.actions.declare_file(ctx.label.name+".bash")
-  action_with_go_env(ctx, go_toolchain, mode,
+  args = ctx.actions.args()
+  add_go_env(args, stdlib, mode)
+  args.add(["-script", "-out", out])
+  ctx.actions.run(
       inputs = [],
       outputs = [out],
       mnemonic = "GoInfo",
       executable = ctx.executable._go_info,
-      arguments = ["-script", "-out", out.path],
+      arguments = [args],
   )
   return [
       DefaultInfo(

--- a/go/private/tools/embed_data.bzl
+++ b/go/private/tools/embed_data.bzl
@@ -18,12 +18,12 @@ def _go_embed_data_impl(ctx):
   if ctx.attr.src and ctx.attr.flatten:
     fail("%s: src and flatten attributes cannot both be specified" % ctx.label)
 
+  args = ctx.actions.args()
   if ctx.attr.src:
     srcs = [ctx.file.src]
-    args = []
   else:
     srcs = ctx.files.srcs
-    args = ["-multi"]
+    args.add("-multi")
 
   if ctx.attr.package:
     package = ctx.attr.package
@@ -32,24 +32,24 @@ def _go_embed_data_impl(ctx):
     if package == "":
       fail("%s: must provide package attribute for go_embed_data rules in the repository root directory" % ctx.label)
 
-  args += [
+  args.add([
     "-workspace", ctx.workspace_name,
     "-label", str(ctx.label),
-    "-out", ctx.outputs.out.path,
+    "-out", ctx.outputs.out,
     "-package", package,
     "-var", ctx.attr.var,
-  ]
+  ])
   if ctx.attr.flatten:
-    args += ["-flatten"]
+    args.add("-flatten")
   if ctx.attr.string:
-    args += ["-string"]
-  args += [f.path for f in srcs]
+    args.add("-string")
+  args.add(srcs)
 
   ctx.actions.run(
       outputs = [ctx.outputs.out],
       inputs = srcs,
       executable = ctx.executable._embed,
-      arguments = args,
+      arguments = [args],
       mnemonic = "GoEmbedData",
   )
 

--- a/tests/bazel_tests.bzl
+++ b/tests/bazel_tests.bzl
@@ -166,11 +166,14 @@ def bazel_test(name, command = None, args=None, targets = None, go_version = Non
 
 def _md5_sum_impl(ctx):
   out = ctx.actions.declare_file(ctx.label.name+".md5")
+  arguments = ctx.actions.args()
+  arguments.add(["-output", out.path])
+  arguments.add(ctx.files.srcs)
   ctx.actions.run(
       inputs = ctx.files.srcs,
       outputs = [out],
       executable = ctx.file._md5sum,
-      arguments = ["-output", out.path] + [src.path for src in ctx.files.srcs],
+      arguments = [arguments],
   )
   return struct(files=depset([out]))
 


### PR DESCRIPTION
All ctx.action.run actions now use ctx.actions.args to build the arguments.
This allows depsets and paths to be lazily expanded, which should help with
performance.