### PR TITLE
Various fixes and changes

### DIFF
--- a/extras/bindata.bzl
+++ b/extras/bindata.bzl
@@ -61,6 +61,8 @@ bindata = go_rule(
         "_bindata": attr.label(
             allow_files = True,
             single_file = True,
+            executable = True,
+            cfg = "host",
             default = Label("@com_github_kevinburke_go_bindata//go-bindata:go-bindata"),
         ),
     },

--- a/extras/bindata.bzl
+++ b/extras/bindata.bzl
@@ -34,6 +34,8 @@ def _bindata_impl(ctx):
     arguments.add("-nocompress")
   if not ctx.attr.metadata:
     arguments.add("-nometadata")
+  if not ctx.attr.modtime:
+    arguments.add(["-modtime", "0"])
   arguments.add(ctx.files.srcs)
   ctx.actions.run(
     inputs = ctx.files.srcs,
@@ -58,6 +60,7 @@ bindata = go_rule(
         "package": attr.string(mandatory = True),
         "compress": attr.bool(default = True),
         "metadata": attr.bool(default = False),
+        "modtime": attr.bool(default = False),
         "_bindata": attr.label(
             allow_files = True,
             single_file = True,

--- a/extras/bindata.bzl
+++ b/extras/bindata.bzl
@@ -34,8 +34,12 @@ def _bindata_impl(ctx):
     arguments.add("-nocompress")
   if not ctx.attr.metadata:
     arguments.add("-nometadata")
+  if not ctx.attr.memcopy:
+    arguments.add("-nomemcopy")
   if not ctx.attr.modtime:
     arguments.add(["-modtime", "0"])
+  if ctx.attr.extra_args:
+    arguments.add(ctx.attr.extra_args)
   arguments.add(ctx.files.srcs)
   ctx.actions.run(
     inputs = ctx.files.srcs,
@@ -60,7 +64,9 @@ bindata = go_rule(
         "package": attr.string(mandatory = True),
         "compress": attr.bool(default = True),
         "metadata": attr.bool(default = False),
+        "memcopy": attr.bool(default = True),
         "modtime": attr.bool(default = False),
+        "extra_args": attr.string_list(),
         "_bindata": attr.label(
             allow_files = True,
             single_file = True,

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -23,6 +23,10 @@ load(
 load(
     "@io_bazel_rules_go//go/private:providers.bzl",
     _GoLibrary = "GoLibrary",
+    _GoSource = "GoSource",
+    _GoPath = "GoPath",
+    _GoArchive = "GoArchive",
+    _GoArchiveData = "GoArchiveData",
 )
 load(
     "@io_bazel_rules_go//go/private:repositories.bzl",
@@ -81,6 +85,18 @@ RULES_GO_VERSION = "0.10.0"
 
 GoLibrary = _GoLibrary
 """See go/providers.rst#GoLibrary for full documentation."""
+
+GoSource = _GoSource
+"""See go/providers.rst#GoSource for full documentation."""
+
+GoPath = _GoPath
+"""See go/providers.rst#GoPath for full documentation."""
+
+GoArchive = _GoArchive
+"""See go/providers.rst#GoArchive for full documentation."""
+
+GoArchiveData = _GoArchiveData
+"""See go/providers.rst#GoArchiveData for full documentation."""
 
 go_library = _go_library_macro
 """See go/core.rst#go_library for full documentation."""

--- a/go/private/actions/asm.bzl
+++ b/go/private/actions/asm.bzl
@@ -40,5 +40,6 @@ def emit_asm(go,
       mnemonic = "GoAsmCompile",
       executable = go.builders.asm,
       arguments = [asm_args],
+      env = go.env,
   )
   return out_obj

--- a/go/private/actions/compile.bzl
+++ b/go/private/actions/compile.bzl
@@ -86,6 +86,7 @@ def emit_compile(go,
       mnemonic = "GoCompile",
       executable = go.builders.compile,
       arguments = [args],
+      env = go.env,
   )
 
 def _bootstrap_compile(go, sources, out_lib, gc_goopts):

--- a/go/private/actions/cover.bzl
+++ b/go/private/actions/cover.bzl
@@ -46,6 +46,7 @@ def emit_cover(go, source):
         mnemonic = "GoCover",
         executable = go.builders.cover,
         arguments = [args],
+        env = go.env,
     )
   members = structs.to_dict(source)
   members["srcs"] = covered

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -116,6 +116,7 @@ def emit_link(go,
       mnemonic = "GoLink",
       executable = go.builders.link,
       arguments = [args],
+      env = go.env,
   )
 
 def _bootstrap_link(go, archive, executable, gc_linkopts):

--- a/go/private/actions/pack.bzl
+++ b/go/private/actions/pack.bzl
@@ -42,4 +42,5 @@ def emit_pack(go,
       mnemonic = "GoPack",
       executable = go.builders.pack,
       arguments = [arguments],
+      env = go.env,
   )

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -268,6 +268,7 @@ def _go_context_data(ctx):
   compiler_options = [o for o in raw_compiler_options if not o in [
     "-fcolor-diagnostics",
     "-Wall",
+    "-g0",
   ]]
   linker_options = [o for o in raw_linker_options if not o in [
     "-Wl,--gc-sections",

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -46,6 +46,19 @@ INFERRED_PATH = "inferred"
 
 EXPORT_PATH = "export"
 
+_COMPILER_OPTIONS_BLACKLIST = {
+  "-fcolor-diagnostics": None,
+  "-Wall": None,
+  "-g0": None, # symbols are needed by Go, so keep them
+}
+
+_LINKER_OPTIONS_BLACKLIST = {
+  "-Wl,--gc-sections": None
+}
+
+def _filter_options(options, blacklist):
+  return [option for option in options if option not in blacklist]
+
 def _child_name(go, path, ext, name):
   childname = mode_string(go.mode) + "/"
   childname += name if name else go._ctx.label.name
@@ -259,20 +272,13 @@ def go_context(ctx, attr=None):
 def _go_context_data(ctx):
   cpp = ctx.fragments.cpp
   features = ctx.features
-  raw_compiler_options = cpp.compiler_options(features)
-  raw_linker_options = cpp.mostly_static_link_options(features, False)
-  options = (raw_compiler_options +
-      cpp.unfiltered_compiler_options(features) +
-      cpp.link_options +
-      raw_linker_options)
-  compiler_options = [o for o in raw_compiler_options if not o in [
-    "-fcolor-diagnostics",
-    "-Wall",
-    "-g0",
-  ]]
-  linker_options = [o for o in raw_linker_options if not o in [
-    "-Wl,--gc-sections",
-  ]]
+  compiler_options = _filter_options(
+    cpp.compiler_options(features) + cpp.unfiltered_compiler_options(features),
+    _COMPILER_OPTIONS_BLACKLIST)
+  linker_options = _filter_options(
+    cpp.link_options + cpp.mostly_static_link_options(features, False),
+    _LINKER_OPTIONS_BLACKLIST)
+
   env = {}
   tags = []
   if "gotags" in ctx.var:
@@ -292,7 +298,7 @@ def _go_context_data(ctx):
           ld_executable = cpp.ld_executable,
           compiler_options = compiler_options,
           linker_options = linker_options,
-          options = options,
+          options = compiler_options + linker_options,
           c_options = cpp.c_options,
       ),
   )

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -74,6 +74,9 @@ def _new_args(go):
       "-goarch", go.mode.goarch,
       "-cgo=" + ("0" if go.mode.pure else "1"),
   ])
+  if len(go.tags) > 0:
+    args.add("-tags")
+    args.add(go.tags, join_with = ",")
   if go.cgo_tools:
     args.add([
       "-compiler_path", go.cgo_tools.compiler_path,
@@ -231,6 +234,8 @@ def go_context(ctx, attr=None):
       pathtype = pathtype,
       cgo_tools = context_data.cgo_tools,
       builders = builders,
+      env = context_data.env,
+      tags = context_data.tags,
       # Action generators
       archive = toolchain.actions.archive,
       asm = toolchain.actions.asm,
@@ -267,6 +272,10 @@ def _go_context_data(ctx):
   linker_options = [o for o in raw_linker_options if not o in [
     "-Wl,--gc-sections",
   ]]
+  env = {}
+  tags = []
+  if "gotags" in ctx.var:
+    tags = ctx.var["gotags"].split(",")
   compiler_path, _ = cpp.ld_executable.rsplit("/", 1)
   return struct(
       strip = ctx.attr.strip,
@@ -274,6 +283,8 @@ def _go_context_data(ctx):
       package_list = ctx.file._package_list,
       sdk_files = ctx.files._sdk_files,
       sdk_tools = ctx.files._sdk_tools,
+      tags = tags,
+      env = env,
       cgo_tools = struct(
           compiler_path = compiler_path,
           compiler_executable = cpp.compiler_executable,

--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -86,7 +86,7 @@ def _cgo_codegen_impl(ctx):
   if not go.cgo_tools:
     fail("Go toolchain does not support cgo")
   linkopts = ctx.attr.linkopts[:]
-  copts = go.cgo_tools.c_options + ctx.attr.copts
+  copts = go.cgo_tools.c_options + go.cgo_tools.compiler_options + ctx.attr.copts
   deps = depset([], order="topological")
   cgo_export_h = go.declare_file(go, path="_cgo_export.h")
   cgo_export_c = go.declare_file(go, path="_cgo_export.c")
@@ -150,7 +150,7 @@ def _cgo_codegen_impl(ctx):
   args.add(["--", "--"])
   args.add(copts)
   ctx.actions.run(
-      inputs = inputs,
+      inputs = inputs + go.crosstool,
       outputs = c_outs + go_outs + [cgo_main],
       mnemonic = "CGoCodeGen",
       progress_message = "CGoCodeGen %s" % ctx.label,

--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -143,6 +143,8 @@ def _cgo_codegen_impl(ctx):
         linkopts.append(lib.path)
     linkopts.extend(d.cc.link_flags)
 
+  args.add(linkopts, before_each="-ld_flag")
+
   # The first -- below is to stop the cgo from processing args, the
   # second is an actual arg to forward to the underlying go tool
   args.add(["--", "--"])
@@ -154,9 +156,6 @@ def _cgo_codegen_impl(ctx):
       progress_message = "CGoCodeGen %s" % ctx.label,
       executable = go.builders.cgo,
       arguments = [args],
-      env = {
-          "CGO_LDFLAGS": " ".join(linkopts),
-      },
   )
 
   return [

--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -156,6 +156,7 @@ def _cgo_codegen_impl(ctx):
       progress_message = "CGoCodeGen %s" % ctx.label,
       executable = go.builders.cgo,
       arguments = [args],
+      env = go.env,
   )
 
   return [

--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -352,7 +352,7 @@ def setup_cgo_library(name, srcs, cdeps, copts, clinkopts):
   # into binaries that depend on this cgo_library. It will also be used
   # in _cgo_.o.
   platform_copts = select({
-      "@io_bazel_rules_go//go/platform:darwin_amd64": [],
+      "@io_bazel_rules_go//go/platform:darwin": [],
       "@io_bazel_rules_go//go/platform:windows_amd64": ["-mthreads"],
       "//conditions:default": ["-pthread"],
   })

--- a/go/private/rules/stdlib.bzl
+++ b/go/private/rules/stdlib.bzl
@@ -35,7 +35,7 @@ def _stdlib_library_to_source(go, attr, source, merge):
     args.add("-race")
   go.actions.write(root_file, "")
   go.actions.run(
-      inputs = go.sdk_files + go.sdk_tools + [go.package_list, root_file],
+      inputs = go.sdk_files + go.sdk_tools + go.crosstool + [go.package_list, root_file],
       outputs = [pkg],
       mnemonic = "GoStdlib",
       executable = attr._stdlib_builder.files.to_list()[0],

--- a/go/private/rules/stdlib.bzl
+++ b/go/private/rules/stdlib.bzl
@@ -40,6 +40,7 @@ def _stdlib_library_to_source(go, attr, source, merge):
       mnemonic = "GoStdlib",
       executable = attr._stdlib_builder.files.to_list()[0],
       arguments = [args],
+      env = go.env,
   )
   source["stdlib"] = GoStdLib(
       root_file = root_file,

--- a/go/tools/builders/asm.go
+++ b/go/tools/builders/asm.go
@@ -59,12 +59,10 @@ func run(args []string) error {
 	}
 	goargs = append(goargs, remains...)
 	goargs = append(goargs, source)
-	env := os.Environ()
-	env = append(env, goenv.Env()...)
 	cmd := exec.Command(goenv.Go, goargs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Env = env
+	cmd.Env = goenv.Env()
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("error running assembler: %v", err)
 	}

--- a/go/tools/builders/cgo.go
+++ b/go/tools/builders/cgo.go
@@ -47,10 +47,7 @@ func run(args []string) error {
 	if err := goenv.update(); err != nil {
 		return err
 	}
-	// TODO: work out why setting CGO_LDFLAGS breaks cgo
-	goenv.ld_flags = []string{}
-	env := os.Environ()
-	env = append(env, goenv.Env()...)
+	env := goenv.Env()
 
 	if len(dynout) > 0 {
 		dynpackage, err := extractPackage(sources[0])

--- a/go/tools/builders/compile.go
+++ b/go/tools/builders/compile.go
@@ -113,12 +113,10 @@ func run(args []string) error {
 		return err
 	}
 
-	env := os.Environ()
-	env = append(env, goenv.Env()...)
 	cmd := exec.Command(goenv.Go, goargs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Env = env
+	cmd.Env = goenv.Env()
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("error running compiler: %v", err)
 	}

--- a/go/tools/builders/cover.go
+++ b/go/tools/builders/cover.go
@@ -35,12 +35,10 @@ func run(args []string) error {
 	}
 	goargs := []string{"tool", "cover"}
 	goargs = append(goargs, flags.Args()...)
-	env := os.Environ()
-	env = append(env, goenv.Env()...)
 	cmd := exec.Command(goenv.Go, goargs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Env = env
+	cmd.Env = goenv.Env()
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("error running cover: %v", err)
 	}

--- a/go/tools/builders/link.go
+++ b/go/tools/builders/link.go
@@ -107,12 +107,10 @@ func run(args []string) error {
 
 	// add in the unprocess pass through options
 	goargs = append(goargs, goopts...)
-	env := os.Environ()
-	env = append(env, goenv.Env()...)
 	cmd := exec.Command(goenv.Go, goargs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Env = env
+	cmd.Env = goenv.Env()
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("error running linker: %v", err)
 	}

--- a/go/tools/builders/pack.go
+++ b/go/tools/builders/pack.go
@@ -294,11 +294,9 @@ func simpleName(name string, names map[string]bool) string {
 
 func appendFiles(goenv *GoEnv, archive string, files []string) error {
 	args := append([]string{"tool", "pack", "r", archive}, files...)
-	env := os.Environ()
-	env = append(env, goenv.Env()...)
 	cmd := exec.Command(goenv.Go, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Env = env
+	cmd.Env = goenv.Env()
 	return cmd.Run()
 }

--- a/go/tools/builders/stdlib.go
+++ b/go/tools/builders/stdlib.go
@@ -24,6 +24,9 @@ import (
 )
 
 func install_stdlib(goenv *GoEnv, target string, args []string) error {
+	if goenv.tags != "" {
+		args = append(args, "-tags", goenv.tags)
+	}
 	args = append(args, target)
 	env := os.Environ()
 	env = append(env, goenv.Env()...)

--- a/go/tools/builders/stdlib.go
+++ b/go/tools/builders/stdlib.go
@@ -28,12 +28,10 @@ func install_stdlib(goenv *GoEnv, target string, args []string) error {
 		args = append(args, "-tags", goenv.tags)
 	}
 	args = append(args, target)
-	env := os.Environ()
-	env = append(env, goenv.Env()...)
 	cmd := exec.Command(goenv.Go, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Env = env
+	cmd.Env = goenv.Env()
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("error running go install %s: %v", target, err)
 	}

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -58,7 +58,7 @@ GOGO_VARIANTS = [
 
 GOGO_WELL_KNOWN_TYPE_REMAPS = [
     "Mgoogle/protobuf/{}.proto=github.com/gogo/protobuf/types".format(t)
-    for t in WELL_KNOWN_PROTOS
+    for t in WELL_KNOWN_PROTOS + ["field_mask"]
 ]
 
 [go_proto_compiler(


### PR DESCRIPTION
This PR is a mix of various changes and fixes we've made on https://github.com/znly/rules_go that I think are upstream-able first. Of course we can split and shrink if you guys want.

Here goes:
36bc7cc: Add runfiles to GoArchiveData and use them in the GoPath
Some binaries (such as https://github.com/golang/mobile/tree/master/cmd/gobind) rely on runtime files to be in the `GOPATH`

060c171: Expose GoPath provider
Title says it all. Useful for custom rules.

f59a93d: Add tags and environment to go_context
Title says it all.

e4a157e: Expose GoSource provider
Title says it all. Useful for custom rules.

7d1d956: Make the Go environment an update of the OS environment
This ensures that the Go environment also has the OS environment keys.

f789bcd: Propagate build tags when `go install`ing `stdlib`
`std` has a few tags here and there (for instance `crypto/x509` needs the `ios` tag to build on `darwin_arm64`). This makes sure they are propagated.

93ce009: Make stdlib building depend on `CROSSTOOL` (for `runtime/cgo`)
`runtime/cgo` needs the C compiler, and it's not declared as a dependency. As a result, when using a different `CROSSTOOL` (such as Android), it will fail to find the compiler (`clang`).

aad1ce3: extras/bindata: make it executable and run on host
Needed to use cross compilation (via `--platforms`) and bindata.