### PR TITLE
Trimpath for asm

### DIFF
--- a/go/private/actions/asm.bzl
+++ b/go/private/actions/asm.bzl
@@ -38,8 +38,9 @@ def emit_asm(ctx, go_toolchain,
 
   asm_args = ctx.actions.args()
   add_go_env(asm_args, stdlib, mode)
-  asm_args.add([source.path, "-o", out_obj])
+  asm_args.add(["-o", out_obj, "-trimpath", "."])
   asm_args.add(includes, before_each="-I")
+  asm_args.add(source.path)
   ctx.actions.run(
       inputs = inputs,
       outputs = [out_obj],

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -25,6 +25,7 @@ go_tool_binary(
         "asm.go",
         "env.go",
         "filter.go",
+        "flags.go",
     ],
     visibility = ["//visibility:public"],
 )

--- a/go/tools/builders/asm.go
+++ b/go/tools/builders/asm.go
@@ -25,12 +25,12 @@ import (
 )
 
 func run(args []string) error {
-	// process the args
-	if len(args) < 2 {
-		return fmt.Errorf("Usage: asm -go gotool source.s -- <extra options>")
-	}
+	search := multiFlag{}
 	flags := flag.NewFlagSet("asm", flag.ExitOnError)
 	goenv := envFlags(flags)
+	flags.Var(&search, "I", "Search paths of a direct dependency")
+	trimpath := flags.String("trimpath", "", "The base of the paths to trim")
+	output := flags.String("o", "", "The output object file to write")
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
@@ -50,6 +50,10 @@ func run(args []string) error {
 		source = os.DevNull
 	}
 	goargs := []string{"tool", "asm"}
+	goargs = append(goargs, "-trimpath", abs(*trimpath), "-o", *output)
+	for _, path := range search {
+		goargs = append(goargs, "-I", abs(path))
+	}
 	goargs = append(goargs, remains...)
 	goargs = append(goargs, source)
 	env := os.Environ()

--- a/go/tools/builders/compile.go
+++ b/go/tools/builders/compile.go
@@ -26,18 +26,9 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 )
-
-func abs(path string) string {
-	if abs, err := filepath.Abs(path); err != nil {
-		return path
-	} else {
-		return abs
-	}
-}
 
 func run(args []string) error {
 	unfiltered := multiFlag{}

--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -37,6 +37,14 @@ type GoEnv struct {
 	tags     string
 }
 
+func abs(path string) string {
+	if abs, err := filepath.Abs(path); err != nil {
+		return path
+	} else {
+		return abs
+	}
+}
+
 func envFlags(flags *flag.FlagSet) *GoEnv {
 	env := &GoEnv{}
 	flags.StringVar(&env.Go, "go", "", "The path to the go tool.")
@@ -51,10 +59,7 @@ func envFlags(flags *flag.FlagSet) *GoEnv {
 
 func (env *GoEnv) absRoot() string {
 	if env.rootPath == "" {
-		env.rootPath = env.rootFile
-		if abs, err := filepath.Abs(env.rootPath); err == nil {
-			env.rootPath = abs
-		}
+		env.rootPath = abs(env.rootFile)
 		if s, err := os.Stat(env.rootPath); err == nil {
 			if !s.IsDir() {
 				env.rootPath = filepath.Dir(env.rootPath)


### PR DESCRIPTION
This uses the same solution as we did for compile, abs the path inside the
execution wrapper so that it works on all platforms.

Fixes: #1083