### PR TITLE
Write an empty package if there are no source files

### DIFF
--- a/go/tools/builders/compile.go
+++ b/go/tools/builders/compile.go
@@ -63,7 +63,7 @@ func run(args []string) error {
 		return err
 	}
 	if len(sources) <= 0 {
-		return fmt.Errorf("no unfiltered sources to compile")
+		return ioutil.WriteFile(*output, []byte(""), 0644)
 	}
 
 	// Check that the filtered sources don't import anything outside of deps.

--- a/tests/empty_package/BUILD.bazel
+++ b/tests/empty_package/BUILD.bazel
@@ -1,0 +1,45 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "cgo",
+    srcs = [
+        "cgo.c",
+        "cgo.go",
+    ],
+    importpath = "github.com/bazelbuild/rules_go/tests/empty_package/cgo",
+    cgo = True,
+)
+
+go_library(
+    name = "mixed",
+    srcs = [
+        "mixed_cgo.go",
+        "mixed_pure.go",
+    ],
+    importpath = "github.com/bazelbuild/rules_go/tests/empty_package/mixed",
+    deps = [":cgo"],
+)
+
+go_test(
+    name = "empty_package_cgo",
+    size = "small",
+    srcs = ["empty_package_test.go"],
+    deps = [":mixed"],
+    pure = "off",
+    importpath = "github.com/bazelbuild/rules_go/tests/empty_package_test",
+    x_defs = {
+        "github.com/bazelbuild/rules_go/tests/empty_package_test.Expect": "2",
+    },
+)
+
+go_test(
+    name = "empty_package_pure",
+    size = "small",
+    srcs = ["empty_package_test.go"],
+    deps = [":mixed"],
+    pure = "on",
+    importpath = "github.com/bazelbuild/rules_go/tests/empty_package_test",
+    x_defs = {
+        "github.com/bazelbuild/rules_go/tests/empty_package_test.Expect": "1",
+    },
+)

--- a/tests/empty_package/cgo.c
+++ b/tests/empty_package/cgo.c
@@ -1,0 +1,1 @@
+const int value = 2;

--- a/tests/empty_package/cgo.go
+++ b/tests/empty_package/cgo.go
@@ -1,0 +1,8 @@
+package cgo
+
+/*
+const int value;
+*/
+import "C"
+
+var Value = int(C.value)

--- a/tests/empty_package/empty_package_test.go
+++ b/tests/empty_package/empty_package_test.go
@@ -1,0 +1,17 @@
+package empty_package_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/tests/empty_package/mixed"
+)
+
+var Expect = ""
+
+func TestValue(t *testing.T) {
+	got := fmt.Sprintf("%d", mixed.Value)
+	if got != Expect {
+		t.Errorf("got %q; want %q", got, Expect)
+	}
+}

--- a/tests/empty_package/mixed_cgo.go
+++ b/tests/empty_package/mixed_cgo.go
@@ -1,0 +1,10 @@
+//+build cgo
+
+package mixed
+
+import (
+	"github.com/bazelbuild/rules_go/tests/empty_package/cgo"
+)
+
+var Value = cgo.Value
+var Expect = ""

--- a/tests/empty_package/mixed_pure.go
+++ b/tests/empty_package/mixed_pure.go
@@ -1,0 +1,5 @@
+//+build !cgo
+
+package mixed
+
+var Value = 1


### PR DESCRIPTION
This used to be a hard failure, but pure cgo libraries need to be silent at
compile time, complaining only if they are linked.
Also add a test for this use case.