### PR TITLE
Don't include compilation mode in binary output filenames.

### DIFF
--- a/go/core.rst
+++ b/go/core.rst
@@ -360,6 +360,11 @@ Attributes
 | Map of defines to add to the go link command.                                                    |
 | See `Defines and stamping`_ for examples of how to use these.                                    |
 +----------------------------+-----------------------------+---------------------------------------+
+| :param:`output_path`       | :type:`string`              | :value:`{mode}/{name}{path}{ext}`     |
++----------------------------+-----------------------------+---------------------------------------+
+| Template used to generate the output path. By default, Go binaries are written to paths          |
+| containing their target platform, build mode, and executable extension.                          |
++----------------------------+-----------------------------+---------------------------------------+
 | :param:`cgo`               | :type:`boolean`             | :value:`False`                        |
 +----------------------------+-----------------------------+---------------------------------------+
 | If :value:`True`, the binary uses cgo_.                                                          |

--- a/go/private/actions/binary.bzl
+++ b/go/private/actions/binary.bzl
@@ -18,13 +18,14 @@ def emit_binary(go,
     gc_linkopts = [],
     linkstamp=None,
     version_file=None,
-    info_file=None):
+    info_file=None,
+    output_path=None):
   """See go/toolchains.rst#binary for full documentation."""
 
   if name == "": fail("name is a required parameter")
 
   archive = go.archive(go, source)
-  executable = go.declare_file(go, name=name, ext=go.exe_extension)
+  executable = go.declare_file(go, name=name, ext=go.exe_extension, output_path=output_path)
   go.link(go,
       archive=archive,
       executable=executable,

--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -167,3 +167,5 @@ def as_set(v):
   if type(v) == "tuple":
     return depset(v)
   fail("as_tuple failed on {}".format(v))
+
+DEFAULT_OUTPUT_PATH = "{mode}/{name}{path}{ext}"

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -36,6 +36,7 @@ load(
     "structs",
     "goos_to_extension",
     "as_iterable",
+    "DEFAULT_OUTPUT_PATH",
 )
 
 GoContext = provider()
@@ -59,20 +60,22 @@ _LINKER_OPTIONS_BLACKLIST = {
 def _filter_options(options, blacklist):
   return [option for option in options if option not in blacklist]
 
-def _child_name(go, path, ext, name):
-  childname = mode_string(go.mode) + "/"
-  childname += name if name else go._ctx.label.name
-  if path:
-    childname += "~/" + path
-  if ext:
-    childname += ext
-  return childname
+def _child_name(go, path, ext, name, output_path):
+  if output_path == None:
+    output_path = DEFAULT_OUTPUT_PATH
 
-def _declare_file(go, path="", ext="", name = ""):
-  return go.actions.declare_file(_child_name(go, path, ext, name))
+  return output_path.format(
+    mode = mode_string(go.mode),
+    name = name if name else go._ctx.label.name,
+    path = "~/" + path if path else "",
+    ext = ext,
+  )
 
-def _declare_directory(go, path="", ext="", name = ""):
-  return go.actions.declare_directory(_child_name(go, path, ext, name))
+def _declare_file(go, path="", ext="", name="", output_path=None):
+  return go.actions.declare_file(_child_name(go, path, ext, name, output_path))
+
+def _declare_directory(go, path="", ext="", name="", output_path=None):
+  return go.actions.declare_directory(_child_name(go, path, ext, name, output_path))
 
 def _new_args(go):
   args = go.actions.args()

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -19,6 +19,7 @@ load(
 load(
     "@io_bazel_rules_go//go/private:common.bzl",
     "go_filetype",
+    "DEFAULT_OUTPUT_PATH",
 )
 load(
     "@io_bazel_rules_go//go/private:rules/prefix.bzl",
@@ -65,6 +66,7 @@ def _go_binary_impl(ctx):
       linkstamp=ctx.attr.linkstamp,
       version_file=ctx.version_file,
       info_file=ctx.info_file,
+      output_path=ctx.attr.output_path,
   )
   return [
       library, source, archive,
@@ -137,6 +139,7 @@ go_binary = go_rule(
         "linkstamp": attr.string(),
         "x_defs": attr.string_dict(),
         "linkmode": attr.string(values=LINKMODES, default=LINKMODE_NORMAL),
+        "output_path": attr.string(default = DEFAULT_OUTPUT_PATH),
     },
     executable = True,
 )
@@ -159,6 +162,7 @@ go_tool_binary = go_rule(
         "linkstamp": attr.string(),
         "x_defs": attr.string_dict(),
         "linkmode": attr.string(values=LINKMODES, default=LINKMODE_NORMAL),
+        "output_path": attr.string(default = DEFAULT_OUTPUT_PATH),
         "_hostonly": attr.bool(default=True),
     },
     executable = True,

--- a/tests/core/README.rst
+++ b/tests/core/README.rst
@@ -10,6 +10,7 @@ Contents
 
 * `Cross compilation <cross/README.rst>`_
 * `Import maps <importmap/README.rst>`_
+* `Basic go_binary functionality <go_binary/README.rst>`_
 * `Basic go_test functionality <go_test/README.rst>`_
 * `go_proto_library importmap <go_proto_library_importmap/README.rst>`_
 

--- a/tests/core/go_binary/BUILD.bazel
+++ b/tests/core/go_binary/BUILD.bazel
@@ -1,0 +1,48 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_test", "go_source")
+
+test_suite(
+    name = "go_binary",
+)
+
+go_binary(
+    name = "hello_plain",
+    srcs = ["hello_world.go"],
+    goarch = "amd64",
+    goos = "windows",
+    pure = "on",
+)
+
+go_binary(
+    name = "hello_no_mode",
+    srcs = ["hello_world.go"],
+    goarch = "amd64",
+    goos = "windows",
+    output_path = "{name}{path}{ext}",
+    pure = "on",
+)
+
+go_binary(
+    name = "hello_no_ext",
+    srcs = ["hello_world.go"],
+    goarch = "amd64",
+    goos = "windows",
+    output_path = "{mode}/{name}{path}",
+    pure = "on",
+)
+
+go_test(
+    name = "output_path_test",
+    size = "small",
+    srcs = ["output_path_test.go"],
+    args = [
+        "-plain $(location :hello_plain)",
+        "-no_mode $(location :hello_no_mode)",
+        "-no_ext $(location :hello_no_ext)",
+    ],
+    data = [
+        ":hello_no_ext",
+        ":hello_no_mode",
+        ":hello_plain",
+    ],
+    rundir = ".",
+)

--- a/tests/core/go_binary/README.rst
+++ b/tests/core/go_binary/README.rst
@@ -1,0 +1,15 @@
+Basic go_binary functionality
+=============================
+
+.. _go_binary: /go/core.rst#_go_binary
+
+Tests to ensure that basic features of go_binary_ are working as expected.
+
+.. contents::
+
+output_path_test
+----------------
+
+Test that a go_binary_ rule with custom output path layouts generates expected
+output filenames. It uses a Win32 target and verifies that mode or extension
+can be dropped from the output path.

--- a/tests/core/go_binary/hello_world.go
+++ b/tests/core/go_binary/hello_world.go
@@ -1,0 +1,5 @@
+package main
+
+import "fmt"
+
+func main() { fmt.Printf("Hello world!\n") }

--- a/tests/core/go_binary/output_path_test.go
+++ b/tests/core/go_binary/output_path_test.go
@@ -1,0 +1,40 @@
+package outpath_opts_test
+
+import (
+	"flag"
+	"testing"
+)
+
+var (
+	plain  = flag.String("plain", "", "")
+	noMode = flag.String("no_mode", "", "")
+	noExt  = flag.String("no_ext", "", "")
+)
+
+func TestPathOpts(t *testing.T) {
+	checks := []struct {
+		label, got, want string
+	}{
+		{
+			label: ":hello_plain",
+			got:   *plain,
+			want:  "tests/core/go_binary/windows_amd64_pure_stripped/hello_plain.exe",
+		},
+		{
+			label: ":hello_no_mode",
+			got:   *noMode,
+			want:  "tests/core/go_binary/hello_no_mode.exe",
+		},
+		{
+			label: ":hello_no_ext",
+			got:   *noExt,
+			want:  "tests/core/go_binary/windows_amd64_pure_stripped/hello_no_ext",
+		},
+	}
+
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("incorrect output path for label %q\nExpected %v\nGot      %v", c.label, c.want, c.got)
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_go/issues/1239

This should maintain nearly all of the caching benefits of the arch-specific filenames, because libraries are still built with the included mode. Binaries will need to be relinked if `-c` changes, but the filenames are consistent with other languages commonly used with Bazel.