### PR TITLE
coverage: Only print importpath and base name in log file

### DIFF
--- a/go/tools/builders/generate_test_main.go
+++ b/go/tools/builders/generate_test_main.go
@@ -37,6 +37,10 @@ type CoverFile struct {
 	Var  string
 }
 
+func (f *CoverFile) Base() string {
+	return filepath.Base(f.File)
+}
+
 type CoverPackage struct {
 	Name   string
 	Import string
@@ -138,7 +142,7 @@ func coverRegisterAll() testing.Cover {
 	//{{$p.Import}}
 {{range $v := $p.Files}}
 	{{$var := printf "%s.%s" $p.Name $v.Var}}
-	coverRegisterFile(&coverage, "{{printf "%s/%s" $p.Import $v.File}}", {{$var}}.Count[:], {{$var}}.Pos[:], {{$var}}.NumStmt[:])
+	coverRegisterFile(&coverage, "{{printf "%s/%s" $p.Import $v.Base}}", {{$var}}.Count[:], {{$var}}.Pos[:], {{$var}}.NumStmt[:])
 {{end}}
 {{end}}
 	return coverage

--- a/tests/legacy/coverage/BUILD.bazel
+++ b/tests/legacy/coverage/BUILD.bazel
@@ -24,7 +24,7 @@ if ! grep -q '^coverage: 50.0% of statements' "bazel-testlogs/$RULES_GO_OUTPUT/g
   echo "error: no coverage output found in test log file" >&2
   exit 1
 fi
-if ! grep -q 'io_bazel_rules_go/tests/legacy/coverage/lib.go:' "bazel-testlogs/$RULES_GO_OUTPUT/go_default_test/coverage.dat"; then
+if ! grep -q 'github.com/bazelbuild/rules_go/tests/coverage/lib.go:' "bazel-testlogs/$RULES_GO_OUTPUT/go_default_test/coverage.dat"; then
   echo "error: no coverage data found in bazel-testlogs"
   exit 1
 fi


### PR DESCRIPTION
This fixes a filename stutter bug introduced in #1407.

Related #1406
Related #1150