### PR TITLE
Miscelaneous windows fixes

### DIFF
--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -103,15 +103,16 @@ def env_execute(ctx, arguments, environment = {}, **kwargs):
   are removed from the environment. This should be preferred to "ctx.execut"e
   in most situations.
   """
-  if not ctx.os.name.startswith('windows'):
-    env_args = ["env", "-i"]
-    environment = dict(environment)
-    for var in ["TMP", "TMPDIR"]:
-      if var in ctx.os.environ and not var in environment:
-        environment[var] = ctx.os.environ[var]
-    for k, v in environment.items():
-      env_args.append("%s=%s" % (k, v))
-    arguments = env_args + arguments
+  if ctx.os.name.startswith('windows'):
+    return ctx.execute(arguments, environment=environment, **kwargs)
+  env_args = ["env", "-i"]
+  environment = dict(environment)
+  for var in ["TMP", "TMPDIR"]:
+    if var in ctx.os.environ and not var in environment:
+      environment[var] = ctx.os.environ[var]
+  for k, v in environment.items():
+    env_args.append("%s=%s" % (k, v))
+  arguments = env_args + arguments
   return ctx.execute(arguments, **kwargs)
 
 def to_set(v):

--- a/tests/bazel_tests.bzl
+++ b/tests/bazel_tests.bzl
@@ -210,10 +210,13 @@ def _test_environment_impl(ctx):
     bazel = ctx.which("bazel")
 
   # Get a temporary directory to use as our scratch workspace
-  result = env_execute(ctx, ["mktemp", "-d"])
-  if result.return_code:
-    fail("failed to create temporary directory for bazel tests: {}".format(result.stderr))
-  scratch_dir = result.stdout.strip()
+  if ctx.os.name.startswith('windows'):
+    scratch_dir = ctx.os.environ["TMP"].replace("\\","/") + "/bazel_go_test"
+  else:
+    result = env_execute(ctx, ["mktemp", "-d"])
+    if result.return_code:
+      fail("failed to create temporary directory for bazel tests: {}".format(result.stderr))
+    scratch_dir = result.stdout.strip()
 
   # Work out where we are running so we can find externals
   exec_root, _, _ = str(ctx.path(".")).rpartition("/external/")


### PR DESCRIPTION
Set the environment correctly in env_execute on windows
Force standard library compilation into pure mode for now on windows
Add the compiler path to PATH so it can find dll's
Don't try to run mktemp on windows