### PR TITLE
Fix cgo filtering

### DIFF
--- a/go/tools/builders/asm.go
+++ b/go/tools/builders/asm.go
@@ -42,7 +42,7 @@ func run(args []string) error {
 
 	// filter our input file list
 	bctx := goenv.BuildContext()
-	matched, err := matchFile(bctx, source)
+	matched, _, _, err := matchFile(bctx, source, false)
 	if err != nil {
 		return err
 	}

--- a/go/tools/builders/filter.go
+++ b/go/tools/builders/filter.go
@@ -15,8 +15,15 @@
 package main
 
 import (
+	"go/ast"
 	"go/build"
+	"go/parser"
+	"go/token"
+	"io/ioutil"
+	"log"
 	"path/filepath"
+	"strconv"
+	"strings"
 )
 
 // filterFiles applies build constraints to a list of input files. It returns
@@ -24,7 +31,7 @@ import (
 func filterFiles(bctx build.Context, inputs []string) ([]string, error) {
 	var outputs []string
 	for _, input := range inputs {
-		if match, err := matchFile(bctx, input); err != nil {
+		if match, _, _, err := matchFile(bctx, input, false); err != nil {
 			return nil, err
 		} else if match {
 			outputs = append(outputs, input)
@@ -37,7 +44,57 @@ func filterFiles(bctx build.Context, inputs []string) ([]string, error) {
 // it should be compiled.
 // TODO(#70): cross compilation: support GOOS, GOARCH that are different
 // from the host platform.
-func matchFile(bctx build.Context, input string) (bool, error) {
+func matchFile(bctx build.Context, input string, needPackage bool) (bool, bool, string, error) {
 	dir, base := filepath.Split(input)
-	return bctx.MatchFile(dir, base)
+	// First check tag filtering
+	match, err := bctx.MatchFile(dir, base)
+	if err != nil {
+		return false, false, "", err
+	}
+	// if we don't need the package, and we are cgo, no need to parse the file
+	if !needPackage && bctx.CgoEnabled {
+		return match, false, "", nil
+	}
+	// if it's not a go file, there is no package or cgo
+	if !strings.HasSuffix(input, ".go") {
+		return match, false, "", nil
+	}
+	data, err := ioutil.ReadFile(input)
+	if err != nil {
+		return false, false, "", err
+	}
+	isCgo, pkg, err := testCgo(input, data)
+	if err != nil {
+		return false, false, "", err
+	}
+	// match if cgo is enabled or the file is not cgo
+	return match && (bctx.CgoEnabled || !isCgo), isCgo, pkg, err
+}
+
+func testCgo(src string, data []byte) (bool, string, error) {
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, src, data, parser.ImportsOnly)
+	if err != nil {
+		return false, "", err
+	}
+	for _, decl := range parsed.Decls {
+		d, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		for _, dspec := range d.Specs {
+			spec, ok := dspec.(*ast.ImportSpec)
+			if !ok {
+				continue
+			}
+			imp, err := strconv.Unquote(spec.Path.Value)
+			if err != nil {
+				log.Panicf("%s: invalid string `%s`", src, spec.Path.Value)
+			}
+			if imp == "C" {
+				return true, parsed.Name.String(), nil
+			}
+		}
+	}
+	return false, parsed.Name.String(), nil
 }

--- a/tests/cgo_pure/BUILD.bazel
+++ b/tests/cgo_pure/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "cgo.c",
         "cgo.go",
+        "cgo_no_tag.go",
         "common.go",
         "pure.go",
     ],

--- a/tests/cgo_pure/cgo_no_tag.go
+++ b/tests/cgo_pure/cgo_no_tag.go
@@ -1,0 +1,8 @@
+package cgo_pure
+
+/*
+const int value;
+*/
+import "C"
+
+var AnotherValue = int(C.value)


### PR DESCRIPTION
This changes our filtering code to understand the implied build tags caused by
import "C" lines in go files that build.Context.Match does not handle.
It also changes our cgo processing code to share the same logic.