### PR TITLE
Adjust Travis CI config

### DIFF
--- a/.test-bazelrc
+++ b/.test-bazelrc
@@ -1,4 +1,0 @@
-# This file contains options passed to Bazel when running tests.
-# They are used by Travis CI and by non-Bazel test scripts.
-build --verbose_failures --sandbox_debug --test_output=errors --spawn_strategy=standalone --genrule_strategy=standalone
-test --test_strategy=standalone

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,8 +52,8 @@ script:
       --batch \
       --host_jvm_args=-Xmx500m \
       --host_jvm_args=-Xms500m \
-      --bazelrc=.test-bazelrc \
       test \
+      --config=ci \
       --experimental_repository_cache="$HOME/.bazel_repository_cache" \
       --local_resources=400,1,1.0 \
       --test_tag_filters=-dev \

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,0 +1,11 @@
+# This file contains options passed to Bazel when running tests
+# on continuous integration services.
+# Run with: bazel test --config=ci
+
+common:ci --color=no
+build:ci --verbose_failures
+build:ci --sandbox_debug
+build:ci --spawn_strategy=standalone
+build:ci --genrule_strategy=standalone
+test:ci --test_strategy=standalone
+test:ci --test_output=errors


### PR DESCRIPTION
* Move configuration to tools/bazel.rc so that Bazel finds it
  automatically.
* Use --config=ci.
* Add --color=no; color makes Travis raw logs unreadable, and the
  regular logs are too big.