### PR TITLE
Add fields to GoArchiveData needed to rewrite go_path

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -49,6 +49,7 @@ def emit_archive(go, source=None):
 
   direct = [get_archive(dep) for dep in source.deps]
   runfiles = source.runfiles
+  data_files = runfiles.files
   for a in direct:
     runfiles = runfiles.merge(a.runfiles)
     if a.source.mode != go.mode: fail("Archive mode does not match {} is {} expected {}".format(a.data.label, mode_string(a.source.mode), mode_string(go.mode)))
@@ -83,8 +84,11 @@ def emit_archive(go, source=None):
       label = source.library.label,
       importpath = source.library.importpath,
       importmap = source.library.importmap,
+      pathtype = source.library.pathtype,
       file = out_lib,
       srcs = as_tuple(source.srcs),
+      orig_srcs = as_tuple(source.orig_srcs),
+      data_files = as_tuple(data_files),
       searchpath = searchpath,
   )
   x_defs = dict(source.x_defs)

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -111,7 +111,7 @@ def _new_library(go, name=None, importpath=None, resolver=None, importable=True,
       label = go._ctx.label,
       importpath = importpath,
       importmap = importmap,
-      pathtype = go.pathtype if importable else EXPORT_PATH,
+      pathtype = go.pathtype,
       resolve = resolver,
       testfilter = testfilter,
       **kwargs
@@ -120,6 +120,7 @@ def _new_library(go, name=None, importpath=None, resolver=None, importable=True,
 def _merge_embed(source, embed):
   s = get_source(embed)
   source["srcs"] = s.srcs + source["srcs"]
+  source["orig_srcs"] = s.orig_srcs + source["orig_srcs"]
   source["cover"] = source["cover"] + s.cover
   source["deps"] = source["deps"] + s.deps
   source["x_defs"].update(s.x_defs)
@@ -136,10 +137,12 @@ def _library_to_source(go, attr, library, coverage_instrumented):
   #TODO: stop collapsing a depset in this line...
   attr_srcs = [f for t in getattr(attr, "srcs", []) for f in as_iterable(t.files)]
   generated_srcs = getattr(library, "srcs", [])
+  srcs = attr_srcs + generated_srcs
   source = {
-      "library" : library,
-      "mode" : go.mode,
-      "srcs" : generated_srcs + attr_srcs,
+      "library": library,
+      "mode": go.mode,
+      "srcs": srcs,
+      "orig_srcs": srcs,
       "cover" : [],
       "x_defs" : {},
       "deps" : getattr(attr, "deps", []),

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -147,6 +147,7 @@ def _go_test_impl(ctx):
   # and will save that file to the build events + test outputs.
   return struct(
       providers = [
+          test_archive,
           DefaultInfo(
               files = depset([executable]),
               runfiles = runfiles,

--- a/go/providers.rst
+++ b/go/providers.rst
@@ -178,6 +178,20 @@ GoArchiveData represents the compiled form of a package.
 +--------------------------------+-----------------------------------------------------------------+
 | The import path for this library. Will always be set.                                            |
 +--------------------------------+-----------------------------------------------------------------+
+| :param:`importmap`             | :type:`string`                                                  |
++--------------------------------+-----------------------------------------------------------------+
+| The package path for this library. The compiler and linker use this to                           |
+| disambiguoate packages with the same ``importpath``. It's usually the same                       |
+| as ``importpath``, but is frequently different for vendored libraries.                           |
++--------------------------------+-----------------------------------------------------------------+
+| :param:`pathtype`              | :type:`string`                                                  |
++--------------------------------+-----------------------------------------------------------------+
+| Indicates how ``importpath`` was determined. May be one of:                                      |
+|                                                                                                  |
+| * ``"explicit"``: was explicitly set.                                                            |
+| * ``"inferred"``: was inferred based on label name.                                              |
+| * ``"export"``: a special name for synthetic packages. Not importable.                           |
++--------------------------------+-----------------------------------------------------------------+
 | :param:`file`                  | :type:`compiled archive file`                                   |
 +--------------------------------+-----------------------------------------------------------------+
 | The archive file representing the library compiled in a specific :param:`mode` ready for linking |
@@ -185,7 +199,17 @@ GoArchiveData represents the compiled form of a package.
 +--------------------------------+-----------------------------------------------------------------+
 | :param:`srcs`                  | :type:`list of File`                                            |
 +--------------------------------+-----------------------------------------------------------------+
-| The sources compiled into the archive.                                                           |
+| The .go sources compiled into the archive. May have been generated or                            |
+| transformed with tools like cgo and cover.                                                       |
++--------------------------------+-----------------------------------------------------------------+
+| :param:`orig_srcs`             | :type:`list of File`                                            |
++--------------------------------+-----------------------------------------------------------------+
+| The unmodified sources provided to the rule, including .go, .s, .h, .c files.                    |
++--------------------------------+-----------------------------------------------------------------+
+| :param:`data_files`            | :type:`list of File`                                            |
++--------------------------------+-----------------------------------------------------------------+
+| Data files which should be available at runtime to binaries and tests built                      |
+| from this archive.                                                                               |
 +--------------------------------+-----------------------------------------------------------------+
 | :param:`searchpath`            | :type:`string`                                                  |
 +--------------------------------+-----------------------------------------------------------------+


### PR DESCRIPTION
go_path currently copies generated cgo and cover files, which is
almost never useful. This changes adds the original source files to a
separate field in GoArchiveData so go_path can consume them.

Also, some other go_path prerequisite changes:

* Don't mark all non-importable libraries as EXPORT_PATH. That should
  only be used for synthetic paths.
* Rearrange internal cgo providers to separate generated and
  transformed files. Communicate more with providers and less with
  output groups.
* Add GoArchive provider to go_test so that go_path can use it.