### PR TITLE
specify go version in beta SDK instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -433,6 +433,6 @@ must be named ``go_sdk``, and it must come *before* the call to
       },
   )
 
-  go_register_toolchains()
+  go_register_toolchains(go_version="1.10beta1")
 
   


### PR DESCRIPTION
The README suggests using `go_download_sdk` to download a beta version, but does not actually specify the version in `go_register_toolchains`. This change should help users use beta versions easier.