### PR TITLE
Map @bazel_tools//platforms:ppc to GOARCH ppc64le instead of ppc64

### DIFF
--- a/go/platform/list.bzl
+++ b/go/platform/list.bzl
@@ -36,8 +36,8 @@ GOARCH = {
     "mips64": None,
     "mips64le": None,
     "mipsle": None,
-    "ppc64": "@bazel_tools//platforms:ppc",
-    "ppc64le": None,
+    "ppc64": None,
+    "ppc64le": "@bazel_tools//platforms:ppc",
     "s390x": "@bazel_tools//platforms:s390x",
 }
 


### PR DESCRIPTION
This constraint_value is selected for ppc64le machines, but we have
no ppc64 host toolchain, so it breaks the build.

Related #1186