### PR TITLE
Change proto compilation system (again)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,7 +4,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_too
 load("@io_bazel_rules_go//proto:def.bzl", "proto_register_toolchains")
 go_rules_dependencies()
 go_register_toolchains()
-proto_register_toolchains()
 
 # Needed for tests
 load("@io_bazel_rules_go//tests:bazel_tests.bzl", "test_environment")

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -1,36 +1,15 @@
-load('//proto:toolchain.bzl', 'proto_toolchain', 'go_proto_toolchain')
+load('//proto:compiler.bzl', 'go_proto_compiler')
 
-proto_toolchain(
-    name = "proto_impl",
-    visibility = ["//visibility:public"],
-)
-
-toolchain(
-    name = "proto",
-    toolchain_type = "@io_bazel_rules_go//proto:proto",
-    exec_compatible_with = [],
-    target_compatible_with = [],
-    toolchain = "proto_impl",
-)
-
-go_proto_toolchain(
-    name = "go_proto_impl",
+go_proto_compiler(
+    name = "go_proto",
     deps = [
         "@com_github_golang_protobuf//proto:go_default_library",
     ],
     visibility = ["//visibility:public"],
 )
 
-toolchain(
-    name = "go_proto",
-    toolchain_type = "@io_bazel_rules_go//proto:go_proto",
-    exec_compatible_with = [],
-    target_compatible_with = [],
-    toolchain = "go_proto_impl",
-)
-
-go_proto_toolchain(
-    name = "go_grpc_impl",
+go_proto_compiler(
+    name = "go_grpc",
     deps = [
         "@com_github_golang_protobuf//proto:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
@@ -38,12 +17,4 @@ go_proto_toolchain(
     ],
     options = ["plugins=grpc"],
     visibility = ["//visibility:public"],
-)
-
-toolchain(
-    name = "go_grpc",
-    toolchain_type = "@io_bazel_rules_go//proto:go_grpc",
-    exec_compatible_with = [],
-    target_compatible_with = [],
-    toolchain = "go_grpc_impl",
 )

--- a/proto/core.rst
+++ b/proto/core.rst
@@ -23,12 +23,3 @@ go_proto_library
 
 **TODO**: More information
 
-go_grpc_library
-~~~~~~~~~~~~~~~
-
-**TODO**: More information
-
-proto_register_toolchains
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-**TODO**: More information


### PR DESCRIPTION
Instead of using toolchains, we are switching to allowing a per go_proto_library
specification of a compiler.
This allows easy mixing of multiple plugins, and fixes the issues with deps from
toolchains being built in the wrong mode.

Fixes #990