### PR TITLE
compile: write empty archives instead of empty files

### DIFF
--- a/go/tools/builders/compile.go
+++ b/go/tools/builders/compile.go
@@ -25,6 +25,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -81,8 +82,15 @@ func run(args []string) error {
 			files = append(files, f)
 		}
 	}
-	if len(files) <= 0 {
-		return ioutil.WriteFile(absOutput, []byte(""), 0644)
+	if len(files) == 0 {
+		// We need to run the compiler to create a valid archive, even if there's
+		// nothing in it. GoPack will complain if we try to add assembly or cgo
+		// objects.
+		emptyPath := filepath.Join(abs(*trimpath), "_empty.go")
+		if err := ioutil.WriteFile(emptyPath, []byte("package empty\n"), 0666); err != nil {
+			return err
+		}
+		files = append(files, &goMetadata{filename: emptyPath})
 	}
 
 	goargs := []string{"tool", "compile"}

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -6,10 +6,10 @@ Main test areas
 
 .. Child list start
 
+* `Go rules examples <examples/README.rst>`_
 * `Core Go rules tests <core/README.rst>`_
 * `Integration tests <integration/README.rst>`_
 * `Legacy tests <legacy/README.rst>`_
-* `Go rules examples <examples/README.rst>`_
 
 .. Child list end
 

--- a/tests/core/README.rst
+++ b/tests/core/README.rst
@@ -8,13 +8,15 @@ Contents
 
 .. Child list start
 
-* `go_proto_library importmap <go_proto_library_importmap/README.rst>`_
+* `Basic go_path functionality <go_path/README.rst>`_
+* `Basic go_binary functionality <go_binary/README.rst>`_
+* `Basic go_library functionality <go_library/README.rst>`_
 * `Cross compilation <cross/README.rst>`_
 * `Basic go_proto_library functionality <go_proto_library/README.rst>`_
 * `c-archive / c-shared linkmodes <c_linkmodes/README.rst>`_
-* `Basic go_test functionality <go_test/README.rst>`_
 * `Import maps <importmap/README.rst>`_
-* `Basic go_path functionality <go_path/README.rst>`_
+* `Basic go_test functionality <go_test/README.rst>`_
+* `go_proto_library importmap <go_proto_library_importmap/README.rst>`_
 
 .. Child list end
 

--- a/tests/core/go_library/BUILD.bazel
+++ b/tests/core/go_library/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "empty",
+    srcs = [
+        # foo and bar have different package names
+        "empty_foo.go",
+        "empty_bar.go",
+        "empty_baz.s",
+    ],
+    importpath = "empty",
+)

--- a/tests/core/go_library/README.rst
+++ b/tests/core/go_library/README.rst
@@ -1,0 +1,10 @@
+Basic go_library functionality
+==============================
+
+.. _go_library: /go/core.rst#_go_library
+
+empty
+-----
+
+Checks that a `go_library`_ will compile and link even if all the sources
+(including assembly sources) are filtered out by build constraints.

--- a/tests/core/go_library/empty_bar.go
+++ b/tests/core/go_library/empty_bar.go
@@ -1,0 +1,3 @@
+// +build ignore
+
+package bar

--- a/tests/core/go_library/empty_baz.s
+++ b/tests/core/go_library/empty_baz.s
@@ -1,0 +1,1 @@
+// +build ignore

--- a/tests/core/go_library/empty_foo.go
+++ b/tests/core/go_library/empty_foo.go
@@ -1,0 +1,3 @@
+// +build ignore
+
+package foo


### PR DESCRIPTION
Previously, the compile builder wrote 0-byte files when all .go
sources were filtered out. Now it will write a .go file which only
contains a package declaration, then compile that into a trivial
archive file.

This is needed because GoPack reports errors when it attempts to add a
.o file from assembly or cgo.