### PR TITLE
Gazelle: allow directives in top-level comments anywhere in file

### DIFF
--- a/go/tools/gazelle/config/directives.go
+++ b/go/tools/gazelle/config/directives.go
@@ -53,7 +53,6 @@ var knownTopLevelDirectives = map[string]bool{
 // out of place (after the first statement).
 func ParseDirectives(f *bf.File) []Directive {
 	var directives []Directive
-	beforeStmt := true
 	parseComment := func(com bf.Comment) {
 		match := directiveRe.FindStringSubmatch(com.Token)
 		if match == nil {
@@ -64,21 +63,12 @@ func ParseDirectives(f *bf.File) []Directive {
 			log.Printf("%s:%d: unknown directive: %s", f.Path, com.Start.Line, com.Token)
 			return
 		}
-		if !beforeStmt {
-			log.Printf("%s:%d: top-level directive may not appear after the first statement", f.Path, com.Start.Line)
-			return
-		}
 		directives = append(directives, Directive{key, value})
 	}
 
 	for _, s := range f.Stmt {
 		coms := s.Comment()
 		for _, com := range coms.Before {
-			parseComment(com)
-		}
-		_, isComment := s.(*bf.CommentBlock)
-		beforeStmt = beforeStmt && isComment
-		for _, com := range coms.Suffix {
 			parseComment(com)
 		}
 		for _, com := range coms.After {

--- a/go/tools/gazelle/config/directives_test.go
+++ b/go/tools/gazelle/config/directives_test.go
@@ -43,6 +43,8 @@ foo(
 			want: []Directive{
 				{"ignore", "top"},
 				{"ignore", "before"},
+				{"ignore", "after"},
+				{"ignore", "bottom"},
 			},
 		},
 	} {

--- a/go/tools/gazelle/merger/merger_test.go
+++ b/go/tools/gazelle/merger/merger_test.go
@@ -129,7 +129,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 		previous: `
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 # gazelle:ignore`,
-		ignore: false,
+		ignore: true,
 	}, {
 		desc: "merge dicts",
 		previous: `


### PR DESCRIPTION
Previously, directives were restricted to comments before the first
statement, including load statements. This was awkward and prevented
directives from being written contextually.