### PR TITLE
Gazelle: support prefix directive

### DIFF
--- a/go/tools/gazelle/config/directives.go
+++ b/go/tools/gazelle/config/directives.go
@@ -40,6 +40,7 @@ var knownTopLevelDirectives = map[string]bool{
 	"build_file_name": true,
 	"build_tags":      true,
 	"exclude":         true,
+	"prefix":          true,
 	"ignore":          true,
 	"proto":           true,
 }
@@ -89,10 +90,10 @@ func ParseDirectives(f *bf.File) []Directive {
 
 var directiveRe = regexp.MustCompile(`^#\s*gazelle:(\w+)\s*(.*?)\s*$`)
 
-// ApplyDirectives applies directives that modify the configuration to a
-// copy of c, which is returned. If there are no configuration directives,
-// c is returned unmodified.
-func ApplyDirectives(c *Config, directives []Directive) *Config {
+// ApplyDirectives applies directives that modify the configuration to a copy of
+// c, which is returned. If there are no configuration directives, c is returned
+// unmodified.
+func ApplyDirectives(c *Config, directives []Directive, rel string) *Config {
 	modified := *c
 	didModify := false
 	for _, d := range directives {
@@ -107,6 +108,14 @@ func ApplyDirectives(c *Config, directives []Directive) *Config {
 			}
 		case "build_file_name":
 			modified.ValidBuildFileNames = strings.Split(d.Value, ",")
+			didModify = true
+		case "prefix":
+			if err := CheckPrefix(d.Value); err != nil {
+				log.Print(err)
+				continue
+			}
+			modified.GoPrefix = d.Value
+			modified.GoPrefixRel = rel
 			didModify = true
 		case "proto":
 			protoMode, err := ProtoModeFromString(d.Value)

--- a/go/tools/gazelle/config/directives_test.go
+++ b/go/tools/gazelle/config/directives_test.go
@@ -64,6 +64,7 @@ func TestApplyDirectives(t *testing.T) {
 	for _, tc := range []struct {
 		desc       string
 		directives []Directive
+		rel        string
 		want       Config
 	}{
 		{
@@ -78,12 +79,17 @@ func TestApplyDirectives(t *testing.T) {
 			desc:       "build_file_name",
 			directives: []Directive{{"build_file_name", "foo,bar"}},
 			want:       Config{ValidBuildFileNames: []string{"foo", "bar"}},
+		}, {
+			desc:       "prefix",
+			directives: []Directive{{"prefix", "example.com/repo"}},
+			rel:        "sub",
+			want:       Config{GoPrefix: "example.com/repo", GoPrefixRel: "sub"},
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			c := &Config{}
 			c.PreprocessTags()
-			got := ApplyDirectives(c, tc.directives)
+			got := ApplyDirectives(c, tc.directives, tc.rel)
 			tc.want.PreprocessTags()
 			if !reflect.DeepEqual(*got, tc.want) {
 				t.Errorf("got %#v ; want %#v", *got, tc.want)

--- a/go/tools/gazelle/gazelle/fix_test.go
+++ b/go/tools/gazelle/gazelle/fix_test.go
@@ -36,6 +36,7 @@ func defaultConfig(dir string) *config.Config {
 	c := &config.Config{
 		Dirs:                []string{dir},
 		RepoRoot:            dir,
+		GoPrefix:            "example.com/repo",
 		GenericTags:         config.BuildTags{},
 		ValidBuildFileNames: config.DefaultValidBuildFileNames,
 	}

--- a/go/tools/gazelle/packages/package.go
+++ b/go/tools/gazelle/packages/package.go
@@ -96,24 +96,16 @@ func (p *Package) isBuildable(c *config.Config) bool {
 		p.Proto.HasProto() && c.ProtoMode == config.DefaultProtoMode
 }
 
-// ImportPath returns the inferred Go import path for this package. This
-// is determined as follows:
-//
-// * If "vendor" is a component in p.Rel, everything after the last "vendor"
-//   component is returned.
-// * Otherwise, prefix joined with Rel is returned.
-//
+// ImportPath returns the inferred Go import path for this package.
 // TODO(jayconrod): extract canonical import paths from comments on
 // package statements.
-func (p *Package) ImportPath(prefix string) string {
-	components := strings.Split(p.Rel, "/")
-	for i := len(components) - 1; i >= 0; i-- {
-		if components[i] == "vendor" {
-			return path.Join(components[i+1:]...)
-		}
+func (p *Package) ImportPath(c *config.Config) string {
+	if p.Rel == c.GoPrefixRel {
+		return c.GoPrefix
+	} else {
+		fromPrefixRel := strings.TrimPrefix(p.Rel, c.GoPrefixRel+"/")
+		return path.Join(c.GoPrefix, fromPrefixRel)
 	}
-
-	return path.Join(prefix, p.Rel)
 }
 
 // firstGoFile returns the name of a .go file if the package contains at least

--- a/go/tools/gazelle/packages/package_test.go
+++ b/go/tools/gazelle/packages/package_test.go
@@ -17,78 +17,12 @@ package packages
 
 import (
 	"fmt"
-	"path"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/bazelbuild/rules_go/go/tools/gazelle/config"
 )
-
-func TestImportPath(t *testing.T) {
-	prefix := "example.com/repo"
-	for _, tc := range []struct {
-		name, rel, prefix, want string
-	}{
-		{
-			name: "simple_vendor",
-			rel:  "vendor/foo/bar",
-			want: "foo/bar",
-		}, {
-			name: "empty_vendor",
-			rel:  "vendor",
-			want: "",
-		}, {
-			name: "multi_vendor",
-			rel:  "vendor/foo/vendor/bar",
-			want: "bar",
-		}, {
-			name: "prefix",
-			rel:  "foo/bar",
-			want: "example.com/repo/foo/bar",
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			pkg := Package{
-				Name: path.Base(tc.rel),
-				Rel:  tc.rel,
-				Library: GoTarget{
-					Sources: PlatformStrings{
-						Generic: []string{"a.go"},
-					},
-				},
-			}
-			if got := pkg.ImportPath(prefix); got != tc.want {
-				t.Errorf("%s: got %q ; want %q", tc.name, got, tc.want)
-			}
-		})
-	}
-}
-
-func TestImportPathNoLib(t *testing.T) {
-	pkg := Package{
-		Name: "bar",
-		Rel:  "foo/bar",
-	}
-	if got, want := pkg.ImportPath("example.com/repo"), "example.com/repo/foo/bar"; got != want {
-		t.Errorf(`got %q; want %q`, got, want)
-	}
-}
-
-func TestImportPathCmd(t *testing.T) {
-	pkg := Package{
-		Name: "main",
-		Rel:  "foo/bar",
-		Library: GoTarget{
-			Sources: PlatformStrings{
-				Generic: []string{"main.go"},
-			},
-		},
-	}
-	if got, want := pkg.ImportPath("example.com/repo"), "example.com/repo/foo/bar"; got != want {
-		t.Errorf(`got %q; want %q`, got, want)
-	}
-}
 
 func TestAddPlatformStrings(t *testing.T) {
 	c := &config.Config{}


### PR DESCRIPTION
Gazelle now supports '# gazelle:prefix <prefix>' directives in build
files. Such a directive will set the Go importpath prefix for rules in
that directory and in subdirectories.

Prefixes may be empty, but rules cannot be generated in a directory
where the prefix is set to the empty string (an error will be
reported).

Fixes bazelbuild/bazel-gazelle#6