### PR TITLE
proto: embed doesn't have GoProtoImports provider

### DIFF
--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -42,7 +42,6 @@ def get_imports(attr):
   if hasattr(attr, "proto"):
     imports.append(["{}={}".format(proto_path(src), attr.importpath) for src in attr.proto.proto.direct_sources])
   imports.extend([dep[GoProtoImports].imports for dep in getattr(attr, "deps", [])])
-  imports.extend([dep[GoProtoImports].imports for dep in getattr(attr, "embed", [])])
   return sets.union(*imports)
 
 def _go_proto_aspect_impl(target, ctx):

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -49,10 +49,7 @@ def _go_proto_aspect_impl(target, ctx):
 
 _go_proto_aspect = aspect(
     _go_proto_aspect_impl,
-    attr_aspects = [
-        "deps",
-        "embed",
-    ],
+    attr_aspects = ["deps"],
 )
 
 def _proto_library_to_source(go, attr, source, merge):

--- a/tests/core/README.rst
+++ b/tests/core/README.rst
@@ -9,6 +9,7 @@ Contents
 .. Child list start
 
 * `Cross compilation <cross/README.rst>`_
+* `Basic go_proto_library functionality <go_proto_library/README.rst>`_
 * `Import maps <importmap/README.rst>`_
 * `Basic go_test functionality <go_test/README.rst>`_
 * `go_proto_library importmap <go_proto_library_importmap/README.rst>`_

--- a/tests/core/go_proto_library/BUILD.bazel
+++ b/tests/core/go_proto_library/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "embed_proto",
+    srcs = ["embed.proto"],
+)
+
+go_proto_library(
+    name = "embed_go_proto",
+    proto = ":embed_proto",
+    importpath = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/foo",
+    embed = [":extra_lib"],
+)
+
+go_library(
+    name = "extra_lib",
+    srcs = ["extra.go"],
+    importpath = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/foo",
+)
+
+go_test(
+    name = "embed_test",
+    srcs = ["embed_test.go"],
+    deps = [
+        ":embed_go_proto",
+        "@com_github_golang_protobuf//proto:go_default_library",
+    ],
+)

--- a/tests/core/go_proto_library/README.rst
+++ b/tests/core/go_proto_library/README.rst
@@ -1,0 +1,13 @@
+Basic go_proto_library functionality
+====================================
+
+.. _go_proto_library: /proto/core.rst#_go_proto_library
+
+Tests to ensure the basic features of `go_proto_library`_ are working.
+
+.. contents::
+
+embed_test
+----------
+
+Checks that `go_proto_library`_ can embed rules that provide `GoLibrary`_.

--- a/tests/core/go_proto_library/embed.proto
+++ b/tests/core/go_proto_library/embed.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package tests.core.go_proto_library.foo;
+option go_package = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/foo";
+
+message Foo {
+  int64 value = 1;
+}

--- a/tests/core/go_proto_library/embed_test.go
+++ b/tests/core/go_proto_library/embed_test.go
@@ -1,0 +1,45 @@
+/* Copyright 2018 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package embed_test
+
+import (
+	"testing"
+
+	"github.com/bazelbuild/rules_go/tests/core/go_proto_library/foo"
+	"github.com/golang/protobuf/proto"
+)
+
+func TestProto(t *testing.T) {
+	x := foo.Foo{Value: 42}
+	data, err := proto.Marshal(&x)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var y foo.Foo
+	err = proto.Unmarshal(data, &y)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if y.Value != x.Value {
+		t.Errorf("got {x = %d}; want {x = %d}", y.Value, x.Value)
+	}
+}
+
+func TestExtra(t *testing.T) {
+	if got, want := foo.Extra(), 42; got != want {
+		t.Errorf("got %d; want %d", got, want)
+	}
+}

--- a/tests/core/go_proto_library/extra.go
+++ b/tests/core/go_proto_library/extra.go
@@ -1,0 +1,5 @@
+package foo
+
+func Extra() int {
+	return 42
+}


### PR DESCRIPTION
In go_proto_library rule definition, embed is declared as
  "embed": attr.label_list(providers = [GoLibrary]),

This causes the following error when get_imports runs:
  (rule 'go_proto_library') doesn't contain declared provider 'GoProtoImports'