### PR TITLE
Select original go sources in pure mode

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -35,6 +35,7 @@ def emit_archive(ctx, go_toolchain, mode=None, importpath=None, source=None, imp
   if source == None: fail("source is a required parameter")
   if mode == None: fail("mode is a required parameter")
 
+  source = sources.filter(ctx, source, mode)
 
   cover_vars = []
   if ctx.configuration.coverage_enabled:

--- a/go/private/providers.bzl
+++ b/go/private/providers.bzl
@@ -39,7 +39,7 @@ def _merge_runfiles(a, b):
   if not b: return a
   return a.merge(b)
 
-def _source_build_entry(srcs = [], deps = [], gc_goopts=[], runfiles=None, cgo_deps=[], cgo_exports=[], cgo_archive=None, want_coverage = False, source = None):
+def _source_build_entry(srcs = [], deps = [], gc_goopts=[], runfiles=None, cgo_deps=[], cgo_exports=[], cgo_archive=None, want_coverage = False, source = None, exclude = None):
   """Creates a new GoSource from a collection of values and an optional GoSourceList to merge in."""
   for e in (source.entries if source else []):
     srcs = srcs + e.srcs
@@ -62,6 +62,7 @@ def _source_build_entry(srcs = [], deps = [], gc_goopts=[], runfiles=None, cgo_d
       cgo_exports = cgo_exports,
       cgo_archive = cgo_archive,
       want_coverage = want_coverage,
+      exclude = exclude,
   )
 
 def _source_new(**kwargs):
@@ -79,9 +80,13 @@ def _source_flatten(ctx, source):
   """Flattens a GoSourceList to a single GoSource ready for use."""
   return _source_build_entry(source = source)
 
+def _source_filter(ctx, source, mode):
+  return GoSourceList(entries = [s for s in source.entries if not (s.exclude and s.exclude(ctx, mode))])
+
 sources = struct(
   new = _source_new,
   merge = _source_merge,
   flatten = _source_flatten,
+  filter = _source_filter,
 )
 """sources holds the functions for manipulating GoSourceList providers."""

--- a/go/private/rules/aspect.bzl
+++ b/go/private/rules/aspect.bzl
@@ -79,10 +79,10 @@ go_archive_aspect = aspect(
     _go_archive_aspect_impl,
     attr_aspects = ["deps", "embed"],
     attrs = {
-        "pure": attr.string(values=["on", "off", "auto"], default="auto"),
-        "static": attr.string(values=["on", "off", "auto"], default="auto"),
-        "msan": attr.string(values=["on", "off", "auto"], default="auto"),
-        "race": attr.string(values=["on", "off", "auto"], default="auto"),
+        "pure": attr.string(values=["on", "off", "auto"]),
+        "static": attr.string(values=["on", "off", "auto"]),
+        "msan": attr.string(values=["on", "off", "auto"]),
+        "race": attr.string(values=["on", "off", "auto"]),
     },
     toolchains = ["@io_bazel_rules_go//go:toolchain"],
 )

--- a/tests/cgo_pure/BUILD.bazel
+++ b/tests/cgo_pure/BUILD.bazel
@@ -30,5 +30,4 @@ go_test(
     x_defs = {
         "github.com/bazelbuild/rules_go/tests/cgo_pure.Expect": "1",
     },
-    tags = ["manual"], #TODO: remove this once it passes, see #1009
 )


### PR DESCRIPTION
This adds a filtering mechanism to the new GoSourceList logic and uses it to
switch between the cgo processed sources and the unprocessed original sources
depending on whether the archive is being generated in pure mode.

Fixes #1009