### PR TITLE
Add an example of normalising the executable name

### DIFF
--- a/tests/README.rst
+++ b/tests/README.rst
@@ -7,6 +7,7 @@ Main test areas
 .. Child list start
 
 * `Core Go rules tests <core/README.rst>`_
+* `Go rules examples <examples/README.rst>`_
 * `Integration tests <integration/README.rst>`_
 * `Legacy tests <legacy/README.rst>`_
 

--- a/tests/examples/README.rst
+++ b/tests/examples/README.rst
@@ -1,0 +1,14 @@
+Go rules examples
+===================
+
+This contains examples of how to apply the go rules to common problems.
+
+Contents
+--------
+
+.. Child list start
+
+* `Executable name <executable_name/README.rst>`_
+
+.. Child list end
+

--- a/tests/examples/executable_name/BUILD.bazel
+++ b/tests/examples/executable_name/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_test", "go_source")
+
+go_binary(
+    name = "some_binary",
+    srcs = ["main.go"],
+)
+
+genrule(
+    name = "normalised_binary",
+    srcs = [":some_binary"],
+    outs = ["the_binary"],
+    cmd = "cp $(SRCS) $@",
+)
+
+sh_test(
+    name = "executable_name",
+    size = "small",
+    srcs = ["name_test.sh"],
+    data = [ ":normalised_binary" ],
+)

--- a/tests/examples/executable_name/README.rst
+++ b/tests/examples/executable_name/README.rst
@@ -1,0 +1,10 @@
+Executable name
+===============
+
+.. _go_binary: /go/core.rst#go_binary
+
+The filename of the executable produced by a go_binary_ rule is unpredictale, the full path includes
+the compilation mode amongst other things, and the rules offer no backwards compatibility guarantees
+about the filename.
+For the simple case where you know exactly what you want the output filename to be, you can use a
+genrule to copy it to a well known place.

--- a/tests/examples/executable_name/main.go
+++ b/tests/examples/executable_name/main.go
@@ -1,0 +1,24 @@
+/* Copyright 2018 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("The executable ran!")
+}

--- a/tests/examples/executable_name/name_test.sh
+++ b/tests/examples/executable_name/name_test.sh
@@ -1,0 +1,6 @@
+result="$(tests/examples/executable_name/the_binary)"
+expect="The executable ran!"
+if [ "$result" != "$expect" ]; then
+  echo "error: unexpected bazel exit code: want '$expect', got '$result'" >&2
+  exit 1
+fi


### PR DESCRIPTION
This is a very simple demonstration of how to use a genrule to strip out the
compilation mode.