### PR TITLE
proto: Add grpc-gateway compiler

### DIFF
--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -17,8 +17,8 @@
 load("@io_bazel_rules_go//go/private:common.bzl", "check_version", "MINIMUM_BAZEL_VERSION")
 load("@io_bazel_rules_go//go/private:repository_tools.bzl", "go_repository_tools")
 load("@io_bazel_rules_go//go/private:go_repository.bzl", "go_repository")
-load('@io_bazel_rules_go//go/private:rules/stdlib.bzl', "go_stdlib")
-load('@io_bazel_rules_go//go/toolchain:toolchains.bzl', "go_register_toolchains")
+load("@io_bazel_rules_go//go/private:rules/stdlib.bzl", "go_stdlib")
+load("@io_bazel_rules_go//go/toolchain:toolchains.bzl", "go_register_toolchains")
 load("@io_bazel_rules_go//go/platform:list.bzl", "GOOS_GOARCH")
 load("@io_bazel_rules_go//proto:gogo.bzl", "gogo_special_proto")
 
@@ -118,6 +118,12 @@ def go_rules_dependencies():
   )
   _maybe(gogo_special_proto,
       name = "gogo_special_proto",
+  )
+  _maybe(go_repository,
+      name = "com_github_grpc_ecosystem_grpc_gateway",
+      importpath = "github.com/grpc-ecosystem/grpc-gateway",
+      tag = "v1.3.1",  # lastest as of 2018-01-10
+      build_file_proto_mode="disable",
   )
 
   # Only used by deprecated go_proto_library implementation

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -45,6 +45,32 @@ go_proto_compiler(
     ],
 )
 
+GRPC_GATEWAY_GOOGLE_API_TYPE_REMAPS = [
+    "Mgoogle/api/{}.proto=google.golang.org/genproto/googleapis/api/annotations".format(t)
+    for t in [
+        "annotations",
+        "http",
+    ]
+]
+
+go_proto_compiler(
+    name = "go_grpc_gateway",
+    options = GRPC_GATEWAY_GOOGLE_API_TYPE_REMAPS,
+    plugin = "@com_github_grpc_ecosystem_grpc_gateway//protoc-gen-grpc-gateway",
+    suffix = ".pb.gw.go",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_golang_protobuf//proto:go_default_library",
+        "@com_github_grpc_ecosystem_grpc_gateway//runtime:go_default_library",
+        "@com_github_grpc_ecosystem_grpc_gateway//utilities:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes:go_default_library",
+        "@org_golang_google_grpc//grpclog:go_default_library",
+        "@org_golang_google_grpc//status:go_default_library",
+        "@org_golang_x_net//context:go_default_library",
+    ],
+)
+
 GOGO_VARIANTS = [
     "combo",
     "gofast",


### PR DESCRIPTION
Add grpc-gateway compiler in //proto (#992 and #1139).

This CL is a working prototype.  I'll add tests if this direction looks good.