### PR TITLE
go_test: fix filtering of _cgo files in external archives

### DIFF
--- a/go/private/actions/compile.bzl
+++ b/go/private/actions/compile.bzl
@@ -58,15 +58,13 @@ def emit_compile(go,
   #TODO: If we really do then it needs to be moved all the way back out to the rule
   gc_goopts = [go._ctx.expand_make_variables("gc_goopts", f, {}) for f in gc_goopts]
   inputs = sets.union(sources, [go.package_list])
-  go_sources = [s.path for s in sources if not s.basename.startswith("_cgo")]
-  cgo_sources = [s.path for s in sources if s.basename.startswith("_cgo")]
 
   inputs = sets.union(inputs, [archive.data.file for archive in archives])
   inputs = sets.union(inputs, go.stdlib.files)
 
   args = go.args(go)
   args.add(["-package_list", go.package_list])
-  args.add(go_sources, before_each="-src")
+  args.add([s.path for s in sources], before_each="-src")
   args.add(archives, before_each="-dep", map_fn=_importpath)
   args.add(archives, before_each="-I", map_fn=_searchpath)
   args.add(archives, before_each="-importmap", map_fn=_importmap)
@@ -82,7 +80,6 @@ def emit_compile(go,
     args.add(["-N", "-l"])
   if go.mode.link in [LINKMODE_PLUGIN]:
     args.add(["-dynlink"])
-  args.add(cgo_sources)
   go.actions.run(
       inputs = inputs,
       outputs = [out_lib],

--- a/tests/core/go_test/BUILD.bazel
+++ b/tests/core/go_test/BUILD.bazel
@@ -7,6 +7,7 @@ test_suite(
 go_library(
     name = "lib",
     srcs = ["lib.go"],
+    cgo = True,
     importpath = "lib",
 )
 

--- a/tests/core/go_test/lib.go
+++ b/tests/core/go_test/lib.go
@@ -15,4 +15,6 @@ limitations under the License.
 
 package lib
 
+import "C"
+
 var Got = "Got"


### PR DESCRIPTION
Previously, new files that were generated by cgo (those prefixed with
_cgo, like _cgo_gotypes.go, not those ending with .cgo1.go) were
compiled automatically without any filter for tags or package
names. This broke combined tests with an external component that
depended on library that contained cgo: the _cgo files would get
compiled into the external archive since the compile builder did not
filter them by package name. This caused errors when package names in
source files did not match.

With this change, in analysis, we treat cgo files like regular source
files. In the compile builder, we filter them normally, except we
don't check build constraints (these files would always be excluded,
since they start with '_').