### PR TITLE
Fix go proto library for once and for all

### DIFF
--- a/examples/proto/dep/useful.proto
+++ b/examples/proto/dep/useful.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package very.useful;
 
-option go_package = "github.com/bazelbuild/rules_go/examples/proto/dep";
-
 import "google/protobuf/duration.proto";
 
 message VeryUseful {

--- a/go/tools/builders/protoc.go
+++ b/go/tools/builders/protoc.go
@@ -93,7 +93,7 @@ func run(args []string) error {
 		}
 	}
 	// Walk the generated files
-	filepath.Walk(".", func(path string, f os.FileInfo, err error) error {
+	filepath.Walk(*outPath, func(path string, f os.FileInfo, err error) error {
 		if !strings.HasSuffix(path, ".pb.go") {
 			return nil
 		}

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -32,7 +32,7 @@ def go_proto_compile(ctx, compiler, proto, imports, importpath):
         outpath = out.dirname[:-len(importpath)]
   args = ctx.actions.args()
   args.add([
-      "-protoc", compiler.protoc,
+      "--protoc", compiler.protoc,
       "--importpath", importpath,
       "--out_path", outpath,
       "--plugin", compiler.plugin,

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -22,37 +22,32 @@ load("@io_bazel_rules_go//go/private:providers.bzl",
 
 GoProtoCompiler = provider()
 
-_protoc_prefix = "protoc-gen-"
-
-def go_proto_compile(ctx, compiler, lib, importpath):
+def go_proto_compile(ctx, compiler, proto, imports, importpath):
   go_srcs = []
   outpath = None
-  for proto in lib.proto.direct_sources:
-    out = declare_file(ctx, path=importpath+"/"+proto.basename[:-len(".proto")], ext=compiler.suffix)
+  for src in proto.direct_sources:
+    out = declare_file(ctx, path=importpath+"/"+src.basename[:-len(".proto")], ext=compiler.suffix)
     go_srcs.append(out)
     if outpath == None:
         outpath = out.dirname[:-len(importpath)]
-  plugin_base_name = compiler.plugin.basename
-  if plugin_base_name.startswith(_protoc_prefix):
-    plugin_base_name = plugin_base_name[len(_protoc_prefix):]
   args = ctx.actions.args()
-  args.add(["-protoc", compiler.protoc.path])
   args.add([
+      "-protoc", compiler.protoc,
       "--importpath", importpath,
-      "--{}_out={}:{}".format(plugin_base_name, ",".join(compiler.options), outpath),
-      "--plugin={}={}".format(compiler.plugin.basename, compiler.plugin.path),
-      "--descriptor_set_in", ":".join(
-          [s.path for s in lib.proto.transitive_descriptor_sets])
+      "--out_path", outpath,
+      "--plugin", compiler.plugin,
   ])
-  for out in go_srcs:
-      args.add(["--expected", out])
-  args.add(lib.proto.direct_sources, map_fn=_all_proto_paths)
+  args.add(compiler.options, before_each = "--option")
+  args.add(proto.transitive_descriptor_sets, before_each = "--descriptor_set")
+  args.add(go_srcs, before_each = "--expected")
+  args.add(imports, before_each = "--import")
+  args.add(proto.direct_sources, map_fn=_all_proto_paths)
   ctx.actions.run(
       inputs = sets.union([
           compiler.go_protoc,
           compiler.protoc,
           compiler.plugin,
-      ], lib.proto.transitive_descriptor_sets),
+      ], proto.transitive_descriptor_sets),
       outputs = go_srcs,
       progress_message = "Generating into %s" % go_srcs[0].dirname,
       mnemonic = "GoProtocGen",

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -1,5 +1,6 @@
 load("@io_bazel_rules_go//go/private:common.bzl",
     "go_importpath",
+    "sets",
 )
 load("@io_bazel_rules_go//go/private:providers.bzl",
     "GoLibrary",
@@ -18,12 +19,31 @@ load("@io_bazel_rules_go//proto:compiler.bzl",
     "GoProtoCompiler",
 )
 
+GoProtoImports = provider()
+
+def get_imports(attr):
+    imports = []
+    if hasattr(attr, "proto"):
+        imports.append(["{}={}".format(src.path, attr.importpath) for src in attr.proto.proto.direct_sources])
+    imports.extend([dep[GoProtoImports].imports for dep in attr.deps])
+    imports.extend([dep[GoProtoImports].imports for dep in attr.embed])
+    return sets.union(*imports)
+
+def _go_proto_aspect_impl(target, ctx):
+    return [GoProtoImports(imports = get_imports(ctx.rule.attr))]
+
+_go_proto_aspect = aspect(
+    _go_proto_aspect_impl,
+    attr_aspects = ["deps", "embed"],
+)
+
 def _go_proto_library_impl(ctx):
   compiler = ctx.attr.compiler[GoProtoCompiler]
   importpath = go_importpath(ctx)
   go_srcs = compiler.compile(ctx,
     compiler = compiler,
-    lib = ctx.attr.proto,
+    proto = ctx.attr.proto.proto,
+    imports = get_imports(ctx.attr),
     importpath = importpath,
   )
   go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:toolchain"]
@@ -51,7 +71,7 @@ go_proto_library = rule(
     _go_proto_library_impl,
     attrs = {
         "proto": attr.label(mandatory=True, providers=["proto"]),
-        "deps": attr.label_list(providers = [GoLibrary]),
+        "deps": attr.label_list(providers = [GoLibrary], aspects = [_go_proto_aspect]),
         "importpath": attr.string(),
         "embed": attr.label_list(providers = [GoSourceList]),
         "gc_goopts": attr.string_list(),
@@ -69,6 +89,7 @@ attribute) and produces a go library for it.
 """
 
 def go_grpc_library(**kwargs):
+    # TODO: Deprecate once gazelle generates just go_proto_library
     go_proto_library(compiler="@io_bazel_rules_go//proto:go_grpc", **kwargs)
 
 def proto_register_toolchains():

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -22,15 +22,15 @@ load("@io_bazel_rules_go//proto:compiler.bzl",
 GoProtoImports = provider()
 
 def get_imports(attr):
-    imports = []
-    if hasattr(attr, "proto"):
-        imports.append(["{}={}".format(src.path, attr.importpath) for src in attr.proto.proto.direct_sources])
-    imports.extend([dep[GoProtoImports].imports for dep in attr.deps])
-    imports.extend([dep[GoProtoImports].imports for dep in attr.embed])
-    return sets.union(*imports)
+  imports = []
+  if hasattr(attr, "proto"):
+    imports.append(["{}={}".format(src.path, attr.importpath) for src in attr.proto.proto.direct_sources])
+  imports.extend([dep[GoProtoImports].imports for dep in attr.deps])
+  imports.extend([dep[GoProtoImports].imports for dep in attr.embed])
+  return sets.union(*imports)
 
 def _go_proto_aspect_impl(target, ctx):
-    return [GoProtoImports(imports = get_imports(ctx.rule.attr))]
+  return [GoProtoImports(imports = get_imports(ctx.rule.attr))]
 
 _go_proto_aspect = aspect(
     _go_proto_aspect_impl,
@@ -89,8 +89,8 @@ attribute) and produces a go library for it.
 """
 
 def go_grpc_library(**kwargs):
-    # TODO: Deprecate once gazelle generates just go_proto_library
-    go_proto_library(compiler="@io_bazel_rules_go//proto:go_grpc", **kwargs)
+  # TODO: Deprecate once gazelle generates just go_proto_library
+  go_proto_library(compiler="@io_bazel_rules_go//proto:go_grpc", **kwargs)
 
 def proto_register_toolchains():
   print("You no longer need to call proto_register_toolchains(), it does nothing")

--- a/tests/proto_ignore_go_package_option/BUILD.bazel
+++ b/tests/proto_ignore_go_package_option/BUILD.bazel
@@ -1,20 +1,37 @@
-load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_proto_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
-go_proto_library(
+proto_library(
     name = "a_proto",
     srcs = ["a.proto"],
-    ignore_go_package_option = 1,
+    deps = [
+        "@com_google_protobuf//:struct_proto",
+    ],
+)
+
+proto_library(
+    name = "b_proto",
+    srcs = ["b.proto"],
+    deps = [
+        ":a_proto",
+        "@com_google_protobuf//:any_proto",
+    ],
+)
+
+go_proto_library(
+    name = "a_go_proto",
+    importpath = "github.com/bazelbuild/rules_go/test/proto_ignore_go_package_option/a",
+    proto = ":a_proto",
     deps = [
         "@com_github_golang_protobuf//ptypes/struct:go_default_library",
     ],
 )
 
 go_proto_library(
-    name = "b_proto",
-    srcs = ["b.proto"],
-    ignore_go_package_option = 1,
+    name = "b_go_proto",
+    importpath = "github.com/bazelbuild/rules_go/test/proto_ignore_go_package_option/b",
+    proto = ":b_proto",
     deps = [
-        ":a_proto",
+        ":a_go_proto",
         "@com_github_golang_protobuf//ptypes/any:go_default_library",
     ],
 )


### PR DESCRIPTION
This uses an aspect to collect up the full set of proto imports and what their
go import path should be, and then hands that to the proto compile line.
It then attempts to map the outputs to the expected outputs by basename.
All of this means that the option go_package lines are not needed for a correct
build.

Fixes #1021
Fixes #910
Fixes #173