### PR TITLE
Default to linux_amd64 when uname returns something we don't recognize

### DIFF
--- a/go/private/toolchain.bzl
+++ b/go/private/toolchain.bzl
@@ -31,14 +31,12 @@ go_host_sdk = repository_rule(_go_host_sdk_impl, environ = ["GOROOT"])
 def _go_download_sdk_impl(ctx):
   if ctx.os.name == 'linux':
     res = ctx.execute(['uname', '-p'])
-    if res.return_code != 0:
-      host = "linux_amd64"
-    elif 's390x' in res.stdout:
+    if res.return_code == 0 and res.stdout == 's390x':
       host = "linux_s390x"
-    elif 'x86_64' in res.stdout:
-      host = "linux_amd64"
     else:
-      fail("Unsupported architecture: " + res.stdout)
+      # uname -p, -i, and -m can return wildly different values on different
+      # distributions and versions. Always default to amd64.
+      host = "linux_amd64"
   elif ctx.os.name == 'mac os x':
     host = "darwin_amd64"
   elif ctx.os.name.startswith('windows'):


### PR DESCRIPTION
Fixes #1111