### PR TITLE
deptool

### DIFF
--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -141,6 +141,18 @@ def go_rules_dependencies():
       commit = "a0ff2567cfb70903282db057e799fd826784d41d",
   )
 
+  _maybe(go_repository,
+      name = "com_github_pelletier_go_buffruneio",
+      importpath = "github.com/pelletier/go-buffruneio",
+      commit = "c37440a7cf42ac63b919c752ca73a85067e05992",
+  )
+
+  _maybe(go_repository,
+      name = "com_github_pelletier_go_toml",
+      importpath = "github.com/pelletier/go-toml",
+      commit = "5ccdfb18c776b740aecaf085c4d9a2779199c279",
+  )
+
 
 def _maybe(repo_rule, name, **kwargs):
   if name not in native.existing_rules():

--- a/go/tools/deptool/BUILD.bazel
+++ b/go/tools/deptool/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/bazelbuild/rules_go/go/tools/deptool",
+    visibility = ["//visibility:private"],
+    deps = ["@com_github_pelletier_go_toml//:go_default_library"],
+)
+
+go_binary(
+    name = "deptool",
+    embed = [":go_default_library"],
+    importpath = "github.com/bazelbuild/rules_go/go/tools/deptool",
+    visibility = ["//visibility:public"],
+)

--- a/go/tools/deptool/main.go
+++ b/go/tools/deptool/main.go
@@ -1,0 +1,96 @@
+/*
+deptool generates vendor.bzl file base on Gopkg.lock.
+Gopkg.lock can be generated with:
+  dep ensure -no-vendor
+
+Example Usage:
+  deptool -lock Gopkg.lock -vendor vendor.bzl
+
+In WORKSPACE add this:
+  load("//:vendor.bzl", "vendor_install")
+  vendor_install()
+*/
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/pelletier/go-toml"
+)
+
+const (
+	vendorTmpl = `# Install Go vendored libs
+#
+# Generated from Gopkg.lock
+load("@io_bazel_rules_go//go:def.bzl", "go_repository")
+
+def vendor_install():
+{{range .Projects}}{{$repo := repoName .Name}}
+  if "{{$repo}}" not in native.existing_rules():
+    go_repository(
+        name = "{{$repo}}",
+        importpath = "{{.Name}}",
+        commit = "{{.Revision}}",
+    )
+{{end}}
+`
+)
+
+type rawLock struct {
+	Projects []rawLockedProject `toml:"projects"`
+}
+
+type rawLockedProject struct {
+	Name     string `toml:"name"`
+	Revision string `toml:"revision"`
+}
+
+func repoName(importpath string) string {
+	components := strings.Split(importpath, "/")
+	labels := strings.Split(components[0], ".")
+	var reversed []string
+	for i := range labels {
+		l := labels[len(labels)-i-1]
+		reversed = append(reversed, l)
+	}
+	repo := strings.Join(append(reversed, components[1:]...), "_")
+	return strings.NewReplacer("-", "_", ".", "_").Replace(repo)
+}
+
+func main() {
+	var lockPath string
+	var vendor string
+	flag.StringVar(&lockPath, "lock", "Gopkg.lock", "Gopkg.lock file")
+	flag.StringVar(&vendor, "vendor", "vendor.bzl", "vendor.bzl file")
+	flag.Parse()
+
+	tree, err := toml.LoadFile(lockPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var lock rawLock
+	err = tree.Unmarshal(&lock)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	output, err := os.Create(vendor)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer output.Close()
+
+	funcs := template.FuncMap{
+		"repoName": repoName,
+	}
+
+	tmpl := template.Must(template.New("vendor").Funcs(funcs).Parse(vendorTmpl))
+	if err := tmpl.Execute(output, lock); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
`deptool` generates `vendor.bzl` file based on `Gopkg.lock`. `Gopkg.lock` can be generated with: `dep ensure -no-vendor`.

Example Usage:
```
   deptool -lock Gopkg.lock -vendor vendor.bzl
```

In `WORKSPACE` add this:
```
    load("//:vendor.bzl", "vendor_install")
    vendor_install()
```
`vendor.bzl` looks like this:
```
# Install Go vendored libs
#
# Generated from Gopkg.lock
load("@io_bazel_rules_go//go:def.bzl", "go_repository")

def vendor_install():
  if "com_github_golang_protobuf" not in native.existing_rules():
    go_repository(
        name = "com_github_golang_protobuf",
        importpath = "github.com/golang/protobuf",
        commit = "ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e",
    )
```