### PR TITLE
Prevent AST information loss in mapExprStrings

### DIFF
--- a/go/tools/gazelle/resolve/resolve.go
+++ b/go/tools/gazelle/resolve/resolve.go
@@ -124,7 +124,9 @@ func mapExprStrings(e bf.Expr, f func(string) string) bf.Expr {
 		if s == "" {
 			return nil
 		}
-		return &bf.StringExpr{Value: s}
+		ret := *expr
+		ret.Value = s
+		return &ret
 
 	case *bf.ListExpr:
 		var list []bf.Expr
@@ -137,7 +139,9 @@ func mapExprStrings(e bf.Expr, f func(string) string) bf.Expr {
 		if len(list) == 0 && len(expr.List) > 0 {
 			return nil
 		}
-		return &bf.ListExpr{List: list}
+		ret := *expr
+		ret.List = list
+		return &ret
 
 	case *bf.DictExpr:
 		var cases []bf.Expr
@@ -158,7 +162,9 @@ func mapExprStrings(e bf.Expr, f func(string) string) bf.Expr {
 		if isEmpty {
 			return nil
 		}
-		return &bf.DictExpr{List: cases}
+		ret := *expr
+		ret.List = cases
+		return &ret
 
 	case *bf.CallExpr:
 		if x, ok := expr.X.(*bf.LiteralExpr); !ok || x.Token != "select" || len(expr.List) != 1 {


### PR DESCRIPTION
Ran into a bug whilst trying to add a check that Gazelle generated build files were up to date in CI. 

Whereby the first run of Gazelle would produce subtly differently output from the second run (creating a new file vs. merging with an existing file).

Tracked it down to the `ForceMultiLine` field of the ListExpr, which was being explicitly set for merged expressions and should have always been set for generated expressions (https://github.com/bazelbuild/rules_go/commit/2fe0791602ae90ab2f2878a80c5fb7cf4529596a)

However, whilst `ForceMultiLine` is set in construct.go (https://github.com/bazelbuild/rules_go/blob/master/go/tools/gazelle/rules/construct.go#L153) the setting was being lost when run through `mapExprStrings`.

This diff means that all fields in expressions run through `mapExprStrings` are kept, so behaviour should remain consistent when merging and creating a file for the first time.