### PR TITLE
Add c-shared and c-archive link modes

### DIFF
--- a/go/private/actions/asm.bzl
+++ b/go/private/actions/asm.bzl
@@ -16,6 +16,9 @@ load(
     "@io_bazel_rules_go//go/private:common.bzl",
     "sets",
 )
+load("@io_bazel_rules_go//go/private:mode.bzl",
+    "LINKMODE_C_SHARED",
+)
 
 def emit_asm(go,
     source = None,
@@ -32,6 +35,8 @@ def emit_asm(go,
 
   asm_args = go.args(go)
   asm_args.add(["-o", out_obj, "-trimpath", "."])
+  if go.mode.link == LINKMODE_C_SHARED:
+    asm_args.add("-shared")
   asm_args.add(includes, before_each="-I")
   asm_args.add(source.path)
   go.actions.run(

--- a/go/private/actions/binary.bzl
+++ b/go/private/actions/binary.bzl
@@ -12,6 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(
+    "@io_bazel_rules_go//go/private:mode.bzl",
+    "LINKMODE_C_SHARED",
+    "LINKMODE_C_ARCHIVE",
+)
+load(
+    "@io_bazel_rules_go//go/private:common.bzl",
+    "ARCHIVE_EXTENSION",
+)
+
 def emit_binary(go,
     name="",
     source = None,
@@ -24,7 +34,13 @@ def emit_binary(go,
   if name == "": fail("name is a required parameter")
 
   archive = go.archive(go, source)
-  executable = go.declare_file(go, name=name, ext=go.exe_extension)
+  extension = go.exe_extension
+  if go.mode.link == LINKMODE_C_SHARED:
+    name = "lib" + name # shared libraries need a "lib" prefix in their name
+    extension = go.shared_extension
+  elif go.mode.link == LINKMODE_C_ARCHIVE:
+    extension = ARCHIVE_EXTENSION
+  executable = go.declare_file(go, name=name, ext=extension)
   go.link(go,
       archive=archive,
       executable=executable,

--- a/go/private/actions/compile.bzl
+++ b/go/private/actions/compile.bzl
@@ -18,6 +18,7 @@ load(
 )
 load("@io_bazel_rules_go//go/private:mode.bzl",
     "LINKMODE_PLUGIN",
+    "LINKMODE_C_SHARED",
 )
 
 def _importpath(l):
@@ -50,6 +51,8 @@ def emit_compile(go,
     gc_goopts = gc_goopts + ["-race"]
   if go.mode.msan:
     gc_goopts = gc_goopts + ["-msan"]
+  if go.mode.link == LINKMODE_C_SHARED:
+    gc_goopts = gc_goopts + ["-shared"]
 
   #TODO: Check if we really need this expand make variables in here
   #TODO: If we really do then it needs to be moved all the way back out to the rule

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -62,6 +62,7 @@ def emit_link(go,
   if go.mode.link != LINKMODE_NORMAL:
     args.add(["-buildmode", go.mode.link])
     link_external = True
+
   if link_external:
     gc_linkopts.extend(["-linkmode", "external"])
 

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -49,6 +49,8 @@ def emit_link(go,
 
   gc_linkopts, extldflags = _extract_extldflags(gc_linkopts, extldflags)
 
+  args = go.args(go)
+
   # Add in any mode specific behaviours
   link_external = False
   if go.mode.race:
@@ -58,14 +60,12 @@ def emit_link(go,
   if go.mode.static:
     extldflags.append("-static")
   if go.mode.link != LINKMODE_NORMAL:
-    gc_linkopts.extend(["-buildmode", go.mode.link])
+    args.add(["-buildmode", go.mode.link])
     link_external = True
   if link_external:
     gc_linkopts.extend(["-linkmode", "external"])
 
-  args = go.args(go)
   args.add(["-L", "."])
-
   args.add(archive.searchpaths, before_each="-L")
 
   for d in as_iterable(archive.cgo_deps):
@@ -94,8 +94,9 @@ def emit_link(go,
     if linkstamp:
       args.add(["-linkstamp", linkstamp])
 
+  args.add(["-out", executable])
+
   args.add(["--"])
-  args.add(["-o", executable])
   args.add(gc_linkopts)
   args.add(go.toolchain.flags.link)
   if go.mode.strip:

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -94,6 +94,7 @@ def emit_link(go,
     if linkstamp:
       args.add(["-linkstamp", linkstamp])
 
+  args.add(extldflags, before_each = "-ld_flag")
   args.add(["-out", executable])
 
   args.add(["--"])
@@ -105,11 +106,9 @@ def emit_link(go,
   if ld:
     args.add([
         "-extld", ld,
-        "-extldflags", " ".join(extldflags),
     ])
 
   args.add(archive.data.file)
-
   go.actions.run(
       inputs = sets.union(archive.libs, archive.cgo_deps,
                 go.crosstool, stamp_inputs, go.stdlib.files),

--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -130,6 +130,14 @@ def goos_to_extension(goos):
     return ".exe"
   return ""
 
+ARCHIVE_EXTENSION = ".a"
+
+def goos_to_shared_extension(goos):
+  return {
+    "windows": ".dll",
+    "darwin": ".dylib",
+  }.get(goos, ".so")
+
 MINIMUM_BAZEL_VERSION = "0.8.0"
 
 def as_list(v):

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -35,6 +35,7 @@ load(
     "paths",
     "structs",
     "goos_to_extension",
+    "goos_to_shared_extension",
     "as_iterable",
 )
 
@@ -241,6 +242,7 @@ def go_context(ctx, attr=None):
       sdk_tools = context_data.sdk_tools,
       actions = ctx.actions,
       exe_extension = goos_to_extension(mode.goos),
+      shared_extension = goos_to_shared_extension(mode.goos),
       crosstool = context_data.crosstool,
       package_list = context_data.package_list,
       importpath = importpath,

--- a/go/private/mode.bzl
+++ b/go/private/mode.bzl
@@ -22,7 +22,11 @@ LINKMODE_PIE = "pie"
 
 LINKMODE_PLUGIN = "plugin"
 
-LINKMODES = [LINKMODE_NORMAL, LINKMODE_PLUGIN]
+LINKMODE_C_SHARED = "c-shared"
+
+LINKMODE_C_ARCHIVE = "c-archive"
+
+LINKMODES = [LINKMODE_NORMAL, LINKMODE_PLUGIN, LINKMODE_C_SHARED, LINKMODE_C_ARCHIVE]
 
 def mode_string(mode):
   result = [mode.goos, mode.goarch]
@@ -59,6 +63,10 @@ def get_mode(ctx, host_only, go_toolchain, go_context_data):
   force_pure = "on" if go_toolchain.cross_compile else "auto"
   force_race = "off" if host_only else "auto"
 
+  linkmode = getattr(ctx.attr, "linkmode", LINKMODE_NORMAL)
+  if linkmode in [LINKMODE_C_SHARED, LINKMODE_C_ARCHIVE]:
+    force_pure = "off"
+
   static = _ternary(
       getattr(ctx.attr, "static", None),
       "static" in ctx.features,
@@ -77,7 +85,6 @@ def get_mode(ctx, host_only, go_toolchain, go_context_data):
       force_pure,
       "pure" in ctx.features,
   )
-  linkmode = getattr(ctx.attr, "linkmode", LINKMODE_NORMAL)
   if race and pure:
     # You are not allowed to compile in race mode with pure enabled
     race = False

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -68,6 +68,9 @@ def _go_binary_impl(ctx):
   )
   return [
       library, source, archive,
+      OutputGroupInfo(
+          cgo_exports = archive.cgo_exports,
+      ),
       DefaultInfo(
           files = depset([executable]),
           runfiles = archive.runfiles,

--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -427,7 +427,7 @@ def go_binary_c_archive_shared(name, kwargs):
   if linkmode not in [LINKMODE_C_SHARED, LINKMODE_C_ARCHIVE]:
     return
   cgo_exports = name + ".cgo_exports"
-  c_hdrs = name + ".c_hdrs" # will also be used as a container directory
+  c_hdrs = name + ".c_hdrs"
   cc_import_name = name + ".cc_import"
   cc_library_name = name + ".cc"
   native.filegroup(
@@ -439,8 +439,8 @@ def go_binary_c_archive_shared(name, kwargs):
   native.genrule(
     name = c_hdrs,
     srcs = [cgo_exports],
-    outs = ["%s/%s.h" % (c_hdrs, name)],
-    cmd = "mkdir -p $(@D) && cat $(SRCS) > $(@)",
+    outs = ["%s.h" % name],
+    cmd = "cat $(SRCS) > $(@)",
     visibility = ["//visibility:private"],
   )
   cc_import_kwargs = {}
@@ -458,7 +458,6 @@ def go_binary_c_archive_shared(name, kwargs):
     name = cc_library_name,
     hdrs = [c_hdrs],
     deps = [cc_import_name],
-    includes = [c_hdrs],
     alwayslink = 1,
     linkstatic = (linkmode == LINKMODE_C_ARCHIVE and 1 or 0),
     copts = _DEFAULT_PLATFORM_COPTS,

--- a/go/private/rules/stdlib.bzl
+++ b/go/private/rules/stdlib.bzl
@@ -24,6 +24,10 @@ load(
     "@io_bazel_rules_go//go/private:rules/rule.bzl",
     "go_rule",
 )
+load(
+    "@io_bazel_rules_go//go/private:mode.bzl",
+    "LINKMODE_C_SHARED",
+)
 
 def _stdlib_library_to_source(go, attr, source, merge):
   pkg = go.declare_directory(go, "pkg")
@@ -33,6 +37,8 @@ def _stdlib_library_to_source(go, attr, source, merge):
   args.add(["-out", root_file.dirname])
   if go.mode.race:
     args.add("-race")
+  if go.mode.link == LINKMODE_C_SHARED:
+    args.add("-shared")
   go.actions.write(root_file, "")
   go.actions.run(
       inputs = go.sdk_files + go.sdk_tools + go.crosstool + [go.package_list, root_file],

--- a/go/private/rules/wrappers.bzl
+++ b/go/private/rules/wrappers.bzl
@@ -73,7 +73,7 @@ def _go_binary_c_archive_shared(name, kwargs):
   if linkmode not in [LINKMODE_C_SHARED, LINKMODE_C_ARCHIVE]:
     return
   cgo_exports = name + ".cgo_exports"
-  c_hdrs = name + ".c_hdrs"
+  c_hdrs = name + ".c_hdrs" # will also be used as a container directory
   cc_import_name = name + ".cc_import"
   cc_library_name = name + ".cc"
   native.filegroup(
@@ -84,8 +84,8 @@ def _go_binary_c_archive_shared(name, kwargs):
   native.genrule(
     name = c_hdrs,
     srcs = [cgo_exports],
-    outs = [name + ".h"],
-    cmd = "cat $(SRCS) > $(@)",
+    outs = ["%s/%s.h" % (c_hdrs, name)],
+    cmd = "mkdir -p $(@D) && cat $(SRCS) > $(@)",
   )
   cc_import_kwargs = {}
   if linkmode == LINKMODE_C_SHARED:
@@ -101,7 +101,7 @@ def _go_binary_c_archive_shared(name, kwargs):
     name = cc_library_name,
     hdrs = [c_hdrs],
     deps = [cc_import_name],
-    includes = ["."],
+    includes = [c_hdrs],
     alwayslink = 1,
     linkstatic = 1,
     copts = select({

--- a/go/private/rules/wrappers.bzl
+++ b/go/private/rules/wrappers.bzl
@@ -104,6 +104,16 @@ def _go_binary_c_archive_shared(name, kwargs):
     includes = ["."],
     alwayslink = 1,
     linkstatic = 1,
+    copts = select({
+        "@io_bazel_rules_go//go/platform:darwin": [],
+        "@io_bazel_rules_go//go/platform:windows_amd64": ["-mthreads"],
+        "//conditions:default": ["-pthread"],
+    }),
+    linkopts = select({
+        "@io_bazel_rules_go//go/platform:darwin": [],
+        "@io_bazel_rules_go//go/platform:windows_amd64": ["-mthreads"],
+        "//conditions:default": ["-pthread"],
+    }),
     visibility = ["//visibility:public"],
   )
 

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -81,6 +81,7 @@ go_tool_binary(
 go_tool_binary(
     name = "link",
     srcs = [
+        "ar.go",
         "env.go",
         "flags.go",
         "link.go",

--- a/go/tools/builders/ar.go
+++ b/go/tools/builders/ar.go
@@ -1,0 +1,116 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	// arHeader appears at the beginning of archives created by "ar" and
+	// "go tool pack" on all platforms.
+	arHeader = "!<arch>\n"
+
+	// entryLength is the size in bytes of the metadata preceding each file
+	// in an archive.
+	entryLength = 60
+)
+
+var zeroBytes = []byte("0                    ")
+
+type header struct {
+	NameRaw     [16]byte
+	ModTimeRaw  [12]byte
+	OwnerIdRaw  [6]byte
+	GroupIdRaw  [6]byte
+	FileModeRaw [8]byte
+	FileSizeRaw [10]byte
+	EndRaw      [2]byte
+}
+
+func (h *header) name() string {
+	return strings.TrimRight(string(h.NameRaw[:]), " ")
+}
+
+func (h *header) size() int64 {
+	s, err := strconv.Atoi(strings.TrimRight(string(h.FileSizeRaw[:]), " "))
+	if err != nil {
+		panic(err)
+	}
+	return int64(s)
+}
+
+func (h *header) next() int64 {
+	size := h.size()
+	return size + size%2
+}
+
+func (h *header) deterministic() *header {
+	h2 := *h
+	copy(h2.ModTimeRaw[:], zeroBytes)
+	copy(h2.OwnerIdRaw[:], zeroBytes)
+	copy(h2.GroupIdRaw[:], zeroBytes)
+	copy(h2.FileModeRaw[:], zeroBytes) // GNU ar also clears this
+	return &h2
+}
+
+// stripArMetadata strips the archive metadata of non-deterministic data:
+// - Timestamps
+// - User IDs
+// - Group IDs
+// - File Modes
+// The archive is modified in place.
+func stripArMetadata(archivePath string) error {
+	archive, err := os.OpenFile(archivePath, os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	defer archive.Close()
+
+	magic := make([]byte, len(arHeader))
+	if _, err := io.ReadFull(archive, magic); err != nil {
+		return err
+	}
+
+	if string(magic) != arHeader {
+		return fmt.Errorf("%s is not an archive", archivePath)
+	}
+
+	for {
+		hdr := &header{}
+		if err := binary.Read(archive, binary.BigEndian, hdr); err == io.EOF {
+			return nil
+		} else if err != nil {
+			return err
+		}
+
+		// Seek back at the beginning of the header and overwrite it.
+		archive.Seek(-entryLength, os.SEEK_CUR)
+		if err := binary.Write(archive, binary.BigEndian, hdr.deterministic()); err != nil {
+			return err
+		}
+
+		if _, err := archive.Seek(hdr.next(), os.SEEK_CUR); err == io.EOF {
+			return nil
+		} else if err != nil {
+			return err
+		}
+	}
+}

--- a/go/tools/builders/asm.go
+++ b/go/tools/builders/asm.go
@@ -53,6 +53,9 @@ func run(args []string) error {
 		source = os.DevNull
 	}
 	goargs := []string{"tool", "asm"}
+	if goenv.shared {
+		goargs = append(goargs, "-shared")
+	}
 	goargs = append(goargs, "-trimpath", abs(*trimpath), "-o", *output)
 	for _, path := range search {
 		goargs = append(goargs, "-I", abs(path))

--- a/go/tools/builders/compile.go
+++ b/go/tools/builders/compile.go
@@ -85,6 +85,9 @@ func run(args []string) error {
 	}
 
 	goargs := []string{"tool", "compile"}
+	if goenv.shared {
+		goargs = append(goargs, "-shared")
+	}
 	goargs = append(goargs, "-trimpath", abs(*trimpath))
 	for _, path := range search {
 		goargs = append(goargs, "-I", abs(path))

--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -39,6 +39,7 @@ type GoEnv struct {
 	cc           string
 	cpp_flags    multiFlag
 	ld_flags     multiFlag
+	shared       bool
 }
 
 // abs returns the absolute representation of path. Some tools/APIs require
@@ -82,6 +83,7 @@ func envFlags(flags *flag.FlagSet) *GoEnv {
 	flags.StringVar(&env.goarch, "goarch", "", "The value for GOARCH.")
 	flags.BoolVar(&env.Verbose, "v", false, "Enables verbose debugging prints.")
 	flags.StringVar(&env.tags, "tags", "", "Only pass through files that match these tags.")
+	flags.BoolVar(&env.shared, "shared", false, "Build in shared mode")
 	flags.StringVar(&env.cc, "cc", "", "Sets the c compiler to use")
 	flags.Var(&env.cpp_flags, "cpp_flag", "An entry to add to the c compiler flags")
 	flags.Var(&env.ld_flags, "ld_flag", "An entry to add to the c linker flags")

--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -23,6 +23,16 @@ import (
 	"strings"
 )
 
+var (
+	// goBuildTags holds the build tags with which Go was built as a map.
+	// This is useful for detecting the presence of a particular build tag.
+	goBuildTags = map[string]bool{}
+
+	// goReleaseTags holds the release tags with which Go was built as a map.
+	// This is useful for detecting mininum required Go versions.
+	goReleaseTags = map[string]bool{}
+)
+
 // GoEnv holds the go environment as specified on the command line.
 type GoEnv struct {
 	// Go is the path to the go executable.
@@ -40,6 +50,15 @@ type GoEnv struct {
 	cpp_flags    multiFlag
 	ld_flags     multiFlag
 	shared       bool
+}
+
+func init() {
+	for _, tag := range build.Default.BuildTags {
+		goBuildTags[tag] = true
+	}
+	for _, tag := range build.Default.ReleaseTags {
+		goReleaseTags[tag] = true
+	}
 }
 
 // abs returns the absolute representation of path. Some tools/APIs require

--- a/go/tools/builders/link.go
+++ b/go/tools/builders/link.go
@@ -112,6 +112,8 @@ func run(args []string) error {
 	}
 	goargs = append(goargs, "-o", *outFile)
 
+	goargs = append(goargs, "-extldflags", strings.Join(goenv.ld_flags, " "))
+
 	// add in the unprocess pass through options
 	goargs = append(goargs, goopts...)
 	cmd := exec.Command(goenv.Go, goargs...)

--- a/go/tools/builders/link.go
+++ b/go/tools/builders/link.go
@@ -47,6 +47,8 @@ func run(args []string) error {
 	libPaths := multiFlag{}
 	flags := flag.NewFlagSet("link", flag.ExitOnError)
 	goenv := envFlags(flags)
+	outFile := flags.String("out", "", "Path to output file.")
+	buildmode := flags.String("buildmode", "", "Build mode used.")
 	flags.Var(&xstamps, "Xstamp", "A link xdef that may need stamping.")
 	flags.Var(&xdefs, "Xdef", "A link xdef that may need stamping.")
 	flags.Var(&libPaths, "L", "A library search path.")
@@ -105,6 +107,11 @@ func run(args []string) error {
 		}
 	}
 
+	if *buildmode != "" {
+		goargs = append(goargs, "-buildmode", *buildmode)
+	}
+	goargs = append(goargs, "-o", *outFile)
+
 	// add in the unprocess pass through options
 	goargs = append(goargs, goopts...)
 	cmd := exec.Command(goenv.Go, goargs...)
@@ -114,6 +121,13 @@ func run(args []string) error {
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("error running linker: %v", err)
 	}
+
+	if *buildmode == "c-archive" {
+		if err := stripArMetadata(*outFile); err != nil {
+			return fmt.Errorf("error stripping archive metadata: %v", err)
+		}
+	}
+
 	return nil
 }
 

--- a/go/tools/builders/stdlib.go
+++ b/go/tools/builders/stdlib.go
@@ -45,7 +45,6 @@ func run(args []string) error {
 	goenv := envFlags(flags)
 	out := flags.String("out", "", "Path to output go root")
 	race := flags.Bool("race", false, "Build in race mode")
-	shared := flags.Bool("shared", false, "Build in shared mode")
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
@@ -68,7 +67,7 @@ func run(args []string) error {
 	if *race {
 		installArgs = append(installArgs, "-race")
 	}
-	if *shared {
+	if goenv.shared {
 		gcflags = append(gcflags, "-shared")
 		ldflags = append(ldflags, "-shared")
 		asmflags = append(asmflags, "-shared")

--- a/go/tools/builders/stdlib.go
+++ b/go/tools/builders/stdlib.go
@@ -73,9 +73,16 @@ func run(args []string) error {
 		asmflags = append(asmflags, "-shared")
 	}
 
-	installArgs = append(installArgs, "-gcflags", strings.Join(gcflags, " "))
-	installArgs = append(installArgs, "-ldflags", strings.Join(ldflags, " "))
-	installArgs = append(installArgs, "-asmflags", strings.Join(asmflags, " "))
+	// Since Go 1.10, an all= prefix indicates the flags should apply to the package
+	// and its dependencies, rather than just the package itself. This was the
+	// default behavior before Go 1.10.
+	allSlug := ""
+	if goReleaseTags["go1.10"] {
+		allSlug = "all="
+	}
+	installArgs = append(installArgs, "-gcflags="+allSlug+strings.Join(gcflags, " "))
+	installArgs = append(installArgs, "-ldflags="+allSlug+strings.Join(ldflags, " "))
+	installArgs = append(installArgs, "-asmflags="+allSlug+strings.Join(asmflags, " "))
 
 	if err := install_stdlib(goenv, "std", installArgs); err != nil {
 		return err

--- a/tests/core/c_linkmodes/BUILD.bazel
+++ b/tests/core/c_linkmodes/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+
+test_suite(
+    name = "c_archive",
+)
+
+go_binary(
+    name = "adder_archive",
+    srcs = ["add.go"],
+    cgo = True,
+    linkmode = "c-archive"
+)
+
+cc_test(
+    name = "c-archive_test",
+    srcs = ["add_test_archive.c"],
+    deps = [":adder_archive.cc"],
+)
+
+go_binary(
+    name = "adder_shared",
+    srcs = ["add.go"],
+    cgo = True,
+    linkmode = "c-shared"
+)
+
+cc_test(
+    name = "c-shared_test",
+    srcs = ["add_test_shared.c"],
+    deps = [":adder_shared.cc"],
+)

--- a/tests/core/c_linkmodes/README.rst
+++ b/tests/core/c_linkmodes/README.rst
@@ -1,0 +1,22 @@
+c-archive / c-shared linkmodes
+==============================
+
+.. _go_binary: /go/core.rst#go_binary
+
+Tests to ensure that c-archive link mode is working as expected.
+
+.. contents::
+
+add_test_archive.c
+------------------
+
+Test that calls a CGo exported `GoAdd` method from C and check that the return
+value is correct. This is a `cc_test` that links statically against a
+`go_binary`.
+
+add_test_shared.c
+-----------------
+
+Test that calls a CGo exported `GoAdd` method from C and check that the return
+value is correct. This is a `cc_test` that links dynamically against a
+`go_binary`.

--- a/tests/core/c_linkmodes/add.go
+++ b/tests/core/c_linkmodes/add.go
@@ -1,0 +1,10 @@
+package main
+
+import "C"
+
+//export GoAdd
+func GoAdd(a, b int) int {
+	return a + b
+}
+
+func main() {}

--- a/tests/core/c_linkmodes/add_test_archive.c
+++ b/tests/core/c_linkmodes/add_test_archive.c
@@ -1,0 +1,7 @@
+#include <assert.h>
+#include "adder_archive.h"
+
+int main(int argc, char** argv) {
+    assert(GoAdd(42, 42) == 84);
+    return 0;
+}

--- a/tests/core/c_linkmodes/add_test_archive.c
+++ b/tests/core/c_linkmodes/add_test_archive.c
@@ -1,5 +1,5 @@
 #include <assert.h>
-#include "adder_archive.h"
+#include "tests/core/c_linkmodes/adder_archive.h"
 
 int main(int argc, char** argv) {
     assert(GoAdd(42, 42) == 84);

--- a/tests/core/c_linkmodes/add_test_shared.c
+++ b/tests/core/c_linkmodes/add_test_shared.c
@@ -1,5 +1,5 @@
 #include <assert.h>
-#include "adder_shared.h"
+#include "tests/core/c_linkmodes/adder_shared.h"
 
 int main(int argc, char** argv) {
     assert(GoAdd(42, 42) == 84);

--- a/tests/core/c_linkmodes/add_test_shared.c
+++ b/tests/core/c_linkmodes/add_test_shared.c
@@ -1,0 +1,7 @@
+#include <assert.h>
+#include "adder_shared.h"
+
+int main(int argc, char** argv) {
+    assert(GoAdd(42, 42) == 84);
+    return 0;
+}


### PR DESCRIPTION
This PR does the following:
- Add `c-shared` and `c-archive` link modes
- Exports a `<name>.cc` target for rapid inclusion as dep for `cc_` rules
- Changes the link builder to know the buildmode and output files
- When using the `c-archive` mode, strips the non-deterministic data from the archive from inside the builder
  - This could be reused in the pack builder, not early check suggest `go tool pack` is already deterministic (I may be wrong)
  - I could have went through and did it anyway, but it would require factoring `pack` a bit to clean the duplicates with `ar.go`