### PR TITLE
Cleaning up transitive provider fields

### DIFF
--- a/go/private/actions/compile.bzl
+++ b/go/private/actions/compile.bzl
@@ -21,10 +21,10 @@ load("@io_bazel_rules_go//go/private:actions/action.bzl",
 )
 
 def _importpath(l):
-  return [v.library.importpath for v in l]
+  return [v.data.importpath for v in l]
 
 def _searchpath(l):
-  return [v.searchpath for v in l]
+  return [v.data.searchpath for v in l]
 
 def emit_compile(ctx, go_toolchain,
     sources = None,
@@ -50,7 +50,7 @@ def emit_compile(ctx, go_toolchain,
   go_sources = [s.path for s in sources if not s.basename.startswith("_cgo")]
   cgo_sources = [s.path for s in sources if s.basename.startswith("_cgo")]
 
-  inputs = sets.union(inputs, [archive.file for archive in archives])
+  inputs = sets.union(inputs, [archive.data.file for archive in archives])
 
   stdlib = go_toolchain.stdlib.get(ctx, go_toolchain, mode)
   inputs = sets.union(inputs, stdlib.files)

--- a/go/private/providers.bzl
+++ b/go/private/providers.bzl
@@ -17,6 +17,8 @@ load("@io_bazel_rules_go//go/private:mode.bzl", "mode_string")
 GoLibrary = provider()
 """See go/providers.rst#GoLibrary for full documentation."""
 
+GoPackage = provider()
+
 GoPath = provider()
 
 GoEmbed = provider()
@@ -24,6 +26,8 @@ GoEmbed = provider()
 
 GoArchive = provider()
 """See go/providers.rst#GoArchive for full documentation."""
+
+GoArchiveData = provider()
 
 CgoInfo = provider()
 GoStdLib = provider()

--- a/go/private/rules/library.bzl
+++ b/go/private/rules/library.bzl
@@ -49,7 +49,7 @@ def _go_library_impl(ctx):
   return [
       golib, goembed, goarchive,
       DefaultInfo(
-          files = depset([goarchive.file]),
+          files = depset([goarchive.data.file]),
           runfiles = golib.runfiles,
       ),
       OutputGroupInfo(

--- a/go/private/tools/path.bzl
+++ b/go/private/tools/path.bzl
@@ -23,9 +23,7 @@ Please do not rely on it for production use, but feel free to use it and file is
   # First gather all the library rules
   golibs = depset()
   for dep in ctx.attr.deps:
-    golib = dep[GoLibrary]
-    golibs += [golib]
-    golibs += golib.transitive
+    golibs += dep[GoLibrary].transitive
 
   # Now scan them for sources
   seen_libs = {}
@@ -42,7 +40,7 @@ Found {} in
   {}
 and
   {}
-""".format(golib.importpath, golib.label, seen_libs[golib.importpath].label))
+""".format(golib.importpath, golib.name, seen_libs[golib.importpath].name))
       # for now we don't fail if we see duplicate packages
       # the most common case is the same source from two different workspaces
       continue


### PR DESCRIPTION
Reducing the information in the transitive parts to the minimum needed.
This is to prevent the pathalogical hashing that happens in complex graphs of
deps.