### PR TITLE
Reverse sense of importpath and importmap

### DIFF
--- a/go/core.rst
+++ b/go/core.rst
@@ -162,9 +162,17 @@ Attributes
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`importpath`        | :type:`string`              | :value:`""`                           |
 +----------------------------+-----------------------------+---------------------------------------+
-| The import path of this library. If unspecified, the library will have an implicit               |
-| dependency on ``//:go_prefix``, and the import path will be derived from the prefix              |
-| and the library's label.                                                                         |
+| The source import path of this library. Other libraries can import this                          |
+| library using this path. If unspecified, the library will have an implicit                       |
+| dependency on ``//:go_prefix``, and the import path will be derived from the                     |
+| prefix and the library's label.                                                                  |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`importmap`         | :type:`string`              | :value:`""`                           |
++----------------------------+-----------------------------+---------------------------------------+
+| The actual import path of this library. This is mostly only visible to the                       |
+| compiler and linker, but it may also be seen in stack traces. This may be set                    |
+| to prevent a binary from linking multiple packages with the same import path                     |
+| e.g., from different vendor directories.                                                         |
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`srcs`              | :type:`label_list`          | :value:`None`                         |
 +----------------------------+-----------------------------+---------------------------------------+

--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -38,7 +38,12 @@ def emit_archive(go, source=None):
   if go.cover:
     source, cover_vars = go.cover(go, source)
   split = split_srcs(source.srcs)
-  compilepath = source.library.importpath if source.library.importpath else source.library.name
+  if source.library.importmap:
+    compilepath = source.library.importmap
+  elif source.library.importpath:
+    compilepath = source.library.importpath
+  else:
+    compilepath = source.library.name
   lib_name = compilepath + ".a"
   out_lib = go.declare_file(go, path=lib_name)
   searchpath = out_lib.path[:-len(lib_name)]

--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -38,13 +38,7 @@ def emit_archive(go, source=None):
   if go.cover:
     source, cover_vars = go.cover(go, source)
   split = split_srcs(source.srcs)
-  if source.library.importmap:
-    compilepath = source.library.importmap
-  elif source.library.importpath:
-    compilepath = source.library.importpath
-  else:
-    compilepath = source.library.name
-  lib_name = compilepath + ".a"
+  lib_name = source.library.importmap + ".a"
   out_lib = go.declare_file(go, path=lib_name)
   searchpath = out_lib.path[:-len(lib_name)]
   testfilter = getattr(source.library, "testfilter", None)
@@ -62,7 +56,7 @@ def emit_archive(go, source=None):
   if len(extra_objects) == 0 and source.cgo_archive == None:
     go.compile(go,
         sources = split.go,
-        importpath = compilepath,
+        importpath = source.library.importpath,
         archives = direct,
         out_lib = out_lib,
         gc_goopts = source.gc_goopts,
@@ -72,7 +66,7 @@ def emit_archive(go, source=None):
     partial_lib = go.declare_file(go, path=lib_name+"~partial", ext=".a")
     go.compile(go,
         sources = split.go,
-        importpath = compilepath,
+        importpath = source.library.importpath,
         archives = direct,
         out_lib = partial_lib,
         gc_goopts = source.gc_goopts,

--- a/go/private/actions/compile.bzl
+++ b/go/private/actions/compile.bzl
@@ -27,7 +27,7 @@ def _searchpath(l):
   return [v.data.searchpath for v in l]
 
 def _importmap(l):
-  return ["{}={}".format(v.data.importmap, v.data.importpath) for v in l]
+  return ["{}={}".format(v.data.importpath, v.data.importmap) for v in l]
 
 def emit_compile(go,
     sources = None,

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -84,11 +84,16 @@ def _new_args(go):
   return args
 
 def _new_library(go, name=None, importpath=None, resolver=None, importable=True, testfilter=None, **kwargs):
+  if not importpath:
+    importpath = go.importpath
+  importmap = getattr(go._ctx.attr, "importmap", "")
+  if not importmap:
+    importmap = importpath
   return GoLibrary(
       name = go._ctx.label.name if not name else name,
       label = go._ctx.label,
-      importpath = go.importpath if not importpath else importpath,
-      importmap = getattr(go._ctx.attr, "importmap", ""),
+      importpath = importpath,
+      importmap = importmap,
       pathtype = go.pathtype if importable else EXPORT_PATH,
       resolve = resolver,
       testfilter = testfilter,
@@ -132,10 +137,9 @@ def _library_to_source(go, attr, library, coverage_instrumented):
   for e in getattr(attr, "embed", []):
     _merge_embed(source, e)
   x_defs = source["x_defs"]
-  actual_importpath = library.importmap if library.importmap else library.importpath
   for k,v in getattr(attr, "x_defs", {}).items():
     if "." not in k:
-      k = "{}.{}".format(actual_importpath, k)
+      k = "{}.{}".format(library.importmap, k)
     x_defs[k] = v
   source["x_defs"] = x_defs
   if library.resolve:

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -132,9 +132,10 @@ def _library_to_source(go, attr, library, coverage_instrumented):
   for e in getattr(attr, "embed", []):
     _merge_embed(source, e)
   x_defs = source["x_defs"]
+  actual_importpath = library.importmap if library.importmap else library.importpath
   for k,v in getattr(attr, "x_defs", {}).items():
     if "." not in k:
-      k = "{}.{}".format(library.importpath, k)
+      k = "{}.{}".format(actual_importpath, k)
     x_defs[k] = v
   source["x_defs"] = x_defs
   if library.resolve:

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -117,7 +117,7 @@ def _go_test_impl(ctx):
       name = go._ctx.label.name + "~testmain",
       label = go._ctx.label,
       importpath = "testmain",
-      importmap = None,
+      importmap = "testmain",
       pathtype = EXPORT_PATH,
       resolve = None,
   )

--- a/go/tools/builders/compile.go
+++ b/go/tools/builders/compile.go
@@ -92,15 +92,15 @@ func run(args []string) error {
 	for _, mapping := range importmap {
 		i := strings.Index(mapping, "=")
 		if i < 0 {
-			return fmt.Errorf("Invalid importmap %v", mapping)
+			return fmt.Errorf("Invalid importmap %v: no = separator", mapping)
 		}
-		importmap := mapping[0:i]
-		importpath := mapping[i+1 : len(mapping)]
-		if importmap == "" || importpath == "" {
+		source := mapping[:i]
+		actual := mapping[i+1:]
+		if source == "" || actual == "" || source == actual {
 			continue
 		}
 		goargs = append(goargs, "-importmap", mapping)
-		strictdeps = append(strictdeps, importmap)
+		strictdeps = append(strictdeps, source)
 	}
 	goargs = append(goargs, "-pack", "-o", *output)
 	goargs = append(goargs, flags.Args()...)

--- a/tests/core/importmap/BUILD.bazel
+++ b/tests/core/importmap/BUILD.bazel
@@ -7,17 +7,17 @@ test_suite(
 go_library(
     name = "lib_a",
     srcs = ["lib.go"],
-    importpath = "a/lib",
-    importmap = "lib",
-    x_defs = {"Value":"ValueA"},
+    importmap = "a/lib",
+    importpath = "lib",
+    x_defs = {"Value": "ValueA"},
 )
 
 go_library(
     name = "lib_b",
     srcs = ["lib.go"],
-    importpath = "b/lib",
-    importmap = "lib",
-    x_defs = {"Value":"ValueB"},
+    importmap = "b/lib",
+    importpath = "lib",
+    x_defs = {"Value": "ValueB"},
 )
 
 go_library(
@@ -38,5 +38,8 @@ go_test(
     name = "importmap_test",
     size = "small",
     srcs = ["importmap_test.go"],
-    deps = [":a", ":b"],
+    deps = [
+        ":a",
+        ":b",
+    ],
 )


### PR DESCRIPTION
importpath is the source importpath. Packages can reference other
packages using import declarations with this string.

importmap is the actual importpath. The compiler and linker use this,
and it's visible in stack traces. This only needs to be set when
multiple packages with the same import path would otherwise be linked.

Related #1237 
Fixes #1253 