### PR TITLE
Clean out tmp handling

### DIFF
--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -123,7 +123,7 @@ def go_importpath(ctx):
     path = path[1:]
   return path
 
-def env_execute(ctx, arguments, environment = None, **kwargs):
+def env_execute(ctx, arguments, environment = {}, **kwargs):
   """env_executes a command in a repository context. It prepends "env -i"
   to "arguments" before calling "ctx.execute".
 
@@ -132,9 +132,12 @@ def env_execute(ctx, arguments, environment = None, **kwargs):
   in most situations.
   """
   env_args = ["env", "-i"]
-  if environment:
-    for k, v in environment.items():
-      env_args.append("%s=%s" % (k, v))
+  environment = dict(environment)
+  for var in ["TMP", "TMPDIR"]:
+    if var in ctx.os.environ and not var in environment:
+      environment[var] = ctx.os.environ[var]
+  for k, v in environment.items():
+    env_args.append("%s=%s" % (k, v))
   return ctx.execute(env_args + arguments, **kwargs)
 
 def to_set(v):

--- a/go/private/repository_tools.bzl
+++ b/go/private/repository_tools.bzl
@@ -51,12 +51,6 @@ def _go_repository_tools_impl(ctx):
       type = "zip",
   )
 
-  if "TMP" in ctx.os.environ:
-    tmp = ctx.os.environ["TMP"]
-  else:
-    ctx.file("tmp/ignore", content="") # make a file to force the directory to exist
-    tmp = str(ctx.path("tmp").realpath)
-
   # Build something that looks like a normal GOPATH so go install will work
   ctx.symlink(x_tools_path, "src/golang.org/x/tools")
   ctx.symlink(buildtools_path, "src/github.com/bazelbuild/buildtools")
@@ -64,7 +58,6 @@ def _go_repository_tools_impl(ctx):
   env = {
     'GOROOT': str(go_tool.dirname.dirname),
     'GOPATH': str(ctx.path('')),
-    'TMP': tmp,
   }
 
   # build all the repository tools

--- a/go/private/toolchain.bzl
+++ b/go/private/toolchain.bzl
@@ -86,13 +86,6 @@ def _go_sdk_impl(ctx):
 
 
 def _prepare(ctx):
-  if "TMP" in ctx.os.environ:
-    tmp = ctx.os.environ["TMP"]
-    ctx.symlink(tmp, "tmp")
-  else:
-    ctx.file("tmp/ignore", content="") # make a file to force the directory to exist
-    tmp = str(ctx.path("tmp").realpath)
-
   # Create a text file with a list of standard packages.
   # OPT: just list directories under src instead of running "go list". No
   # need to read all source files. We need a portable way to run code though.

--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -72,7 +72,6 @@ func (env *GoEnv) Env() []string {
 	return []string{
 		fmt.Sprintf("GOROOT=%s", env.absRoot()),
 		"GOROOT_FINAL=GOROOT",
-		fmt.Sprintf("TMP=%s", "/tmp"), // TODO: may need to be different on windows
 		fmt.Sprintf("GOOS=%s", env.goos),
 		fmt.Sprintf("GOARCH=%s", env.goarch),
 		fmt.Sprintf("CGO_ENABLED=%s", cgoEnabled),


### PR DESCRIPTION
In Bazel0.8 temp directories were fixed, so now we just rely on  them rather
than trying to make our own.