### PR TITLE
Roll back buildtools, roll forward gazelle

### DIFF
--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -33,14 +33,17 @@ def go_rules_dependencies():
   _maybe(git_repository,
       name = "bazel_gazelle",
       remote = "https://github.com/bazelbuild/bazel-gazelle",
-      commit = "a85b63b06c2e0c75931e57c4a1a18d4e566bb6f4", # master as of 2018-02-26
+      commit = "b345aed922d0a31528180a73f097e2f755e6da60", # master as of 2018-03-21
   )
 
+  # Old version of buildtools, before breaking API changes. Old versions of
+  # gazelle (0.9) need this. Newer versions vendor this library, so it's only
+  # needed by old versions.
   _maybe(http_archive,
       name = "com_github_bazelbuild_buildtools",
-      # master, as of 2018-02-26
-      urls = ["https://codeload.github.com/bazelbuild/buildtools/zip/80c7f0d45d7e40fa1f7362852697d4a03df557b3"],
-      strip_prefix = "buildtools-80c7f0d45d7e40fa1f7362852697d4a03df557b3",
+      # master, as of 2017-08-14
+      urls = ["https://codeload.github.com/bazelbuild/buildtools/zip/799e530642bac55de7e76728fa0c3161484899f6"],
+      strip_prefix = "buildtools-799e530642bac55de7e76728fa0c3161484899f6",
       type = "zip",
   )
 

--- a/tests/legacy/build_with_old_sdk/BUILD.bazel
+++ b/tests/legacy/build_with_old_sdk/BUILD.bazel
@@ -18,7 +18,6 @@ bazel_test(
     command = "test",
     config = "fetch",
     externals = [
-        "@com_github_bazelbuild_buildtools//differ:go_default_library",
         "@org_golang_x_tools//go/vcs:go_default_library",
     ],
     go_version = "1.8.5",


### PR DESCRIPTION
This fixes build errors when old versions of Gazelle are used with new
versions of rules_go.

@com_github_bazelbuild_buildtools now points to an old version of the
repository, before several breaking API changes landed. Old versions
of Gazelle depend on this.

@bazel_gazelle now points to a new version of Gazelle that vendors
packages from buildtools, so it won't be broken by this change.

These repositories will be removed when we completely migrate people
to Gazelle's go_repository.

Fixes #1396