### PR TITLE
Add functions to locate the runfiles tree of a binary

### DIFF
--- a/go/tools/bazel/README.md
+++ b/go/tools/bazel/README.md
@@ -4,4 +4,6 @@ This directory contains useful utilities for interacting with Bazel from Go.
 
 Currently the `bazel` package supports:
 
-1.  Getting the path for a runfile in a test.
+*   Getting the path for a runfile in a test.
+
+*   Finding and entering the location of the runfiles of a binary.


### PR DESCRIPTION
This change adds a bunch of Bazel-specific functions to locate the
runfiles trees of built binaries and to find binaries within them.

This extra logic is required to support the recent change in the Go
rules that causes the paths to built Go binaries to not be deterministic
(issue #1239).