### PR TITLE
Check Bazel version in def.bzl

### DIFF
--- a/go/def.bzl
+++ b/go/def.bzl
@@ -57,8 +57,6 @@ load("@io_bazel_rules_go//go/private:tools/path.bzl",
 load("@io_bazel_rules_go//go/private:tools/vet.bzl",
     _go_vet_test = "go_vet_test",
 )
-load("@io_bazel_rules_go//go/private:common.bzl",
-    _check_version = "check_version")
 
 # Current version or next version to be tagged. Gazelle and other tools may
 # check this to determine compatibility.
@@ -118,6 +116,3 @@ def go_repositories(
   else:
     go_register_toolchains()
 
-_MINIMUM_BAZEL_VERSION = "0.8.0"
-
-_check_version(_MINIMUM_BAZEL_VERSION)

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -57,6 +57,8 @@ load("@io_bazel_rules_go//go/private:tools/path.bzl",
 load("@io_bazel_rules_go//go/private:tools/vet.bzl",
     _go_vet_test = "go_vet_test",
 )
+load("@io_bazel_rules_go//go/private:common.bzl",
+    _check_version = "check_version")
 
 # Current version or next version to be tagged. Gazelle and other tools may
 # check this to determine compatibility.
@@ -116,3 +118,6 @@ def go_repositories(
   else:
     go_register_toolchains()
 
+_MINIMUM_BAZEL_VERSION = "0.8.0"
+
+_check_version(_MINIMUM_BAZEL_VERSION)

--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -119,6 +119,8 @@ def to_set(v):
     fail("Do not pass a depset to to_set")
   return depset(v)
 
+MINIMUM_BAZEL_VERSION = "0.8.0"
+
 # _parse_bazel_version and check_version copied from
 # github.com/tensorflow/tensorflow/blob/cfd0d3f2aa24b3078d2e79ad0a212c7c53916de9/tensorflow/workspace.bzl
 

--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -119,3 +119,34 @@ def to_set(v):
     fail("Do not pass a depset to to_set")
   return depset(v)
 
+# _parse_bazel_version and check_version copied from
+# github.com/tensorflow/tensorflow/blob/cfd0d3f2aa24b3078d2e79ad0a212c7c53916de9/tensorflow/workspace.bzl
+
+# Parse the bazel version string from `native.bazel_version`.
+def _parse_bazel_version(bazel_version):
+  # Remove commit from version.
+  version = bazel_version.split(" ", 1)[0]
+  # Split into (release, date) parts and only return the release
+  # as a tuple of integers.
+  parts = version.split("-", 1)
+  # Turn "release" into a tuple of strings
+  version_tuple = ()
+  for number in parts[0].split("."):
+    version_tuple += (str(number),)
+  return version_tuple
+
+# Check that a specific bazel version is being used.
+def check_version(bazel_version):
+  if "bazel_version" not in dir(native):
+    fail("\nCurrent Bazel version is lower than 0.2.1, expected at least %s\n" %
+         bazel_version)
+  elif not native.bazel_version:
+    print("\nCurrent Bazel is not a release version, cannot check for " +
+          "compatibility.")
+    print("Make sure that you are running at least Bazel %s.\n" % bazel_version)
+  else:
+    current_bazel_version = _parse_bazel_version(native.bazel_version)
+    minimum_bazel_version = _parse_bazel_version(bazel_version)
+    if minimum_bazel_version > current_bazel_version:
+      fail("\nCurrent Bazel version is {}, expected at least {}\n".format(
+          native.bazel_version, bazel_version))

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -14,6 +14,7 @@
 
 # Once nested repositories work, this file should cease to exist.
 
+load("@io_bazel_rules_go//go/private:common.bzl", "check_version", "MINIMUM_BAZEL_VERSION")
 load("@io_bazel_rules_go//go/private:repository_tools.bzl", "go_repository_tools")
 load("@io_bazel_rules_go//go/private:go_repository.bzl", "go_repository")
 load('@io_bazel_rules_go//go/private:rules/stdlib.bzl', "go_stdlib")
@@ -22,6 +23,8 @@ load("@io_bazel_rules_go//go/platform:list.bzl", "GOOS_GOARCH")
 
 def go_rules_dependencies():
   """See /go/workspace.rst#go-rules-dependencies for full documentation."""
+
+  check_version(MINIMUM_BAZEL_VERSION)
 
   # Needed for gazelle and wtool
   _maybe(native.http_archive,


### PR DESCRIPTION
When def.bzl is loaded, it will parse native.bazel_version and compare
against a defined minimum.

The implementation for this is borrowed from TensorFlow. k8s also uses
this.

Fixes #1108