### PR TITLE
Include goos and goarch in the mode

### DIFF
--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -38,6 +38,8 @@ def _go_toolchain_impl(ctx):
   return [platform_common.ToolchainInfo(
       name = ctx.label.name,
       cross_compile = ctx.attr.cross_compile,
+      goos = ctx.attr.goos,
+      goarch = ctx.attr.goarch,
       stdlib = struct(
           cgo = ctx.attr._stdlib_cgo[GoStdLib],
           pure = ctx.attr._stdlib_pure[GoStdLib],

--- a/go/private/mode.bzl
+++ b/go/private/mode.bzl
@@ -20,7 +20,7 @@ LINKMODE_PIE = "pie"
 LINKMODE_PLUGIN = "plugin"
 
 def mode_string(mode):
-  result = []
+  result = [mode.goos, mode.goarch]
   if mode.static:
     result.append("static")
   if mode.race:
@@ -52,9 +52,12 @@ def _ternary(*values):
 def get_mode(ctx, toolchain_flags):
   force_pure = None
   if "@io_bazel_rules_go//go:toolchain" in ctx.toolchains:
-    if ctx.toolchains["@io_bazel_rules_go//go:toolchain"].cross_compile:
-      # We always have to user the pure stdlib in cross compilation mode
-      force_pure = True
+    go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:toolchain"]
+  else:
+    go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:bootstrap_toolchain"]
+
+  # We always have to user the pure stdlib in cross compilation mode
+  force_pure = go_toolchain.cross_compile
 
   #TODO: allow link mode selection
   debug = ctx.var["COMPILATION_MODE"] == "debug"
@@ -87,4 +90,6 @@ def get_mode(ctx, toolchain_flags):
       link = LINKMODE_NORMAL,
       debug = debug,
       strip = strip,
+      goos = go_toolchain.goos,
+      goarch = go_toolchain.goarch,
   )

--- a/go/private/mode.bzl
+++ b/go/private/mode.bzl
@@ -50,13 +50,12 @@ def _ternary(*values):
   fail("_ternary failed to produce a final result from {}".format(values))
 
 def get_mode(ctx, toolchain_flags):
-  force_pure = None
   if "@io_bazel_rules_go//go:toolchain" in ctx.toolchains:
     go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:toolchain"]
   else:
     go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:bootstrap_toolchain"]
 
-  # We always have to user the pure stdlib in cross compilation mode
+  # We always have to use the pure stdlib in cross compilation mode
   force_pure = go_toolchain.cross_compile
 
   #TODO: allow link mode selection


### PR DESCRIPTION
This should enable cross compilations to not destroy the cache