### PR TITLE
Warn when linking archive with the same package path

### DIFF
--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -66,8 +66,10 @@ def emit_link(go,
   if link_external:
     gc_linkopts.extend(["-linkmode", "external"])
 
-  args.add(["-L", "."])
-  args.add(archive.searchpaths, before_each="-L")
+  deps = depset(transitive = [d.transitive for d in archive.direct])
+  dep_args = ["{}={}={}".format(d.label, d.importmap, d.file.path)
+              for d in deps.to_list()]
+  args.add(dep_args, before_each="-dep")
 
   for d in as_iterable(archive.cgo_deps):
     if d.basename.endswith('.so'):

--- a/go/providers.rst
+++ b/go/providers.rst
@@ -189,7 +189,7 @@ GoArchiveData represents the compiled form of a package.
 +--------------------------------+-----------------------------------------------------------------+
 | :param:`searchpath`            | :type:`string`                                                  |
 +--------------------------------+-----------------------------------------------------------------+
-| The search path entry under which the :param:`lib` would be found.                               |
+| **Deprecated:** The search path entry under which the :param:`lib` would be found.               |
 +--------------------------------+-----------------------------------------------------------------+
 
 GoArchive
@@ -210,21 +210,22 @@ This is used when compiling and linking dependant libraries or binaries.
 +--------------------------------+-----------------------------------------------------------------+
 | The non transitive data for this archive.                                                        |
 +--------------------------------+-----------------------------------------------------------------+
-| :param:`direct`                | :type:`depset of GoLibrary`                                     |
+| :param:`direct`                | :type:`list of GoArchive`                                       |
 +--------------------------------+-----------------------------------------------------------------+
-| The direct depencancies of the library.                                                          |
+| The direct dependencies of this archive.                                                         |
 +--------------------------------+-----------------------------------------------------------------+
 | :param:`searchpaths`           | :type:`depset of string`                                        |
 +--------------------------------+-----------------------------------------------------------------+
-| The transitive set of search paths needed to link with this archive.                             |
+| **Deprecated:** The transitive set of search paths needed to link with this archive.             |
 +--------------------------------+-----------------------------------------------------------------+
 | :param:`libs`                  | :type:`depset of File`                                          |
 +--------------------------------+-----------------------------------------------------------------+
 | The transitive set of libraries needed to link with this archive.                                |
 +--------------------------------+-----------------------------------------------------------------+
-| :param:`transitive`            | :type:`depset(GoLibrary)`                                       |
+| :param:`transitive`            | :type:`depset of GoArchiveData`                                 |
 +--------------------------------+-----------------------------------------------------------------+
-| The full transitive set of GoArchiveData's  depended on, including this one.                     |
+| The full set of transitive dependencies. This includes ``data`` for this                         |
+| archive and all ``data`` members transitively reachable through ``direct``.                      |
 +--------------------------------+-----------------------------------------------------------------+
 | :param:`x_defs`                | :type:`string_dict`                                             |
 +--------------------------------+-----------------------------------------------------------------+


### PR DESCRIPTION
The link wrapper will now print a warning when linking more than one
package with the same package path. This is dangerous, since only one
of the packages will be linked, and the compiler and linker may see
different code.

This will be a warning in 0.11.0 and an error in releases after that.

Also:

* Corrected documentation for direct / transitive members of
  GoArchive.
* Marked searchpath and searchpaths members as deprecated. They will
  not be needed when we switch to importcfg after dropping Go 1.8.

Related #1327