### PR TITLE
Use ctx.var instead of toolchain_flags

### DIFF
--- a/go/private/BUILD.bazel
+++ b/go/private/BUILD.bazel
@@ -7,21 +7,6 @@ filegroup(
 )
 
 config_setting(
-    name = "fastbuild",
-    values = {"compilation_mode": "fastbuild"},
-)
-
-config_setting(
-    name = "debug",
-    values = {"compilation_mode": "dbg"},
-)
-
-config_setting(
-    name = "optimized",
-    values = {"compilation_mode": "opt"},
-)
-
-config_setting(
     name = "strip-always",
     values = {"strip": "always"},
 )
@@ -38,11 +23,6 @@ config_setting(
 
 go_toolchain_flags(
     name = "go_toolchain_flags",
-    compilation_mode = select({
-        "@io_bazel_rules_go//go/private:fastbuild": "fastbuild",
-        "@io_bazel_rules_go//go/private:debug": "debug",
-        "@io_bazel_rules_go//go/private:optimized": "optimized",
-    }),
     strip = select({
         "@io_bazel_rules_go//go/private:strip-always": "always",
         "@io_bazel_rules_go//go/private:strip-sometimes": "sometimes",

--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -97,7 +97,7 @@ def emit_archive(ctx, go_toolchain, mode=None, importpath=None, goembed=None, di
   cgo_deps = getattr(goembed, "cgo_deps", [])
 
   for a in direct:
-    if a.mode != mode: fail("Archive mode does not match {} is {} expected {}".format(a.name, mode_string(a.mode), mode_string(mode)))
+    if a.mode != mode: fail("Archive mode does not match {} is {} expected {}".format(a.data.importpath, mode_string(a.mode), mode_string(mode)))
 
   cover_vars = ["{}={}".format(var, importpath) for var in goembed.cover_vars]
 

--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -209,14 +209,12 @@ def go_toolchain(name, target, host=None, constraints=[], **kwargs):
 
 def _go_toolchain_flags(ctx):
     return struct(
-        compilation_mode = ctx.attr.compilation_mode,
         strip = ctx.attr.strip,
     )
 
 go_toolchain_flags = rule(
     _go_toolchain_flags,
     attrs = {
-        "compilation_mode": attr.string(mandatory=True),
         "strip": attr.string(mandatory=True),
     },
 )

--- a/go/private/mode.bzl
+++ b/go/private/mode.bzl
@@ -57,14 +57,15 @@ def get_mode(ctx, toolchain_flags):
       force_pure = True
 
   #TODO: allow link mode selection
-  debug = False
-  strip = True
+  debug = ctx.var["COMPILATION_MODE"] == "debug"
+  strip_mode = "sometimes"
   if toolchain_flags:
-    debug = toolchain_flags.compilation_mode == "debug"
-    if toolchain_flags.strip == "always":
-      strip = True
-    elif toolchain_flags.strip == "sometimes":
-      strip = not debug
+    strip_mode = toolchain_flags.strip
+  strip = True
+  if strip_mode == "always":
+    strip = True
+  elif strip_mode == "sometimes":
+    strip = not debug
   return struct(
       static = _ternary(
           getattr(ctx.attr, "static", None),


### PR DESCRIPTION
This means we get the debug state correct in the aspect.
We will still get the strip state wrong if it's not the default, as that is not
exposed in the ctx right now.

Fixes #1050