### PR TITLE
cgo: change long filenames in cgo archives

### DIFF
--- a/go/tools/builders/pack.go
+++ b/go/tools/builders/pack.go
@@ -108,6 +108,7 @@ func extractFiles(archive string) (files []string, err error) {
 	}
 
 	var nameData []byte
+	names := make(map[string]bool)
 	for {
 		name, size, err := readMetadata(r, &nameData)
 		if err == io.EOF {
@@ -122,6 +123,8 @@ func extractFiles(archive string) (files []string, err error) {
 			}
 			continue
 		}
+		name = simpleName(name, names)
+		names[name] = true
 		if err := extractFile(r, name, size); err != nil {
 			return nil, err
 		}
@@ -256,6 +259,34 @@ func skipFile(r *bufio.Reader, size int64) error {
 
 func isObjectFile(name string) bool {
 	return strings.HasSuffix(name, ".o")
+}
+
+// simpleName returns a file name which is at most 15 characters
+// and doesn't conflict with other names. If it is not possible to choose
+// such a name, simpleName will truncate the given name to 15 characters
+func simpleName(name string, names map[string]bool) string {
+	if len(name) < 16 && !names[name] {
+		return name
+	}
+	var stem, ext string
+	if i := strings.LastIndexByte(name, '.'); i < 0 || len(name)-i >= 10 {
+		stem = name
+	} else {
+		stem = name[:i]
+		ext = name[i:]
+	}
+	for n := 0; n < 10000; n++ {
+		ns := strconv.Itoa(n)
+		stemLen := 15 - len(ext) - len(ns)
+		if stemLen > len(stem) {
+			stemLen = len(stem)
+		}
+		candidate := stem[:stemLen] + ns + ext
+		if !names[candidate] {
+			return candidate
+		}
+	}
+	return name[:15]
 }
 
 func appendFiles(goenv *GoEnv, archive string, files []string) error {

--- a/go/tools/builders/pack.go
+++ b/go/tools/builders/pack.go
@@ -275,7 +275,7 @@ func simpleName(name string, names map[string]bool) string {
 		stem = name[:i]
 		ext = name[i:]
 	}
-	for n := 0; n < 10000; n++ {
+	for n := 0; n < len(names); n++ {
 		ns := strconv.Itoa(n)
 		stemLen := 15 - len(ext) - len(ns)
 		if stemLen > len(stem) {


### PR DESCRIPTION
The Go .a format does not allow long filenames. This is not a problem
for "go build", since all the names of files in the archive are
hard-coded. In Bazel, we extract .o files from .a archives produced by
cc_library, then append them to the .a archives produced by Go. If .o
files have long names with similar prefixes, multiple entries can end
up with the same name after truncaction. Linkers don't seem to mind
this, but it's weird and is probably going to bite us some day.

This change renames files as they are extracted from the .a archive
produced by cc_library so they have "safe" names (15 or fewer
characters; no conflicts with other files in the archive).