### PR TITLE
cgo_pure is also using x_def badly

### DIFF
--- a/tests/cgo_pure/BUILD.bazel
+++ b/tests/cgo_pure/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
         "cgo.c",
         "cgo.go",
         "cgo_no_tag.go",
-        "common.go",
         "pure.go",
     ],
     cgo = True,
@@ -17,7 +16,7 @@ go_test(
     size = "small",
     srcs = ["cgo_pure_test.go"],
     x_defs = {
-        "github.com/bazelbuild/rules_go/tests/cgo_pure.Expect": "2",
+        "Expect": "2",
     },
     deps = [":cgo_pure"],
 )
@@ -28,7 +27,7 @@ go_test(
     srcs = ["cgo_pure_test.go"],
     pure = "on",
     x_defs = {
-        "github.com/bazelbuild/rules_go/tests/cgo_pure.Expect": "1",
+        "Expect": "1",
     },
     deps = [":cgo_pure"],
 )

--- a/tests/cgo_pure/cgo_pure_test.go
+++ b/tests/cgo_pure/cgo_pure_test.go
@@ -7,9 +7,11 @@ import (
 	"github.com/bazelbuild/rules_go/tests/cgo_pure"
 )
 
+var Expect = ""
+
 func TestValue(t *testing.T) {
 	got := fmt.Sprintf("%d", cgo_pure.Value)
-	if got != cgo_pure.Expect {
-		t.Errorf("got %q; want %q", got, cgo_pure.Expect)
+	if got != Expect {
+		t.Errorf("got %q; want %q", got, Expect)
 	}
 }

--- a/tests/cgo_pure/common.go
+++ b/tests/cgo_pure/common.go
@@ -1,3 +1,0 @@
-package cgo_pure
-
-var Expect = ""


### PR DESCRIPTION
This cleans it up to put the Expect where it belongs in the test