### PR TITLE
Strip external prefix from proto files

### DIFF
--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -28,10 +28,18 @@ load("@io_bazel_rules_go//proto:compiler.bzl",
 
 GoProtoImports = provider()
 
+def _trim_external_path(src):
+  path = src.path
+  if src.owner and src.owner.workspace_root:
+    prefix = src.owner.workspace_root+"/"
+    if path.startswith(prefix):
+      path = path[len(prefix):]
+  return path
+
 def get_imports(attr):
   imports = []
   if hasattr(attr, "proto"):
-    imports.append(["{}={}".format(src.path, attr.importpath) for src in attr.proto.proto.direct_sources])
+    imports.append(["{}={}".format(_trim_external_path(src), attr.importpath) for src in attr.proto.proto.direct_sources])
   imports.extend([dep[GoProtoImports].imports for dep in attr.deps])
   imports.extend([dep[GoProtoImports].imports for dep in attr.embed])
   return sets.union(*imports)


### PR DESCRIPTION
The source name needs to match the one that was used when the proto was
compiled, not the one it would be if mapped into the sandbox by the existing
rule.
There is no direct way to get that in bazel, hence this fix.

Fixes #1193