### PR TITLE
Move the test library rule to be go_test internal actions

### DIFF
--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -54,10 +54,6 @@ go_filetype = FileType(go_exts + asm_exts)
 
 cc_hdr_filetype = FileType(hdr_exts)
 
-auto_importpath = "~auto~"
-
-test_library_suffix = "~library~"
-
 # Extensions of files we can build with the Go compiler or with cc_library.
 # This is a subset of the extensions recognized by go/build.
 cgo_filetype = FileType(go_exts + asm_exts + c_exts)

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -35,8 +35,6 @@ load(
     "structs",
     "goos_to_extension",
     "as_iterable",
-    "auto_importpath",
-    "test_library_suffix",
 )
 
 GoContext = provider()
@@ -141,8 +139,6 @@ def _infer_importpath(ctx):
   # Check if import path was explicitly set
   path = getattr(ctx.attr, "importpath", "")
   # are we in forced infer mode?
-  if path == auto_importpath:
-    path = ""
   if path != "":
     return path, EXPLICIT_PATH
   # See if we can collect importpath from embeded libraries
@@ -152,18 +148,6 @@ def _infer_importpath(ctx):
       continue
     if embed[GoLibrary].pathtype == EXPLICIT_PATH:
       return embed[GoLibrary].importpath, EXPLICIT_PATH
-  # If we are a test, and we have a dep in the same package, presume
-  # we should be named the same with an _test suffix
-  if ctx.label.name.endswith("_test" + test_library_suffix):
-    for dep in getattr(ctx.attr, "deps", []):
-      if GoLibrary not in dep:
-        continue
-      lib = dep[GoLibrary]
-      if lib.label.workspace_root != ctx.label.workspace_root:
-        continue
-      if lib.label.package != ctx.label.package:
-        continue
-      return lib.importpath + "_test", INFERRED_PATH
   # TODO: stop using the prefix
   prefix = getattr(ctx.attr, "_go_prefix", None)
   path = prefix.go_prefix if prefix else ""

--- a/go/private/providers.bzl
+++ b/go/private/providers.bzl
@@ -57,11 +57,15 @@ def new_aspect_provider(source = None, archive = None):
   )
 
 def get_source(dep):
+  if type(dep) == "struct":
+    return dep
   if GoAspectProviders in dep:
     return dep[GoAspectProviders].source
   return dep[GoSource]
 
 def get_archive(dep):
+  if type(dep) == "struct":
+    return dep
   if GoAspectProviders in dep:
     return dep[GoAspectProviders].archive
   return dep[GoArchive]

--- a/go/private/rules/wrappers.bzl
+++ b/go/private/rules/wrappers.bzl
@@ -16,7 +16,6 @@ load("@io_bazel_rules_go//go/private:rules/binary.bzl", "go_binary")
 load("@io_bazel_rules_go//go/private:rules/library.bzl", "go_library")
 load("@io_bazel_rules_go//go/private:rules/test.bzl", "go_test")
 load("@io_bazel_rules_go//go/private:rules/cgo.bzl", "setup_cgo_library")
-load("@io_bazel_rules_go//go/private:common.bzl", "auto_importpath", "test_library_suffix")
 
 #TODO(#1208): Remove library attribute
 def go_library_macro(name, srcs=None, embed=[], cgo=False, cdeps=[], copts=[], clinkopts=[], importpath="", library=None, **kwargs):
@@ -73,38 +72,28 @@ def go_binary_macro(name, srcs=None, embed=[], cgo=False, cdeps=[], copts=[], cl
 
 #TODO(#1207): Remove importpath
 #TODO(#1208): Remove library attribute
-def go_test_macro(name, srcs=None, deps=None, importpath=None, library=None, embed=[], gc_goopts=[], cgo=False, cdeps=[], copts=[], clinkopts=[], x_defs={}, **kwargs):
+def go_test_macro(name, srcs=None, importpath=None, library=None, embed=[], cgo=False, cdeps=[], copts=[], clinkopts=[], **kwargs):
   """See go/core.rst#go_test for full documentation."""
   if library and native.repository_name() == "@":
     print("\nDEPRECATED: //{}:{} : the library attribute on go_test is deprecated. Please migrate to embed.".format(native.package_name(), name))
     embed = embed + [library]
-  if not importpath:
-    importpath = auto_importpath
   #TODO: Turn on the deprecation warning when gazelle stops adding these
-  #elif native.repository_name() == "@":
-  #  print("\nDEPRECATED: //{}:{} : the importpath attribute on go_test is deprecated.".format(native.package_name(), name))
+  #if importpath and native.repository_name() == "@":
+  #  print("\nDEPRECATED: //{}:{} : the importpath attribute on go_binary is deprecated.".format(native.package_name(), name))
 
-
-  library_name = name + test_library_suffix
-  go_library_macro(
-      name = library_name,
-      visibility = ["//visibility:private"],
-      srcs = srcs,
-      deps = deps,
-      importpath = importpath,
-      embed = embed,
-      gc_goopts = gc_goopts,
-      testonly = True,
-      tags = ["manual"],
-      cgo = False,
-      cdeps = cdeps,
-      copts = copts,
-      clinkopts = clinkopts,
-      x_defs = x_defs,
-  )
+  if cgo:
+    cgo_embed = setup_cgo_library(
+        name = name,
+        srcs = srcs,
+        cdeps = cdeps,
+        copts = copts,
+        clinkopts = clinkopts,
+    )
+    embed = embed + [cgo_embed]
+    srcs = []
   go_test(
       name = name,
-      library = library_name,
-      gc_goopts = gc_goopts,
+      srcs = srcs,
+      embed = embed,
       **kwargs
   )


### PR DESCRIPTION
This removes a rule from the visible graph that the user does not really want to
know about, and also gives the go_test rule more power to control the
compilation of it's library