### PR TITLE
go-bindata repo change as jteeuwen went AWOL

### DIFF
--- a/extras/bindata.bzl
+++ b/extras/bindata.bzl
@@ -61,7 +61,7 @@ bindata = go_rule(
         "_bindata": attr.label(
             allow_files = True,
             single_file = True,
-            default = Label("@com_github_jteeuwen_go_bindata//go-bindata:go-bindata"),
+            default = Label("@com_github_kevinburke_go_bindata//go-bindata:go-bindata"),
         ),
     },
 )

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -126,9 +126,9 @@ def go_rules_dependencies():
       importpath = "github.com/golang/glog",
   )
   _maybe(go_repository,
-      name = "com_github_jteeuwen_go_bindata",
-      importpath = "github.com/jteeuwen/go-bindata",
-      commit = "a0ff2567cfb70903282db057e799fd826784d41d",
+      name = "com_github_kevinburke_go_bindata",
+      importpath = "github.com/kevinburke/go-bindata",
+      tag = "v3.7.0",
   )
 
 def _maybe(repo_rule, name, **kwargs):

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -128,7 +128,7 @@ def go_rules_dependencies():
   _maybe(go_repository,
       name = "com_github_kevinburke_go_bindata",
       importpath = "github.com/kevinburke/go-bindata",
-      tag = "v3.7.0",
+      commit = "95df019c0747a093fef2832ae530a37fd2766d16",  # v3.7.0, latest as of 2018-02-07
   )
 
 def _maybe(repo_rule, name, **kwargs):


### PR DESCRIPTION
The user https://github.com/jteeuwen has disappeared earlier from github.com hosting go-bindata. Meanwhile a hard fork has been put in place by https://github.com/a-urth.
A better maintained fork is available at https://github.com/kevinburke/go-bindata which is referenced by this commit.

#1307 