### PR TITLE
proto: implemented full end-to-end support for well-known-types

### DIFF
--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -1,26 +1,23 @@
 load("//proto:compiler.bzl", "go_proto_compiler")
 load("//proto:gogo.bzl", "gogo_special_proto")
+load("//proto:well_known_types.bzl", "gen_well_known_types", "GOGO_WELL_KNOWN_TYPE_REMAPS")
 
-WELL_KNOWN_PROTOS = [
-    "any",
-    "duration",
-    "empty",
-    "struct",
-    "timestamp",
-    "wrappers",
-]
+WELL_KNOWN_TYPES = gen_well_known_types()
 
-GOLANG_PTYPES = [
-    "@com_github_golang_protobuf//ptypes/{}:go_default_library".format(lib)
-    for lib in WELL_KNOWN_PROTOS
-]
+go_proto_compiler(
+    name = "go_proto_bootstrap",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_golang_protobuf//proto:go_default_library",
+    ],
+)
 
 go_proto_compiler(
     name = "go_proto",
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_golang_protobuf//proto:go_default_library",
-    ] + GOLANG_PTYPES,
+    ] + WELL_KNOWN_TYPES,
 )
 
 go_proto_compiler(
@@ -31,7 +28,7 @@ go_proto_compiler(
         "@com_github_golang_protobuf//proto:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_x_net//context:go_default_library",
-    ] + GOLANG_PTYPES,
+    ] + WELL_KNOWN_TYPES,
 )
 
 go_proto_compiler(
@@ -56,11 +53,6 @@ GOGO_VARIANTS = [
     "gostring",
 ]
 
-GOGO_WELL_KNOWN_TYPE_REMAPS = [
-    "Mgoogle/protobuf/{}.proto=github.com/gogo/protobuf/types".format(t)
-    for t in WELL_KNOWN_PROTOS + ["field_mask"]
-]
-
 [go_proto_compiler(
     name = variant + "_proto",
     options = GOGO_WELL_KNOWN_TYPE_REMAPS,
@@ -71,7 +63,7 @@ GOGO_WELL_KNOWN_TYPE_REMAPS = [
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_gogo_protobuf//sortkeys:go_default_library",
         "@com_github_gogo_protobuf//types:go_default_library",
-    ] + GOLANG_PTYPES,
+    ] + WELL_KNOWN_TYPES,
 ) for variant in GOGO_VARIANTS]
 
 [go_proto_compiler(
@@ -86,5 +78,5 @@ GOGO_WELL_KNOWN_TYPE_REMAPS = [
         "@com_github_gogo_protobuf//types:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_x_net//context:go_default_library",
-    ] + GOLANG_PTYPES,
+    ] + WELL_KNOWN_TYPES,
 ) for variant in GOGO_VARIANTS]

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -1,8 +1,6 @@
 load("//proto:compiler.bzl", "go_proto_compiler")
 load("//proto:gogo.bzl", "gogo_special_proto")
-load("//proto:well_known_types.bzl", "gen_well_known_types", "GOGO_WELL_KNOWN_TYPE_REMAPS")
-
-WELL_KNOWN_TYPES = gen_well_known_types()
+load("//proto/wkt:well_known_types.bzl", "WELL_KNOWN_TYPE_RULES", "GOGO_WELL_KNOWN_TYPE_REMAPS")
 
 go_proto_compiler(
     name = "go_proto_bootstrap",
@@ -17,7 +15,7 @@ go_proto_compiler(
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_golang_protobuf//proto:go_default_library",
-    ] + WELL_KNOWN_TYPES,
+    ] + WELL_KNOWN_TYPE_RULES.values(),
 )
 
 go_proto_compiler(
@@ -28,7 +26,7 @@ go_proto_compiler(
         "@com_github_golang_protobuf//proto:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_x_net//context:go_default_library",
-    ] + WELL_KNOWN_TYPES,
+    ] + WELL_KNOWN_TYPE_RULES.values(),
 )
 
 go_proto_compiler(
@@ -63,7 +61,7 @@ GOGO_VARIANTS = [
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_gogo_protobuf//sortkeys:go_default_library",
         "@com_github_gogo_protobuf//types:go_default_library",
-    ] + WELL_KNOWN_TYPES,
+    ] + WELL_KNOWN_TYPE_RULES.values(),
 ) for variant in GOGO_VARIANTS]
 
 [go_proto_compiler(
@@ -78,5 +76,5 @@ GOGO_VARIANTS = [
         "@com_github_gogo_protobuf//types:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_x_net//context:go_default_library",
-    ] + WELL_KNOWN_TYPES,
+    ] + WELL_KNOWN_TYPE_RULES.values(),
 ) for variant in GOGO_VARIANTS]

--- a/proto/well_known_types.bzl
+++ b/proto/well_known_types.bzl
@@ -1,0 +1,40 @@
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+WELL_KNOWN_TYPES_MAP = {
+    "any": ("github.com/golang/protobuf/ptypes/any", []),
+    "api": ("github.com/golang/protobuf/ptypes/api", ["source_context", "type"]),
+    "compiler_plugin": ("github.com/golang/protobuf/protoc-gen-go/plugin", ["descriptor"]),
+    "descriptor": ("github.com/golang/protobuf/protoc-gen-go/descriptor", []),
+    "duration": ("github.com/golang/protobuf/ptypes/duration", []),
+    "empty": ("github.com/golang/protobuf/ptypes/empty", []),
+    "field_mask": ("google.golang.org/genproto/protobuf/field_mask", []),
+    "source_context": ("google.golang.org/genproto/protobuf/source_context", []),
+    "struct": ("github.com/golang/protobuf/ptypes/struct", []),
+    "timestamp": ("github.com/golang/protobuf/ptypes/timestamp", []),
+    "type": ("google.golang.org/genproto/protobuf/ptype", ["any", "source_context"]),
+    "wrappers": ("github.com/golang/protobuf/ptypes/wrappers", []),
+}
+
+GOGO_WELL_KNOWN_TYPE_REMAPS = [
+    "Mgoogle/protobuf/{}.proto=github.com/gogo/protobuf/types".format(wkt)
+    for wkt, (go_package, _) in WELL_KNOWN_TYPES_MAP.items() if "protoc-gen-go" not in go_package
+] + [
+    "Mgoogle/protobuf/descriptor.proto=github.com/gogo/protobuf/protoc-gen-gogo/descriptor",
+    "Mgoogle/protobuf/compiler_plugin.proto=github.com/gogo/protobuf/protoc-gen-gogo/plugin",
+]
+
+def gen_well_known_types():
+    rules = []
+    for wkt, (go_package, deps) in WELL_KNOWN_TYPES_MAP.items():
+        name = "wkt_{}_proto".format(wkt)
+        rules.append("@io_bazel_rules_go//proto:{}".format(name))
+        go_proto_library(
+            name = name,
+            compilers = ["@io_bazel_rules_go//proto:go_proto_bootstrap"],
+            importpath = go_package,
+            proto = "@com_google_protobuf//:{}_proto".format(wkt),
+            visibility = ["//visibility:public"],
+            deps = ["@io_bazel_rules_go//proto:wkt_{}_proto".format(dep) for dep in deps],
+        )
+    return rules
+

--- a/proto/wkt/BUILD.bazel
+++ b/proto/wkt/BUILD.bazel
@@ -1,0 +1,3 @@
+load("//proto/wkt:well_known_types.bzl", "gen_well_known_types")
+
+gen_well_known_types()

--- a/proto/wkt/well_known_types.bzl
+++ b/proto/wkt/well_known_types.bzl
@@ -1,6 +1,9 @@
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
-WELL_KNOWN_TYPES_MAP = {
+_proto_library_suffix = "proto"
+_go_proto_library_suffix = "go_proto"
+
+_WELL_KNOWN_TYPE_PACKAGES = {
     "any": ("github.com/golang/protobuf/ptypes/any", []),
     "api": ("github.com/golang/protobuf/ptypes/api", ["source_context", "type"]),
     "compiler_plugin": ("github.com/golang/protobuf/protoc-gen-go/plugin", ["descriptor"]),
@@ -17,24 +20,25 @@ WELL_KNOWN_TYPES_MAP = {
 
 GOGO_WELL_KNOWN_TYPE_REMAPS = [
     "Mgoogle/protobuf/{}.proto=github.com/gogo/protobuf/types".format(wkt)
-    for wkt, (go_package, _) in WELL_KNOWN_TYPES_MAP.items() if "protoc-gen-go" not in go_package
+    for wkt, (go_package, _) in _WELL_KNOWN_TYPE_PACKAGES.items() if "protoc-gen-go" not in go_package
 ] + [
     "Mgoogle/protobuf/descriptor.proto=github.com/gogo/protobuf/protoc-gen-gogo/descriptor",
     "Mgoogle/protobuf/compiler_plugin.proto=github.com/gogo/protobuf/protoc-gen-gogo/plugin",
 ]
 
+WELL_KNOWN_TYPE_RULES = {
+    wkt: "@io_bazel_rules_go//proto/wkt:{}_{}".format(wkt, _go_proto_library_suffix)
+    for wkt in _WELL_KNOWN_TYPE_PACKAGES.keys()
+}
+
 def gen_well_known_types():
-    rules = []
-    for wkt, (go_package, deps) in WELL_KNOWN_TYPES_MAP.items():
-        name = "wkt_{}_proto".format(wkt)
-        rules.append("@io_bazel_rules_go//proto:{}".format(name))
+    for wkt, rule in WELL_KNOWN_TYPE_RULES.items():
+        (go_package, deps) = _WELL_KNOWN_TYPE_PACKAGES[wkt]
         go_proto_library(
-            name = name,
+            name = rule.rsplit(":", 1)[1],
             compilers = ["@io_bazel_rules_go//proto:go_proto_bootstrap"],
             importpath = go_package,
-            proto = "@com_google_protobuf//:{}_proto".format(wkt),
+            proto = "@com_google_protobuf//:{}_{}".format(wkt, _proto_library_suffix),
             visibility = ["//visibility:public"],
-            deps = ["@io_bazel_rules_go//proto:wkt_{}_proto".format(dep) for dep in deps],
+            deps = [WELL_KNOWN_TYPE_RULES[dep] for dep in deps],
         )
-    return rules
-


### PR DESCRIPTION
This PR includes complete support for well-known-types; which are now compiled directly via the official `proto_library` rules over at github.com/google/protobuf.

This has been tested on several repositories of us that make heavy use of both protobuf & grpc; everything appears to be working properly for both golang/protobuf & gogo/protobuf.

Thanks for your time!

cc @steeve 