### PR TITLE
Windows cgo fixes.

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -49,6 +49,7 @@ def _new_args(go):
       "-root_file", go.stdlib.root_file,
       "-goos", go.mode.goos,
       "-goarch", go.mode.goarch,
+      "-compiler_path", "" if go.mode.pure else go.compiler_path,
       "-cgo=" + ("0" if go.mode.pure else "1"),
   ])
   return args
@@ -148,6 +149,10 @@ def go_context(ctx, attr=None):
   if not stdlib:
     fail("No matching standard library for "+mode_string(mode))
 
+  compiler_path = ""
+  if ctx.var.get("LD") and ctx.var.get("LD").rfind("/") > 0:
+    compiler_path, _ = ctx.var.get("LD").rsplit("/", 1)
+
   return GoContext(
       # Fields
       toolchain = toolchain,
@@ -157,6 +162,7 @@ def go_context(ctx, attr=None):
       exe_extension = goos_to_extension(mode.goos),
       crosstool = context_data.crosstool,
       package_list = context_data.package_list,
+      compiler_path = compiler_path,
       # Action generators
       archive = toolchain.actions.archive,
       asm = toolchain.actions.asm,

--- a/go/private/rules/stdlib.bzl
+++ b/go/private/rules/stdlib.bzl
@@ -82,9 +82,6 @@ def _stdlib_impl(ctx):
   if not paths.is_absolute(cc_path):
     cc_path = "$(pwd)/" + cc_path
   cgo = ctx.attr.cgo
-  # TODO: This is a temporary work around for bazel not using a gcc that can compile the stdlib on windows
-  if ctx.attr.goos == "windows":
-    cgo = False
   env = {
       "GOROOT": "$(pwd)/{}".format(goroot),
       "GOOS": ctx.attr.goos,
@@ -108,8 +105,8 @@ def _stdlib_impl(ctx):
       outputs = [go, src, pkg],
       mnemonic = "GoStdlib",
       command = " && ".join([
-          "export PATH=${PATH};${COMPILER_PATH}",
           "export " + " ".join(['{}="{}"'.format(key, value) for key, value in env.items()]),
+          "export PATH=$PATH:$(cd $COMPILER_PATH && pwd)",
           "mkdir -p {}".format(src.path),
           "mkdir -p {}".format(pkg.path),
           "cp {}/bin/{} {}".format(sdk, go.basename, go.path),

--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -28,13 +28,14 @@ type GoEnv struct {
 	// Go is the path to the go executable.
 	Go string
 	// Verbose debugging print control
-	Verbose  bool
-	rootFile string
-	rootPath string
-	cgo      bool
-	goos     string
-	goarch   string
-	tags     string
+	Verbose      bool
+	rootFile     string
+	rootPath     string
+	cgo          bool
+	compilerPath string
+	goos         string
+	goarch       string
+	tags         string
 }
 
 func abs(path string) string {
@@ -50,6 +51,7 @@ func envFlags(flags *flag.FlagSet) *GoEnv {
 	flags.StringVar(&env.Go, "go", "", "The path to the go tool.")
 	flags.StringVar(&env.rootFile, "root_file", "", "The go root file to use.")
 	flags.BoolVar(&env.cgo, "cgo", false, "The value for CGO_ENABLED.")
+	flags.StringVar(&env.compilerPath, "compiler_path", "", "The value for PATH.")
 	flags.StringVar(&env.goos, "goos", "", "The value for GOOS.")
 	flags.StringVar(&env.goarch, "goarch", "", "The value for GOARCH.")
 	flags.BoolVar(&env.Verbose, "v", false, "Enables verbose debugging prints.")
@@ -80,6 +82,7 @@ func (env *GoEnv) Env() []string {
 		fmt.Sprintf("GOOS=%s", env.goos),
 		fmt.Sprintf("GOARCH=%s", env.goarch),
 		fmt.Sprintf("CGO_ENABLED=%s", cgoEnabled),
+		fmt.Sprintf("PATH=%s", env.compilerPath),
 	}
 }
 

--- a/go/tools/builders/pack.go
+++ b/go/tools/builders/pack.go
@@ -260,7 +260,11 @@ func isObjectFile(name string) bool {
 
 func appendFiles(goenv *GoEnv, archive string, files []string) error {
 	args := append([]string{"tool", "pack", "r", archive}, files...)
+	env := os.Environ()
+	env = append(env, goenv.Env()...)
 	cmd := exec.Command(goenv.Go, args...)
-	cmd.Env = goenv.Env()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = env
 	return cmd.Run()
 }


### PR DESCRIPTION
- Pass along the compiler path, so that the compiler can find its required DLLs and tools.
- Fix the `PATH` setting in `stdlib.bzl`
  - `:` is the correct path separator
  - Reference `$COMPILER_PATH` after it's been defined
  - Convert the windows paths to bash paths (`c:/blah` contains a colon)
- Fix the env creation in `pack.go` and inherit stderr/stdout there as well.