### PR TITLE
Move coverage

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -35,8 +35,13 @@ def emit_archive(ctx, go_toolchain, mode=None, importpath=None, source=None, imp
   if source == None: fail("source is a required parameter")
   if mode == None: fail("mode is a required parameter")
 
+
+  cover_vars = []
+  if ctx.configuration.coverage_enabled:
+    source, cover_vars = go_toolchain.actions.cover(ctx, go_toolchain, source=source, mode=mode, importpath=importpath)
+
   flat = sources.flatten(ctx, source)
-  split = split_srcs(flat.build_srcs)
+  split = split_srcs(flat.srcs)
   lib_name = importpath + ".a"
   compilepath = importpath if importable else None
   out_dir = "~{}~{}~".format(mode_string(mode), ctx.label.name)
@@ -54,8 +59,6 @@ def emit_archive(ctx, go_toolchain, mode=None, importpath=None, source=None, imp
   for a in direct:
     runfiles = runfiles.merge(a.runfiles)
     if a.mode != mode: fail("Archive mode does not match {} is {} expected {}".format(a.data.importpath, mode_string(a.mode), mode_string(mode)))
-
-  cover_vars = ["{}={}".format(var, importpath) for var in flat.cover_vars]
 
   if len(extra_objects) == 0 and flat.cgo_archive == None:
     go_toolchain.actions.compile(ctx,

--- a/go/private/actions/binary.bzl
+++ b/go/private/actions/binary.bzl
@@ -30,7 +30,7 @@ def emit_binary(ctx, go_toolchain,
   if name == "": fail("name is a required parameter")
 
   mode = get_mode(ctx, ctx.attr._go_toolchain_flags)
-  golib, gosource, goarchive = go_toolchain.actions.library(ctx,
+  golib, goarchive = go_toolchain.actions.library(ctx,
       go_toolchain = go_toolchain,
       mode = mode,
       source = source,
@@ -47,4 +47,4 @@ def emit_binary(ctx, go_toolchain,
       x_defs=x_defs,
   )
 
-  return golib, gosource, goarchive
+  return golib, goarchive

--- a/go/private/actions/cover.bzl
+++ b/go/private/actions/cover.bzl
@@ -15,40 +15,53 @@
 load("@io_bazel_rules_go//go/private:actions/action.bzl",
     "add_go_env",
 )
+load("@io_bazel_rules_go//go/private:providers.bzl",
+    "GoSource",
+    "GoSourceList",
+)
+load("@io_bazel_rules_go//go/private:common.bzl",
+    "structs",
+)
 
 def emit_cover(ctx, go_toolchain,
-               sources = [],
-               mode = None):
+               source = None,
+               mode = None,
+               importpath = ""):
   """See go/toolchains.rst#cover for full documentation."""
 
+  if source == None: fail("source is a required parameter")
   if mode == None: fail("mode is a required parameter")
+  if not importpath: fail("importpath is a required parameter")
 
   stdlib = go_toolchain.stdlib.get(ctx, go_toolchain, mode)
 
-  outputs = []
-  # TODO(linuxerwang): make the mode configurable.
+  covered = []
   cover_vars = []
-
-  for src in sources:
-    if (not src.basename.endswith(".go") or
-        src.basename.endswith("_test.go") or
-        src.basename.endswith(".cover.go")):
-      outputs.append(src)
+  for s in source.entries:
+    if not s.want_coverage:
+      covered.append(s)
       continue
+    outputs = []
+    for src in s.srcs:
+      if not src.basename.endswith(".go"):
+        outputs.append(src)
+        continue
+      cover_var = "Cover_" + src.basename[:-3].replace("-", "_").replace(".", "_")
+      cover_vars.append("{}={}={}".format(cover_var, src.short_path, importpath))
+      out = ctx.actions.declare_file(cover_var + '.cover.go')
+      outputs.append(out)
+      args = ctx.actions.args()
+      add_go_env(args, stdlib, mode)
+      args.add(["--", "--mode=set", "-var=%s" % cover_var, "-o", out, src])
+      ctx.actions.run(
+          inputs = [src] + stdlib.files,
+          outputs = [out],
+          mnemonic = "GoCover",
+          executable = go_toolchain.tools.cover,
+          arguments = [args],
+      )
 
-    cover_var = "Cover_" + src.basename[:-3].replace("-", "_").replace(".", "_")
-    cover_vars.append("{}={}".format(cover_var,src.short_path))
-    out = ctx.actions.declare_file(cover_var + '.cover.go')
-    outputs.append(out)
-    args = ctx.actions.args()
-    add_go_env(args, stdlib, mode)
-    args.add(["--", "--mode=set", "-var=%s" % cover_var, "-o", out, src])
-    ctx.actions.run(
-        inputs = [src],
-        outputs = [out],
-        mnemonic = "GoCover",
-        executable = go_toolchain.tools.cover,
-        arguments = [args],
-    )
-
-  return outputs, cover_vars
+    members = structs.to_dict(s)
+    members["srcs"] = outputs
+    covered.append(GoSource(**members))
+  return GoSourceList(entries=covered), cover_vars

--- a/go/private/providers.bzl
+++ b/go/private/providers.bzl
@@ -39,16 +39,12 @@ def _merge_runfiles(a, b):
   if not b: return a
   return a.merge(b)
 
-def _source_build_entry(srcs = [], build_srcs = [], deps = [], gc_goopts=[], cover_vars=[], runfiles=None, cgo_deps=[], cgo_exports=[], cgo_archive=None, source = None):
+def _source_build_entry(srcs = [], deps = [], gc_goopts=[], runfiles=None, cgo_deps=[], cgo_exports=[], cgo_archive=None, want_coverage = False, source = None):
   """Creates a new GoSource from a collection of values and an optional GoSourceList to merge in."""
-  if not build_srcs:
-    build_srcs = srcs
   for e in (source.entries if source else []):
     srcs = srcs + e.srcs
-    build_srcs = build_srcs + e.build_srcs
     deps = deps + e.deps
     gc_goopts = gc_goopts + e.gc_goopts
-    cover_vars = cover_vars + e.cover_vars
     runfiles = _merge_runfiles(runfiles, e.runfiles)
     cgo_deps = cgo_deps + e.cgo_deps
     cgo_exports = cgo_exports + e.cgo_exports
@@ -59,14 +55,13 @@ def _source_build_entry(srcs = [], build_srcs = [], deps = [], gc_goopts=[], cov
 
   return GoSource(
       srcs = srcs,
-      build_srcs = build_srcs,
       deps = deps,
       gc_goopts = gc_goopts,
-      cover_vars = cover_vars,
       runfiles = runfiles,
       cgo_deps = cgo_deps,
       cgo_exports = cgo_exports,
       cgo_archive = cgo_archive,
+      want_coverage = want_coverage,
   )
 
 def _source_new(**kwargs):

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -35,17 +35,18 @@ def _go_binary_impl(ctx):
     go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:toolchain"]
   else:
     go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:bootstrap_toolchain"]
-
+  gosource = sources.merge([get_source_list(s) for s in ctx.attr.embed] + [sources.new(
+      srcs = ctx.files.srcs,
+      deps = ctx.attr.deps,
+      gc_goopts = ctx.attr.gc_goopts,
+      runfiles = ctx.runfiles(collect_data = True),
+      want_coverage = ctx.coverage_instrumented(),
+  )])
   executable = ctx.outputs.executable
-  golib, gosource, goarchive = go_toolchain.actions.binary(ctx, go_toolchain,
+  golib, goarchive = go_toolchain.actions.binary(ctx, go_toolchain,
       name = ctx.label.name,
       importpath = go_importpath(ctx),
-      source = sources.merge([get_source_list(s) for s in ctx.attr.embed] + [sources.new(
-          srcs = ctx.files.srcs,
-          deps = ctx.attr.deps,
-          gc_goopts = ctx.attr.gc_goopts,
-          runfiles = ctx.runfiles(collect_data = True),
-      )]),
+      source = gosource,
       gc_linkopts = gc_linkopts(ctx),
       x_defs = ctx.attr.x_defs,
       executable = executable,

--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -232,6 +232,7 @@ def _cgo_collect_info_impl(ctx):
           cgo_deps = ctx.attr.codegen[_CgoCodegen].deps,
           cgo_exports = ctx.attr.codegen[_CgoCodegen].exports,
           cgo_archive = _select_archive(ctx.files.lib),
+          want_coverage = ctx.coverage_instrumented(), #TODO: not all sources?
       ),
   ]
 

--- a/go/private/rules/library.bzl
+++ b/go/private/rules/library.bzl
@@ -35,24 +35,24 @@ def _go_library_impl(ctx):
   go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:toolchain"]
   mode = get_mode(ctx, ctx.attr._go_toolchain_flags)
 
-  source = sources.merge([get_source_list(s) for s in ctx.attr.embed] + [sources.new(
+  gosource = sources.merge([get_source_list(s) for s in ctx.attr.embed] + [sources.new(
       srcs = ctx.files.srcs,
       deps = ctx.attr.deps,
       gc_goopts = ctx.attr.gc_goopts,
       runfiles = ctx.runfiles(collect_data = True),
+      want_coverage = ctx.coverage_instrumented() and not ctx.label.name.endswith("~library~"),
   )])
 
-  golib, _, goarchive = go_toolchain.actions.library(ctx,
+  golib, goarchive = go_toolchain.actions.library(ctx,
       go_toolchain = go_toolchain,
       mode = mode,
-      source = source,
-      want_coverage = ctx.coverage_instrumented(),
+      source = gosource,
       importpath = go_importpath(ctx),
       importable = True,
   )
 
   return [
-      golib, source, goarchive,
+      golib, gosource, goarchive,
       DefaultInfo(
           files = depset([goarchive.data.file]),
       ),

--- a/go/private/rules/source.bzl
+++ b/go/private/rules/source.bzl
@@ -37,6 +37,7 @@ def _go_sources_impl(ctx):
           deps = ctx.attr.deps,
           gc_goopts = ctx.attr.gc_goopts,
           runfiles = ctx.runfiles(collect_data = True),
+          want_coverage = ctx.coverage_instrumented(),
       )])
   ]
 

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -84,12 +84,13 @@ def _go_test_impl(ctx):
 
   # Now compile the test binary itself
   executable = ctx.outputs.executable
-  _, _, goarchive = go_toolchain.actions.binary(ctx, go_toolchain,
+  _, goarchive = go_toolchain.actions.binary(ctx, go_toolchain,
       name = ctx.label.name,
       source = sources.new(
           srcs = [main_go],
           deps = [ctx.attr.library],
           runfiles = ctx.runfiles(collect_data = True),
+          want_coverage = False,
       ),
       importpath = ctx.label.name + "~testmain~",
       gc_linkopts = gc_linkopts(ctx),

--- a/go/providers.rst
+++ b/go/providers.rst
@@ -126,10 +126,6 @@ GoSource represents a single entry in a GoSourceList source provider.
 +--------------------------------+-----------------------------------------------------------------+
 | The original sources for this library before transformations like cgo and coverage.              |
 +--------------------------------+-----------------------------------------------------------------+
-| :param:`build_srcs`            | :type:`depset(File)`                                            |
-+--------------------------------+-----------------------------------------------------------------+
-| The sources that are actually compiled after transformations like cgo and coverage.              |
-+--------------------------------+-----------------------------------------------------------------+
 | :param:`deps`                  | :type:`depset(GoLibrary)`                                       |
 +--------------------------------+-----------------------------------------------------------------+
 | The direct dependencies needed by the :param:`srcs`.                                             |

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -27,24 +27,25 @@ def _go_proto_library_impl(ctx):
   )
   go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:toolchain"]
   mode = get_mode(ctx, ctx.attr._go_toolchain_flags)
-  golib, gosource, goarchive = go_toolchain.actions.library(ctx,
+  gosource = sources.merge([get_source_list(s) for s in ctx.attr.embed] + [sources.new(
+      srcs = go_srcs,
+      deps = ctx.attr.deps + go_proto_toolchain.deps,
+      gc_goopts = ctx.attr.gc_goopts,
+      runfiles = ctx.runfiles(collect_data = True),
+      want_coverage = False,
+  )])
+  golib, goarchive = go_toolchain.actions.library(ctx,
       go_toolchain = go_toolchain,
       mode = mode,
-      source = sources.merge([get_source_list(s) for s in ctx.attr.embed] + [sources.new(
-          srcs = go_srcs,
-          deps = ctx.attr.deps + go_proto_toolchain.deps,
-          gc_goopts = ctx.attr.gc_goopts,
-          runfiles = ctx.runfiles(collect_data = True),
-      )]),
-      want_coverage = ctx.coverage_instrumented(),
+      source = gosource,
       importpath = importpath,
       importable = True,
   )
   return [
       golib, gosource, goarchive,
       DefaultInfo(
-          files = depset([]), #TODO:go_archive.lib]),
-          runfiles = golib.runfiles,
+          files = depset([goarchive.data.file]),
+          runfiles = goarchive.runfiles,
       ),
   ]
 


### PR DESCRIPTION
We now do it as late as possible (just before compilation)
We also allow very fine grained control over which packages and source files are
covered.
We also properly obey configuration.coverage_enabled to disable all coverage.
This makes a few interfaces simpler, and is needed for us to handle the pure/cgo
source generation cleanly (which has to come before cover)
