### PR TITLE
Allow stdlib to be built and depended on with --features=race

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -198,10 +198,9 @@ def go_context(ctx, attr=None):
     builders = builders[GoBuilders]
   else:
     builders = GoBuilders(compile=None, link=None)
-  bootstrap = builders.compile == None
 
   context_data = attr._go_context_data
-  mode = get_mode(ctx, bootstrap, toolchain, context_data)
+  mode = get_mode(ctx, toolchain, context_data)
   root, binary = _get_go_binary(context_data)
 
   stdlib = getattr(attr, "_stdlib", None)

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -198,9 +198,10 @@ def go_context(ctx, attr=None):
     builders = builders[GoBuilders]
   else:
     builders = GoBuilders(compile=None, link=None)
+  host_only = getattr(attr, "_hostonly", False)
 
   context_data = attr._go_context_data
-  mode = get_mode(ctx, toolchain, context_data)
+  mode = get_mode(ctx, host_only, toolchain, context_data)
   root, binary = _get_go_binary(context_data)
 
   stdlib = getattr(attr, "_stdlib", None)

--- a/go/private/mode.bzl
+++ b/go/private/mode.bzl
@@ -54,9 +54,10 @@ def _ternary(*values):
     fail("Invalid value {}".format(v))
   fail("_ternary failed to produce a final result from {}".format(values))
 
-def get_mode(ctx, go_toolchain, go_context_data):
+def get_mode(ctx, host_only, go_toolchain, go_context_data):
   # We always have to  use the pure stdlib in cross compilation mode
   force_pure = "on" if go_toolchain.cross_compile else "auto"
+  force_race = "off" if host_only else "auto"
 
   static = _ternary(
       getattr(ctx.attr, "static", None),
@@ -64,7 +65,7 @@ def get_mode(ctx, go_toolchain, go_context_data):
   )
   race = _ternary(
       getattr(ctx.attr, "race", None),
-      getattr(ctx.attr, "_race", None),
+      force_race,
       "race" in ctx.features,
   )
   msan = _ternary(

--- a/go/private/mode.bzl
+++ b/go/private/mode.bzl
@@ -54,10 +54,9 @@ def _ternary(*values):
     fail("Invalid value {}".format(v))
   fail("_ternary failed to produce a final result from {}".format(values))
 
-def get_mode(ctx, bootstrap, go_toolchain, go_context_data):
+def get_mode(ctx, go_toolchain, go_context_data):
   # We always have to  use the pure stdlib in cross compilation mode
   force_pure = "on" if go_toolchain.cross_compile else "auto"
-  force_race = "off" if bootstrap else "auto"
 
   static = _ternary(
       getattr(ctx.attr, "static", None),
@@ -65,7 +64,7 @@ def get_mode(ctx, bootstrap, go_toolchain, go_context_data):
   )
   race = _ternary(
       getattr(ctx.attr, "race", None),
-      force_race,
+      getattr(ctx.attr, "_race", None),
       "race" in ctx.features,
   )
   msan = _ternary(

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -159,6 +159,7 @@ go_tool_binary = go_rule(
         "linkstamp": attr.string(),
         "x_defs": attr.string_dict(),
         "linkmode": attr.string(values=LINKMODES, default=LINKMODE_NORMAL),
+        "_race": attr.string(default="off"),
     },
     executable = True,
 )

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -159,7 +159,7 @@ go_tool_binary = go_rule(
         "linkstamp": attr.string(),
         "x_defs": attr.string_dict(),
         "linkmode": attr.string(values=LINKMODES, default=LINKMODE_NORMAL),
-        "_race": attr.string(default="off"),
+        "_hostonly": attr.bool(default=True),
     },
     executable = True,
 )

--- a/go/private/rules/rule.bzl
+++ b/go/private/rules/rule.bzl
@@ -29,8 +29,6 @@ def go_rule(implementation, attrs={}, toolchains=[], bootstrap=False, **kwargs):
   if not bootstrap:
     attrs["_stdlib"] = attr.label(default = Label("@io_bazel_rules_go//:stdlib"), aspects = aspects)
     attrs["_builders"] = attr.label(default = Label("@io_bazel_rules_go//:builders"))
-  else:
-    attrs["_builders"] = attr.label(default = None)
 
   return rule(
       implementation = implementation,

--- a/tests/legacy/race/BUILD.bazel
+++ b/tests/legacy/race/BUILD.bazel
@@ -52,9 +52,10 @@ bazel_test(
     name = "race_feature",
     args = ["--features=race"],
     check = """
-if [ "$result" -eq 0 ]; then
-  echo "error: test succeeded unexpectedly" >&2
-  result=1
+if [ "$result" -ne 3 ]; then
+  echo "error: bazel test failure expected (code 3). Got code $result" >&2
+  cat bazel-output.txt
+  exit 1
 else
   result=0
 fi


### PR DESCRIPTION
Passing bootstrap = True to go_rule now only controls whether _stdlib
and _builders attributes are added. stdlib continues to do this.

The presence or absence of _builders is no longer used to force off
race mode. This prevented stdlib from being built in race mode without
the aspect. Now, go_tool_binary (the only other bootstrap rule) has a
special _race = "off" attribute, which get_mode looks for.

Fixes #1316