### PR TITLE
Add shebang to .pb.go.run generated file.

### DIFF
--- a/proto/go_proto_library.bzl
+++ b/proto/go_proto_library.bzl
@@ -122,7 +122,7 @@ def _go_proto_library_gen_impl(ctx):
   # Create work dir, copy all protos there stripping of any external/bazel- prefixes.
   work_dir = ctx.outputs.outs[0].path + ".protoc"
   root_prefix = "/".join([".." for _ in work_dir.split("/")])
-  cmds = ["set -e", "/bin/rm -rf %s; /bin/mkdir -p %s" % (work_dir, work_dir)]
+  cmds = ["#!/bin/bash", "set -e", "/bin/rm -rf %s; /bin/mkdir -p %s" % (work_dir, work_dir)]
   srcs = list(ctx.files.srcs)
   dirs = depset([s.short_path[:-1-len(s.basename)] for s in srcs + protos])
   cmds += ["mkdir -p %s/%s" % (work_dir, _drop_external(d)) for d in dirs if d]


### PR DESCRIPTION
Without this, not all interpreters know how to run the .run files.