### PR TITLE
Gazelle: ignore "cgo" tag

### DIFF
--- a/go/tools/gazelle/config/config.go
+++ b/go/tools/gazelle/config/config.go
@@ -105,7 +105,6 @@ func (c *Config) PreprocessTags() {
 	if c.GenericTags == nil {
 		c.GenericTags = make(BuildTags)
 	}
-	c.GenericTags["cgo"] = true
 	c.GenericTags["gc"] = true
 }
 

--- a/go/tools/gazelle/config/config_test.go
+++ b/go/tools/gazelle/config/config_test.go
@@ -22,13 +22,13 @@ func TestPreprocessTags(t *testing.T) {
 		GenericTags: map[string]bool{"a": true, "b": true},
 	}
 	c.PreprocessTags()
-	expectedTags := []string{"a", "b", "cgo", "gc"}
+	expectedTags := []string{"a", "b", "gc"}
 	for _, tag := range expectedTags {
 		if !c.GenericTags[tag] {
 			t.Errorf("tag %q not set", tag)
 		}
 	}
-	unexpectedTags := []string{"x", "go1.8", "go1.7"}
+	unexpectedTags := []string{"x", "cgo", "go1.8", "go1.7"}
 	for _, tag := range unexpectedTags {
 		if c.GenericTags[tag] {
 			t.Errorf("tag %q unexpectedly set")

--- a/go/tools/gazelle/packages/fileinfo.go
+++ b/go/tools/gazelle/packages/fileinfo.go
@@ -110,7 +110,7 @@ func (g tagGroup) check(c *config.Config, os, arch string) bool {
 		if not {
 			t = t[1:]
 		}
-		if isReleaseTag(t) {
+		if isIgnoredTag(t) {
 			// Release tags are treated as "unknown" and are considered true,
 			// whether or not they are negated.
 			continue
@@ -406,8 +406,14 @@ func checkConstraints(c *config.Config, os, arch, osSuffix, archSuffix string, f
 	return true
 }
 
-// isReleaseTag returns whether the tag matches the pattern "go[0-9]\.[0-9]+".
-func isReleaseTag(tag string) bool {
+// isIgnoredTag returns whether the tag is "cgo" or is a release tag.
+// Release tags match the pattern "go[0-9]\.[0-9]+".
+// Gazelle won't consider whether an ignored tag is satisfied when evaluating
+// build constraints for a file.
+func isIgnoredTag(tag string) bool {
+	if tag == "cgo" {
+		return true
+	}
 	if len(tag) < 5 || !strings.HasPrefix(tag, "go") {
 		return false
 	}

--- a/go/tools/gazelle/packages/fileinfo_test.go
+++ b/go/tools/gazelle/packages/fileinfo_test.go
@@ -436,24 +436,27 @@ func TestCheckConstraints(t *testing.T) {
 			content:  "// +build foo\n\npackage foo",
 			want:     false,
 		}, {
-			desc:    "tags all satisfied",
-			content: "// +build cgo,gc\n\npackage foo",
-			want:    true,
+			desc:        "tags all satisfied",
+			genericTags: map[string]bool{"a": true, "b": true},
+			content:     "// +build a,b\n\npackage foo",
+			want:        true,
 		}, {
-			desc:    "tags some satisfied",
-			content: "// +build cgo,foo\n\npackage foo",
-			want:    false,
+			desc:        "tags some satisfied",
+			genericTags: map[string]bool{"a": true},
+			content:     "// +build a,b\n\npackage foo",
+			want:        false,
 		}, {
 			desc:    "tag unsatisfied negated",
-			content: "// +build !foo\n\npackage foo",
+			content: "// +build !a\n\npackage foo",
 			want:    true,
 		}, {
-			desc:    "tag satisfied negated",
-			content: "// +build !cgo\n\npackage foo",
-			want:    false,
+			desc:        "tag satisfied negated",
+			genericTags: map[string]bool{"a": true},
+			content:     "// +build !a\n\npackage foo",
+			want:        false,
 		}, {
 			desc:    "tag double negative",
-			content: "// +build !!cgo\n\npackage foo",
+			content: "// +build !!a\n\npackage foo",
 			want:    false,
 		}, {
 			desc:        "tag group and satisfied",
@@ -528,12 +531,20 @@ import "C"
 			desc:    "release tag negated",
 			content: "// +build !go1.8\n\npackage foo",
 			want:    true,
+		}, {
+			desc:    "cgo tag",
+			content: "// +build cgo",
+			want:    true,
+		}, {
+			desc:    "cgo tag negated",
+			content: "// +build !cgo",
+			want:    true,
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			genericTags := tc.genericTags
 			if genericTags == nil {
-				genericTags = map[string]bool{"cgo": true, "gc": true}
+				genericTags = map[string]bool{"gc": true}
 			}
 			c := &config.Config{
 				GenericTags:           genericTags,

--- a/go/tools/gazelle/testdata/repo/platforms/BUILD.want
+++ b/go/tools/gazelle/testdata/repo/platforms/BUILD.want
@@ -6,6 +6,7 @@ go_library(
         "cgo_generic.c",
         "cgo_generic.go",
         "generic.go",
+        "no_cgo.go",
         "release.go",
     ] + select({
         "@io_bazel_rules_go//go/platform:darwin": [


### PR DESCRIPTION
Previously, rules_go always considered the "cgo" tag to be
true. Gazelle excluded files with !cgo.

Now that we support "pure" builds, the tag may be true or false
depending on the build mode. With this change, Gazelle will ignore the
cgo tag when deciding whether to include a file.

Fixes #1037