### PR TITLE
Add GoPath.gopath_file field

### DIFF
--- a/go/private/tools/path.bzl
+++ b/go/private/tools/path.bzl
@@ -90,11 +90,13 @@ def _go_path_impl(ctx):
     out_path = out.path
     out_short_path = out.short_path
     outputs = [out]
+    out_file = out
   elif ctx.attr.mode == "copy":
     out = ctx.actions.declare_directory(ctx.label.name)
     out_path = out.path
     out_short_path = out.short_path
     outputs = [out]
+    out_file = out
   else:  # link
     # Declare individual outputs in link mode. Symlinks can't point outside
     # tree artifacts.
@@ -104,6 +106,7 @@ def _go_path_impl(ctx):
     ctx.actions.write(tag, "")
     out_path = tag.dirname
     out_short_path = tag.short_path.rpartition("/")[0]
+    out_file = tag
   args = [
       "-manifest=" + manifest_file.path,
       "-out=" + out_path,
@@ -124,6 +127,7 @@ def _go_path_impl(ctx):
       ),
       GoPath(
           gopath = out_short_path,
+          gopath_file = out_file,
           packages = pkg_map.values(),
       ),
   ]

--- a/go/providers.rst
+++ b/go/providers.rst
@@ -12,6 +12,7 @@ Go providers
 .. _static linking: modes.rst#building-static-binaries
 .. _race detector: modes.rst#using-the-race-detector
 .. _runfiles: https://docs.bazel.build/versions/master/skylark/lib/runfiles.html
+.. _File: https://docs.bazel.build/versions/master/skylark/lib/File.html
 
 .. role:: param(kbd)
 .. role:: type(emphasis)
@@ -288,6 +289,15 @@ each package.
 +--------------------------------+-----------------------------------------------------------------+
 | The short path to the output file or directory. Useful for constructing                          |
 | ``runfiles`` paths.                                                                              |
++--------------------------------+-----------------------------------------------------------------+
+| :param:`gopath_file`           | :type:`File`                                                    |
++--------------------------------+-----------------------------------------------------------------+
+| A Bazel File_ that points to the output directory.                                               |
+|                                                                                                  |
+| * In ``archive`` mode, this is the archive.                                                      |
+| * In ``copy`` mode, this is the output directory.                                                |
+| * In ``link`` mode, this is an empty file inside the output directory, so                        |
+|   you need to use .dirname to get the path to the directory.                                     |
 +--------------------------------+-----------------------------------------------------------------+
 | :param:`packages`              | :type:`list of struct`                                          |
 +--------------------------------+-----------------------------------------------------------------+


### PR DESCRIPTION
This is a Bazel File that can be used to get the absolute path of the
output file or directory.

Fixes #1416