### PR TITLE
Moving stdlib compilation to a builder

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -211,12 +211,15 @@ def go_context(ctx, attr=None):
 
   stdlib = None
   for check in [s[GoStdLib] for s in context_data.stdlib_all]:
-    if (check.goos == mode.goos and
-        check.goarch == mode.goarch and
-        check.race == mode.race and
-        check.pure == mode.pure):
+    if (check.mode.goos == mode.goos and
+        check.mode.goarch == mode.goarch and
+        check.mode.race == mode.race and
+        check.mode.pure == mode.pure):
       if stdlib:
-        fail("Multiple matching standard library for "+mode_string(mode))
+        fail("Multiple matching standard library for {}: {} and {}".format(
+          mode_string(mode),
+          check.root_file.dirname,
+          stdlib.root_file.dirname))
       stdlib = check
   if not stdlib and context_data.stdlib_all:
     fail("No matching standard library for "+mode_string(mode))
@@ -264,7 +267,6 @@ def _stdlib_all():
       Label("@go_stdlib_{}_{}_cgo".format(goos, goarch)),
       Label("@go_stdlib_{}_{}_pure".format(goos, goarch)),
       Label("@go_stdlib_{}_{}_cgo_race".format(goos, goarch)),
-      Label("@go_stdlib_{}_{}_pure_race".format(goos, goarch)),
     ])
   return stdlibs
 

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -61,28 +61,21 @@ def go_rules_dependencies():
         goos = goos,
         goarch = goarch,
         race = False,
-        cgo = True,
+        pure = False,
     )
     _maybe(go_stdlib,
         name = "go_stdlib_{}_{}_pure".format(goos, goarch),
         goos = goos,
         goarch = goarch,
         race = False,
-        cgo = False,
+        pure = True,
     )
     _maybe(go_stdlib,
         name = "go_stdlib_{}_{}_cgo_race".format(goos, goarch),
         goos = goos,
         goarch = goarch,
         race = True,
-        cgo = True,
-    )
-    _maybe(go_stdlib,
-        name = "go_stdlib_{}_{}_pure_race".format(goos, goarch),
-        goos = goos,
-        goarch = goarch,
-        race = True,
-        cgo = False,
+        pure = False,
     )
 
   _maybe(go_repository_tools,

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -126,3 +126,13 @@ go_tool_binary(
     ],
     visibility = ["//visibility:public"],
 )
+
+go_tool_binary(
+    name = "stdlib",
+    srcs = [
+        "env.go",
+        "flags.go",
+        "stdlib.go",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -132,6 +132,7 @@ go_tool_binary(
     srcs = [
         "env.go",
         "flags.go",
+        "replicate.go",
         "stdlib.go",
     ],
     visibility = ["//visibility:public"],

--- a/go/tools/builders/replicate.go
+++ b/go/tools/builders/replicate.go
@@ -1,0 +1,164 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// stdlib builds the standard library in the appropriate mode into a new goroot.
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+type replicateMode int
+
+const (
+	copyMode replicateMode = iota
+	hardlinkMode
+	softlinkMode
+)
+
+type replicateOption func(*replicateConfig)
+type replicateConfig struct {
+	removeFirst bool
+	fileMode    replicateMode
+	dirMode     replicateMode
+	paths       []string
+}
+
+func replicatePaths(paths ...string) replicateOption {
+	return func(config *replicateConfig) {
+		config.paths = append(config.paths, paths...)
+	}
+}
+
+// replicatePrepare is the common preparation steps for a replication entry
+func replicatePrepare(dst string, config *replicateConfig) error {
+	dir := filepath.Dir(dst)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("Failed to make %s: %v", dir, err)
+	}
+	if config.removeFirst {
+		_ = os.Remove(dst)
+	}
+	return nil
+}
+
+// replicateFile is called internally by replicate to map a single file from src into dst.
+func replicateFile(src, dst string, config *replicateConfig) error {
+	if err := replicatePrepare(dst, config); err != nil {
+		return err
+	}
+	switch config.fileMode {
+	case copyMode:
+		in, err := os.Open(src)
+		if err != nil {
+			return err
+		}
+		defer in.Close()
+		out, err := os.Create(dst)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(out, in)
+		closeerr := out.Close()
+		if err != nil {
+			return err
+		}
+		if closeerr != nil {
+			return closeerr
+		}
+		s, err := os.Stat(src)
+		if err != nil {
+			return err
+		}
+		if err := os.Chmod(dst, s.Mode()); err != nil {
+			return err
+		}
+		return nil
+	case hardlinkMode:
+		return os.Link(src, dst)
+	case softlinkMode:
+		return os.Symlink(src, dst)
+	default:
+		return fmt.Errorf("Invalid replication mode %d", config.fileMode)
+	}
+}
+
+// replicateDir makes a tree of files visible in a new location.
+// It is allowed to take any efficient method of doing so.
+func replicateDir(src, dst string, config *replicateConfig) error {
+	if err := replicatePrepare(dst, config); err != nil {
+		return err
+	}
+	switch config.dirMode {
+	case copyMode:
+		return filepath.Walk(src, func(path string, f os.FileInfo, err error) error {
+			if f.IsDir() {
+				return nil
+			}
+			relative, err := filepath.Rel(src, path)
+			if err != nil {
+				return err
+			}
+			return replicateFile(path, filepath.Join(dst, relative), config)
+		})
+	case hardlinkMode:
+		return os.Link(src, dst)
+	case softlinkMode:
+		return os.Symlink(src, dst)
+	default:
+		return fmt.Errorf("Invalid replication mode %d", config.fileMode)
+	}
+}
+
+// replicateTree is called for each single src dst pair.
+func replicateTree(src, dst string, config *replicateConfig) error {
+	if l, err := os.Readlink(src); err == nil {
+		src = l
+	}
+	s, err := os.Stat(src)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if s.IsDir() {
+		return replicateDir(src, dst, config)
+	}
+	return replicateFile(src, dst, config)
+}
+
+// replicate makes a tree of files visible in a new location.
+// You control how it does so using options, by default it presumes the entire tree
+// of files rooted at src must be visible at dst, and that it should do so by copying.
+// src is allowed to be a file, in which case just the one file is copied.
+func replicate(src, dst string, options ...replicateOption) error {
+	config := replicateConfig{
+		removeFirst: true,
+	}
+	for _, option := range options {
+		option(&config)
+	}
+	if len(config.paths) == 0 {
+		return replicateTree(src, dst, &config)
+	}
+	for _, base := range config.paths {
+		from := filepath.Join(src, base)
+		to := filepath.Join(dst, base)
+		if err := replicateTree(from, to, &config); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/go/tools/builders/stdlib.go
+++ b/go/tools/builders/stdlib.go
@@ -1,0 +1,121 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// stdlib builds the standard library in the appropriate mode into a new goroot.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func link(src, dst, common string) error {
+	src = filepath.Join(src, common)
+	dst = filepath.Join(dst, common)
+	out := filepath.Dir(dst)
+	if err := os.MkdirAll(out, 0755); err != nil {
+		return fmt.Errorf("Failed to make %s: %v", out, err)
+	}
+	_ = os.Remove(dst)
+	if err := os.Symlink(src, dst); err != nil {
+		return fmt.Errorf("Failed link: %v", err)
+	}
+	return nil
+}
+
+func copy(src, dst, common string) error {
+	return filepath.Walk(filepath.Join(src, common), func(path string, f os.FileInfo, err error) error {
+		if f.IsDir() {
+			return nil
+		}
+		relative, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		to := filepath.Join(dst, relative)
+		dir := filepath.Dir(to)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("Failed to make %s: %v", dir, err)
+		}
+		_ = os.Remove(to)
+		if err := os.Link(path, to); err != nil {
+			return fmt.Errorf("Failed link: %v", err)
+		}
+		return nil
+	})
+}
+
+func install_stdlib(goenv *GoEnv, target string, args []string) error {
+	args = append(args, target)
+	env := os.Environ()
+	env = append(env, goenv.Env()...)
+	cmd := exec.Command(goenv.Go, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = env
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error running go install %s: %v", target, err)
+	}
+	return nil
+}
+
+func run(args []string) error {
+	// process the args
+	flags := flag.NewFlagSet("stdlib", flag.ExitOnError)
+	goenv := envFlags(flags)
+	out := flags.String("out", "", "Path to output go root")
+	race := flags.Bool("race", false, "Build in race mode")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if err := goenv.update(); err != nil {
+		return err
+	}
+	goroot := goenv.rootPath
+	output := abs(*out)
+	// Link in the bare minimum needed to the new GOROOT
+	if err := link(goroot, output, "src"); err != nil {
+		return err
+	}
+	if err := copy(goroot, output, "pkg/tool"); err != nil {
+		return err
+	}
+	if err := copy(goroot, output, "pkg/include"); err != nil {
+		return err
+	}
+	// Now switch to the newly created GOROOT
+	goenv.rootPath = output
+	// Run the commands needed to build the std library in the right mode
+	installArgs := []string{"install", "-asmflags", "-trimpath " + abs(".")}
+	if *race {
+		installArgs = append(installArgs, "-race")
+	}
+	if err := install_stdlib(goenv, "std", installArgs); err != nil {
+		return err
+	}
+	if err := install_stdlib(goenv, "runtime/cgo", installArgs); err != nil {
+		return err
+	}
+	return nil
+}
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/tests/bazel_tests.bzl
+++ b/tests/bazel_tests.bzl
@@ -47,6 +47,9 @@ result=$?
 
 {check}
 
+if [ "$result" -ne 0 ]; then
+  cat bazel-output.txt
+fi
 exit $result
 """
 


### PR DESCRIPTION
Now we have cleaned up all the context data cgo handling, we can build the
stdlib using the same builder environment, rather than a nasty && bash command
line.
This also means all the abs path handling will be fixed.
Also removed the _pure_race version that was not legal anyway