### PR TITLE
Use bazel-gazelle instead of go/tools/gazelle everywhere

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,6 +25,7 @@ lines_sorted_test(
 
 gazelle(
     name = "gazelle",
+    prefix = "github.com/bazelbuild/rules_go",
 )
 
 # This could be any file, used as an anchor point for the directory in tests
@@ -42,7 +43,6 @@ go_path(
         "//go/tools/builders:link",
         "//go/tools/builders:md5sum",
         "//go/tools/fetch_repo",
-        "//go/tools/gazelle/gazelle",
         "//go/tools/wtool",
     ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,6 +3,9 @@ load("@io_bazel_rules_go//go/private:tools/lines_sorted_test.bzl", "lines_sorted
 load("@io_bazel_rules_go//go/private:rules/info.bzl", "go_info")
 load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_google_protobuf")
 
+# gazelle:prefix github.com/bazelbuild/rules_go
+
+# TODO(jayconrod): remove when nothing depends on this.
 go_prefix("github.com/bazelbuild/rules_go")
 
 go_google_protobuf()
@@ -25,7 +28,6 @@ lines_sorted_test(
 
 gazelle(
     name = "gazelle",
-    prefix = "github.com/bazelbuild/rules_go",
 )
 
 # This could be any file, used as an anchor point for the directory in tests

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Go rules for Bazel_
   :target: https://travis-ci.org/bazelbuild/rules_go
 .. |jenkins| image:: http://ci.bazel.io/buildStatus/icon?job=PR/rules_go
   :target: http://ci.bazel.io/view/Bazel%20bootstrap%20and%20maintenance/job/PR/job/rules_go/
-.. _gazelle: go/tools/gazelle/README.rst
+.. _gazelle: https://github.com/bazelbuild/bazel-gazelle
 .. _vendoring: Vendoring.md
 .. _protocol buffers: proto/core.rst
 .. _go_repository: go/workspace.rst#go_repository
@@ -34,6 +34,10 @@ Travis   Jenkins
 Announcements
 -------------
 
+December 14, 2017
+  Gazelle has moved to a new repository,
+  `github.com/bazelbuild/bazel-gazelle <https://github.com/bazelbuild/bazel-gazelle>`_.
+  Please try it out and let us know what you think.
 December 13, 2017
   Release `0.8.1 <https://github.com/bazelbuild/rules_go/releases/tag/0.8.1>`_
   is now available.
@@ -90,7 +94,7 @@ The ``master`` branch is only guaranteed to work with the latest version of Baze
 Setup
 -----
 
-* Create a file at the top of your repository named `WORKSPACE` and add one
+* Create a file at the top of your repository named WORKSPACE and add one
   of the snippets below, verbatim. This will let Bazel fetch necessary
   dependencies from this repository and a few others.
 
@@ -145,24 +149,34 @@ Generating build files
 ~~~~~~~~~~~~~~~~~~~~~~
 
 If your project can be built with ``go build``, you can generate and update your
-build files automatically using gazelle_, a tool included in this repository.
+build files automatically using gazelle_.
 
-* Add the code below to the ``BUILD.bazel`` file in your repository's
-  root directory. Replace the ``prefix`` string with the prefix you chose for
-  your project earlier.
+* Add the code below to your WORKSPACE file *after* ``io_bazel_rules_go`` and
+  its dependencies are loaded.
 
-  .. code:: bzl
+.. code:: bzl
 
-    load("@io_bazel_rules_go//go:def.bzl", "gazelle")
-
-    gazelle(
-        name = "gazelle",
-        prefix = "github.com/example/project",
+    http_archive(
+        name = "bazel_gazelle",
+        url = "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.8/bazel-gazelle-0.8.tar.gz",
+        sha256 = "e3dadf036c769d1f40603b86ae1f0f90d11837116022d9b06e4cd88cae786676",
     )
+    load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+    gazelle_dependencies()
+    
+* Add the code below to the BUILD or BUILD.bazel file in the root directory
+  of your repository. Replace the string in ``prefix`` with the prefix you
+  chose for your project earlier.
 
-* If your project uses vendoring, add ``external = "vendored",`` below the
-  ``prefix`` line.
+.. code:: bzl
 
+  load("@bazel_gazelle//:def.bzl", "gazelle")
+
+  gazelle(
+      name = "gazelle",
+      prefix = "github.com/example/project",
+  )
+    
 * After adding the ``gazelle`` rule, run the command below:
 
   ::

--- a/Vendoring.md
+++ b/Vendoring.md
@@ -29,7 +29,7 @@ The other option for using external libraries is to import them in your
 the [`go_repository`](go/workspace.rst#go_repository) rule to import
 repositories that conform to the normal Go directory conventions. This is
 similar to `new_git_repository`, but it automatically generates `BUILD` files
-for you using [gazelle](go/tools/gazelle/README.rst).
+for you using [gazelle](https://github.com/bazelbuild/bazel-gazelle).
 
 You can use [`go_repository`](go/workspace.rst#go_repository) if the project
 you're importing already has `BUILD` files. This is like `git_repository` but it

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -32,6 +32,15 @@ def go_rules_dependencies():
       type = "zip",
   )
 
+  # New location of Gazelle. Needed by go_repository.
+  # TODO(jayconrod): delete this dependency after we've deleted go_repository
+  # or moved it into bazel_gazelle.
+  _maybe(native.http_archive,
+      name = "bazel_gazelle",
+      url = "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.8/bazel-gazelle-0.8.tar.gz",
+      sha256 = "e3dadf036c769d1f40603b86ae1f0f90d11837116022d9b06e4cd88cae786676",
+  )
+
   # Needed for fetch repo
   _maybe(go_repository,
       name = "org_golang_x_tools",

--- a/go/private/tools/gazelle.bzl
+++ b/go/private/tools/gazelle.bzl
@@ -24,6 +24,8 @@ $BASE/{gazelle} {args} $@
 """
 
 def _gazelle_script_impl(ctx):
+  # TODO(jayconrod): add a fix to Gazelle to replace invocations of this rule
+  # with the new one in @bazel_gazelle. Once in place, fail here.
   prefix = ctx.attr.prefix if ctx.attr.prefix else ctx.attr._go_prefix.go_prefix
   args = [ctx.attr.command]
   args += [
@@ -58,7 +60,7 @@ _gazelle_script = rule(
         "args": attr.string_list(),
         "prefix": attr.string(),
         "_gazelle": attr.label(
-            default = Label("@io_bazel_rules_go//go/tools/gazelle/gazelle:gazelle"),
+            default = Label("@bazel_gazelle//cmd/gazelle"),
             allow_files = True,
             single_file = True,
             executable = True,

--- a/go/tools/gazelle/README.rst
+++ b/go/tools/gazelle/README.rst
@@ -1,3 +1,11 @@
+Announcements
+=============
+
+December 14, 2017
+  Gazelle has moved to a new repository, 
+  `github.com/bazelbuild/bazel-gazelle <https://github.com/bazelbuild/bazel-gazelle>`_.
+  This subtree will be removed soon.
+
 Gazelle build file generator
 ============================
 

--- a/go/tools/wtool/BUILD.bazel
+++ b/go/tools/wtool/BUILD.bazel
@@ -5,9 +5,8 @@ go_binary(
     srcs = ["main.go"],
     visibility = ["//visibility:public"],
     deps = [
-        "//go/tools/gazelle/resolve:go_default_library",
-        "//go/tools/gazelle/rules:go_default_library",
-        "//go/tools/gazelle/wspace:go_default_library",
+        "@bazel_gazelle//resolve:go_default_library",
+        "@bazel_gazelle//wspace:go_default_library",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
         "@org_golang_x_tools//go/vcs:go_default_library",
     ],

--- a/go/tools/wtool/main.go
+++ b/go/tools/wtool/main.go
@@ -26,9 +26,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/bazelbuild/bazel-gazelle/resolve"
+	"github.com/bazelbuild/bazel-gazelle/wspace"
 	bf "github.com/bazelbuild/buildtools/build"
-	"github.com/bazelbuild/rules_go/go/tools/gazelle/resolve"
-	"github.com/bazelbuild/rules_go/go/tools/gazelle/wspace"
 	"golang.org/x/tools/go/vcs"
 )
 

--- a/tests/bazel_tests.bzl
+++ b/tests/bazel_tests.bzl
@@ -159,9 +159,9 @@ def bazel_test(name, command = None, args=None, targets = None, go_version = Non
       srcs = [":" + script_name],
       tags = ["local", "bazel", "exclusive"] + tags,
       data = [
+          "@bazel_gazelle//cmd/gazelle",
           "@bazel_test//:bazelrc",
           "//tests:rules_go_deps",
-          "//go/tools/gazelle/gazelle",
       ],
   )
 

--- a/tests/build_with_old_sdk/BUILD.bazel
+++ b/tests/build_with_old_sdk/BUILD.bazel
@@ -10,7 +10,6 @@ go_test(
         "new_test.go",
         "old_test.go",
     ],
-    data = ["@io_bazel_rules_go//go/tools/gazelle/gazelle:gazelle"],
     tags = ["manual"],
 )
 


### PR DESCRIPTION
* go_repository uses new Gazelle. @bazel_gazelle added to
  go_rules_dependencies() until go_repository is moved to
  @bazel_gazelle or removed.
* gazelle rule uses new Gazelle, but users should migrate to new
  gazelle rule in @bazel_gazelle//:def.bzl.
* README.rst and Vendoring.md point to new Gazelle.
* wtool and tests/bazel_tests.bzl also updated. Data dependency
  removed from build_with_old_sdk test (why was it there?).
* Old Gazelle left in place for now.