### PR TITLE
Gazelle: fix deletion of rules with deps

### DIFF
--- a/go/tools/gazelle/gazelle/main.go
+++ b/go/tools/gazelle/gazelle/main.go
@@ -131,6 +131,7 @@ func run(c *config.Config, cmd command, emit emitFunc) {
 			visits = append(visits, visitRecord{
 				pkgRel: rel,
 				rules:  rules,
+				empty:  empty,
 				file:   file,
 			})
 		}
@@ -145,7 +146,7 @@ func run(c *config.Config, cmd command, emit emitFunc) {
 		for j := range visits[i].rules {
 			visits[i].rules[j] = resolver.ResolveRule(visits[i].rules[j], visits[i].pkgRel)
 		}
-		visits[i].file, _ = merger.MergeFile(visits[i].rules, nil, visits[i].file, merger.MergeableResolvedAttrs)
+		visits[i].file, _ = merger.MergeFile(visits[i].rules, visits[i].empty, visits[i].file, merger.MergeableResolvedAttrs)
 	}
 
 	// Emit merged files.

--- a/go/tools/gazelle/resolve/index.go
+++ b/go/tools/gazelle/resolve/index.go
@@ -308,7 +308,7 @@ func (ix *RuleIndex) findRuleByImport(imp importSpec, lang config.Language, from
 
 	if imp.lang == config.ProtoLang && lang == config.GoLang {
 		importpath := bestMatch.rule.AttrString("importpath")
-		if betterMatch, err := ix.findRuleByImport(importSpec{config.GoLang, importpath}, config.GoLang, fromRel); err != nil {
+		if betterMatch, err := ix.findRuleByImport(importSpec{config.GoLang, importpath}, config.GoLang, fromRel); err == nil {
 			return betterMatch, nil
 		}
 	}

--- a/go/tools/gazelle/resolve/resolve_test.go
+++ b/go/tools/gazelle/resolve/resolve_test.go
@@ -246,7 +246,7 @@ go_library(
 		t.Errorf("resolveProto: got %s ; want %s", got, wantProto)
 	}
 
-	wantGoProto := Label{Pkg: "sub", Name: "foo_go_proto"}
+	wantGoProto := Label{Pkg: "sub", Name: "embed"}
 	if got, err := r.resolveGoProto("sub/bar.proto", "baz"); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(got, wantGoProto) {


### PR DESCRIPTION
Rules are deleted after they are merged with empty rules produced by
the generator when they have no attributes other than "name" and
"visibility".
    
An earlier change split merging into two phases: everything except
"deps", and then "deps".
    
With this change, both merge phases have a chance to delete
rules. This means that rules that had deps but are now empty will be
deleted.

Fixes bazelbuild/bazel-gazelle#22