### PR TITLE
Build stdlib from inside the aspect

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,15 +3,10 @@ load("@io_bazel_rules_go//go/private:tools/lines_sorted_test.bzl", "lines_sorted
 load("@io_bazel_rules_go//go/private:rules/info.bzl", "go_info")
 load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_google_protobuf")
 load("@io_bazel_rules_go//go/private:context.bzl", "go_context_data")
+load("@io_bazel_rules_go//go/private:rules/stdlib.bzl", "stdlib")
 
-go_context_data(
-    name = "go_bootstrap_context_data",
-    strip = select({
-        "@io_bazel_rules_go//go/private:strip-always": "always",
-        "@io_bazel_rules_go//go/private:strip-sometimes": "sometimes",
-        "@io_bazel_rules_go//go/private:strip-never": "never",
-    }),
-    stdlib_all = [],
+stdlib(
+    name = "stdlib",
     visibility = ["//visibility:public"],
 )
 

--- a/go/private/BUILD.sdk.bazel
+++ b/go/private/BUILD.sdk.bazel
@@ -1,5 +1,3 @@
-load("@io_bazel_rules_go//go/private:rules/stdlib.bzl", "stdlib")
-
 package(default_visibility = [ "//visibility:public" ])
 
 filegroup(

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -45,7 +45,7 @@ INFERRED_PATH = "inferred"
 
 EXPORT_PATH = "export"
 
-def _declare_child(go, path, ext, name):
+def _child_name(go, path, ext, name):
   childname = mode_string(go.mode) + "/"
   childname += name if name else go._ctx.label.name
   if path:
@@ -55,10 +55,10 @@ def _declare_child(go, path, ext, name):
   return childname
 
 def _declare_file(go, path="", ext="", name = ""):
-  return go.actions.declare_file(_declare_child(go, path, ext, name))
+  return go.actions.declare_file(_child_name(go, path, ext, name))
 
 def _declare_directory(go, path="", ext="", name = ""):
-  return go.actions.declare_directory(_declare_child(go, path, ext, name))
+  return go.actions.declare_directory(_child_name(go, path, ext, name))
 
 def _new_args(go):
   args = go.actions.args()

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -45,14 +45,20 @@ INFERRED_PATH = "inferred"
 
 EXPORT_PATH = "export"
 
-def _declare_file(go, path="", ext="", name = ""):
-  filename = mode_string(go.mode) + "/"
-  filename += name if name else go._ctx.label.name
+def _declare_child(go, path, ext, name):
+  childname = mode_string(go.mode) + "/"
+  childname += name if name else go._ctx.label.name
   if path:
-    filename += "~/" + path
+    childname += "~/" + path
   if ext:
-    filename += ext
-  return go.actions.declare_file(filename)
+    childname += ext
+  return childname
+
+def _declare_file(go, path="", ext="", name = ""):
+  return go.actions.declare_file(_declare_child(go, path, ext, name))
+
+def _declare_directory(go, path="", ext="", name = ""):
+  return go.actions.declare_directory(_declare_child(go, path, ext, name))
 
 def _new_args(go):
   args = go.actions.args()
@@ -195,20 +201,9 @@ def go_context(ctx, attr=None):
   mode = get_mode(ctx, toolchain, context_data)
   root, binary = _get_go_binary(context_data)
 
-  stdlib = None
-  for check in [s[GoStdLib] for s in context_data.stdlib_all]:
-    if (check.mode.goos == mode.goos and
-        check.mode.goarch == mode.goarch and
-        check.mode.race == mode.race and
-        check.mode.pure == mode.pure):
-      if stdlib:
-        fail("Multiple matching standard library for {}: {} and {}".format(
-          mode_string(mode),
-          check.root_file.dirname,
-          stdlib.root_file.dirname))
-      stdlib = check
-  if not stdlib and context_data.stdlib_all:
-    fail("No matching standard library for "+mode_string(mode))
+  stdlib = getattr(attr, "_stdlib", None)
+  if stdlib:
+    stdlib = get_source(stdlib).stdlib
 
   importpath, pathtype = _infer_importpath(ctx)
   return GoContext(
@@ -241,20 +236,11 @@ def go_context(ctx, attr=None):
       new_library = _new_library,
       library_to_source = _library_to_source,
       declare_file = _declare_file,
+      declare_directory = _declare_directory,
 
       # Private
       _ctx = ctx, # TODO: All uses of this should be removed
   )
-
-def _stdlib_all():
-  stdlibs = []
-  for goos, goarch in GOOS_GOARCH:
-    stdlibs.extend([
-      Label("@go_stdlib_{}_{}_cgo".format(goos, goarch)),
-      Label("@go_stdlib_{}_{}_pure".format(goos, goarch)),
-      Label("@go_stdlib_{}_{}_cgo_race".format(goos, goarch)),
-    ])
-  return stdlibs
 
 def _go_context_data(ctx):
   cpp = ctx.fragments.cpp
@@ -275,7 +261,6 @@ def _go_context_data(ctx):
   compiler_path, _ = cpp.ld_executable.rsplit("/", 1)
   return struct(
       strip = ctx.attr.strip,
-      stdlib_all = ctx.attr.stdlib_all,
       crosstool = ctx.files._crosstool,
       package_list = ctx.file._package_list,
       sdk_files = ctx.files._sdk_files,
@@ -295,7 +280,6 @@ go_context_data = rule(
     _go_context_data,
     attrs = {
         "strip": attr.string(mandatory = True),
-        "stdlib_all": attr.label_list(default = _stdlib_all()),
         # Hidden internal attributes
         "_crosstool": attr.label(default = Label("//tools/defaults:crosstool")),
         "_package_list": attr.label(

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -17,7 +17,6 @@
 load("@io_bazel_rules_go//go/private:common.bzl", "MINIMUM_BAZEL_VERSION")
 load("@io_bazel_rules_go//go/private:repository_tools.bzl", "go_repository_tools")
 load("@io_bazel_rules_go//go/private:go_repository.bzl", "go_repository")
-load("@io_bazel_rules_go//go/private:rules/stdlib.bzl", "go_stdlib")
 load("@io_bazel_rules_go//go/private:skylib/lib/versions.bzl", "versions")
 load("@io_bazel_rules_go//go/toolchain:toolchains.bzl", "go_register_toolchains")
 load("@io_bazel_rules_go//go/platform:list.bzl", "GOOS_GOARCH")
@@ -54,29 +53,6 @@ def go_rules_dependencies():
       strip_prefix = "tools-5d2fd3ccab986d52112bf301d47a819783339d0e",
       type = "zip",
   )
-
-  for goos, goarch in GOOS_GOARCH:
-    _maybe(go_stdlib,
-        name = "go_stdlib_{}_{}_cgo".format(goos, goarch),
-        goos = goos,
-        goarch = goarch,
-        race = False,
-        pure = False,
-    )
-    _maybe(go_stdlib,
-        name = "go_stdlib_{}_{}_pure".format(goos, goarch),
-        goos = goos,
-        goarch = goarch,
-        race = False,
-        pure = True,
-    )
-    _maybe(go_stdlib,
-        name = "go_stdlib_{}_{}_cgo_race".format(goos, goarch),
-        goos = goos,
-        goarch = goarch,
-        race = True,
-        pure = False,
-    )
 
   _maybe(go_repository_tools,
       name = "io_bazel_rules_go_repository_tools",

--- a/go/private/rules/aspect.bzl
+++ b/go/private/rules/aspect.bzl
@@ -71,6 +71,7 @@ go_archive_aspect = aspect(
         "embed",
         "compiler",
         "compilers",
+        "_stdlib",
     ],
     attrs = {
         "pure": attr.string(values = [

--- a/go/private/rules/rule.bzl
+++ b/go/private/rules/rule.bzl
@@ -17,10 +17,13 @@ load(
     "go_archive_aspect",
 )
 
+_ASPECT_ATTRS = ["pure", "static", "msan", "race"]
+
 def go_rule(implementation, attrs={}, toolchains=[], bootstrap=False, **kwargs):
   attrs["_go_context_data"] = attr.label(default = Label("@io_bazel_rules_go//:go_context_data"))
   aspects = []
-  if all([k in attrs for k in ["pure", "static", "msan", "race"]]):
+  # If all the aspect attributes are present, also trigger the aspect on the stdlib attribute
+  if all([k in attrs for k in _ASPECT_ATTRS]):
     aspects.append(go_archive_aspect)
   if not bootstrap:
     attrs["_stdlib"] = attr.label(default = Label("@io_bazel_rules_go//:stdlib"), aspects = aspects)

--- a/go/private/rules/rule.bzl
+++ b/go/private/rules/rule.bzl
@@ -18,11 +18,14 @@ load(
 )
 
 def go_rule(implementation, attrs={}, toolchains=[], bootstrap=False, **kwargs):
+  attrs["_go_context_data"] = attr.label(default = Label("@io_bazel_rules_go//:go_context_data"))
+  aspects = []
+  if all([k in attrs for k in ["pure", "static", "msan", "race"]]):
+    aspects.append(go_archive_aspect)
   if not bootstrap:
-    attrs["_go_context_data"] = attr.label(default = Label("@io_bazel_rules_go//:go_context_data"))
+    attrs["_stdlib"] = attr.label(default = Label("@io_bazel_rules_go//:stdlib"), aspects = aspects)
     toolchains = toolchains + ["@io_bazel_rules_go//go:toolchain"]
   else:
-    attrs["_go_context_data"] = attr.label(default = Label("@io_bazel_rules_go//:go_bootstrap_context_data"))
     toolchains = toolchains + ["@io_bazel_rules_go//go:bootstrap_toolchain"]
 
   return rule(


### PR DESCRIPTION
This removes the hard coded list of standard libraries, and builds it per aspect
being propagated.
This is both cleaner and a pre-requisite for the additional link modes to work.

Related to #1264 and #54 and #539