### PR TITLE
stdlib: dereference all symlinks before copying a directory

### DIFF
--- a/go/tools/builders/replicate.go
+++ b/go/tools/builders/replicate.go
@@ -129,7 +129,7 @@ func replicateTree(src, dst string, config *replicateConfig) error {
 	if err := os.RemoveAll(dst); err != nil {
 		return fmt.Errorf("Failed to remove file at destination %s: %v", dst, err)
 	}
-	if l, err := os.Readlink(src); err == nil {
+	if l, err := filepath.EvalSymlinks(src); err == nil {
 		src = l
 	}
 	s, err := os.Stat(src)


### PR DESCRIPTION
Fixes #1345