### PR TITLE
Add github.com/mwitkow/go-proto-validators

### DIFF
--- a/examples/proto/embed/BUILD.bazel
+++ b/examples/proto/embed/BUILD.bazel
@@ -12,6 +12,10 @@ go_proto_library(
     # Note that if you forget the importpath everything will break horribly.
     importpath = "github.com/bazelbuild/rules_go/examples/proto/embed",
     proto = ":embed_proto",
+    compilers = [
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_proto_validate",
+    ],
     deps = [
         "@com_github_golang_protobuf//ptypes/any:go_default_library",
     ],

--- a/examples/proto/proto_test.go
+++ b/examples/proto/proto_test.go
@@ -35,3 +35,9 @@ func TestEmbed(t *testing.T) {
 		t.Errorf("Unable to call method from embedded go files")
 	}
 }
+
+func TestValidate(t *testing.T) {
+	if err := embed.OtherThing().Validate(); err != nil {
+		t.Errorf("Proto did not pass validation")
+	}
+}

--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -47,7 +47,7 @@ def emit_archive(go, source=None):
   runfiles = source.runfiles
   for a in direct:
     runfiles = runfiles.merge(a.runfiles)
-    if a.source.mode != go.mode: fail("Archive mode does not match {} is {} expected {}".format(a.data.source.library.label, mode_string(a.source.mode), mode_string(go.mode)))
+    if a.source.mode != go.mode: fail("Archive mode does not match {} is {} expected {}".format(a.data.label, mode_string(a.source.mode), mode_string(go.mode)))
 
   if len(extra_objects) == 0 and source.cgo_archive == None:
     go.compile(go,

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -101,6 +101,20 @@ def go_rules_dependencies():
       strip_prefix = "protobuf-2761122b810fe8861004ae785cc3ab39f384d342",
       type = "zip",
   )
+  _maybe(go_repository,
+      name = "com_github_mwitkow_go_proto_validators",
+      importpath = "github.com/mwitkow/go-proto-validators",
+      commit = "a55ca57f374a8846924b030f534d8b8211508cf0",  # master, as of 2017-11-24
+      build_file_proto_mode="disable",
+  )
+  _maybe(go_repository,
+      name = "com_github_gogo_protobuf",
+      importpath = "github.com/gogo/protobuf",
+      urls = ["https://codeload.github.com/ianthehat/protobuf/zip/41168f6614b7bb144818ec8967b8c702705df564"],
+      strip_prefix = "protobuf-41168f6614b7bb144818ec8967b8c702705df564",
+      type = "zip",
+      build_file_proto_mode="disable",
+  )
 
   # Only used by deprecated go_proto_library implementation
   _maybe(native.http_archive,

--- a/go/private/rules/aspect.bzl
+++ b/go/private/rules/aspect.bzl
@@ -61,7 +61,7 @@ def _go_archive_aspect_impl(target, ctx):
 
 go_archive_aspect = aspect(
     _go_archive_aspect_impl,
-    attr_aspects = ["deps", "embed", "compiler"],
+    attr_aspects = ["deps", "embed", "compiler", "compilers"],
     attrs = {
         "pure": attr.string(values=["on", "off", "auto"]),
         "static": attr.string(values=["on", "off", "auto"]),

--- a/go/tools/builders/protoc.go
+++ b/go/tools/builders/protoc.go
@@ -140,7 +140,7 @@ func run(args []string) error {
 				return err
 			}
 		case !f.expected:
-			fmt.Fprintf(buf, "Unexpected output %v.\n", f.path)
+			//fmt.Fprintf(buf, "Unexpected output %v.\n", f.path)
 		}
 		if buf.Len() > 0 {
 			fmt.Fprintf(buf, "Check that the go_package option is %q.", *importpath)

--- a/go/tools/builders/protoc.go
+++ b/go/tools/builders/protoc.go
@@ -94,7 +94,7 @@ func run(args []string) error {
 	}
 	// Walk the generated files
 	filepath.Walk(*outPath, func(path string, f os.FileInfo, err error) error {
-		if !strings.HasSuffix(path, ".pb.go") {
+		if !strings.HasSuffix(path, ".go") {
 			return nil
 		}
 		info := files[path]

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -18,3 +18,15 @@ go_proto_compiler(
         "@org_golang_x_net//context:go_default_library",
     ],
 )
+
+go_proto_compiler(
+    name = "go_proto_validate",
+    plugin = "@com_github_mwitkow_go_proto_validators//protoc-gen-govalidators",
+    visibility = ["//visibility:public"],
+    suffix = ".validator.pb.go",
+    valid_archive = False,
+    deps = [
+        "@com_github_golang_protobuf//proto:go_default_library",
+    ],
+)
+

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -87,6 +87,7 @@ def _go_proto_compiler_impl(ctx):
           go_protoc = ctx.file._go_protoc,
           protoc = ctx.file._protoc,
           plugin = ctx.file.plugin,
+          valid_archive = ctx.attr.valid_archive,
       ),
       library, source,
   ]
@@ -97,6 +98,7 @@ go_proto_compiler = rule(
         "deps": attr.label_list(providers = [GoLibrary]),
         "options": attr.string_list(),
         "suffix": attr.string(default = ".pb.go"),
+        "valid_archive": attr.bool(default=True),
         "plugin": attr.label(
             allow_files = True,
             single_file = True,


### PR DESCRIPTION
This both adds a go_proto_compiler rule for
github.com/mwitkow/go-proto-validators and also adds support for
go_proto_libraries that are incomplete (not compilable to a package) and also
running multiple compilers to generate a single package (so you can use the
validator alongside any other compiler)

Work for #992 and #1139