### PR TITLE
Update skylib and replace our version check with versions.check

### DIFF
--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -132,37 +132,6 @@ def goos_to_extension(goos):
 
 MINIMUM_BAZEL_VERSION = "0.8.0"
 
-# _parse_bazel_version and check_version originally copied from
-# github.com/tensorflow/tensorflow/blob/cfd0d3f2aa24b3078d2e79ad0a212c7c53916de9/tensorflow/workspace.bzl
-
-# Parse the bazel version string from `native.bazel_version`.
-# For example, "0.10.0-rc1 0123abc"
-def _parse_bazel_version(bazel_version):
-  # Find the first character that is not a digit or '.' and break there.
-  for i in range(len(bazel_version)):
-    c = bazel_version[i]
-    if not (c.isdigit() or c == "."):
-      bazel_version = bazel_version[:i]
-      break
-  # Split on '.' and convert the pieces to integers.
-  return tuple([int(n) for n in bazel_version.split(".")])
-
-# Check that a specific bazel version is being used.
-def check_version(bazel_version):
-  if "bazel_version" not in dir(native):
-    fail("\nCurrent Bazel version is lower than 0.2.1, expected at least %s\n" %
-         bazel_version)
-  elif not native.bazel_version:
-    print("\nCurrent Bazel is not a release version, cannot check for " +
-          "compatibility.")
-    print("Make sure that you are running at least Bazel %s.\n" % bazel_version)
-  else:
-    current_bazel_version = _parse_bazel_version(native.bazel_version)
-    minimum_bazel_version = _parse_bazel_version(bazel_version)
-    if minimum_bazel_version > current_bazel_version:
-      fail("\nCurrent Bazel version is {}, expected at least {}\n".format(
-          native.bazel_version, bazel_version))
-
 def as_list(v):
   if type(v) == "list":
     return v

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -14,18 +14,18 @@
 
 # Once nested repositories work, this file should cease to exist.
 
-load("@io_bazel_rules_go//go/private:common.bzl", "check_version", "MINIMUM_BAZEL_VERSION")
+load("@io_bazel_rules_go//go/private:common.bzl", "MINIMUM_BAZEL_VERSION")
 load("@io_bazel_rules_go//go/private:repository_tools.bzl", "go_repository_tools")
 load("@io_bazel_rules_go//go/private:go_repository.bzl", "go_repository")
 load("@io_bazel_rules_go//go/private:rules/stdlib.bzl", "go_stdlib")
+load("@io_bazel_rules_go//go/private:skylib/lib/versions.bzl", "versions")
 load("@io_bazel_rules_go//go/toolchain:toolchains.bzl", "go_register_toolchains")
 load("@io_bazel_rules_go//go/platform:list.bzl", "GOOS_GOARCH")
 load("@io_bazel_rules_go//proto:gogo.bzl", "gogo_special_proto")
 
 def go_rules_dependencies():
   """See /go/workspace.rst#go-rules-dependencies for full documentation."""
-
-  check_version(MINIMUM_BAZEL_VERSION)
+  versions.check(MINIMUM_BAZEL_VERSION)
 
   # Needed for gazelle and wtool
   _maybe(native.http_archive,

--- a/go/private/skylib/README.rst
+++ b/go/private/skylib/README.rst
@@ -1,8 +1,7 @@
-This entire directory is a subset of the functionality in bazel-skylib
-Individual modules are unmodified, but lib.bzl has had the paths changed, and 
-not all modules are included.
+This directory is a copy of github.com/bazelbuild/bazel-skylib/lib.
+Commit 2169ae1, retrieved on 2018-01-12
 
 This is needed only until nested workspaces works.
 It has to be copied in because we use the functionality inside code that 
 go_rules_dependencies itself depends on, which means we cannot automatically 
-add the skylib dependancy.
+add the skylib dependency.

--- a/go/private/skylib/lib/collections.bzl
+++ b/go/private/skylib/lib/collections.bzl
@@ -1,0 +1,70 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skylib module containing functions that operate on collections."""
+
+
+def _after_each(separator, iterable):
+  """Inserts `separator` after each item in `iterable`.
+
+  Args:
+    separator: The value to insert after each item in `iterable`.
+    iterable: The list into which to intersperse the separator.
+  Returns:
+    A new list with `separator` after each item in `iterable`.
+  """
+  result = []
+  for x in iterable:
+    result.append(x)
+    result.append(separator)
+
+  return result
+
+
+def _before_each(separator, iterable):
+  """Inserts `separator` before each item in `iterable`.
+
+  Args:
+    separator: The value to insert before each item in `iterable`.
+    iterable: The list into which to intersperse the separator.
+  Returns:
+    A new list with `separator` before each item in `iterable`.
+  """
+  result = []
+  for x in iterable:
+    result.append(separator)
+    result.append(x)
+
+  return result
+
+
+def _uniq(iterable):
+  """Returns a list of unique elements in `iterable`.
+
+  Requires all the elements to be hashable.
+
+  Args:
+    iterable: An iterable to filter.
+  Returns:
+    A new list with all unique elements from `iterable`.
+  """
+  unique_elements = {element: None for element in iterable}
+  return unique_elements.keys()
+
+
+collections = struct(
+    after_each=_after_each,
+    before_each=_before_each,
+    uniq=_uniq,
+)

--- a/go/private/skylib/lib/paths.bzl
+++ b/go/private/skylib/lib/paths.bzl
@@ -65,7 +65,7 @@ def _is_absolute(path):
   Returns:
     `True` if `path` is an absolute path.
   """
-  return path.startswith("/") or path[1] == ":"
+  return path.startswith("/")
 
 
 def _join(path, *others):

--- a/go/private/skylib/lib/selects.bzl
+++ b/go/private/skylib/lib/selects.bzl
@@ -1,0 +1,83 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skylib module containing convenience interfaces for select()."""
+
+def _with_or(input_dict):
+  """Drop-in replacement for `select()` that supports ORed keys.
+
+  Args:
+    input_dict: The same dictionary `select()` takes, except keys may take
+        either the usual form `"//foo:config1"` or
+        `("//foo:config1", "//foo:config2", ...)` to signify
+        `//foo:config1` OR `//foo:config2` OR `...`.
+
+        Example:
+
+        ```build
+        deps = selects.with_or({
+            "//configs:one": [":dep1"],
+            ("//configs:two", "//configs:three"): [":dep2or3"],
+            "//configs:four": [":dep4"],
+            "//conditions:default": [":default"]
+        })
+        ```
+
+        Key labels may appear at most once anywhere in the input.
+
+  Returns:
+    A native `select()` that expands
+
+    `("//configs:two", "//configs:three"): [":dep2or3"]`
+
+    to
+
+    ```build
+    "//configs:two": [":dep2or3"],
+    "//configs:three": [":dep2or3"],
+    ```
+  """
+  return select(_with_or_dict(input_dict))
+
+
+def _with_or_dict(input_dict):
+  """Variation of `with_or` that returns the dict of the `select()`.
+
+  Unlike `select()`, the contents of the dict can be inspected by Skylark
+  macros.
+
+  Args:
+    input_dict: Same as `with_or`.
+
+  Returns:
+    A dictionary usable by a native `select()`.
+  """
+  output_dict = {}
+  for (key, value) in input_dict.items():
+    if type(key) == type(()):
+      for config_setting in key:
+        if config_setting in output_dict.keys():
+          fail("key %s appears multiple times" % config_setting)
+        output_dict[config_setting] = value
+    else:
+      if key in output_dict.keys():
+        fail("key %s appears multiple times" % config_setting)
+      output_dict[key] = value
+  return output_dict
+
+
+selects = struct(
+    with_or=_with_or,
+    with_or_dict=_with_or_dict
+)

--- a/go/private/skylib/lib/unittest.bzl
+++ b/go/private/skylib/lib/unittest.bzl
@@ -1,0 +1,270 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit testing support.
+
+Unlike most Skylib files, this exports two modules: `unittest` which contains
+functions to declare and define unit tests, and `asserts` which contains the
+assertions used to within tests.
+"""
+
+load(":sets.bzl", "sets")
+
+
+def _make(impl, attrs=None):
+  """Creates a unit test rule from its implementation function.
+
+  Each unit test is defined in an implementation function that must then be
+  associated with a rule so that a target can be built. This function handles
+  the boilerplate to create and return a test rule and captures the
+  implementation function's name so that it can be printed in test feedback.
+
+  The optional `attrs` argument can be used to define dependencies for this
+  test, in order to form unit tests of rules.
+
+  An example of a unit test:
+
+  ```
+  def _your_test(ctx):
+    env = unittest.begin(ctx)
+
+    # Assert statements go here
+
+    unittest.end(env)
+
+  your_test = unittest.make(_your_test)
+  ```
+
+  Recall that names of test rules must end in `_test`.
+
+  Args:
+    impl: The implementation function of the unit test.
+    attrs: An optional dictionary to supplement the attrs passed to the
+        unit test's `rule()` constructor.
+  Returns:
+    A rule definition that should be stored in a global whose name ends in
+    `_test`.
+  """
+
+  # Derive the name of the implementation function for better test feedback.
+  # Skylark currently stringifies a function as "<function NAME>", so we use
+  # that knowledge to parse the "NAME" portion out. If this behavior ever
+  # changes, we'll need to update this.
+  # TODO(bazel-team): Expose a ._name field on functions to avoid this.
+  impl_name = str(impl)
+  impl_name = impl_name.partition("<function ")[-1]
+  impl_name = impl_name.rpartition(">")[0]
+
+  attrs = dict(attrs) if attrs else {}
+  attrs["_impl_name"] = attr.string(default=impl_name)
+
+  return rule(
+      impl,
+      attrs=attrs,
+      _skylark_testable=True,
+      test=True,
+  )
+
+
+def _suite(name, *test_rules):
+  """Defines a `test_suite` target that contains multiple tests.
+
+  After defining your test rules in a `.bzl` file, you need to create targets
+  from those rules so that `blaze test` can execute them. Doing this manually
+  in a BUILD file would consist of listing each test in your `load` statement
+  and then creating each target one by one. To reduce duplication, we recommend
+  writing a macro in your `.bzl` file to instantiate all targets, and calling
+  that macro from your BUILD file so you only have to load one symbol.
+
+  For the case where your unit tests do not take any (non-default) attributes --
+  i.e., if your unit tests do not test rules -- you can use this function to
+  create the targets and wrap them in a single test_suite target. In your
+  `.bzl` file, write:
+
+  ```
+  def your_test_suite():
+    unittest.suite(
+        "your_test_suite",
+        your_test,
+        your_other_test,
+        yet_another_test,
+    )
+  ```
+
+  Then, in your `BUILD` file, simply load the macro and invoke it to have all
+  of the targets created:
+
+  ```
+  load("//path/to/your/package:tests.bzl", "your_test_suite")
+  your_test_suite()
+  ```
+
+  If you pass _N_ unit test rules to `unittest.suite`, _N_ + 1 targets will be
+  created: a `test_suite` target named `${name}` (where `${name}` is the name
+  argument passed in here) and targets named `${name}_test_${i}`, where `${i}`
+  is the index of the test in the `test_rules` list, which is used to uniquely
+  name each target.
+
+  Args:
+    name: The name of the `test_suite` target, and the prefix of all the test
+        target names.
+    *test_rules: A list of test rules defines by `unittest.test`.
+  """
+  test_names = []
+  for index, test_rule in enumerate(test_rules):
+    test_name = "%s_test_%d" % (name, index)
+    test_rule(name=test_name)
+    test_names.append(test_name)
+
+  native.test_suite(
+      name=name,
+      tests=[":%s" % t for t in test_names]
+  )
+
+
+def _begin(ctx):
+  """Begins a unit test.
+
+  This should be the first function called in a unit test implementation
+  function. It initializes a "test environment" that is used to collect
+  assertion failures so that they can be reported and logged at the end of the
+  test.
+
+  Args:
+    ctx: The Skylark context. Pass the implementation function's `ctx` argument
+        in verbatim.
+  Returns:
+    A test environment struct that must be passed to assertions and finally to
+    `unittest.end`. Do not rely on internal details about the fields in this
+    struct as it may change.
+  """
+  return struct(ctx=ctx, failures=[])
+
+
+def _end(env):
+  """Ends a unit test and logs the results.
+
+  This must be called before the end of a unit test implementation function so
+  that the results are reported.
+
+  Args:
+    env: The test environment returned by `unittest.begin`.
+  """
+  cmd = "\n".join([
+      "cat << EOF",
+      "\n".join(env.failures),
+      "EOF",
+      "exit %d" % len(env.failures),
+  ])
+  env.ctx.file_action(
+      output=env.ctx.outputs.executable,
+      content=cmd,
+      executable=True,
+  )
+
+
+def _fail(env, msg):
+  """Unconditionally causes the current test to fail.
+
+  Args:
+    env: The test environment returned by `unittest.begin`.
+    msg: The message to log describing the failure.
+  """
+  full_msg = "In test %s: %s" % (env.ctx.attr._impl_name, msg)
+  print(full_msg)
+  env.failures.append(full_msg)
+
+
+def _assert_true(env,
+                 condition,
+                 msg="Expected condition to be true, but was false."):
+  """Asserts that the given `condition` is true.
+
+  Args:
+    env: The test environment returned by `unittest.begin`.
+    condition: A value that will be evaluated in a Boolean context.
+    msg: An optional message that will be printed that describes the failure.
+        If omitted, a default will be used.
+  """
+  if not condition:
+    _fail(env, msg)
+
+
+def _assert_false(env,
+                  condition,
+                  msg="Expected condition to be false, but was true."):
+  """Asserts that the given `condition` is false.
+
+  Args:
+    env: The test environment returned by `unittest.begin`.
+    condition: A value that will be evaluated in a Boolean context.
+    msg: An optional message that will be printed that describes the failure.
+        If omitted, a default will be used.
+  """
+  if condition:
+    _fail(env, msg)
+
+
+def _assert_equals(env, expected, actual, msg=None):
+  """Asserts that the given `expected` and `actual` values are equal.
+
+  Args:
+    env: The test environment returned by `unittest.begin`.
+    expected: The expected value of some computation.
+    actual: The actual value returned by some computation.
+    msg: An optional message that will be printed that describes the failure.
+        If omitted, a default will be used.
+  """
+  if expected != actual:
+    expectation_msg = 'Expected "%s", but got "%s"' % (expected, actual)
+    if msg:
+      full_msg = "%s (%s)" % (msg, expectation_msg)
+    else:
+      full_msg = expectation_msg
+    _fail(env, full_msg)
+
+
+def _assert_set_equals(env, expected, actual, msg=None):
+  """Asserts that the given `expected` and `actual` sets are equal.
+
+  Args:
+    env: The test environment returned by `unittest.begin`.
+    expected: The expected set resulting from some computation.
+    actual: The actual set returned by some computation.
+    msg: An optional message that will be printed that describes the failure.
+        If omitted, a default will be used.
+  """
+  if type(actual) != type(depset()) or not sets.is_equal(expected, actual):
+    expectation_msg = "Expected %r, but got %r" % (expected, actual)
+    if msg:
+      full_msg = "%s (%s)" % (msg, expectation_msg)
+    else:
+      full_msg = expectation_msg
+    _fail(env, full_msg)
+
+
+asserts = struct(
+    equals=_assert_equals,
+    false=_assert_false,
+    set_equals=_assert_set_equals,
+    true=_assert_true,
+)
+
+unittest = struct(
+    make=_make,
+    suite=_suite,
+    begin=_begin,
+    end=_end,
+    fail=_fail,
+)

--- a/go/private/skylib/lib/versions.bzl
+++ b/go/private/skylib/lib/versions.bzl
@@ -1,0 +1,126 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skylib module containing functions for checking Bazel versions."""
+
+def _get_bazel_version():
+  """Returns the current Bazel version"""
+
+  return native.bazel_version
+
+
+def _extract_version_number(bazel_version):
+  """Extracts the semantic version number from a version string
+
+  Args:
+    bazel_version: the version string that begins with the semantic version
+      e.g. "1.2.3rc1 abc1234" where "abc1234" is a commit hash.
+
+  Returns:
+    The semantic version string, like "1.2.3".
+  """
+  for i in range(len(bazel_version)):
+    c = bazel_version[i]
+    if not (c.isdigit() or c == "."):
+      return bazel_version[:i]
+  return bazel_version
+
+# Parse the bazel version string from `native.bazel_version`.
+# e.g.
+# "0.10.0rc1 abc123d" => (0, 10, 0)
+# "0.3.0" => (0, 3, 0)
+def _parse_bazel_version(bazel_version):
+  """Parses a version string into a 3-tuple of ints
+
+  int tuples can be compared directly using binary operators (<, >).
+
+  Args:
+    bazel_version: the Bazel version string
+
+  Returns:
+    An int 3-tuple of a (major, minor, patch) version.
+  """
+
+  version = _extract_version_number(bazel_version)
+  return tuple([int(n) for n in version.split(".")])
+
+
+def _is_at_most(threshold, version):
+  """Check that a version is lower or equals to a threshold.
+
+  Args:
+    threshold: the maximum version string
+    version: the version string to be compared to the threshold
+
+  Returns:
+    True if version <= threshold.
+  """
+  return _parse_bazel_version(version) <= _parse_bazel_version(threshold)
+
+
+def _is_at_least(threshold, version):
+  """Check that a version is higher or equals to a threshold.
+
+  Args:
+    threshold: the minimum version string
+    version: the version string to be compared to the threshold
+
+  Returns:
+    True if version >= threshold.
+  """
+
+  return _parse_bazel_version(version) >= _parse_bazel_version(threshold)
+
+
+def _check_bazel_version(minimum_bazel_version, maximum_bazel_version=None, bazel_version=None):
+  """Check that the version of Bazel is valid within the specified range.
+
+  Args:
+    minimum_bazel_version: minimum version of Bazel expected
+    maximum_bazel_version: maximum version of Bazel expected
+    bazel_version: the version of Bazel to check. Used for testing, defaults to native.bazel_version
+  """
+  if not bazel_version:
+    if "bazel_version" not in dir(native):
+      fail("\nCurrent Bazel version is lower than 0.2.1, expected at least %s\n" % minimum_bazel_version)
+    elif not native.bazel_version:
+      print("\nCurrent Bazel is not a release version, cannot check for compatibility.")
+      print("Make sure that you are running at least Bazel %s.\n" % minimum_bazel_version)
+      return
+    else:
+      bazel_version = native.bazel_version
+
+  if not _is_at_least(
+      threshold = minimum_bazel_version,
+      version = bazel_version):
+    fail("\nCurrent Bazel version is {}, expected at least {}\n".format(
+        bazel_version, minimum_bazel_version))
+
+  if maximum_bazel_version:
+    max_bazel_version = _parse_bazel_version(maximum_bazel_version)
+    if not _is_at_most(
+        threshold = maximum_bazel_version,
+        version = bazel_version):
+      fail("\nCurrent Bazel version is {}, expected at most {}\n".format(
+          bazel_version, maximum_bazel_version))
+
+  pass
+
+versions = struct(
+    get=_get_bazel_version,
+    parse=_parse_bazel_version,
+    check=_check_bazel_version,
+    is_at_most=_is_at_most,
+    is_at_least=_is_at_least,
+)


### PR DESCRIPTION
This copies all Skylib modules into go/private/skylib/lib, including modules we aren't using yet.