### PR TITLE
Fix empty package x_def test

### DIFF
--- a/go/private/rules/wrappers.bzl
+++ b/go/private/rules/wrappers.bzl
@@ -63,7 +63,7 @@ def go_binary_macro(name, srcs=None, embed=[], cgo=False, cdeps=[], copts=[], cl
       **kwargs
   )
 
-def go_test_macro(name, srcs=None, deps=None, importpath="", library=None, embed=[], gc_goopts=[], cgo=False, cdeps=[], copts=[], clinkopts=[], **kwargs):
+def go_test_macro(name, srcs=None, deps=None, importpath="", library=None, embed=[], gc_goopts=[], cgo=False, cdeps=[], copts=[], clinkopts=[], x_defs={}, **kwargs):
   """See go/core.rst#go_test for full documentation."""
   if library:
     #TODO: print("DEPRECATED: {}//{}:{} : the library attribute is deprecated. Please migrate to embed.".format(native.repository_name(), native.package_name(), name))
@@ -84,6 +84,7 @@ def go_test_macro(name, srcs=None, deps=None, importpath="", library=None, embed
       cdeps = cdeps,
       copts = copts,
       clinkopts = clinkopts,
+      x_defs = x_defs,
   )
   go_test(
       name = name,

--- a/tests/empty_package/BUILD.bazel
+++ b/tests/empty_package/BUILD.bazel
@@ -27,7 +27,7 @@ go_test(
     importpath = "github.com/bazelbuild/rules_go/tests/empty_package_test",
     pure = "off",
     x_defs = {
-        "github.com/bazelbuild/rules_go/tests/empty_package_test.Expect": "2",
+        "Expect": "2",
     },
     deps = [":mixed"],
 )
@@ -39,7 +39,7 @@ go_test(
     importpath = "github.com/bazelbuild/rules_go/tests/empty_package_test",
     pure = "on",
     x_defs = {
-        "github.com/bazelbuild/rules_go/tests/empty_package_test.Expect": "1",
+        "Expect": "1",
     },
     deps = [":mixed"],
 )


### PR DESCRIPTION
With the newer x_def code it is best to let it add the package for you, but it
can only do it if the x_def's are on the library where they belong.