### PR TITLE
Minor documentation fixes

### DIFF
--- a/roadmap.rst
+++ b/roadmap.rst
@@ -63,7 +63,7 @@ generally valid in a Bazel environment. Tools that collect build metadata with
 `go/build`_ produce incomplete or inaccurate results since `go/build`_ does not
 understand Bazel.
 
-hWe are developing a new framework for collecting build metadata that will
+We are developing a new framework for collecting build metadata that will
 decouple tools from the build system. This framework is important for both Bazel
 and vgo, which will be the primary Go build system in future releases. Tools
 using framework will be aware of generated code in Bazel workspaces.


### PR DESCRIPTION
* Fix typo in roadmap.rst.
* Add FAQ on cross-compilation to README.rst.
* Rearrange links in README.rst.

[skip ci]
[ci skip]