### PR TITLE
Fix for windows (again)

### DIFF
--- a/go/private/skylib/lib/paths.bzl
+++ b/go/private/skylib/lib/paths.bzl
@@ -65,7 +65,7 @@ def _is_absolute(path):
   Returns:
     `True` if `path` is an absolute path.
   """
-  return path.startswith("/")
+  return path.startswith("/") or path[1] == ":"
 
 
 def _join(path, *others):


### PR DESCRIPTION
Put back the windows abs path fix added in 90a722b8963fb08810b514647b08c958a1753e13 which was clobbered in e12cbbfd0e7dfeb73df4a16ccd562369e2ef8e11