### PR TITLE
go_path: improve handling of data files

### DIFF
--- a/go/core.rst
+++ b/go/core.rst
@@ -728,6 +728,12 @@ Attributes
 | * ``"link"``: Source files are symlinked into the tree. All of the symlink                       |
 |   files are provided as separate output files.                                                   |
 +----------------------------+-----------------------------+---------------------------------------+
+| :param:`include_data`      | :type:`bool`                | :value:`True`                         |
++----------------------------+-----------------------------+---------------------------------------+
+| When true, data files referenced by libraries, binaries, and tests will be                       |
+| included in the output directory. Files listed in the :param:`data` attribute                    |
+| for this rule will be included regardless of this attribute.                                     |
++----------------------------+-----------------------------+---------------------------------------+
 
 go_rule
 ~~~~~~~

--- a/tests/core/go_path/BUILD.bazel
+++ b/tests/core/go_path/BUILD.bazel
@@ -4,17 +4,26 @@ test_suite(name = "go_path")
 
 [go_path(
     name = mode + "_path",
+    testonly = True,
+    data = ["extra.txt"],
+    mode = mode,
     deps = [
         "//tests/core/go_path/cmd/bin",
-        "//tests/core/go_path/pkg/lib:go_default_library",
         "//tests/core/go_path/pkg/lib:embed_test",
+        "//tests/core/go_path/pkg/lib:go_default_library",
         "//tests/core/go_path/pkg/lib:go_default_test",
         "//tests/core/go_path/pkg/lib:vendored",
     ],
-    data = ["extra.txt"],
-    mode = mode,
-    testonly = True,
 ) for mode in ("archive", "copy", "link")]
+
+go_path(
+    name = "nodata_path",
+    testonly = True,
+    data = ["extra.txt"],
+    include_data = False,
+    mode = "copy",
+    deps = ["//tests/core/go_path/pkg/lib:go_default_library"],
+)
 
 go_test(
     name = "go_path_test",
@@ -22,12 +31,14 @@ go_test(
     args = [
         "-archive_path=$(location :archive_path)",
         "-copy_path=$(location :copy_path)",
-        "-link_path=tests/core/go_path/link_path", # can't use location; not a single file
+        "-link_path=tests/core/go_path/link_path",  # can't use location; not a single file
+        "-nodata_path=$(location :nodata_path)",
     ],
     data = [
         ":archive_path",
         ":copy_path",
         ":link_path",
+        ":nodata_path",
     ],
     rundir = ".",
 )

--- a/tests/core/go_path/go_path_test.go
+++ b/tests/core/go_path/go_path_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 )
 
-var copyPath, linkPath, archivePath string
+var copyPath, linkPath, archivePath, nodataPath string
 
 var files = []string{
 	"extra.txt",
@@ -41,6 +41,7 @@ var files = []string{
 	// "src/example.com/repo/pkg/lib/external_test.go",
 	"-src/example.com/repo/pkg/lib_test/embed_test.go",
 	"src/example.com/repo/pkg/lib/data.txt",
+	"src/example.com/repo/pkg/lib/testdata/testdata.txt",
 	"src/example.com/repo/vendor/example.com/repo2/vendored.go",
 }
 
@@ -48,6 +49,7 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&copyPath, "copy_path", "", "path to copied go_path")
 	flag.StringVar(&linkPath, "link_path", "", "path to symlinked go_path")
 	flag.StringVar(&archivePath, "archive_path", "", "path to archive go_path")
+	flag.StringVar(&nodataPath, "nodata_path", "", "path to go_path without data")
 	flag.Parse()
 	os.Exit(m.Run())
 }
@@ -104,6 +106,18 @@ func TestArchivePath(t *testing.T) {
 	}
 
 	checkPath(t, dir, files, os.FileMode(0))
+}
+
+func TestNoDataPath(t *testing.T) {
+	if nodataPath == "" {
+		t.Fatal("-nodata_path not set")
+	}
+	files := []string{
+		"extra.txt",
+		"src/example.com/repo/pkg/lib/lib.go",
+		"-src/example.com/repo/pkg/lib/data.txt",
+	}
+	checkPath(t, nodataPath, files, os.FileMode(0))
 }
 
 // checkPath checks that dir contains a list of files. files is a list of

--- a/tests/core/go_path/pkg/lib/BUILD.bazel
+++ b/tests/core/go_path/pkg/lib/BUILD.bazel
@@ -4,7 +4,10 @@ go_library(
     name = "go_default_library",
     srcs = ["lib.go"],
     cgo = True,
-    data = ["data.txt"],
+    data = [
+        "data.txt",
+        "testdata/testdata.txt",
+    ],
     importpath = "example.com/repo/pkg/lib",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
* Data files referenced by go rules are placed in their package
  directories with their basenames UNLESS they have testdata in their
  path, in which case, the part of the path below testdata/ is
  preserved.
* New attribute: include_data. Can be set to False to prevent data
  files from appearing in the output. Will be useful for tools when
  data files don't matter or cause problems.

Fixes #1449