### PR TITLE
compile: set -p to the actual import path, not the source import path

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -56,7 +56,7 @@ def emit_archive(go, source=None):
   if len(extra_objects) == 0 and source.cgo_archive == None:
     go.compile(go,
         sources = split.go,
-        importpath = source.library.importpath,
+        importpath = source.library.importmap,
         archives = direct,
         out_lib = out_lib,
         gc_goopts = source.gc_goopts,
@@ -66,7 +66,7 @@ def emit_archive(go, source=None):
     partial_lib = go.declare_file(go, path=lib_name+"~partial", ext=".a")
     go.compile(go,
         sources = split.go,
-        importpath = source.library.importpath,
+        importpath = source.library.importmap,
         archives = direct,
         out_lib = partial_lib,
         gc_goopts = source.gc_goopts,

--- a/go/toolchains.rst
+++ b/go/toolchains.rst
@@ -610,7 +610,9 @@ It does not return anything.
 +--------------------------------+-----------------------------+-----------------------------------+
 | :param:`importpath`            | :type:`string`              | :value:`""`                       |
 +--------------------------------+-----------------------------+-----------------------------------+
-| The import path this package represents. This is passed to the -p flag.                          |
+| The import path this package represents. This is passed to the -p flag. When the actual import   |
+| path is different than the source import path (i.e., when ``importmap`` is set in a              |
+| ``go_library`` rule), this should be the actual import path.                                     |
 +--------------------------------+-----------------------------+-----------------------------------+
 | :param:`archives`              | :type:`GoArchive iterable`  | :value:`[]`                       |
 +--------------------------------+-----------------------------+-----------------------------------+


### PR DESCRIPTION
Go 1.10 expects this now.

Related #1237