### PR TITLE
go_path: de-duplicate files in manifest

### DIFF
--- a/tests/core/go_path/cmd/bin/BUILD.bazel
+++ b/tests/core/go_path/cmd/bin/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["bin.go"],
+    data = ["bin.go"],  # test duplicate
     importpath = "example.com/repo/cmd/bin",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Duplicate files may happen because multiple rules have the same srcs
or data. genrule also treats all its inputs as data, so generated
source files get treated as data.

Previously, duplicate files caused problems in link mode, because
symlinks aren't automatically overwritten. They may have also been an
issue in archive mode. With this change, duplicate files won't be
passed to the go_path builder.

Fixes #1439