### PR TITLE
Add a protoc wrapper

### DIFF
--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -115,3 +115,12 @@ go_tool_binary(
     ],
     visibility = ["//visibility:public"],
 )
+
+go_tool_binary(
+    name = "go-protoc",
+    srcs = [
+        "flags.go",
+        "protoc.go",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/go/tools/builders/protoc.go
+++ b/go/tools/builders/protoc.go
@@ -1,0 +1,86 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// protoc invokes the protobuf compiler and captures the resulting .pb.go file.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func run(args []string) error {
+	// process the args
+	expected := multiFlag{}
+	flags := flag.NewFlagSet("protoc", flag.ExitOnError)
+	protoc := flags.String("protoc", "", "The path to the real protoc.")
+	descriptor_set_in := flags.String("descriptor_set_in", "", "The descriptor set to read.")
+	go_out := flags.String("go_out", "", "The go plugin options.")
+	plugin := flags.String("plugin", "", "The go plugin to use.")
+	importpath := flags.String("importpath", "", "The importpath for the generated sources.")
+	flags.Var(&expected, "expected", "The expected output files.")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	protoc_args := []string{
+		"--go_out", *go_out,
+		"--plugin", *plugin,
+		"--descriptor_set_in", *descriptor_set_in,
+	}
+	protoc_args = append(protoc_args, flags.Args()...)
+	env := os.Environ()
+	cmd := exec.Command(*protoc, protoc_args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = env
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error running protoc: %v", err)
+	}
+	notFound := []string{}
+	for _, src := range expected {
+		if _, err := os.Stat(src); os.IsNotExist(err) {
+			notFound = append(notFound, src)
+		}
+	}
+	if len(notFound) > 0 {
+		unexpected := []string{}
+		filepath.Walk(".", func(path string, f os.FileInfo, err error) error {
+			if strings.HasSuffix(path, ".pb.go") {
+				wasExpected := false
+				for _, s := range expected {
+					if s == path {
+						wasExpected = true
+					}
+				}
+				if !wasExpected {
+					unexpected = append(unexpected, path)
+				}
+			}
+			return nil
+		})
+		return fmt.Errorf("protoc failed to make all outputs\nGot      %v\nExpected %v\nCheck the go package stanza is %v", unexpected, notFound, *importpath)
+	}
+	return nil
+}
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/go/tools/builders/protoc.go
+++ b/go/tools/builders/protoc.go
@@ -44,11 +44,9 @@ func run(args []string) error {
 		"--descriptor_set_in", *descriptor_set_in,
 	}
 	protoc_args = append(protoc_args, flags.Args()...)
-	env := os.Environ()
 	cmd := exec.Command(*protoc, protoc_args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Env = env
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("error running protoc: %v", err)
 	}
@@ -74,7 +72,7 @@ func run(args []string) error {
 			}
 			return nil
 		})
-		return fmt.Errorf("protoc failed to make all outputs\nGot      %v\nExpected %v\nCheck the go package stanza is %v", unexpected, notFound, *importpath)
+		return fmt.Errorf("protoc failed to make all outputs\nGot      %v\nExpected %v\nCheck that the go_package option is %q.", unexpected, notFound, *importpath)
 	}
 	return nil
 }

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -36,22 +36,28 @@ def go_proto_compile(ctx, compiler, lib, importpath):
   if plugin_base_name.startswith(_protoc_prefix):
     plugin_base_name = plugin_base_name[len(_protoc_prefix):]
   args = ctx.actions.args()
+  args.add(["-protoc", compiler.protoc.path])
+  options = compiler.options + ["import_path="+"goats"]
   args.add([
+      "--importpath", importpath,
       "--{}_out={}:{}".format(plugin_base_name, ",".join(compiler.options), outpath),
       "--plugin={}={}".format(compiler.plugin.basename, compiler.plugin.path),
       "--descriptor_set_in", ":".join(
           [s.path for s in lib.proto.transitive_descriptor_sets])
   ])
+  for out in go_srcs:
+      args.add(["--expected", out])
   args.add(lib.proto.direct_sources, map_fn=_all_proto_paths)
   ctx.actions.run(
       inputs = sets.union([
+          compiler.go_protoc,
           compiler.protoc,
           compiler.plugin,
       ], lib.proto.transitive_descriptor_sets),
       outputs = go_srcs,
       progress_message = "Generating into %s" % go_srcs[0].dirname,
       mnemonic = "GoProtocGen",
-      executable = compiler.protoc,
+      executable = compiler.go_protoc,
       arguments = [args],
   )
   return go_srcs
@@ -80,6 +86,7 @@ def _go_proto_compiler_impl(ctx):
       compile = go_proto_compile,
       options = ctx.attr.options,
       suffix = ctx.attr.suffix,
+      go_protoc = ctx.file._go_protoc,
       protoc = ctx.file._protoc,
       plugin = ctx.file.plugin,
   )]
@@ -96,6 +103,13 @@ go_proto_compiler = rule(
             executable = True,
             cfg = "host",
             default = Label("@com_github_golang_protobuf//protoc-gen-go"),
+        ),
+        "_go_protoc":  attr.label(
+            allow_files=True,
+            single_file=True,
+            executable = True,
+            cfg = "host",
+            default=Label("@io_bazel_rules_go//go/tools/builders:go-protoc"),
         ),
         "_protoc": attr.label(
             allow_files = True,

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -37,7 +37,6 @@ def go_proto_compile(ctx, compiler, lib, importpath):
     plugin_base_name = plugin_base_name[len(_protoc_prefix):]
   args = ctx.actions.args()
   args.add(["-protoc", compiler.protoc.path])
-  options = compiler.options + ["import_path="+"goats"]
   args.add([
       "--importpath", importpath,
       "--{}_out={}:{}".format(plugin_base_name, ",".join(compiler.options), outpath),


### PR DESCRIPTION
This version lets us add a much more informative message when the importpaths
are wrong for example:

```
2017/12/04 10:58:59 protoc failed to make all outputs
Got
[bazel-out/k8-fastbuild/bin/examples/proto/dep/useful_go_proto~/examples/proto/dep/useful.pb.go]
Expected
[bazel-out/k8-fastbuild/bin/examples/proto/dep/useful_go_proto~/github.com/bazelbuild/rules_go/examples/proto/dep/useful.pb.go]
Check the go package stanza is github.com/bazelbuild/rules_go/examples/proto/dep
```