### PR TITLE
Set strip value to false by default.

### DIFF
--- a/go/private/mode.bzl
+++ b/go/private/mode.bzl
@@ -85,7 +85,7 @@ def get_mode(ctx, host_only, go_toolchain, go_context_data):
   strip_mode = "sometimes"
   if go_context_data:
     strip_mode = go_context_data.strip
-  strip = True
+  strip = False
   if strip_mode == "always":
     strip = True
   elif strip_mode == "sometimes":


### PR DESCRIPTION
This change will ensure that unstripped binaries will be built when
the --strip=never. By default, stripped binaries should still
be created, where --compilation_mode defaults to fastbuild and
--strip defaults to sometimes.