### PR TITLE
protoc: only present import_path when using protoc-gen-go

### DIFF
--- a/go/tools/builders/protoc.go
+++ b/go/tools/builders/protoc.go
@@ -58,7 +58,9 @@ func run(args []string) error {
 	}
 	pluginBase := filepath.Base(*plugin)
 	pluginName := strings.TrimPrefix(filepath.Base(*plugin), "protoc-gen-")
-	options = append(options, fmt.Sprintf("import_path=%v", *importpath))
+	if pluginName == "go" {
+		options = append(options, fmt.Sprintf("import_path=%v", *importpath))
+	}
 	for _, m := range imports {
 		options = append(options, fmt.Sprintf("M%v", m))
 	}


### PR DESCRIPTION
This is an attempt on fixing #1139, which makes it possible to add grpc-gateway protoc compiler.