### PR TITLE
cgo: avoid generating long file names

### DIFF
--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -37,10 +37,33 @@ load(
 
 _CgoCodegen = provider()
 
-def _mangle(src):
-    src_stem, _, src_ext = src.path.rpartition('.')
-    mangled_stem = src_stem.replace('/', '_')
-    return mangled_stem, src_ext
+# Maximum number of characters in stem of base name for mangled cgo files.
+# Some file systems have fairly short limits (eCryptFS has a limit of 143),
+# and this should be kept below those to accomodate number suffixes and
+# extensions.
+MAX_MANGLED_STEM_LENGTH = 130
+
+def _mangle(src, stems):
+  """_mangle returns a file stem and extension for a source file that will
+  be passed to cgo. The stem will be unique among other sources in the same
+  library. It will not contain any separators, so cgo's name mangling algorithm
+  will be a no-op."""
+  src_stem, _, src_ext = src.path.rpartition('.')
+  mangled_stem = src_stem.replace('/', '_')
+  if len(mangled_stem) > MAX_MANGLED_STEM_LENGTH:
+    mangled_stem = src.basename.rpartition('.')[0]
+  if len(mangled_stem) > MAX_MANGLED_STEM_LENGTH:
+    mangled_stem = mangled_stem[:MAX_MANGLED_STEM_LENGTH]
+  if mangled_stem in stems:
+    for i in range(100):
+      next_stem = "{}_{}".format(mangled_stem, i)
+      if next_stem not in stems:
+        break
+    if next_stem in stems:
+      fail("could not find unique manged name for {}".format(src.path))
+    mangled_stem = next_stem
+  stems[mangled_stem] = None
+  return mangled_stem, src_ext
 
 def _c_filter_options(options, blacklist):
   return [opt for opt in options
@@ -83,21 +106,22 @@ def _cgo_codegen_impl(ctx):
 
   source = split_srcs(ctx.files.srcs)
   for src in source.headers:
-      copts.extend(['-iquote', src.dirname])
+    copts.extend(['-iquote', src.dirname])
+  stems = {}
   for src in source.go:
-    mangled_stem, src_ext = _mangle(src)
+    mangled_stem, src_ext = _mangle(src, stems)
     gen_file = go.declare_file(go, path=mangled_stem + ".cgo1."+src_ext)
     gen_c_file = go.declare_file(go, path=mangled_stem + ".cgo2.c")
     go_outs.append(gen_file)
     c_outs.append(gen_c_file)
     args.add(["-src", gen_file.path + "=" + src.path])
   for src in source.asm:
-    mangled_stem, src_ext = _mangle(src)
+    mangled_stem, src_ext = _mangle(src, stems)
     gen_file = go.declare_file(go, path=mangled_stem + ".cgo1."+src_ext)
     go_outs.append(gen_file)
     args.add(["-src", gen_file.path + "=" + src.path])
   for src in source.c:
-    mangled_stem, src_ext = _mangle(src)
+    mangled_stem, src_ext = _mangle(src, stems)
     gen_file = go.declare_file(go, path=mangled_stem + ".cgo1."+src_ext)
     c_outs.append(gen_file)
     args.add(["-src", gen_file.path + "=" + src.path])

--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -41,29 +41,26 @@ _CgoCodegen = provider()
 # Some file systems have fairly short limits (eCryptFS has a limit of 143),
 # and this should be kept below those to accomodate number suffixes and
 # extensions.
-MAX_MANGLED_STEM_LENGTH = 130
+MAX_STEM_LENGTH = 130
 
 def _mangle(src, stems):
   """_mangle returns a file stem and extension for a source file that will
   be passed to cgo. The stem will be unique among other sources in the same
   library. It will not contain any separators, so cgo's name mangling algorithm
   will be a no-op."""
-  src_stem, _, src_ext = src.path.rpartition('.')
-  mangled_stem = src_stem.replace('/', '_')
-  if len(mangled_stem) > MAX_MANGLED_STEM_LENGTH:
-    mangled_stem = src.basename.rpartition('.')[0]
-  if len(mangled_stem) > MAX_MANGLED_STEM_LENGTH:
-    mangled_stem = mangled_stem[:MAX_MANGLED_STEM_LENGTH]
-  if mangled_stem in stems:
+  stem, _, ext = src.basename.rpartition('.')
+  if len(stem) > MAX_STEM_LENGTH:
+    stem = stem[:MAX_STEM_LENGTH]
+  if stem in stems:
     for i in range(100):
-      next_stem = "{}_{}".format(mangled_stem, i)
+      next_stem = "{}_{}".format(stem, i)
       if next_stem not in stems:
         break
     if next_stem in stems:
-      fail("could not find unique manged name for {}".format(src.path))
-    mangled_stem = next_stem
-  stems[mangled_stem] = None
-  return mangled_stem, src_ext
+      fail("could not find unique mangled name for {}".format(src.path))
+    stem = next_stem
+  stems[stem] = True
+  return stem, ext
 
 def _c_filter_options(options, blacklist):
   return [opt for opt in options

--- a/go/tools/builders/cgo.go
+++ b/go/tools/builders/cgo.go
@@ -31,13 +31,13 @@ import (
 
 func run(args []string) error {
 	sources := multiFlag{}
-	objdir := ""
+	objDir := ""
 	dynout := ""
 	dynimport := ""
 	flags := flag.NewFlagSet("cgo", flag.ContinueOnError)
 	goenv := envFlags(flags)
 	flags.Var(&sources, "src", "A source file to be filtered and compiled")
-	flags.StringVar(&objdir, "objdir", "", "The output directory")
+	flags.StringVar(&objDir, "objdir", "", "The output directory")
 	flags.StringVar(&dynout, "dynout", "", "The output directory")
 	flags.StringVar(&dynimport, "dynimport", "", "The output directory")
 	// process the args
@@ -72,6 +72,14 @@ func run(args []string) error {
 		}
 		return nil
 	}
+
+	// create a temporary directory. sources actually passed to cgo will be moved
+	// here first so that we can use -srcdir to avoid very long mangled filenames.
+	srcDir, err := ioutil.TempDir("", "srcdir")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(srcDir)
 
 	// apply build constraints to the source list
 	// also pick out the cgo sources
@@ -137,7 +145,12 @@ func run(args []string) error {
 
 		if metadata.isCgo {
 			// add to cgo file list
-			cgoSrcs = append(cgoSrcs, in)
+			srcInBase := strings.TrimSuffix(filepath.Base(out), ".cgo1.go") + ".go"
+			srcIn := filepath.Join(srcDir, srcInBase)
+			if err := ioutil.WriteFile(srcIn, data, 0644); err != nil {
+				return err
+			}
+			cgoSrcs = append(cgoSrcs, srcInBase)
 			cgoOuts = append(cgoOuts, out)
 		} else {
 			// Non cgo file, copy the go and fake the c
@@ -156,11 +169,12 @@ func run(args []string) error {
 	if len(cgoSrcs) == 0 {
 		// If there were no cgo sources present, generate a minimal cgo input
 		// This is so we can still run the cgo tool to build all the other outputs
-		nullCgo := filepath.Join(objdir, "_cgo_empty.go")
-		cgoSrcs = append(cgoSrcs, nullCgo)
+		nullCgoBase := "_cgo_empty.go"
+		nullCgo := filepath.Join(srcDir, nullCgoBase)
 		if err := ioutil.WriteFile(nullCgo, []byte("package "+pkgName+"\n/*\n*/\nimport \"C\"\n"), 0644); err != nil {
 			return err
 		}
+		cgoSrcs = append(cgoSrcs, nullCgoBase)
 	}
 
 	// Tokenize copts. cc_library does this automatically, but cgo does not,
@@ -174,7 +188,7 @@ func run(args []string) error {
 		copts = append(copts, args...)
 	}
 
-	goargs := []string{"tool", "cgo", "-objdir", objdir}
+	goargs := []string{"tool", "cgo", "-srcdir", srcDir, "-objdir", objDir}
 	goargs = append(goargs, copts...)
 	goargs = append(goargs, cgoSrcs...)
 	cmd := exec.Command(goenv.Go, goargs...)


### PR DESCRIPTION
cgo chooses output file names by replacing slashes in source file
names with underscores. This can result in long names for source files
in deeply nested directories: names long enough to exceed length
limits on some file systems (143 on eCryptFS).

With this change, we choose unique stems that are reasonably short
(at most 130 characters). Before invoking cgo, we move filtered source
files into a temporary directory which is passed to cgo via -srcdir to
avoid further mangling.

Fixes #1224