### PR TITLE
Kill the bootstrap toolchain

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,9 +4,15 @@ load("@io_bazel_rules_go//go/private:rules/info.bzl", "go_info")
 load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_google_protobuf")
 load("@io_bazel_rules_go//go/private:context.bzl", "go_context_data")
 load("@io_bazel_rules_go//go/private:rules/stdlib.bzl", "stdlib")
+load("@io_bazel_rules_go//go/private:rules/builders.bzl", "builders")
 
 stdlib(
     name = "stdlib",
+    visibility = ["//visibility:public"],
+)
+
+builders(
+    name = "builders",
     visibility = ["//visibility:public"],
 )
 

--- a/go/private/actions/asm.bzl
+++ b/go/private/actions/asm.bzl
@@ -38,7 +38,7 @@ def emit_asm(go,
       inputs = inputs,
       outputs = [out_obj],
       mnemonic = "GoAsmCompile",
-      executable = go.toolchain.tools.asm,
+      executable = go.builders.asm,
       arguments = [asm_args],
   )
   return out_obj

--- a/go/private/actions/compile.bzl
+++ b/go/private/actions/compile.bzl
@@ -41,6 +41,10 @@ def emit_compile(go,
   if sources == None: fail("sources is a required parameter")
   if out_lib == None: fail("out_lib is a required parameter")
 
+  if not go.builders.compile:
+    if archives:  fail("compile does not accept deps in bootstrap mode")
+    return _bootstrap_compile(go, sources, out_lib, gc_goopts)
+
   # Add in any mode specific behaviours
   if go.mode.race:
     gc_goopts = gc_goopts + ["-race"]
@@ -80,23 +84,11 @@ def emit_compile(go,
       inputs = inputs,
       outputs = [out_lib],
       mnemonic = "GoCompile",
-      executable = go.toolchain.tools.compile,
+      executable = go.builders.compile,
       arguments = [args],
   )
 
-def bootstrap_compile(go,
-    sources = None,
-    importpath = "",
-    archives = [],
-    out_lib = None,
-    gc_goopts = [],
-    testfilter = None):
-  """See go/toolchains.rst#compile for full documentation."""
-
-  if sources == None: fail("sources is a required parameter")
-  if out_lib == None: fail("out_lib is a required parameter")
-  if archives:  fail("compile does not accept deps in bootstrap mode")
-
+def _bootstrap_compile(go, sources, out_lib, gc_goopts):
   args = ["tool", "compile", "-trimpath", "$(pwd)", "-o", out_lib.path]
   args.extend(gc_goopts)
   args.extend([s.path for s in sources])

--- a/go/private/actions/cover.bzl
+++ b/go/private/actions/cover.bzl
@@ -44,7 +44,7 @@ def emit_cover(go, source):
         inputs = [src] + go.stdlib.files,
         outputs = [out],
         mnemonic = "GoCover",
-        executable = go.toolchain.tools.cover,
+        executable = go.builders.cover,
         arguments = [args],
     )
   members = structs.to_dict(source)

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -33,6 +33,8 @@ def emit_link(go,
 
   if archive == None: fail("archive is a required parameter")
   if executable == None: fail("executable is a required parameter")
+  if not go.builders.link:
+    return _bootstrap_link(go, archive, executable, gc_linkopts)
 
   #TODO: There has to be a better way to work out the rpath
   config_strip = len(go._ctx.configuration.bin_dir.path) + 1
@@ -113,21 +115,12 @@ def emit_link(go,
                 go.crosstool, stamp_inputs, go.stdlib.files),
       outputs = [executable],
       mnemonic = "GoLink",
-      executable = go.toolchain.tools.link,
+      executable = go.builders.link,
       arguments = [args],
   )
 
-def bootstrap_link(go,
-    archive = None,
-    executable = None,
-    gc_linkopts = [],
-    linkstamp=None,
-    version_file=None,
-    info_file=None):
+def _bootstrap_link(go, archive, executable, gc_linkopts):
   """See go/toolchains.rst#link for full documentation."""
-
-  if archive == None: fail("archive is a required parameter")
-  if executable == None: fail("executable is a required parameter")
 
   inputs = depset([archive.data.file])
   args = ["tool", "link", "-s", "-o", executable.path]

--- a/go/private/actions/pack.bzl
+++ b/go/private/actions/pack.bzl
@@ -40,6 +40,6 @@ def emit_pack(go,
       inputs = inputs,
       outputs = [out_lib],
       mnemonic = "GoPack",
-      executable = go.toolchain.tools.pack,
+      executable = go.builders.pack,
       arguments = [arguments],
   )

--- a/go/private/mode.bzl
+++ b/go/private/mode.bzl
@@ -54,10 +54,10 @@ def _ternary(*values):
     fail("Invalid value {}".format(v))
   fail("_ternary failed to produce a final result from {}".format(values))
 
-def get_mode(ctx, go_toolchain, go_context_data):
+def get_mode(ctx, bootstrap, go_toolchain, go_context_data):
   # We always have to  use the pure stdlib in cross compilation mode
   force_pure = "on" if go_toolchain.cross_compile else "auto"
-  force_race = "off" if go_toolchain.bootstrap else "auto"
+  force_race = "off" if bootstrap else "auto"
 
   static = _ternary(
       getattr(ctx.attr, "static", None),

--- a/go/private/providers.bzl
+++ b/go/private/providers.bzl
@@ -50,6 +50,8 @@ GoPath = provider()
 
 GoStdLib = provider()
 
+GoBuilders = provider()
+
 def new_aspect_provider(source = None, archive = None):
   return GoAspectProviders(
       source = source,

--- a/go/private/rules/builders.bzl
+++ b/go/private/rules/builders.bzl
@@ -1,0 +1,94 @@
+# Copyright 2018 The Bazel Go Rules Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go/private:providers.bzl", "GoBuilders")
+
+def _builders_impl(ctx):
+  return [
+      GoBuilders(
+          asm = ctx.executable._asm,
+          compile = ctx.executable._compile,
+          pack = ctx.executable._pack,
+          link = ctx.executable._link,
+          cgo = ctx.executable._cgo,
+          test_generator = ctx.executable._test_generator,
+          cover = ctx.executable._cover,
+      ),
+      DefaultInfo(
+          files = depset([
+              ctx.executable._asm,
+              ctx.executable._compile,
+              ctx.executable._pack,
+              ctx.executable._link,
+              ctx.executable._cgo,
+              ctx.executable._test_generator,
+              ctx.executable._cover,
+          ]),
+      ),
+  ]
+
+builders = rule(
+    _builders_impl,
+    attrs = {
+        "_asm": attr.label(
+            allow_files = True,
+            single_file = True,
+            executable = True,
+            cfg = "host",
+            default = "//go/tools/builders:asm",
+        ),
+        "_compile": attr.label(
+            allow_files = True,
+            single_file = True,
+            executable = True,
+            cfg = "host",
+            default = "//go/tools/builders:compile",
+        ),
+        "_pack": attr.label(
+            allow_files = True,
+            single_file = True,
+            executable = True,
+            cfg = "host",
+            default = "//go/tools/builders:pack",
+        ),
+        "_link": attr.label(
+            allow_files = True,
+            single_file = True,
+            executable = True,
+            cfg = "host",
+            default = "//go/tools/builders:link",
+        ),
+        "_cgo": attr.label(
+            allow_files = True,
+            single_file = True,
+            executable = True,
+            cfg = "host",
+            default = "//go/tools/builders:cgo",
+        ),
+        "_test_generator": attr.label(
+            allow_files = True,
+            single_file = True,
+            executable = True,
+            cfg = "host",
+            default = "//go/tools/builders:generate_test_main",
+        ),
+        "_cover": attr.label(
+            allow_files = True,
+            single_file = True,
+            executable = True,
+            cfg = "host",
+            default = "//go/tools/builders:cover",
+        ),
+    },
+)

--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -131,7 +131,7 @@ def _cgo_codegen_impl(ctx):
       outputs = c_outs + go_outs + [cgo_main],
       mnemonic = "CGoCodeGen",
       progress_message = "CGoCodeGen %s" % ctx.label,
-      executable = go.toolchain.tools.cgo,
+      executable = go.builders.cgo,
       arguments = [args],
       env = {
           "CGO_LDFLAGS": " ".join(linkopts),
@@ -185,7 +185,7 @@ def _cgo_import_impl(ctx):
           ctx.files.sample_go_srcs[0],
       ] + go.stdlib.files,
       outputs = [out],
-      executable = go.toolchain.tools.cgo,
+      executable = go.builders.cgo,
       arguments = [args],
       mnemonic = "CGoImportGen",
   )

--- a/go/private/rules/rule.bzl
+++ b/go/private/rules/rule.bzl
@@ -25,11 +25,12 @@ def go_rule(implementation, attrs={}, toolchains=[], bootstrap=False, **kwargs):
   # If all the aspect attributes are present, also trigger the aspect on the stdlib attribute
   if all([k in attrs for k in _ASPECT_ATTRS]):
     aspects.append(go_archive_aspect)
+  toolchains = toolchains + ["@io_bazel_rules_go//go:toolchain"]
   if not bootstrap:
     attrs["_stdlib"] = attr.label(default = Label("@io_bazel_rules_go//:stdlib"), aspects = aspects)
-    toolchains = toolchains + ["@io_bazel_rules_go//go:toolchain"]
+    attrs["_builders"] = attr.label(default = Label("@io_bazel_rules_go//:builders"))
   else:
-    toolchains = toolchains + ["@io_bazel_rules_go//go:bootstrap_toolchain"]
+    attrs["_builders"] = attr.label(default = None)
 
   return rule(
       implementation = implementation,

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -105,7 +105,7 @@ def _go_test_impl(ctx):
       inputs = go_srcs,
       outputs = [main_go],
       mnemonic = "GoTestGenTest",
-      executable = go.toolchain.tools.test_generator,
+      executable = go.builders.test_generator,
       arguments = [arguments],
       env = {
           "RUNDIR" : ctx.label.package,

--- a/go/toolchain/toolchains.bzl
+++ b/go/toolchain/toolchains.bzl
@@ -173,9 +173,6 @@ def go_register_toolchains(go_version=DEFAULT_VERSION):
   for toolchain in _toolchains:
     name = _label_prefix + toolchain["name"]
     native.register_toolchains(name)
-    if toolchain["host"] == toolchain["target"]:
-      name = name + "-bootstrap"
-      native.register_toolchains(name)
 
 def declare_constraints():
   for goos, constraint in GOOS.items():

--- a/go/toolchains.rst
+++ b/go/toolchains.rst
@@ -66,10 +66,7 @@ platforms. It should be considered an opaqute type, you only ever use it through
 Declaration
 ^^^^^^^^^^^
 
-Toolchains are declared using the go_toolchain_ macro. This actually registers two Bazel
-toolchains, the main Go toolchain, and a special bootstrap toolchain. The bootstrap toolchain
-is needed because the full toolchain includes tools that are compiled on demand and written in
-go, so we need a special cut down version of the toolchain to build those tools.
+Toolchains are declared using the go_toolchain_ macro.
 
 Toolchains are pre-declared for all the known combinations of host and target, and the names
 are a predictable
@@ -82,7 +79,6 @@ it's default name, the following toolchain labels (along with many others) will 
 .. code::
 
   @io_bazel_rules_go//go/toolchain:linux_amd64
-  @io_bazel_rules_go//go/toolchain:linux_amd64-bootstrap
   @io_bazel_rules_go//go/toolchain:linux_amd64_cross_windows_amd64
 
 The toolchains are not usable until you register_ them.
@@ -101,9 +97,6 @@ go_register_toolchains_.
 If you wish to have more control over the toolchains you can instead just make direct
 calls to register_toolchains_ with only the toolchains you wish to install. You can see an
 example of this in `limiting the available toolchains`_.
-It is important to note that you **must** also register the bootstrap toolchain for any other
-toolchain that you register, otherwise the tools for that toolchain cannot be built.
-
 
 
 The context
@@ -208,7 +201,7 @@ WORKSPACE
 
     go_download_sdk(name="my_linux_sdk", url="https://storage.googleapis.com/golang/go1.8.1.linux-amd64.tar.gz")
     register_toolchains(
-        "@//:my_linux_toolchain", "@//:my_linux_toolchain-bootstrap",
+        "@//:my_linux_toolchain",
     )
 
     go_rules_dependencies()
@@ -239,7 +232,6 @@ WORKSPACE
     go_rules_dependencies()
     register_toolchains(
         "@io_bazel_rules_go//go/toolchain:1.8.3_darwin_amd64",
-        "@io_bazel_rules_go//go/toolchain:1.8.3_darwin_amd64-bootstrap",
     )
 
 
@@ -353,8 +345,7 @@ This prepares a local path to use as the Go SDK in toolchains.
 go_toolchain
 ~~~~~~~~~~~~
 
-This adds a toolchain of type :value:`"@io_bazel_rules_go//go:toolchain"` and also a bootstrapping
-toolchain of type :value:`"@io_bazel_rules_go//go:bootstrap_toolchain"`.
+This adds a toolchain of type :value:`"@io_bazel_rules_go//go:toolchain"`.
 
 +--------------------------------+-----------------------------+-----------------------------------+
 | **Name**                       | **Type**                    | **Default value**                 |
@@ -362,8 +353,6 @@ toolchain of type :value:`"@io_bazel_rules_go//go:bootstrap_toolchain"`.
 | :param:`name`                  | :type:`string`              | |mandatory|                       |
 +--------------------------------+-----------------------------+-----------------------------------+
 | A unique name for the toolchain.                                                                 |
-| The base toolchain will have the name you supply, the bootstrap toolchain with have              |
-| :value:`"-bootstrap"` appended.                                                                  |
 | You will need to use this name when registering the toolchain in the WORKSPACE.                  |
 +--------------------------------+-----------------------------+-----------------------------------+
 | :param:`target`                | :type:`string`              | |mandatory|                       |

--- a/tests/legacy/custom_go_toolchain/BUILD.bazel
+++ b/tests/legacy/custom_go_toolchain/BUILD.bazel
@@ -35,8 +35,8 @@ go_download_sdk(
     },
 )
 register_toolchains(
-    "@//:my_linux_toolchain", "@//:my_linux_toolchain-bootstrap",
-    "@//:my_darwin_toolchain", "@//:my_darwin_toolchain-bootstrap",
+    "@//:my_linux_toolchain",
+    "@//:my_darwin_toolchain",
 )
 
 go_rules_dependencies()


### PR DESCRIPTION
To do this, we extract the builders and pass them separaetly, which means the
normal toolchain always works.

Fixes #1304