### PR TITLE
Strip out sandbox paths from built assembly code

### DIFF
--- a/go/private/actions/asm.bzl
+++ b/go/private/actions/asm.bzl
@@ -40,10 +40,12 @@ def emit_asm(ctx, go_toolchain,
   add_go_env(asm_args, stdlib, mode)
   asm_args.add([source.path, "-o", out_obj])
   asm_args.add(includes, before_each="-I")
+  asm_args.add(['-trimpath', '/proc/self/cwd'])
   ctx.actions.run(
       inputs = inputs,
       outputs = [out_obj],
       mnemonic = "GoAsmCompile",
       executable = go_toolchain.tools.asm,
       arguments = [asm_args],
+      env = {"PWD": "/proc/self/cwd"},
   )


### PR DESCRIPTION
The full source filename gets put in the resulting binary by default.
According to 'go tool asm':

-trimpath string
        remove prefix from recorded source file paths

We can use the same trick as the C++ rules by setting PWD to be /proc/self/cwd, and then mapping that out.

Fixes: #1083