### PR TITLE
Move cc toolchain information

### DIFF
--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -40,9 +40,9 @@ def emit_link(go,
 
   ld = None
   extldflags = []
-  if go.stdlib.cgo_tools:
-    ld = go.stdlib.cgo_tools.compiler_executable
-    extldflags.extend(go.stdlib.cgo_tools.options)
+  if go.cgo_tools:
+    ld = go.cgo_tools.compiler_executable
+    extldflags.extend(go.cgo_tools.options)
   extldflags.extend(["-Wl,-rpath,$ORIGIN/" + ("../" * pkg_depth)])
 
   gc_linkopts, extldflags = _extract_extldflags(gc_linkopts, extldflags)

--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -59,10 +59,10 @@ def _select_archive(files):
 
 def _cgo_codegen_impl(ctx):
   go = go_context(ctx)
-  if not go.stdlib.cgo_tools:
+  if not go.cgo_tools:
     fail("Go toolchain does not support cgo")
   linkopts = ctx.attr.linkopts[:]
-  copts = go.stdlib.cgo_tools.c_options + ctx.attr.copts
+  copts = go.cgo_tools.c_options + ctx.attr.copts
   deps = depset([], order="topological")
   cgo_export_h = go.declare_file(go, path="_cgo_export.h")
   cgo_export_c = go.declare_file(go, path="_cgo_export.c")
@@ -70,7 +70,7 @@ def _cgo_codegen_impl(ctx):
   cgo_types = go.declare_file(go, path="_cgo_gotypes.go")
   out_dir = cgo_main.dirname
 
-  cc = go.stdlib.cgo_tools.compiler_executable
+  cc = go.cgo_tools.compiler_executable
   args = go.args(go)
   args.add(["-cc", str(cc), "-objdir", out_dir])
 

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -46,6 +46,7 @@ go_tool_binary(
     srcs = [
         "cover.go",
         "env.go",
+        "flags.go",
     ],
     visibility = ["//visibility:public"],
 )
@@ -71,6 +72,7 @@ go_tool_binary(
     name = "info",
     srcs = [
         "env.go",
+        "flags.go",
         "info.go",
     ],
     visibility = ["//visibility:public"],

--- a/go/tools/builders/cgo.go
+++ b/go/tools/builders/cgo.go
@@ -31,14 +31,12 @@ import (
 
 func run(args []string) error {
 	sources := multiFlag{}
-	cc := ""
 	objdir := ""
 	dynout := ""
 	dynimport := ""
 	flags := flag.NewFlagSet("cgo", flag.ContinueOnError)
 	goenv := envFlags(flags)
 	flags.Var(&sources, "src", "A source file to be filtered and compiled")
-	flags.StringVar(&cc, "cc", "", "Sets the c compiler to use")
 	flags.StringVar(&objdir, "objdir", "", "The output directory")
 	flags.StringVar(&dynout, "dynout", "", "The output directory")
 	flags.StringVar(&dynimport, "dynimport", "", "The output directory")
@@ -49,6 +47,8 @@ func run(args []string) error {
 	if err := goenv.update(); err != nil {
 		return err
 	}
+	// TODO: work out why setting CGO_LDFLAGS breaks cgo
+	goenv.ld_flags = []string{}
 	env := os.Environ()
 	env = append(env, goenv.Env()...)
 
@@ -171,13 +171,6 @@ func run(args []string) error {
 		}
 		copts = append(copts, args...)
 	}
-
-	// Add the absoulute path to the c compiler to the environment
-	if abs, err := filepath.Abs(cc); err == nil {
-		cc = abs
-	}
-	env = append(env, fmt.Sprintf("CC=%s", cc))
-	env = append(env, fmt.Sprintf("CXX=%s", cc))
 
 	goargs := []string{"tool", "cgo", "-objdir", objdir}
 	goargs = append(goargs, copts...)

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -38,7 +38,7 @@ def go_proto_compile(go, compiler, proto, imports, importpath):
       "--importpath", importpath,
       "--out_path", outpath,
       "--plugin", compiler.plugin,
-      "--compiler_path", go.compiler_path,
+      "--compiler_path", go.cgo_tools.compiler_path,
   ])
   options = compiler.options
   if compiler.import_path_option:


### PR DESCRIPTION
Lives on the go_context_data rather than the stdlib
Also standardise the way it is collected and handed in to the builders