### PR TITLE
bazel_test: fix a relative label used in the bazel_test macro

### DIFF
--- a/tests/bazel_tests.bzl
+++ b/tests/bazel_tests.bzl
@@ -190,7 +190,7 @@ def bazel_test(name, command = None, args=None, targets = None, go_version = Non
       data = [
           "@bazel_gazelle//cmd/gazelle",
           "@bazel_test//:bazelrc",
-          "//tests:rules_go_deps",
+          "@io_bazel_rules_go//tests:rules_go_deps",
       ],
   )
 


### PR DESCRIPTION
This allows bazel_test to be used outside of rules_go (Gazelle).