### PR TITLE
Finishing go_source rule and using it in a test

### DIFF
--- a/go/core.rst
+++ b/go/core.rst
@@ -95,7 +95,7 @@ Attributes
 +----------------------------+-----------------------------+---------------------------------------+
 | List of Go libraries this test library directly.                                                 |
 | These may be go_library rules or compatible rules with the GoSourceList_ provider.               |
-| These can provide both :param:`srcs` and param:`deps` to this library.                           |
+| These can provide both :param:`srcs` and :param:`deps` to this library.                          |
 | See Embedding_ for more information about how and when to use this.                              |
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`data`              | :type:`label_list`          | :value:`None`                         |
@@ -203,7 +203,7 @@ Attributes
 +----------------------------+-----------------------------+---------------------------------------+
 | List of Go libraries this binary embeds directly.                                                |
 | These may be go_library rules or compatible rules with the GoSourceList_ provider.               |
-| These can provide both :param:`srcs` and param:`deps` to this binary.                            |
+| These can provide both :param:`srcs` and :param:`deps` to this binary.                           |
 | See Embedding_ for more information about how and when to use this.                              |
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`data`              | :type:`label_list`          | :value:`None`                         |
@@ -315,7 +315,7 @@ Attributes
 +----------------------------+-----------------------------+---------------------------------------+
 | List of Go libraries this test embeds directly.                                                  |
 | These may be go_library rules or compatible rules with the GoSourceList_ provider.               |
-| These can provide both :param:`srcs` and param:`deps` to this test.                              |
+| These can provide both :param:`srcs` and :param:`deps` to this test.                             |
 | See Embedding_ for more information about how and when to use this.                              |
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`data`              | :type:`label_list`          | :value:`None`                         |
@@ -431,7 +431,7 @@ It references the library(s) being tested with :param:`deps`.
 go_source
 ~~~~~~~~~
 
-This declares a set of source files and related dependancies that can be embedded into on of the
+This declares a set of source files and related dependencies that can be embedded into one of the
 other rules.
 This is used as a way of easily declaring a common set of sources re-used in multiple rules.
 
@@ -465,7 +465,7 @@ Attributes
 +----------------------------+-----------------------------+---------------------------------------+
 | List of sources to directly embed in this list.                                                  |
 | These may be go_library rules or compatible rules with the GoSourceList_ provider.               |
-| These can provide both :param:`srcs` and param:`deps` to this library.                           |
+| These can provide both :param:`srcs` and :param:`deps` to this library.                          |
 | See Embedding_ for more information about how and when to use this.                              |
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`data`              | :type:`label_list`          | :value:`None`                         |

--- a/go/core.rst
+++ b/go/core.rst
@@ -427,3 +427,57 @@ It references the library(s) being tested with :param:`deps`.
       srcs = ["lib_x_test.go"],
       deps = [":go_default_library"],
   )
+
+go_source
+~~~~~~~~~
+
+This declares a set of source files and related dependancies that can be embedded into on of the
+other rules.
+This is used as a way of easily declaring a common set of sources re-used in multiple rules.
+
+Providers
+^^^^^^^^^
+
+* GoSourceList_
+
+Attributes
+^^^^^^^^^^
+
++----------------------------+-----------------------------+---------------------------------------+
+| **Name**                   | **Type**                    | **Default value**                     |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`name`              | :type:`string`              | |mandatory|                           |
++----------------------------+-----------------------------+---------------------------------------+
+| A unique name for this rule.                                                                     |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`srcs`              | :type:`label_list`          | :value:`None`                         |
++----------------------------+-----------------------------+---------------------------------------+
+| The list of Go source files that are compiled to create the package.                             |
+| The following file types are permitted: :value:`.go, .c, .s, .S .h`.                             |
+| The files may contain Go-style `build constraints`_.                                             |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`deps`              | :type:`label_list`          | :value:`None`                         |
++----------------------------+-----------------------------+---------------------------------------+
+| List of Go libraries this source list imports directly.                                          |
+| These may be go_library rules or compatible rules with the GoLibrary_ provider.                  |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`embed`             | :type:`label_list`          | :value:`None`                         |
++----------------------------+-----------------------------+---------------------------------------+
+| List of sources to directly embed in this list.                                                  |
+| These may be go_library rules or compatible rules with the GoSourceList_ provider.               |
+| These can provide both :param:`srcs` and param:`deps` to this library.                           |
+| See Embedding_ for more information about how and when to use this.                              |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`data`              | :type:`label_list`          | :value:`None`                         |
++----------------------------+-----------------------------+---------------------------------------+
+| The list of files needed by this rule at runtime. Targets named in the data attribute will       |
+| appear in the *.runfiles area of this rule, if it has one. This may include data files needed    |
+| by the binary, or other programs needed by it. See `data dependencies`_ for more information     |
+| about how to depend on and use data files.                                                       |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`gc_goopts`         | :type:`string_list`         | :value:`[]`                           |
++----------------------------+-----------------------------+---------------------------------------+
+| List of flags to add to the Go compilation command when using the gc compiler.                   |
+| Subject to `"Make variable"`_ substitution and `Bourne shell tokenization`_.                     |
++----------------------------+-----------------------------+---------------------------------------+
+

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -40,6 +40,9 @@ load("@io_bazel_rules_go//go/private:rules/wrappers.bzl",
     _go_binary_macro = "go_binary_macro",
     _go_test_macro = "go_test_macro",
 )
+load("@io_bazel_rules_go//go/private:rules/source.bzl",
+    _go_source = "go_source",
+)
 load("@io_bazel_rules_go//go/private:tools/embed_data.bzl",
     "go_embed_data",
 )
@@ -66,6 +69,9 @@ go_binary = _go_binary_macro
 """See go/core.rst#go_binary for full documentation."""
 
 go_test = _go_test_macro
+"""See go/core.rst#go_test for full documentation."""
+
+go_source = _go_source
 """See go/core.rst#go_test for full documentation."""
 
 go_path = _go_path

--- a/go/private/rules/aspect.bzl
+++ b/go/private/rules/aspect.bzl
@@ -42,15 +42,17 @@ def get_source_list(dep):
   return dep[GoSourceList]
 
 
-def collect_src(ctx, aspect=False, srcs = None, want_coverage = None):
+def collect_src(ctx, aspect=False, srcs = None, deps=None, want_coverage = None):
   rule = ctx.rule if aspect else ctx
   if srcs == None:
     srcs = rule.files.srcs
+  if deps == None:
+    deps = rule.attr.deps
   if want_coverage == None:
     want_coverage = ctx.coverage_instrumented() and not rule.label.name.endswith("~library~")
   return sources.merge([get_source_list(s) for s in rule.attr.embed] + [sources.new(
       srcs = srcs,
-      deps = rule.attr.deps,
+      deps = deps,
       gc_goopts = rule.attr.gc_goopts,
       runfiles = ctx.runfiles(collect_data = True),
       want_coverage = want_coverage,

--- a/go/private/rules/aspect.bzl
+++ b/go/private/rules/aspect.bzl
@@ -41,9 +41,28 @@ def get_source_list(dep):
     return dep[GoAspectProviders].source
   return dep[GoSourceList]
 
+
+def collect_src(ctx, aspect=False, srcs = None, want_coverage = None):
+  rule = ctx.rule if aspect else ctx
+  if srcs == None:
+    srcs = rule.files.srcs
+  if want_coverage == None:
+    want_coverage = ctx.coverage_instrumented() and not rule.label.name.endswith("~library~")
+  return sources.merge([get_source_list(s) for s in rule.attr.embed] + [sources.new(
+      srcs = srcs,
+      deps = rule.attr.deps,
+      gc_goopts = rule.attr.gc_goopts,
+      runfiles = ctx.runfiles(collect_data = True),
+      want_coverage = want_coverage,
+  )])
+
 def _go_archive_aspect_impl(target, ctx):
   mode = get_mode(ctx, ctx.rule.attr._go_toolchain_flags)
   if GoArchive not in target:
+    if GoSourceList in target and hasattr(ctx.rule.attr, "embed"):
+      return [GoAspectProviders(
+        source = collect_src(ctx, aspect=True),
+      )]
     return []
   goarchive = target[GoArchive]
   if goarchive.mode == mode:
@@ -52,12 +71,7 @@ def _go_archive_aspect_impl(target, ctx):
         archive = goarchive,
     )]
 
-  source = sources.merge([get_source_list(s) for s in ctx.rule.attr.embed] + [sources.new(
-      srcs = ctx.rule.files.srcs,
-      deps = ctx.rule.attr.deps,
-      gc_goopts = ctx.rule.attr.gc_goopts,
-      runfiles = ctx.runfiles(collect_data = True),
-  )])
+  source = collect_src(ctx, aspect=True)
   for dep in ctx.rule.attr.deps:
     a = get_archive(dep)
     if a.mode != mode: fail("In aspect on {} found {} is {} expected {}".format(ctx.label, a.data.importpath, mode_string(a.mode), mode_string(mode)))

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -21,7 +21,7 @@ load("@io_bazel_rules_go//go/private:rules/prefix.bzl",
 )
 load("@io_bazel_rules_go//go/private:rules/aspect.bzl",
     "go_archive_aspect",
-    "get_source_list",
+    "collect_src",
 )
 load("@io_bazel_rules_go//go/private:providers.bzl",
     "GoLibrary",
@@ -35,13 +35,7 @@ def _go_binary_impl(ctx):
     go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:toolchain"]
   else:
     go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:bootstrap_toolchain"]
-  gosource = sources.merge([get_source_list(s) for s in ctx.attr.embed] + [sources.new(
-      srcs = ctx.files.srcs,
-      deps = ctx.attr.deps,
-      gc_goopts = ctx.attr.gc_goopts,
-      runfiles = ctx.runfiles(collect_data = True),
-      want_coverage = ctx.coverage_instrumented(),
-  )])
+  gosource = collect_src(ctx)
   executable = ctx.outputs.executable
   golib, goarchive = go_toolchain.actions.binary(ctx, go_toolchain,
       name = ctx.label.name,

--- a/go/private/rules/library.bzl
+++ b/go/private/rules/library.bzl
@@ -27,7 +27,7 @@ load("@io_bazel_rules_go//go/private:rules/prefix.bzl",
     "go_prefix_default",
 )
 load("@io_bazel_rules_go//go/private:rules/aspect.bzl",
-    "get_source_list",
+    "collect_src",
 )
 
 def _go_library_impl(ctx):
@@ -35,14 +35,7 @@ def _go_library_impl(ctx):
   go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:toolchain"]
   mode = get_mode(ctx, ctx.attr._go_toolchain_flags)
 
-  gosource = sources.merge([get_source_list(s) for s in ctx.attr.embed] + [sources.new(
-      srcs = ctx.files.srcs,
-      deps = ctx.attr.deps,
-      gc_goopts = ctx.attr.gc_goopts,
-      runfiles = ctx.runfiles(collect_data = True),
-      want_coverage = ctx.coverage_instrumented() and not ctx.label.name.endswith("~library~"),
-  )])
-
+  gosource = collect_src(ctx)
   golib, goarchive = go_toolchain.actions.library(ctx,
       go_toolchain = go_toolchain,
       mode = mode,

--- a/go/private/rules/source.bzl
+++ b/go/private/rules/source.bzl
@@ -21,34 +21,26 @@
 # info provider.
 
 load("@io_bazel_rules_go//go/private:providers.bzl",
+    "GoLibrary",
     "GoSourceList",
-    "sources",
 )
 load("@io_bazel_rules_go//go/private:rules/aspect.bzl",
-    "get_source_list",
+    "collect_src",
 )
 
+def _go_source_impl(ctx):
+  """Implements the go_source() rule."""
+  return [collect_src(ctx)]
 
-def _go_sources_impl(ctx):
-  """Implements the go_sources() rule."""
-  return [
-      sources.merge([get_source_list(s) for s in ctx.attr.embed] + [sources.new(
-          srcs = ctx.files.srcs,
-          deps = ctx.attr.deps,
-          gc_goopts = ctx.attr.gc_goopts,
-          runfiles = ctx.runfiles(collect_data = True),
-          want_coverage = ctx.coverage_instrumented(),
-      )])
-  ]
-
-go_sources = rule(
-    _go_sources_impl,
+go_source = rule(
+    _go_source_impl,
     attrs = {
         "data": attr.label_list(allow_files = True, cfg = "data"),
         "srcs": attr.label_list(allow_files = True),
         "deps": attr.label_list(providers = [GoLibrary]),
         "embed": attr.label_list(providers = [GoSourceList]),
         "gc_goopts": attr.string_list(),
+        "_go_toolchain_flags": attr.label(default=Label("@io_bazel_rules_go//go/private:go_toolchain_flags")),
     },
 )
-"""See go/core.rst#go_sources for full documentation."""
+"""See go/core.rst#go_source for full documentation."""

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -13,7 +13,7 @@ load("@io_bazel_rules_go//go/private:mode.bzl",
     "get_mode",
 )
 load("@io_bazel_rules_go//go/private:rules/aspect.bzl",
-    "get_source_list",
+    "collect_src",
 )
 
 def _go_proto_library_impl(ctx):
@@ -27,13 +27,7 @@ def _go_proto_library_impl(ctx):
   )
   go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:toolchain"]
   mode = get_mode(ctx, ctx.attr._go_toolchain_flags)
-  gosource = sources.merge([get_source_list(s) for s in ctx.attr.embed] + [sources.new(
-      srcs = go_srcs,
-      deps = ctx.attr.deps + go_proto_toolchain.deps,
-      gc_goopts = ctx.attr.gc_goopts,
-      runfiles = ctx.runfiles(collect_data = True),
-      want_coverage = False,
-  )])
+  gosource = collect_src(ctx, srcs = go_srcs)
   golib, goarchive = go_toolchain.actions.library(ctx,
       go_toolchain = go_toolchain,
       mode = mode,

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -27,7 +27,10 @@ def _go_proto_library_impl(ctx):
   )
   go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:toolchain"]
   mode = get_mode(ctx, ctx.attr._go_toolchain_flags)
-  gosource = collect_src(ctx, srcs = go_srcs)
+  gosource = collect_src(
+      ctx, srcs = go_srcs,
+      deps=ctx.attr.deps + go_proto_toolchain.deps,
+  )
   golib, goarchive = go_toolchain.actions.library(ctx,
       go_toolchain = go_toolchain,
       mode = mode,

--- a/tests/race/BUILD.bazel
+++ b/tests/race/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test", "go_binary")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test", "go_binary", "go_source")
 load("@io_bazel_rules_go//tests:bazel_tests.bzl", "bazel_test")
 
 go_library(
@@ -13,18 +13,22 @@ go_binary(
     deps = [":go_default_library"],
 )
 
-go_test(
-    name = "race_auto_test",
-    size = "small",
+go_source(
+    name = "race_test",
     srcs = ["race_test.go"],
     embed = [":go_default_library"],
 )
 
 go_test(
+    name = "race_auto_test",
+    size = "small",
+    embed = [":race_test"],
+)
+
+go_test(
     name = "race_on_tester",
     size = "small",
-    srcs = ["race_test.go"],
-    embed = [":go_default_library"],
+    embed = [":race_test"],
     tags = ["manual"],
     race = "on",
 )


### PR DESCRIPTION
This also fixes a double embedding case that was broken.