### PR TITLE
Gazelle: extract import resolution out of rules package

### DIFF
--- a/go/tools/gazelle/config/constants.go
+++ b/go/tools/gazelle/config/constants.go
@@ -44,4 +44,8 @@ const (
 	// WellKnownTypesGoPrefix is the import path for the Go repository containing
 	// pre-generated code for the Well Known Types.
 	WellKnownTypesGoPrefix = "github.com/golang/protobuf"
+
+	// GazelleImportsKey is an internal attribute that lists imported packages
+	// on generated rules. It is replaced with "deps" during import resolution.
+	GazelleImportsKey = "_gazelle_imports"
 )

--- a/go/tools/gazelle/resolve/BUILD.bazel
+++ b/go/tools/gazelle/resolve/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "@com_github_bazelbuild_buildtools//build:go_default_library",
         "@io_bazel_rules_go//go/tools/gazelle/config:go_default_library",
         "@org_golang_x_tools//go/vcs:go_default_library",
     ],
@@ -39,6 +40,6 @@ genrule(
     name = "std_package_list",
     srcs = ["@go_sdk//:packages.txt"],
     outs = ["std_package_list.go"],
-    tools = ["//go/tools/gazelle/resolve/internal/gen_std_package_list"],
     cmd = "$(location //go/tools/gazelle/resolve/internal/gen_std_package_list) $< $@",
+    tools = ["//go/tools/gazelle/resolve/internal/gen_std_package_list"],
 )

--- a/go/tools/gazelle/resolve/resolve.go
+++ b/go/tools/gazelle/resolve/resolve.go
@@ -22,6 +22,7 @@ import (
 	"path"
 	"strings"
 
+	bf "github.com/bazelbuild/buildtools/build"
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/config"
 )
 
@@ -59,10 +60,128 @@ func NewResolver(c *config.Config, l Labeler) *Resolver {
 	}
 }
 
-// ResolveGo resolves an import path from a Go source file to a label.
+// ResolveRule modifies a generated rule e by replacing the import paths in the
+// "_gazelle_imports" attribute with labels in a "deps" attribute. This may
+// may safely called on expressions that aren't Go rules (nothing will happen).
+func (r *Resolver) ResolveRule(e bf.Expr, pkgRel, buildRel string) {
+	call, ok := e.(*bf.CallExpr)
+	if !ok {
+		return
+	}
+	rule := bf.Rule{Call: call}
+
+	var resolve func(imp, pkgRel string) (Label, error)
+	switch rule.Kind() {
+	case "go_library", "go_binary", "go_test":
+		resolve = r.resolveGo
+	case "proto_library":
+		resolve = r.resolveProto
+	case "go_proto_library", "go_grpc_library":
+		resolve = r.resolveGoProto
+	default:
+		return
+	}
+
+	imports := rule.AttrDefn(config.GazelleImportsKey)
+	if imports == nil {
+		return
+	}
+
+	deps := mapExprStrings(imports.Y, func(imp string) string {
+		label, err := resolve(imp, pkgRel)
+		if err != nil {
+			log.Print(err)
+			return ""
+		}
+		label.Relative = label.Repo == "" && label.Pkg == buildRel
+		return label.String()
+	})
+	if deps == nil {
+		rule.DelAttr(config.GazelleImportsKey)
+	} else {
+		imports.X.(*bf.LiteralExpr).Token = "deps"
+		imports.Y = deps
+	}
+}
+
+// mapExprStrings applies a function f to the strings in e and returns a new
+// expression with the results. Scalar strings, lists, dicts, selects, and
+// concatenations are supported.
+func mapExprStrings(e bf.Expr, f func(string) string) bf.Expr {
+	switch expr := e.(type) {
+	case *bf.StringExpr:
+		s := f(expr.Value)
+		if s == "" {
+			return nil
+		}
+		return &bf.StringExpr{Value: s}
+
+	case *bf.ListExpr:
+		var list []bf.Expr
+		for _, elem := range expr.List {
+			elem = mapExprStrings(elem, f)
+			if elem != nil {
+				list = append(list, elem)
+			}
+		}
+		if len(list) == 0 && len(expr.List) > 0 {
+			return nil
+		}
+		return &bf.ListExpr{List: list}
+
+	case *bf.DictExpr:
+		var cases []bf.Expr
+		for _, kv := range expr.List {
+			keyval, ok := kv.(*bf.KeyValueExpr)
+			if !ok {
+				log.Panicf("unexpected expression in generated imports dict: %#v", kv)
+			}
+			value := mapExprStrings(keyval.Value, f)
+			if value != nil {
+				cases = append(cases, &bf.KeyValueExpr{Key: keyval.Key, Value: value})
+			}
+		}
+		if len(cases) == 0 {
+			return nil
+		}
+		return &bf.DictExpr{List: cases}
+
+	case *bf.CallExpr:
+		if x, ok := expr.X.(*bf.LiteralExpr); !ok || x.Token != "select" || len(expr.List) != 1 {
+			log.Panicf("unexpected call expression in generated imports: %#v", e)
+		}
+		arg := mapExprStrings(expr.List[0], f)
+		if arg == nil {
+			return nil
+		}
+		call := *expr
+		call.List[0] = arg
+		return &call
+
+	case *bf.BinaryExpr:
+		x := mapExprStrings(expr.X, f)
+		y := mapExprStrings(expr.Y, f)
+		if x == nil {
+			return y
+		}
+		if y == nil {
+			return x
+		}
+		binop := *expr
+		binop.X = x
+		binop.Y = y
+		return &binop
+
+	default:
+		log.Panicf("unexpected expression in generated imports: %#v", e)
+		return nil
+	}
+}
+
+// resolveGo resolves an import path from a Go source file to a label.
 // pkgRel is the path to the Go package relative to the repository root; it
 // is used to resolve relative imports.
-func (r *Resolver) ResolveGo(imp, pkgRel string) (Label, error) {
+func (r *Resolver) resolveGo(imp, pkgRel string) (Label, error) {
 	if build.IsLocalImport(imp) {
 		cleanRel := path.Clean(path.Join(pkgRel, imp))
 		if build.IsLocalImport(cleanRel) {
@@ -89,9 +208,9 @@ const (
 	descriptorPkg       = "protoc-gen-go/descriptor"
 )
 
-// ResolveProto resolves an import statement in a .proto file to a label
+// resolveProto resolves an import statement in a .proto file to a label
 // for a proto_library rule.
-func (r *Resolver) ResolveProto(imp, pkgRel string) (Label, error) {
+func (r *Resolver) resolveProto(imp, pkgRel string) (Label, error) {
 	if !strings.HasSuffix(imp, ".proto") {
 		return Label{}, fmt.Errorf("can't import non-proto: %q", imp)
 	}
@@ -111,9 +230,9 @@ func (r *Resolver) ResolveProto(imp, pkgRel string) (Label, error) {
 	return r.l.ProtoLabel(rel, name), nil
 }
 
-// ResolveGoProto resolves an import statement in a .proto file to a
+// resolveGoProto resolves an import statement in a .proto file to a
 // label for a go_library rule that embeds the corresponding go_proto_library.
-func (r *Resolver) ResolveGoProto(imp, pkgRel string) (Label, error) {
+func (r *Resolver) resolveGoProto(imp, pkgRel string) (Label, error) {
 	if !strings.HasSuffix(imp, ".proto") {
 		return Label{}, fmt.Errorf("can't import non-proto: %q", imp)
 	}

--- a/go/tools/gazelle/resolve/resolve_test.go
+++ b/go/tools/gazelle/resolve/resolve_test.go
@@ -92,13 +92,13 @@ func TestResolveGoLocal(t *testing.T) {
 		c := &config.Config{GoPrefix: "example.com/repo", StructureMode: spec.mode}
 		l := NewLabeler(c)
 		r := NewResolver(c, l)
-		label, err := r.ResolveGo(spec.importpath, spec.pkgRel)
+		label, err := r.resolveGo(spec.importpath, spec.pkgRel)
 		if err != nil {
-			t.Errorf("r.ResolveGo(%q) failed with %v; want success", spec.importpath, err)
+			t.Errorf("r.resolveGo(%q) failed with %v; want success", spec.importpath, err)
 			continue
 		}
 		if got, want := label, spec.want; !reflect.DeepEqual(got, want) {
-			t.Errorf("r.ResolveGo(%q) = %s; want %s", spec.importpath, got, want)
+			t.Errorf("r.resolveGo(%q) = %s; want %s", spec.importpath, got, want)
 		}
 	}
 }
@@ -114,13 +114,13 @@ func TestResolveGoLocalError(t *testing.T) {
 		"example.com/another/sub",
 		"example.com/repo_suffix",
 	} {
-		if l, err := r.ResolveGo(importpath, ""); err == nil {
-			t.Errorf("r.ResolveGo(%q) = %s; want error", importpath, l)
+		if l, err := r.resolveGo(importpath, ""); err == nil {
+			t.Errorf("r.resolveGo(%q) = %s; want error", importpath, l)
 		}
 	}
 
-	if l, err := r.ResolveGo("..", ""); err == nil {
-		t.Errorf("r.ResolveGo(%q) = %s; want error", "..", l)
+	if l, err := r.resolveGo("..", ""); err == nil {
+		t.Errorf("r.resolveGo(%q) = %s; want error", "..", l)
 	}
 }
 
@@ -131,15 +131,15 @@ func TestResolveGoEmptyPrefix(t *testing.T) {
 
 	imp := "foo"
 	want := Label{Pkg: "foo", Name: config.DefaultLibName}
-	if got, err := r.ResolveGo(imp, ""); err != nil {
-		t.Errorf("r.ResolveGo(%q) failed with %v; want success", imp, err)
+	if got, err := r.resolveGo(imp, ""); err != nil {
+		t.Errorf("r.resolveGo(%q) failed with %v; want success", imp, err)
 	} else if !reflect.DeepEqual(got, want) {
-		t.Errorf("r.ResolveGo(%q) = %s; want %s", imp, got, want)
+		t.Errorf("r.resolveGo(%q) = %s; want %s", imp, got, want)
 	}
 
 	imp = "fmt"
-	if _, err := r.ResolveGo(imp, ""); err == nil {
-		t.Errorf("r.ResolveGo(%q) succeeded; want failure")
+	if _, err := r.resolveGo(imp, ""); err == nil {
+		t.Errorf("r.resolveGo(%q) succeeded; want failure")
 	}
 }
 
@@ -221,20 +221,20 @@ func TestResolveProto(t *testing.T) {
 			l := NewLabeler(c)
 			r := NewResolver(c, l)
 
-			got, err := r.ResolveProto(tc.imp, tc.pkgRel)
+			got, err := r.resolveProto(tc.imp, tc.pkgRel)
 			if err != nil {
-				t.Errorf("ResolveProto: got error %v ; want success", err)
+				t.Errorf("resolveProto: got error %v ; want success", err)
 			}
 			if !reflect.DeepEqual(got, tc.wantProto) {
-				t.Errorf("ResolveProto: got %s ; want %s", got, tc.wantProto)
+				t.Errorf("resolveProto: got %s ; want %s", got, tc.wantProto)
 			}
 
-			got, err = r.ResolveGoProto(tc.imp, tc.pkgRel)
+			got, err = r.resolveGoProto(tc.imp, tc.pkgRel)
 			if err != nil {
-				t.Errorf("ResolveGoProto: go error %v ; want success", err)
+				t.Errorf("resolveGoProto: go error %v ; want success", err)
 			}
 			if !reflect.DeepEqual(got, tc.wantGoProto) {
-				t.Errorf("ResolveGoProto: got %s ; want %s", got, tc.wantGoProto)
+				t.Errorf("resolveGoProto: got %s ; want %s", got, tc.wantGoProto)
 			}
 		})
 	}

--- a/go/tools/gazelle/rules/generator.go
+++ b/go/tools/gazelle/rules/generator.go
@@ -31,15 +31,14 @@ import (
 // "buildRel" is a slash-separated path to the directory containing the
 // build file being generated, relative to the repository root.
 // "oldFile" is the existing build file. May be nil.
-func NewGenerator(c *config.Config, r *resolve.Resolver, l resolve.Labeler, buildRel string, oldFile *bf.File) *Generator {
+func NewGenerator(c *config.Config, l resolve.Labeler, buildRel string, oldFile *bf.File) *Generator {
 	shouldSetVisibility := oldFile == nil || !hasDefaultVisibility(oldFile)
-	return &Generator{c: c, r: r, l: l, buildRel: buildRel, shouldSetVisibility: shouldSetVisibility}
+	return &Generator{c: c, l: l, buildRel: buildRel, shouldSetVisibility: shouldSetVisibility}
 }
 
 // Generator generates Bazel build rules for Go build targets.
 type Generator struct {
 	c                   *config.Config
-	r                   *resolve.Resolver
 	l                   resolve.Labeler
 	buildRel            string
 	shouldSetVisibility bool
@@ -111,12 +110,10 @@ func (g *Generator) generateProto(pkg *packages.Package) (string, []bf.Expr) {
 		{"srcs", g.sources(pkg.Proto.Sources, pkg.Rel)},
 		{"visibility", visibility},
 	}
-	resolveProto := func(imp string) (resolve.Label, error) {
-		return g.r.ResolveProto(imp, pkg.Rel)
-	}
-	protoDeps := g.dependencies(pkg.Proto.Imports, resolveProto)
-	if !protoDeps.IsEmpty() {
-		protoAttrs = append(protoAttrs, keyvalue{"deps", protoDeps})
+	imports := pkg.Proto.Imports
+	imports.Clean()
+	if !imports.IsEmpty() {
+		protoAttrs = append(protoAttrs, keyvalue{config.GazelleImportsKey, imports})
 	}
 	rules = append(rules, newRule("proto_library", protoAttrs))
 
@@ -126,12 +123,8 @@ func (g *Generator) generateProto(pkg *packages.Package) (string, []bf.Expr) {
 		{"importpath", pkg.ImportPath(g.c.GoPrefix)},
 		{"visibility", visibility},
 	}
-	resolveGoProto := func(imp string) (resolve.Label, error) {
-		return g.r.ResolveGoProto(imp, pkg.Rel)
-	}
-	goProtoDeps := g.dependencies(pkg.Proto.Imports, resolveGoProto)
-	if !goProtoDeps.IsEmpty() {
-		goProtoAttrs = append(goProtoAttrs, keyvalue{"deps", goProtoDeps})
+	if !imports.IsEmpty() {
+		goProtoAttrs = append(goProtoAttrs, keyvalue{config.GazelleImportsKey, imports})
 	}
 
 	// If a developer adds or removes services from existing protos, this
@@ -263,15 +256,10 @@ func (g *Generator) commonAttrs(pkgRel, name, visibility string, target packages
 	if g.shouldSetVisibility && visibility != "" {
 		attrs = append(attrs, keyvalue{"visibility", []string{visibility}})
 	}
-	resolveFunc := func(imp string) (resolve.Label, error) {
-		if resolve.IsStandard(imp) {
-			return resolve.Label{}, packages.Skip
-		}
-		return g.r.ResolveGo(imp, pkgRel)
-	}
-	deps := g.dependencies(target.Imports, resolveFunc)
-	if !deps.IsEmpty() {
-		attrs = append(attrs, keyvalue{"deps", deps})
+	imports := target.Imports
+	imports.Clean()
+	if !imports.IsEmpty() {
+		attrs = append(attrs, keyvalue{config.GazelleImportsKey, imports})
 	}
 	return attrs
 }
@@ -305,27 +293,6 @@ func (g *Generator) buildPkgRel(pkgRel string) string {
 		log.Panicf("relative path to go package %s must start with relative path to Bazel package %s", pkgRel, g.buildRel)
 	}
 	return rel
-}
-
-type resolveFunc func(imp string) (resolve.Label, error)
-
-// dependencies converts import paths in "imports" into Bazel labels.
-func (g *Generator) dependencies(imports packages.PlatformStrings, resolve resolveFunc) packages.PlatformStrings {
-	resolveToString := func(imp string) (string, error) {
-		label, err := resolve(imp)
-		if err != nil {
-			return "", err
-		}
-		label.Relative = label.Repo == "" && label.Pkg == g.buildRel
-		return label.String(), nil
-	}
-
-	deps, errors := imports.Map(resolveToString)
-	for _, err := range errors {
-		log.Print(err)
-	}
-	deps.Clean()
-	return deps
 }
 
 var (

--- a/go/tools/gazelle/rules/generator_test.go
+++ b/go/tools/gazelle/rules/generator_test.go
@@ -59,7 +59,6 @@ func TestGenerator(t *testing.T) {
 	goPrefix := "example.com/repo"
 	c := testConfig(repoRoot, goPrefix)
 	l := resolve.NewLabeler(c)
-	r := resolve.NewResolver(c, l)
 
 	var dirs []string
 	err := filepath.Walk(repoRoot, func(path string, info os.FileInfo, err error) error {
@@ -82,7 +81,7 @@ func TestGenerator(t *testing.T) {
 		}
 
 		pkg, oldFile := packageFromDir(c, dir)
-		g := rules.NewGenerator(c, r, l, rel, oldFile)
+		g := rules.NewGenerator(c, l, rel, oldFile)
 		rs, _ := g.GenerateRules(pkg)
 		f := &bf.File{Stmt: rs}
 		rules.SortLabels(f)
@@ -106,8 +105,7 @@ func TestGenerator(t *testing.T) {
 func TestGeneratorEmpty(t *testing.T) {
 	c := testConfig("", "example.com/repo")
 	l := resolve.NewLabeler(c)
-	r := resolve.NewResolver(c, l)
-	g := rules.NewGenerator(c, r, l, "", nil)
+	g := rules.NewGenerator(c, l, "", nil)
 
 	pkg := packages.Package{Name: "foo"}
 	want := `filegroup(name = "go_default_library_protos")
@@ -141,8 +139,7 @@ func TestGeneratorEmptyLegacyProto(t *testing.T) {
 	c := testConfig("", "example.com/repo")
 	c.ProtoMode = config.LegacyProtoMode
 	l := resolve.NewLabeler(c)
-	r := resolve.NewResolver(c, l)
-	g := rules.NewGenerator(c, r, l, "", nil)
+	g := rules.NewGenerator(c, l, "", nil)
 
 	pkg := packages.Package{Name: "foo"}
 	_, empty := g.GenerateRules(&pkg)

--- a/go/tools/gazelle/testdata/repo/allcgolib/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/allcgolib/BUILD.want
@@ -6,15 +6,19 @@ go_library(
         "foo.c",
         "foo.go",
     ],
+    _gazelle_imports = [
+        "example.com/repo/lib",
+        "fmt",
+    ],
     cgo = True,
     importpath = "example.com/repo/allcgolib",
     visibility = ["//visibility:public"],
-    deps = ["//lib:go_default_library"],
 )
 
 go_test(
     name = "go_default_test",
     srcs = ["foo_test.go"],
+    _gazelle_imports = ["testing"],
     embed = [":go_default_library"],
     importpath = "example.com/repo/allcgolib",
 )

--- a/go/tools/gazelle/testdata/repo/bin/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/bin/BUILD.want
@@ -3,9 +3,12 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
+    _gazelle_imports = [
+        "example.com/repo/lib",
+        "fmt",
+    ],
     importpath = "example.com/repo/bin",
     visibility = ["//visibility:private"],
-    deps = ["//lib:go_default_library"],
 )
 
 go_binary(

--- a/go/tools/gazelle/testdata/repo/bin_with_tests/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/bin_with_tests/BUILD.want
@@ -3,9 +3,12 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
+    _gazelle_imports = [
+        "example.com/repo/lib",
+        "fmt",
+    ],
     importpath = "example.com/repo/bin_with_tests",
     visibility = ["//visibility:private"],
-    deps = ["//lib:go_default_library"],
 )
 
 go_binary(
@@ -18,6 +21,7 @@ go_binary(
 go_test(
     name = "go_default_test",
     srcs = ["bin_test.go"],
+    _gazelle_imports = ["testing"],
     embed = [":go_default_library"],
     importpath = "example.com/repo/bin_with_tests",
 )

--- a/go/tools/gazelle/testdata/repo/cgolib/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/cgolib/BUILD.want
@@ -9,6 +9,11 @@ go_library(
         "foo.h",
         "pure.go",
     ],
+    _gazelle_imports = [
+        "example.com/repo/lib",
+        "example.com/repo/lib/deep",
+        "fmt",
+    ],
     cgo = True,
     clinkopts = ["-lweird"],
     copts = [
@@ -17,15 +22,12 @@ go_library(
     ],
     importpath = "example.com/repo/cgolib",
     visibility = ["//visibility:public"],
-    deps = [
-        "//lib:go_default_library",
-        "//lib/deep:go_default_library",
-    ],
 )
 
 go_test(
     name = "go_default_test",
     srcs = ["foo_test.go"],
+    _gazelle_imports = ["testing"],
     embed = [":go_default_library"],
     importpath = "example.com/repo/cgolib",
 )

--- a/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/cgolib_with_build_tags/BUILD.want
@@ -58,6 +58,42 @@ go_library(
         ],
         "//conditions:default": [],
     }),
+    _gazelle_imports = [
+        "example.com/repo/lib",
+        "fmt",
+    ] + select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "example.com/repo/lib/deep",
+        ],
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "example.com/repo/lib/deep",
+        ],
+        "@io_bazel_rules_go//go/platform:dragonfly": [
+            "example.com/repo/lib/deep",
+        ],
+        "@io_bazel_rules_go//go/platform:freebsd": [
+            "example.com/repo/lib/deep",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "example.com/repo/lib/deep",
+        ],
+        "@io_bazel_rules_go//go/platform:netbsd": [
+            "example.com/repo/lib/deep",
+        ],
+        "@io_bazel_rules_go//go/platform:openbsd": [
+            "example.com/repo/lib/deep",
+        ],
+        "@io_bazel_rules_go//go/platform:plan9": [
+            "example.com/repo/lib/deep",
+        ],
+        "@io_bazel_rules_go//go/platform:solaris": [
+            "example.com/repo/lib/deep",
+        ],
+        "@io_bazel_rules_go//go/platform:windows": [
+            "example.com/repo/lib/deep",
+        ],
+        "//conditions:default": [],
+    }),
     cgo = True,
     clinkopts = ["-lweird"],
     copts = [
@@ -76,46 +112,12 @@ go_library(
     }),
     importpath = "example.com/repo/cgolib_with_build_tags",
     visibility = ["//visibility:public"],
-    deps = [
-        "//lib:go_default_library",
-    ] + select({
-        "@io_bazel_rules_go//go/platform:android": [
-            "//lib/deep:go_default_library",
-        ],
-        "@io_bazel_rules_go//go/platform:darwin": [
-            "//lib/deep:go_default_library",
-        ],
-        "@io_bazel_rules_go//go/platform:dragonfly": [
-            "//lib/deep:go_default_library",
-        ],
-        "@io_bazel_rules_go//go/platform:freebsd": [
-            "//lib/deep:go_default_library",
-        ],
-        "@io_bazel_rules_go//go/platform:linux": [
-            "//lib/deep:go_default_library",
-        ],
-        "@io_bazel_rules_go//go/platform:netbsd": [
-            "//lib/deep:go_default_library",
-        ],
-        "@io_bazel_rules_go//go/platform:openbsd": [
-            "//lib/deep:go_default_library",
-        ],
-        "@io_bazel_rules_go//go/platform:plan9": [
-            "//lib/deep:go_default_library",
-        ],
-        "@io_bazel_rules_go//go/platform:solaris": [
-            "//lib/deep:go_default_library",
-        ],
-        "@io_bazel_rules_go//go/platform:windows": [
-            "//lib/deep:go_default_library",
-        ],
-        "//conditions:default": [],
-    }),
 )
 
 go_test(
     name = "go_default_test",
     srcs = ["foo_test.go"],
+    _gazelle_imports = ["testing"],
     embed = [":go_default_library"],
     importpath = "example.com/repo/cgolib_with_build_tags",
 )

--- a/go/tools/gazelle/testdata/repo/gen_and_exclude/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/gen_and_exclude/BUILD.want
@@ -14,12 +14,12 @@ go_library(
         ],
         "//conditions:default": [],
     }),
-    importpath = "example.com/repo/gen_and_exclude",
-    visibility = ["//visibility:public"],
-    deps = select({
+    _gazelle_imports = select({
         "@io_bazel_rules_go//go/platform:darwin": [
-            "@com_github_jr_hacker_darwin//:go_default_library",
+            "github.com/jr_hacker/darwin",
         ],
         "//conditions:default": [],
     }),
+    importpath = "example.com/repo/gen_and_exclude",
+    visibility = ["//visibility:public"],
 )

--- a/go/tools/gazelle/testdata/repo/lib/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/lib/BUILD.want
@@ -8,14 +8,20 @@ go_library(
         "doc.go",
         "lib.go",
     ],
+    _gazelle_imports = [
+        "archive/tar",
+        "bufio",
+        "example.com/repo/lib/internal/deep",
+        "lib.invalid/does/not/exist",
+    ],
     importpath = "example.com/repo/lib",
     visibility = ["//visibility:public"],
-    deps = ["//lib/internal/deep:go_default_library"],
 )
 
 go_test(
     name = "go_default_test",
     srcs = ["lib_test.go"],
+    _gazelle_imports = ["testing"],
     embed = [":go_default_library"],
     importpath = "example.com/repo/lib",
 )
@@ -23,6 +29,9 @@ go_test(
 go_test(
     name = "go_default_xtest",
     srcs = ["lib_external_test.go"],
+    _gazelle_imports = [
+        "example.com/repo/lib",
+        "testing",
+    ],
     importpath = "example.com/repo/lib_test",
-    deps = [":go_default_library"],
 )

--- a/go/tools/gazelle/testdata/repo/lib/relativeimporter/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/lib/relativeimporter/BUILD.want
@@ -3,7 +3,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["importer.go"],
+    _gazelle_imports = [
+        "../internal/deep",
+        "log",
+    ],
     importpath = "example.com/repo/lib/relativeimporter",
     visibility = ["//visibility:public"],
-    deps = ["//lib/internal/deep:go_default_library"],
 )

--- a/go/tools/gazelle/testdata/repo/platforms/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/platforms/BUILD.want
@@ -29,6 +29,17 @@ go_library(
         ],
         "//conditions:default": [],
     }),
+    _gazelle_imports = [
+        "example.com/repo/platforms/generic",
+    ] + select({
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "example.com/repo/platforms/darwin",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "example.com/repo/platforms/linux",
+        ],
+        "//conditions:default": [],
+    }),
     cgo = True,
     copts = [
         "-DGENERIC",
@@ -40,17 +51,6 @@ go_library(
     }),
     importpath = "example.com/repo/platforms",
     visibility = ["//visibility:public"],
-    deps = [
-        "//platforms/generic:go_default_library",
-    ] + select({
-        "@io_bazel_rules_go//go/platform:darwin": [
-            "//platforms/darwin:go_default_library",
-        ],
-        "@io_bazel_rules_go//go/platform:linux": [
-            "//platforms/linux:go_default_library",
-        ],
-        "//conditions:default": [],
-    }),
 )
 
 go_test(

--- a/go/tools/gazelle/testdata/repo/protos/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/protos/BUILD.want
@@ -4,22 +4,22 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "protos_proto",
     srcs = ["foo.proto"],
-    visibility = ["//visibility:public"],
-    deps = [
-        "//protos/sub:sub_proto",
-        "@com_google_protobuf//:any_proto",
+    _gazelle_imports = [
+        "google/protobuf/any.proto",
+        "protos/sub/sub.proto",
     ],
+    visibility = ["//visibility:public"],
 )
 
 go_proto_library(
     name = "protos_go_proto",
+    _gazelle_imports = [
+        "google/protobuf/any.proto",
+        "protos/sub/sub.proto",
+    ],
     importpath = "example.com/repo/protos",
     proto = ":protos_proto",
     visibility = ["//visibility:public"],
-    deps = [
-        "//protos/sub:go_default_library",
-        "@com_github_golang_protobuf//ptypes/any:go_default_library",
-    ],
 )
 
 go_library(

--- a/go/tools/gazelle/testdata/repo/service/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/service/BUILD.want
@@ -4,22 +4,22 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_grpc_library")
 proto_library(
     name = "service_proto",
     srcs = ["service.proto"],
-    visibility = ["//visibility:public"],
-    deps = [
-        "//service/sub:sub_proto",
-        "@com_google_protobuf//:any_proto",
+    _gazelle_imports = [
+        "google/protobuf/any.proto",
+        "service/sub/sub.proto",
     ],
+    visibility = ["//visibility:public"],
 )
 
 go_grpc_library(
     name = "service_go_proto",
+    _gazelle_imports = [
+        "google/protobuf/any.proto",
+        "service/sub/sub.proto",
+    ],
     importpath = "example.com/repo/service",
     proto = ":service_proto",
     visibility = ["//visibility:public"],
-    deps = [
-        "//service/sub:go_default_library",
-        "@com_github_golang_protobuf//ptypes/any:go_default_library",
-    ],
 )
 
 go_library(

--- a/go/tools/gazelle/testdata/repo/tests_import_testdata/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/tests_import_testdata/BUILD.want
@@ -3,13 +3,19 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 go_test(
     name = "go_default_test",
     srcs = ["internal_test.go"],
+    _gazelle_imports = [
+        "example.com/repo/tests_import_testdata/testdata",
+        "testing",
+    ],
     importpath = "example.com/repo/tests_import_testdata",
-    deps = ["//tests_import_testdata/testdata:go_default_library"],
 )
 
 go_test(
     name = "go_default_xtest",
     srcs = ["external_test.go"],
+    _gazelle_imports = [
+        "example.com/repo/tests_import_testdata/testdata",
+        "testing",
+    ],
     importpath = "example.com/repo/tests_import_testdata_test",
-    deps = ["//tests_import_testdata/testdata:go_default_library"],
 )

--- a/go/tools/gazelle/testdata/repo/tests_with_testdata/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/tests_with_testdata/BUILD.want
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 go_test(
     name = "go_default_test",
     srcs = ["internal_test.go"],
+    _gazelle_imports = ["testing"],
     data = glob(["testdata/**"]),
     importpath = "example.com/repo/tests_with_testdata",
 )
@@ -10,6 +11,7 @@ go_test(
 go_test(
     name = "go_default_xtest",
     srcs = ["external_test.go"],
+    _gazelle_imports = ["testing"],
     data = glob(["testdata/**"]),
     importpath = "example.com/repo/tests_with_testdata_test",
 )


### PR DESCRIPTION
Previously, rules.Generator performed import resolution (using the
resolve package) as it generated rules. With this change, Generator
now produces a "_gazelle_imports" attribute, which is resolved and
replaced with "deps".

This is necessary since we must be able to index generated rules. We
need to generate and index all rules, then resolve imports to deps in
a separate phase.

Related #859