### PR TITLE
control executable names

### DIFF
--- a/go/private/actions/binary.bzl
+++ b/go/private/actions/binary.bzl
@@ -16,6 +16,9 @@ load("@io_bazel_rules_go//go/private:mode.bzl",
     "mode_string",
     "get_mode",
 )
+load("@io_bazel_rules_go//go/private:common.bzl",
+    "declare_file",
+)
 
 def emit_binary(ctx, go_toolchain,
     name="",
@@ -23,7 +26,6 @@ def emit_binary(ctx, go_toolchain,
     source = None,
     gc_linkopts = [],
     x_defs = {},
-    executable = None,
     wrap = None):
   """See go/toolchains.rst#binary for full documentation."""
 
@@ -37,7 +39,7 @@ def emit_binary(ctx, go_toolchain,
       importpath = importpath,
       importable = False,
   )
-
+  executable = declare_file(ctx, ext=go_toolchain.data.extension, mode=mode)
   go_toolchain.actions.link(ctx,
       go_toolchain = go_toolchain,
       archive=goarchive,
@@ -47,4 +49,4 @@ def emit_binary(ctx, go_toolchain,
       x_defs=x_defs,
   )
 
-  return golib, goarchive
+  return golib, goarchive, executable

--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -34,6 +34,11 @@ def _get_stdlib(ctx, go_toolchain, mode):
   else:
     return go_toolchain.stdlib.cgo
 
+def _goos_to_extension(goos):
+  if goos == "windows":
+    return ".exe"
+  return ""
+
 def _go_toolchain_impl(ctx):
   return [platform_common.ToolchainInfo(
       name = ctx.label.name,
@@ -74,6 +79,7 @@ def _go_toolchain_impl(ctx):
       data = struct(
           crosstool = ctx.files._crosstool,
           package_list = ctx.file._package_list,
+          extension = _goos_to_extension(ctx.attr.goos),
       ),
   )]
 

--- a/go/private/repository_tools.bzl
+++ b/go/private/repository_tools.bzl
@@ -33,9 +33,7 @@ def _go_repository_tools_impl(ctx):
   # We work this out here because you can't use a toolchain from a repository rule
   # TODO: This is an ugly non sustainable hack, we need to kill repository tools.
 
-  extension = ""
-  if ctx.os.name.startswith('windows'):
-    extension = ".exe"
+  extension = executable_extension(ctx)
   go_tool = ctx.path(Label("@go_sdk//:bin/go{}".format(extension)))
 
   x_tools_commit = "3d92dd60033c312e3ae7cac319c792271cf67e37"

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -36,20 +36,19 @@ def _go_binary_impl(ctx):
   else:
     go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:bootstrap_toolchain"]
   gosource = collect_src(ctx)
-  executable = ctx.outputs.executable
-  golib, goarchive = go_toolchain.actions.binary(ctx, go_toolchain,
+  golib, goarchive, executable = go_toolchain.actions.binary(ctx, go_toolchain,
       name = ctx.label.name,
       importpath = go_importpath(ctx),
       source = gosource,
       gc_linkopts = gc_linkopts(ctx),
       x_defs = ctx.attr.x_defs,
-      executable = executable,
   )
   return [
       golib, gosource, goarchive,
       DefaultInfo(
           files = depset([executable]),
           runfiles = goarchive.runfiles,
+          executable = executable,
       ),
   ]
 

--- a/go/private/rules/stdlib.bzl
+++ b/go/private/rules/stdlib.bzl
@@ -30,19 +30,19 @@ stdlib(
 """
 
 def _stdlib_impl(ctx):
-  go = ctx.actions.declare_file("bin/go") # TODO: .exe
   src = ctx.actions.declare_directory("src")
   pkg = ctx.actions.declare_directory("pkg")
   root_file = ctx.actions.declare_file("ROOT")
-  files = [root_file, go, pkg]
   goroot = root_file.path[:-(len(root_file.basename)+1)]
   sdk = ""
   for f in ctx.files._host_sdk:
-    prefix, found, _  = f.path.partition("bin/go")
+    prefix, found, extension  = f.path.partition("bin/go")
     if found:
       sdk = prefix
   if not sdk:
     fail("Could not find go executable in go_sdk")
+  go = ctx.actions.declare_file("bin/go" + extension)
+  files = [root_file, go, pkg]
   cpp = ctx.fragments.cpp
   features = ctx.features
   options = (cpp.compiler_options(features) +

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -84,8 +84,7 @@ def _go_test_impl(ctx):
   )
 
   # Now compile the test binary itself
-  executable = ctx.outputs.executable
-  _, goarchive = go_toolchain.actions.binary(ctx, go_toolchain,
+  _, goarchive, executable = go_toolchain.actions.binary(ctx, go_toolchain,
       name = ctx.label.name,
       source = sources.new(
           srcs = [main_go],
@@ -95,7 +94,6 @@ def _go_test_impl(ctx):
       ),
       importpath = ctx.label.name + "~testmain~",
       gc_linkopts = gc_linkopts(ctx),
-      executable = executable,
       x_defs=ctx.attr.x_defs,
   )
 
@@ -107,6 +105,7 @@ def _go_test_impl(ctx):
       DefaultInfo(
           files = depset([executable]),
           runfiles = runfiles,
+          executable = executable,
       ),
 ]
 

--- a/go/private/toolchain.bzl
+++ b/go/private/toolchain.bzl
@@ -132,7 +132,6 @@ def _sdk_build_file(ctx):
   ctx.file("ROOT")
   ctx.template("BUILD.bazel",
       Label("@io_bazel_rules_go//go/private:BUILD.sdk.bazel"),
-      substitutions = {"{extension}": executable_extension(ctx)},
       executable = False,
   )
 


### PR DESCRIPTION
This fixes executable extensions and also separates executables by build mode
for better cache hits.
This requires bazel 0.8 or higher to work