### PR TITLE
Fix error check in stdlib builder

### DIFF
--- a/go/tools/builders/replicate.go
+++ b/go/tools/builders/replicate.go
@@ -129,14 +129,14 @@ func replicateTree(src, dst string, config *replicateConfig) error {
 	if err := os.RemoveAll(dst); err != nil {
 		return fmt.Errorf("Failed to remove file at destination %s: %v", dst, err)
 	}
-	if l, err := filepath.EvalSymlinks(src); err == nil {
+	if l, err := filepath.EvalSymlinks(src); err != nil {
+		return err
+	} else {
 		src = l
 	}
-	s, err := os.Stat(src)
-	if err != nil && !os.IsNotExist(err) {
+	if s, err := os.Stat(src); err != nil {
 		return err
-	}
-	if s.IsDir() {
+	} else if s.IsDir() {
 		return replicateDir(src, dst, config)
 	}
 	return replicateFile(src, dst, config)


### PR DESCRIPTION
Previously, replicateTree ignored ENOENT errors. This caused a panic
when we later checked whether a path was a directory. This change
removes the check for that error. All replicated paths must exist.

Fixes #1360
