### PR TITLE
Make the stdlib reproducible by silencing the build id

### DIFF
--- a/go/private/rules/stdlib.bzl
+++ b/go/private/rules/stdlib.bzl
@@ -32,6 +32,7 @@ load(
 def _stdlib_library_to_source(go, attr, source, merge):
   pkg = go.declare_directory(go, "pkg")
   root_file = go.declare_file(go, "ROOT")
+  filter_buildid = attr._filter_buildid_builder.files.to_list()[0]
   files = [root_file, go.go, pkg]
   args = go.args(go)
   args.add(["-out", root_file.dirname])
@@ -39,9 +40,10 @@ def _stdlib_library_to_source(go, attr, source, merge):
     args.add("-race")
   if go.mode.link == LINKMODE_C_SHARED:
     args.add("-shared")
+  args.add(["-filter_buildid", filter_buildid.path])
   go.actions.write(root_file, "")
   go.actions.run(
-      inputs = go.sdk_files + go.sdk_tools + go.crosstool + [go.package_list, root_file],
+      inputs = go.sdk_files + go.sdk_tools + go.crosstool + [filter_buildid, go.package_list, root_file],
       outputs = [pkg],
       mnemonic = "GoStdlib",
       executable = attr._stdlib_builder.files.to_list()[0],
@@ -70,6 +72,11 @@ stdlib = go_rule(
             executable = True,
             cfg = "host",
             default = Label("@io_bazel_rules_go//go/tools/builders:stdlib"),
+        ),
+        "_filter_buildid_builder": attr.label(
+            executable = True,
+            cfg = "host",
+            default = Label("@io_bazel_rules_go//go/tools/builders:filter_buildid"),
         ),
     },
 )

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -145,3 +145,11 @@ go_tool_binary(
     ],
     visibility = ["//visibility:public"],
 )
+
+go_tool_binary(
+    name = "filter_buildid",
+    srcs = [
+        "filter_buildid.go",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -151,6 +151,8 @@ func (env *GoEnv) env() []string {
 		)
 	}
 	if len(env.cpp_flags) > 0 {
+		// Make sure the sandbox path doesn't appear in DWARF
+		env.cpp_flags = append(env.cpp_flags, "-fdebug-prefix-map="+abs(".")+"=.")
 		v := strings.Join(env.cpp_flags, " ")
 		result = append(result,
 			fmt.Sprintf("CGO_CFLAGS=%s", v),

--- a/go/tools/builders/filter_buildid.go
+++ b/go/tools/builders/filter_buildid.go
@@ -1,0 +1,37 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This tool filters out the -buildid args from any Go tool invocation when
+// passed via -toolexec.
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+func main() {
+	args := os.Args[1:]
+	newArgs := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "-buildid" {
+			i++
+			continue
+		}
+		newArgs = append(newArgs, arg)
+	}
+	syscall.Exec(newArgs[0], newArgs, os.Environ())
+}

--- a/go/tools/builders/stdlib.go
+++ b/go/tools/builders/stdlib.go
@@ -43,6 +43,7 @@ func run(args []string) error {
 	// process the args
 	flags := flag.NewFlagSet("stdlib", flag.ExitOnError)
 	goenv := envFlags(flags)
+	filter_buildid := flags.String("filter_buildid", "", "Path to filter_buildid tool")
 	out := flags.String("out", "", "Path to output go root")
 	race := flags.Bool("race", false, "Build in race mode")
 	if err := flags.Parse(args); err != nil {
@@ -60,7 +61,7 @@ func run(args []string) error {
 	// Now switch to the newly created GOROOT
 	goenv.rootPath = output
 	// Run the commands needed to build the std library in the right mode
-	installArgs := []string{"install"}
+	installArgs := []string{"install", "-toolexec", abs(*filter_buildid)}
 	gcflags := []string{}
 	ldflags := []string{"-trimpath", abs(".")}
 	asmflags := []string{"-trimpath", abs(".")}

--- a/tests/core/stdlib/BUILD.bazel
+++ b/tests/core/stdlib/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_test", "go_source")
+
+test_suite(
+    name = "stdlib",
+)
+
+go_test(
+    name = "buildid_test",
+    size = "small",
+    srcs = ["buildid_test.go"],
+)

--- a/tests/core/stdlib/buildid_test.go
+++ b/tests/core/stdlib/buildid_test.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestEmptyBuildId(t *testing.T) {
+	// TODO: run go tool buildid on .a stdlib files to check it is empty
+}

--- a/tests/core/stdlib/reproduce_test.sh
+++ b/tests/core/stdlib/reproduce_test.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -eux -o pipefail
+
+function run_bazel() {
+    bazel clean --expunge
+    bazel test //tests/core/go_binary:all
+    find bazel-out/ -name '*.a' | sort | uniq | grep stdlib | xargs shasum > $1
+}
+
+FILE1=$(mktemp)
+FILE2=$(mktemp)
+
+echo First run
+run_bazel ${FILE1}
+
+echo Second run
+run_bazel ${FILE2}
+
+echo Diffing runs
+diff ${FILE1} ${FILE2}
+
+echo Removing files
+rm ${FILE1} ${FILE2}


### PR DESCRIPTION
When go install'ing the stdlib, leverage `-toolexec` to remove the `-buildid` flag from `compile` invocations.

To run the test:
```
$ ./tests/core/stdlib/test_reproduce.sh
```

Note that this will expunge the current bazel workspace.

At the moment the everything is reproducible, save for `runtime/cgo` on Linux only. I'm investigating.

Looking at the hexdump diff, it looks like the sandbox path is built into the archive:
```
< 000076e0  2f 62 61 7a 65 6c 2d 73  61 6e 64 62 6f 78 2f 37  |/bazel-sandbox/7|
< 000076f0  33 37 34 35 37 31 39 37  32 36 32 34 30 33 31 36  |3745719726240316|
< 00007700  32 32 2f 65 78 65 63 72  6f 6f 74 2f 69 6f 5f 62  |22/execroot/io_b|
< 00007710  61 7a 65 6c 5f 72 75 6c  65 73 5f 67 6f 2f 62 61  |azel_rules_go/ba|
< 00007720  7a 65 6c 2d 6f 75 74 2f  6b 38 2d 66 61 73 74 62  |zel-out/k8-fastb|
< 00007730  75 69 6c 64 2f 62 69 6e  2f 65 78 74 65 72 6e 61  |uild/bin/externa|
< 00007740  6c 2f 69 6f 5f 62 61 7a  65 6c 5f 72 75 6c 65 73  |l/io_bazel_rules|
< 00007750  5f 67 6f 2f 6c 69 6e 75  78 5f 61 6d 64 36 34 5f  |_go/linux_amd64_|
< 00007760  73 74 72 69 70 70 65 64  2f 73 74 64 6c 69 62 7e  |stripped/stdlib~|
< 00007770  2f 73 72 63 2f 72 75 6e  74 69 6d 65 2f 63 67 6f  |/src/runtime/cgo|
< 00007780  00 47 4e 55 20 41 53 20  32 2e 32 38 00 01 80 01  |.GNU AS 2.28....|
< 00007790  11 00 10 06 11 01 12 01  03 08 1b 08 25 08 13 05  |............%...|
< 000077a0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
< 000077b0  00 00 2c 00 00 00 02 00  00 00 00 00 08 00 00 00  |..,.............|
< 000077c0  00 00 00 00 00 00 00 00  00 00 17 00 00 00 00 00  |................|
< 000077d0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
---
> 000076e0  2f 62 61 7a 65 6c 2d 73  61 6e 64 62 6f 78 2f 39  |/bazel-sandbox/9|
> 000076f0  35 38 34 30 30 33 33 30  34 35 32 32 30 38 32 38  |5840033045220828|
> 00007700  2f 65 78 65 63 72 6f 6f  74 2f 69 6f 5f 62 61 7a  |/execroot/io_baz|
> 00007710  65 6c 5f 72 75 6c 65 73  5f 67 6f 2f 62 61 7a 65  |el_rules_go/baze|
> 00007720  6c 2d 6f 75 74 2f 6b 38  2d 66 61 73 74 62 75 69  |l-out/k8-fastbui|
> 00007730  6c 64 2f 62 69 6e 2f 65  78 74 65 72 6e 61 6c 2f  |ld/bin/external/|
> 00007740  69 6f 5f 62 61 7a 65 6c  5f 72 75 6c 65 73 5f 67  |io_bazel_rules_g|
> 00007750  6f 2f 6c 69 6e 75 78 5f  61 6d 64 36 34 5f 73 74  |o/linux_amd64_st|
> 00007760  72 69 70 70 65 64 2f 73  74 64 6c 69 62 7e 2f 73  |ripped/stdlib~/s|
> 00007770  72 63 2f 72 75 6e 74 69  6d 65 2f 63 67 6f 00 47  |rc/runtime/cgo.G|
> 00007780  4e 55 20 41 53 20 32 2e  32 38 00 01 80 01 11 00  |NU AS 2.28......|
> 00007790  10 06 11 01 12 01 03 08  1b 08 25 08 13 05 00 00  |..........%.....|
> 000077a0  00 00 2c 00 00 00 02 00  00 00 00 00 08 00 00 00  |..,.............|
> 000077b0  00 00 00 00 00 00 00 00  00 00 17 00 00 00 00 00  |................|
> 000077c0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
```