### PR TITLE
Add _go_proto_aspect to the embed attribute of go_proto_library.

### DIFF
--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -93,7 +93,7 @@ go_proto_library = rule(
         "proto": attr.label(mandatory=True, providers=["proto"]),
         "deps": attr.label_list(providers = [GoLibrary], aspects = [_go_proto_aspect]),
         "importpath": attr.string(),
-        "embed": attr.label_list(providers = [GoLibrary]),
+        "embed": attr.label_list(providers = [GoLibrary], aspects = [_go_proto_aspect]),
         "gc_goopts": attr.string_list(),
         "compiler": attr.label(providers = [GoProtoCompiler]),
         "compilers": attr.label_list(providers = [GoProtoCompiler], default = ["@io_bazel_rules_go//proto:go_proto"]),


### PR DESCRIPTION
This aspect provides the GoProtoImports provider, which is expected on both deps and embed. The deps attribute already specifies the aspect, but embed does not.

Let me know if you want the commit message formatted a certain way or if I should have filed an issue first.