### PR TITLE
Fix go proto rules for Windows

### DIFF
--- a/go/tools/builders/generate_test_main.go
+++ b/go/tools/builders/generate_test_main.go
@@ -187,7 +187,7 @@ func run(args []string) error {
 
 	cases := Cases{
 		Package: *pkg,
-		RunDir:  filepath.FromSlash(*runDir),
+		RunDir:  strings.Replace(filepath.FromSlash(*runDir), `\`, `\\`, -1),
 	}
 	covered := map[string]*CoverPackage{}
 	for _, c := range cover {

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -36,6 +36,7 @@ def go_proto_compile(go, compiler, proto, imports, importpath):
       "--importpath", importpath,
       "--out_path", outpath,
       "--plugin", compiler.plugin,
+      "--compiler_path", go.compiler_path,
   ])
   options = compiler.options
   if compiler.import_path_option:


### PR DESCRIPTION
 - Pass the compiler path along
 - Strip .exe from plugin names
 - Use the system dependent path separator