### PR TITLE
Bump minimum Bazel version to 0.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ os:
 env:
   # TODO(bazelbuild/continuous-integration#95): re-enable HEAD builds with stable URL
   # - V=HEAD
-  - V=0.8.0
+  - V=0.10.0
 
 before_install:
   - |

--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ They currently do not support (in order of importance):
 * coverage
 * test sharding
 
-:Note: The latest version of these rules (0.10.1) requires Bazel ≥ 0.8.0 to work.
+:Note: The latest version of these rules (0.10.1) requires Bazel ≥ 0.10.0 to work.
 
 The ``master`` branch is only guaranteed to work with the latest version of Bazel.
 


### PR DESCRIPTION
This is needed for cc_import, which was introduced in 0.9.0 (but that
version has problems with Go cross compilation).

Related #1365