### PR TITLE
Be principled about generated file names

### DIFF
--- a/examples/bindata/bindata.bzl
+++ b/examples/bindata/bindata.bzl
@@ -1,7 +1,8 @@
 load("@io_bazel_rules_go//go/private:go_repository.bzl", "go_repository")
+load("@io_bazel_rules_go//go/private:common.bzl", "declare_file")
 
 def _bindata_impl(ctx):
-  out = ctx.actions.declare_file(ctx.label.name + ".go")
+  out = declare_file(ctx, ext=".go")
   arguments = ctx.actions.args()
   arguments.add([
       "-o", out.path,

--- a/go/extras.rst
+++ b/go/extras.rst
@@ -24,7 +24,7 @@ This rule should only occur once in the top level build file.
 Running
 
 .. code::
-  
+
   bazel run //:gazelle
 
 will cause gazelle to run with the supplied options in the source tree at the root.
@@ -89,10 +89,6 @@ It should be consumed in the srcs list of one of the `core go rules`_.
 +----------------------------+-----------------------------+---------------------------------------+
 | A unique name for this rule.                                                                     |
 +----------------------------+-----------------------------+---------------------------------------+
-| :param:`out`               | :type:`string`              | |mandatory|                           |
-+----------------------------+-----------------------------+---------------------------------------+
-| File name of the .go file to generate.                                                           |
-+----------------------------+-----------------------------+---------------------------------------+
 | :param:`package`           | :type:`string`              | :value:`""`                           |
 +----------------------------+-----------------------------+---------------------------------------+
 | Go package name for the generated .go file.                                                      |
@@ -125,5 +121,5 @@ It should be consumed in the srcs list of one of the `core go rules`_.
 +----------------------------+-----------------------------+---------------------------------------+
 | If :value:`true`, the embedded data will be stored as :type:`string` instead of :type:`[]byte`.  |
 +----------------------------+-----------------------------+---------------------------------------+
-        
-       
+
+

--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@io_bazel_rules_go//go/private:common.bzl",
+    "declare_file",
     "split_srcs",
     "sets",
 )
@@ -45,13 +46,12 @@ def emit_archive(ctx, go_toolchain, mode=None, importpath=None, source=None, imp
   split = split_srcs(flat.srcs)
   lib_name = importpath + ".a"
   compilepath = importpath if importable else None
-  out_dir = "~{}~{}~".format(mode_string(mode), ctx.label.name)
-  out_lib = ctx.actions.declare_file("{}/{}".format(out_dir, lib_name))
+  out_lib = declare_file(ctx, path=lib_name, mode=mode)
   searchpath = out_lib.path[:-len(lib_name)]
 
   extra_objects = []
   for src in split.asm:
-    obj = ctx.actions.declare_file("{}/{}.o".format(out_dir, src.basename[:-2]))
+    obj = declare_file(ctx, path=src.basename[:-2], ext=".o", mode=mode)
     go_toolchain.actions.asm(ctx, go_toolchain, mode=mode, source=src, hdrs=split.headers, out_obj=obj)
     extra_objects.append(obj)
 
@@ -72,7 +72,7 @@ def emit_archive(ctx, go_toolchain, mode=None, importpath=None, source=None, imp
         gc_goopts = flat.gc_goopts,
     )
   else:
-    partial_lib = ctx.actions.declare_file("{}/~partial.a".format(out_dir))
+    partial_lib = declare_file(ctx, path="partial", ext=".a", mode=mode)
     go_toolchain.actions.compile(ctx,
         go_toolchain = go_toolchain,
         sources = split.go,

--- a/go/private/actions/cover.bzl
+++ b/go/private/actions/cover.bzl
@@ -20,6 +20,7 @@ load("@io_bazel_rules_go//go/private:providers.bzl",
     "GoSourceList",
 )
 load("@io_bazel_rules_go//go/private:common.bzl",
+    "declare_file",
     "structs",
 )
 
@@ -48,7 +49,7 @@ def emit_cover(ctx, go_toolchain,
         continue
       cover_var = "Cover_" + src.basename[:-3].replace("-", "_").replace(".", "_")
       cover_vars.append("{}={}={}".format(cover_var, src.short_path, importpath))
-      out = ctx.actions.declare_file(cover_var + '.cover.go')
+      out = declare_file(ctx, path=cover_var, ext='.cover.go')
       outputs.append(out)
       args = ctx.actions.args()
       add_go_env(args, stdlib, mode)

--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -18,6 +18,7 @@ load("//go/private:skylib/lib/paths.bzl", "paths")
 load("//go/private:skylib/lib/sets.bzl", "sets")
 load("//go/private:skylib/lib/shell.bzl", "shell")
 load("//go/private:skylib/lib/structs.bzl", "structs")
+load("@io_bazel_rules_go//go/private:mode.bzl", "mode_string")
 
 DEFAULT_LIB = "go_default_library"
 VENDOR_PREFIX = "/vendor/"
@@ -140,3 +141,14 @@ def to_set(v):
   if type(v) == "depset":
     fail("Do not pass a depset to to_set")
   return depset(v)
+
+def declare_file(ctx, path="", ext="", mode=None):
+  name = ""
+  if mode:
+    name += mode_string(mode) + "/"
+  name += ctx.label.name
+  if path:
+    name += "~/" + path
+  if ext:
+    name += ext
+  return ctx.actions.declare_file(name)

--- a/go/private/rules/info.bzl
+++ b/go/private/rules/info.bzl
@@ -18,12 +18,15 @@ load("@io_bazel_rules_go//go/private:mode.bzl",
 load("@io_bazel_rules_go//go/private:actions/action.bzl",
     "add_go_env",
 )
+load("@io_bazel_rules_go//go/private:common.bzl",
+    "declare_file",
+)
 
 def _go_info_script_impl(ctx):
   go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:toolchain"]
   mode = get_mode(ctx, ctx.attr._go_toolchain_flags)
   stdlib = go_toolchain.stdlib.get(ctx, go_toolchain, mode)
-  out = ctx.actions.declare_file(ctx.label.name+".bash")
+  out = declare_file(ctx, ext=".bash")
   args = ctx.actions.args()
   add_go_env(args, stdlib, mode)
   args.add(["-script", "-out", out])

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -17,6 +17,7 @@ load("@io_bazel_rules_go//go/private:common.bzl",
     "go_importpath",
     "split_srcs",
     "pkg_dir",
+    "declare_file",
 )
 load("@io_bazel_rules_go//go/private:mode.bzl",
     "get_mode",
@@ -57,7 +58,7 @@ def _go_test_impl(ctx):
   else:
     run_dir = pkg_dir(ctx.label.workspace_root, ctx.label.package)
 
-  main_go = ctx.actions.declare_file(ctx.label.name + "_main_test.go")
+  main_go = declare_file(ctx, "testmain.go")
   arguments = ctx.actions.args()
   add_go_env(arguments, stdlib, mode)
   arguments.add([

--- a/go/private/tools/gazelle.bzl
+++ b/go/private/tools/gazelle.bzl
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@io_bazel_rules_go//go/private:common.bzl",
+    "declare_file",
+)
+
 _script_content = """
 BASE=$(pwd)
 WORKSPACE=$(dirname $(readlink WORKSPACE))
@@ -32,7 +36,7 @@ def _gazelle_script_impl(ctx):
     args += ["-build_tags", ",".join(ctx.attr.build_tags)]
   args += ctx.attr.args
   script_content = _script_content.format(gazelle=ctx.file._gazelle.short_path, args=" ".join(args))
-  script_file = ctx.actions.declare_file(ctx.label.name+".bash")
+  script_file = declare_file(ctx, ext=".bash")
   ctx.actions.write(output=script_file, is_executable=True, content=script_content)
   return struct(
     files = depset([script_file]),

--- a/go/private/tools/path.bzl
+++ b/go/private/tools/path.bzl
@@ -17,6 +17,7 @@ load("@io_bazel_rules_go//go/private:common.bzl", "declare_file")
 
 
 def _tag(ctx, path, outputs):
+  """this generates a existance tag file for dependancies, and returns the path to the tag file"""
   tag = declare_file(ctx, path=path+".tag")
   path, _, _ = tag.short_path.rpartition("/")
   ctx.actions.write(tag, content="")

--- a/go/private/tools/path.bzl
+++ b/go/private/tools/path.bzl
@@ -13,6 +13,15 @@
 # limitations under the License.
 
 load("@io_bazel_rules_go//go/private:providers.bzl", "GoLibrary", "GoPath")
+load("@io_bazel_rules_go//go/private:common.bzl", "declare_file")
+
+
+def _tag(ctx, path, outputs):
+  tag = declare_file(ctx, path=path+".tag")
+  path, _, _ = tag.short_path.rpartition("/")
+  ctx.actions.write(tag, content="")
+  outputs.append(tag)
+  return path
 
 def _go_path_impl(ctx):
   print("""
@@ -28,7 +37,7 @@ Please do not rely on it for production use, but feel free to use it and file is
   # Now scan them for sources
   seen_libs = {}
   seen_paths = {}
-  outputs = depset()
+  outputs = []
   packages = []
   for golib in golibs:
     if golib.importpath in seen_libs:
@@ -38,7 +47,6 @@ Please do not rely on it for production use, but feel free to use it and file is
       print("""Duplicate package
 Found {} in
   {}
-and
   {}
 """.format(golib.importpath, golib.name, seen_libs[golib.importpath].name))
       # for now we don't fail if we see duplicate packages
@@ -46,14 +54,14 @@ and
       continue
     seen_libs[golib.importpath] = golib
     package_files = []
-    outdir = "{}/src/{}".format(ctx.label.name, golib.importpath)
+    prefix = "src/" + golib.importpath + "/"
     for src in golib.srcs:
-      outpath = "{}/{}".format(outdir, src.basename)
+      outpath = prefix + src.basename
       if outpath in seen_paths:
         # If we see the same path twice, it's a fatal error
         fail("Duplicate path {}".format(outpath))
       seen_paths[outpath] = True
-      out = ctx.actions.declare_file(outpath)
+      out = declare_file(ctx, path=outpath)
       package_files += [out]
       outputs += [out]
       if ctx.attr.mode == "copy":
@@ -69,15 +77,13 @@ and
         fail("Invalid go path mode '{}'".format(ctx.attr.mode))
     packages += [struct(
       golib = golib,
-      dir = outdir,
+      dir = _tag(ctx, prefix, outputs),
       files = package_files,
     )]
-  tag = ctx.actions.declare_file("{}/setenv.sh".format(ctx.label.name))
-  gopath, _, _ = tag.short_path.rpartition("/")
-  ctx.actions.write(tag, content="")
+  gopath = _tag(ctx, "", outputs)
   return [
       DefaultInfo(
-          files = outputs + [tag],
+          files = depset(outputs),
       ),
       GoPath(
         gopath = gopath,

--- a/go/private/tools/vet.bzl
+++ b/go/private/tools/vet.bzl
@@ -17,6 +17,9 @@ load("@io_bazel_rules_go//go/private:providers.bzl", "GoPath")
 load("@io_bazel_rules_go//go/private:mode.bzl",
     "get_mode",
 )
+load("@io_bazel_rules_go//go/private:common.bzl",
+    "declare_file",
+)
 
 def _go_vet_generate_impl(ctx):
   print("""
@@ -26,7 +29,7 @@ Please do not rely on it for production use, but feel free to use it and file is
   go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:toolchain"]
   mode = get_mode(ctx, ctx.attr._go_toolchain_flags)
   stdlib = go_toolchain.stdlib.get(ctx, go_toolchain, mode)
-  script_file = ctx.actions.declare_file(ctx.label.name+".bash")
+  script_file = declare_file(ctx, ext=".bash")
   gopath = []
   files = ctx.files.data + stdlib.files
   gopath = []

--- a/proto/toolchain.bzl
+++ b/proto/toolchain.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@io_bazel_rules_go//go/private:common.bzl",
+    "declare_file",
     "sets",
 )
 
@@ -22,7 +23,7 @@ def _emit_proto_compile(ctx, proto_toolchain, go_proto_toolchain, lib, importpat
   go_srcs = []
   outpath = None
   for proto in lib.proto.direct_sources:
-    out = ctx.actions.declare_file(ctx.label.name + "/" + importpath + "/" + proto.basename[:-len(".proto")] + go_proto_toolchain.suffix)
+    out = declare_file(ctx, path=importpath+"/"+proto.basename[:-len(".proto")], ext=go_proto_toolchain.suffix)
     go_srcs.append(out)
     if outpath == None:
         outpath = out.dirname[:-len(importpath)]

--- a/tests/bazel_tests.bzl
+++ b/tests/bazel_tests.bzl
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go/private:go_repository.bzl", "env_execute")
+load("@io_bazel_rules_go//go/private:common.bzl", "declare_file")
 
 # _bazelrc is the bazel.rc file that sets the default options for tests
 _bazelrc = """
@@ -63,7 +64,7 @@ filegroup(
 CURRENT_VERSION = "current"
 
 def _bazel_test_script_impl(ctx):
-  script_file = ctx.actions.declare_file(ctx.label.name+".bash")
+  script_file = declare_file(ctx, ext=".bash")
 
   if ctx.attr.go_version == CURRENT_VERSION:
     register = 'go_register_toolchains()\n'
@@ -85,9 +86,9 @@ def _bazel_test_script_impl(ctx):
     workspace_content += _basic_workspace.format()
     workspace_content += register
 
-  workspace_file = ctx.actions.declare_file("WORKSPACE.in")
+  workspace_file = declare_file(ctx, path="WORKSPACE.in")
   ctx.actions.write(workspace_file, workspace_content)
-  build_file = ctx.actions.declare_file("BUILD.in")
+  build_file = declare_file(ctx, path="BUILD.in")
   ctx.actions.write(build_file, ctx.attr.build)
 
   targets = ["@" + ctx.workspace_name + "//" + ctx.label.package + t if t.startswith(":") else t for t in ctx.attr.targets]
@@ -165,7 +166,7 @@ def bazel_test(name, command = None, args=None, targets = None, go_version = Non
   )
 
 def _md5_sum_impl(ctx):
-  out = ctx.actions.declare_file(ctx.label.name+".md5")
+  out = declare_file(ctx, ext=".md5")
   arguments = ctx.actions.args()
   arguments.add(["-output", out.path])
   arguments.add(ctx.files.srcs)

--- a/tests/go_embed_data/BUILD.bazel
+++ b/tests/go_embed_data/BUILD.bazel
@@ -14,18 +14,17 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = [
-        "embed_empty.go",
-        "embed_ext.go",
-        "embed_flat.go",
-        "embed_local.go",
-        "embed_single.go",
-        "embed_str.go",
+        ":empty",
+        ":ext",
+        ":flat",
+        ":local",
+        ":single",
+        ":str",
     ],
 )
 
 go_embed_data(
     name = "empty",
-    out = "embed_empty.go",
     package = "go_embed_data",
     var = "empty",
 )
@@ -33,7 +32,6 @@ go_embed_data(
 go_embed_data(
     name = "single",
     src = "//:AUTHORS",
-    out = "embed_single.go",
     package = "go_embed_data",
     var = "single",
 )
@@ -44,7 +42,6 @@ go_embed_data(
         ":BUILD.bazel",
         "@io_bazel_rules_go//:AUTHORS",
     ],
-    out = "embed_local.go",
     package = "go_embed_data",
     var = "local",
 )
@@ -52,7 +49,6 @@ go_embed_data(
 go_embed_data(
     name = "ext",
     srcs = ["@io_bazel_rules_go_repository_tools//:BUILD.bazel"],
-    out = "embed_ext.go",
     package = "go_embed_data",
     var = "ext",
 )
@@ -60,7 +56,6 @@ go_embed_data(
 go_embed_data(
     name = "flat",
     srcs = [":BUILD.bazel"],
-    out = "embed_flat.go",
     flatten = True,
     package = "go_embed_data",
     var = "flat",
@@ -69,7 +64,6 @@ go_embed_data(
 go_embed_data(
     name = "str",
     srcs = [":BUILD.bazel"],
-    out = "embed_str.go",
     package = "go_embed_data",
     string = True,
     var = "str",


### PR DESCRIPTION
We now direct all file generation through a function that works out an
appropriate name, including the rule label and build mode when needed.