### PR TITLE
Refactor how environment and arguments are passed to builders

### DIFF
--- a/go/private/actions/pack.bzl
+++ b/go/private/actions/pack.bzl
@@ -22,24 +22,19 @@ def emit_pack(go,
   if in_lib == None: fail("in_lib is a required parameter")
   if out_lib == None: fail("out_lib is a required parameter")
 
-  inputs = [in_lib] + go.stdlib.files
+  inputs = [in_lib] + go.stdlib.files + objects + archives
 
-  arguments = go.args(go)
-  arguments.add([
-      "-in", in_lib,
-      "-out", out_lib,
-  ])
-  inputs.extend(objects)
-  arguments.add(objects, before_each="-obj")
-
-  inputs.extend(archives)
-  arguments.add(archives, before_each="-arc")
+  args = go.args(go)
+  args.add(["-in", in_lib])
+  args.add(["-out", out_lib])
+  args.add(objects, before_each="-obj")
+  args.add(archives, before_each="-arc")
 
   go.actions.run(
       inputs = inputs,
       outputs = [out_lib],
       mnemonic = "GoPack",
       executable = go.builders.pack,
-      arguments = [arguments],
+      arguments = [args],
       env = go.env,
   )

--- a/go/private/rules/stdlib.bzl
+++ b/go/private/rules/stdlib.bzl
@@ -42,13 +42,20 @@ def _stdlib_library_to_source(go, attr, source, merge):
     args.add("-shared")
   args.add(["-filter_buildid", filter_buildid.path])
   go.actions.write(root_file, "")
+  env = go.env
+  env.update({
+      "CC": go.cgo_tools.compiler_executable,
+      "CGO_CPPFLAGS": " ".join(go.cgo_tools.compiler_options),
+      "CGO_CFLAGS": " ".join(go.cgo_tools.c_options),
+      "CGO_LDFLAGS": " ".join(go.cgo_tools.linker_options),
+  })
   go.actions.run(
       inputs = go.sdk_files + go.sdk_tools + go.crosstool + [filter_buildid, go.package_list, root_file],
       outputs = [pkg],
       mnemonic = "GoStdlib",
       executable = attr._stdlib_builder.files.to_list()[0],
       arguments = [args],
-      env = go.env,
+      env = env,
   )
   source["stdlib"] = GoStdLib(
       root_file = root_file,

--- a/go/tools/builders/README.rst
+++ b/go/tools/builders/README.rst
@@ -28,7 +28,7 @@ Principles for writing builders
 * Builders should accept arguments in three forms:
 
   * Builder arguments (before ``--``) are interpreted directly by builders.
-    These arguments may or may be passed on to underlying tools.
+    These arguments may or may not be passed on to underlying tools.
   * Tool arguments (after ``--``) are passed on to underlying tools. Builders
     may add additional arguments before or after these.
   * Environment variables are passed on to underlying tools. Builders will

--- a/go/tools/builders/README.rst
+++ b/go/tools/builders/README.rst
@@ -1,0 +1,40 @@
+Go and proto builders
+=====================
+
+This directory contains a set of small programs for building pieces of Go
+programs. These are used by Bazel during the execution phase instead of
+Bash scripts, which are not portable and are prone to spacing and quoting
+errors.
+
+Most builders invoke programs in the Go toolchain. For example, ``compile.go``
+invokes ``go tool compile``. Builders generally perform some extra actions
+(for example, source filtering) before invoking the underlying tool.
+
+Builder programs are constructed using a special rule, ``go_tool_binary``,
+which breaks a cyclic dependency (``go_binary`` and other rules depend on
+builders implicitly). This rule does not allow any library dependencies,
+so all sources need to be compiled together in the ``main`` package.
+
+Principles for writing builders
+-------------------------------
+
+* Builders that need to be directly available on the toolchain should be
+  registered with the ``builder`` rule in ``go/private/rules/builders.bzl``.
+  Special purpose builders like ``stdlib.go`` don't need to do this.
+* Builders should have a package comment describing what the builder is for.
+* ``log.SetFlags(0)`` should be called in ``main`` to avoid logging timestamps.
+  ``log.SetPrefix`` should be called with the builder's mnemonic
+  (e.g., ``GoCompile``).
+* Builders should accept arguments in three forms:
+
+  * Builder arguments (before ``--``) are interpreted directly by builders.
+    These arguments may or may be passed on to underlying tools.
+  * Tool arguments (after ``--``) are passed on to underlying tools. Builders
+    may add additional arguments before or after these.
+  * Environment variables are passed on to underlying tools. Builders will
+    usually not modify these.
+
+* Arguments common to multiple builders (for example, ``-go``, ``-v``) should
+  be handled in ``env.go``.
+* Subcommands should be run through ``env.runGoCommand`` for uniform logging
+  and error reporting.

--- a/go/tools/builders/flags.go
+++ b/go/tools/builders/flags.go
@@ -14,7 +14,11 @@
 
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"go/build"
+	"strings"
+)
 
 // multiFlag allows repeated string flags to be collected into a slice
 type multiFlag []string
@@ -28,5 +32,19 @@ func (m *multiFlag) String() string {
 
 func (m *multiFlag) Set(v string) error {
 	(*m) = append(*m, v)
+	return nil
+}
+
+// tagFlag adds tags to the build.Default context. Tags are expected to be
+// formatted as a comma-separated list.
+type tagFlag struct{}
+
+func (f *tagFlag) String() string {
+	return strings.Join(build.Default.BuildTags, ",")
+}
+
+func (f *tagFlag) Set(opt string) error {
+	tags := strings.Split(opt, ",")
+	build.Default.BuildTags = append(build.Default.BuildTags, tags...)
 	return nil
 }

--- a/go/tools/builders/generate_test_main.go
+++ b/go/tools/builders/generate_test_main.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"go/ast"
+	"go/build"
 	"go/doc"
 	"go/parser"
 	"go/token"
@@ -154,7 +155,7 @@ func run(args []string) error {
 	// Prepare our flags
 	imports := multiFlag{}
 	sources := multiFlag{}
-	flags := flag.NewFlagSet("generate_test_main", flag.ExitOnError)
+	flags := flag.NewFlagSet("GoTestGenTest", flag.ExitOnError)
 	goenv := envFlags(flags)
 	runDir := flags.String("rundir", ".", "Path to directory where tests should run.")
 	out := flags.String("output", "", "output file to write. Defaults to stdout.")
@@ -164,7 +165,7 @@ func run(args []string) error {
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
-	if err := goenv.update(); err != nil {
+	if err := goenv.checkFlags(); err != nil {
 		return err
 	}
 	// Process import args
@@ -190,8 +191,7 @@ func run(args []string) error {
 	}
 
 	// filter our input file list
-	bctx := goenv.BuildContext()
-	filenames, err := filterFiles(bctx, sourceList)
+	filenames, err := filterFiles(build.Default, sourceList)
 	if err != nil {
 		return err
 	}
@@ -315,6 +315,8 @@ func run(args []string) error {
 }
 
 func main() {
+	log.SetFlags(0)
+	log.SetPrefix("GoTestGenTest: ")
 	if err := run(os.Args[1:]); err != nil {
 		log.Fatal(err)
 	}

--- a/go/tools/builders/go_path.go
+++ b/go/tools/builders/go_path.go
@@ -54,6 +54,7 @@ type manifestEntry struct {
 }
 
 func main() {
+	log.SetPrefix("GoPath: ")
 	log.SetFlags(0)
 	if err := run(os.Args[1:]); err != nil {
 		log.Fatal(err)

--- a/go/tools/builders/info.go
+++ b/go/tools/builders/info.go
@@ -21,25 +21,7 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 )
-
-const endOfHereDoc = "EndOfGoInfoReport"
-
-func invoke(goenv *GoEnv, out *os.File, args []string) error {
-	cmd := exec.Command(goenv.Go, args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Env = append(os.Environ(), goenv.Env()...)
-	if out != nil {
-		cmd.Stdout = out
-		cmd.Stderr = out
-	}
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("error running %v: %v", args, err)
-	}
-	return nil
-}
 
 func run(args []string) error {
 	filename := ""
@@ -49,7 +31,7 @@ func run(args []string) error {
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
-	if err := goenv.update(); err != nil {
+	if err := goenv.checkFlags(); err != nil {
 		return err
 	}
 	f := os.Stderr
@@ -61,10 +43,10 @@ func run(args []string) error {
 		}
 		defer f.Close()
 	}
-	if err := invoke(goenv, f, []string{"version"}); err != nil {
+	if err := goenv.runGoCommandToFile(f, []string{"version"}); err != nil {
 		return err
 	}
-	if err := invoke(goenv, f, []string{"env"}); err != nil {
+	if err := goenv.runGoCommandToFile(f, []string{"env"}); err != nil {
 		return err
 	}
 	return nil

--- a/go/tools/builders/md5sum.go
+++ b/go/tools/builders/md5sum.go
@@ -66,6 +66,8 @@ func run(args []string) error {
 }
 
 func main() {
+	log.SetFlags(0)
+	log.SetPrefix("GoMd5sum: ")
 	if err := run(os.Args[1:]); err != nil {
 		log.Fatal(err)
 	}

--- a/go/tools/builders/pack.go
+++ b/go/tools/builders/pack.go
@@ -31,13 +31,12 @@ import (
 	"io"
 	"log"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 )
 
 func run(args []string) error {
-	flags := flag.NewFlagSet("pack", flag.ContinueOnError)
+	flags := flag.NewFlagSet("GoPack", flag.ExitOnError)
 	goenv := envFlags(flags)
 	inArchive := flags.String("in", "", "Path to input archive")
 	outArchive := flags.String("out", "", "Path to output archive")
@@ -48,7 +47,7 @@ func run(args []string) error {
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
-	if err := goenv.update(); err != nil {
+	if err := goenv.checkFlags(); err != nil {
 		return err
 	}
 
@@ -69,6 +68,8 @@ func run(args []string) error {
 }
 
 func main() {
+	log.SetFlags(0)
+	log.SetPrefix("GoPack: ")
 	if err := run(os.Args[1:]); err != nil {
 		log.Fatal(err)
 	}
@@ -293,11 +294,7 @@ func simpleName(name string, names map[string]struct{}) string {
 	return name[:15]
 }
 
-func appendFiles(goenv *GoEnv, archive string, files []string) error {
+func appendFiles(goenv *env, archive string, files []string) error {
 	args := append([]string{"tool", "pack", "r", archive}, files...)
-	cmd := exec.Command(goenv.Go, args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Env = goenv.Env()
-	return cmd.Run()
+	return goenv.runGoCommand(args)
 }

--- a/go/tools/builders/stdlib.go
+++ b/go/tools/builders/stdlib.go
@@ -52,7 +52,11 @@ func run(args []string) error {
 	// Now switch to the newly created GOROOT
 	os.Setenv("GOROOT", output)
 
-	// Run the commands needed to build the std library in the right mode
+	// Make sure we have an absolute path to the C compiler.
+	// TODO(#1357): also take absolute paths of includes and other paths in flags.
+	os.Setenv("CC", abs(os.Getenv("CC")))
+
+	// Build the commands needed to build the std library in the right mode
 	installArgs := []string{"install", "-toolexec", abs(*filterBuildid)}
 	gcflags := []string{}
 	ldflags := []string{"-trimpath", abs(".")}

--- a/go/tools/builders/stdlib.go
+++ b/go/tools/builders/stdlib.go
@@ -18,57 +18,49 @@ package main
 import (
 	"flag"
 	"fmt"
+	"go/build"
 	"log"
 	"os"
-	"os/exec"
 	"strings"
 )
-
-func install_stdlib(goenv *GoEnv, target string, args []string) error {
-	if goenv.tags != "" {
-		args = append(args, "-tags", goenv.tags)
-	}
-	args = append(args, target)
-	cmd := exec.Command(goenv.Go, args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Env = goenv.Env()
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("error running go install %s: %v", target, err)
-	}
-	return nil
-}
 
 func run(args []string) error {
 	// process the args
 	flags := flag.NewFlagSet("stdlib", flag.ExitOnError)
 	goenv := envFlags(flags)
-	filter_buildid := flags.String("filter_buildid", "", "Path to filter_buildid tool")
+	filterBuildid := flags.String("filter_buildid", "", "Path to filter_buildid tool")
 	out := flags.String("out", "", "Path to output go root")
 	race := flags.Bool("race", false, "Build in race mode")
+	shared := flags.Bool("shared", false, "Build in shared mode")
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
-	if err := goenv.update(); err != nil {
+	if err := goenv.checkFlags(); err != nil {
 		return err
 	}
-	goroot := goenv.rootPath
+	goroot := os.Getenv("GOROOT")
+	if goroot == "" {
+		return fmt.Errorf("GOROOT not set")
+	}
 	output := abs(*out)
+
 	// Link in the bare minimum needed to the new GOROOT
 	if err := replicate(goroot, output, replicatePaths("src", "pkg/tool", "pkg/include")); err != nil {
 		return err
 	}
+
 	// Now switch to the newly created GOROOT
-	goenv.rootPath = output
+	os.Setenv("GOROOT", output)
+
 	// Run the commands needed to build the std library in the right mode
-	installArgs := []string{"install", "-toolexec", abs(*filter_buildid)}
+	installArgs := []string{"install", "-toolexec", abs(*filterBuildid)}
 	gcflags := []string{}
 	ldflags := []string{"-trimpath", abs(".")}
 	asmflags := []string{"-trimpath", abs(".")}
 	if *race {
 		installArgs = append(installArgs, "-race")
 	}
-	if goenv.shared {
+	if *shared {
 		gcflags = append(gcflags, "-shared")
 		ldflags = append(ldflags, "-shared")
 		asmflags = append(asmflags, "-shared")
@@ -78,23 +70,27 @@ func run(args []string) error {
 	// and its dependencies, rather than just the package itself. This was the
 	// default behavior before Go 1.10.
 	allSlug := ""
-	if goReleaseTags["go1.10"] {
-		allSlug = "all="
+	for _, t := range build.Default.ReleaseTags {
+		if t == "go1.10" {
+			allSlug = "all="
+			break
+		}
 	}
 	installArgs = append(installArgs, "-gcflags="+allSlug+strings.Join(gcflags, " "))
 	installArgs = append(installArgs, "-ldflags="+allSlug+strings.Join(ldflags, " "))
 	installArgs = append(installArgs, "-asmflags="+allSlug+strings.Join(asmflags, " "))
 
-	if err := install_stdlib(goenv, "std", installArgs); err != nil {
-		return err
-	}
-	if err := install_stdlib(goenv, "runtime/cgo", installArgs); err != nil {
-		return err
+	for _, target := range []string{"std", "runtime/cgo"} {
+		if err := goenv.runGoCommand(append(installArgs, target)); err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
 func main() {
+	log.SetFlags(0)
+	log.SetPrefix("GoStdlib: ")
 	if err := run(os.Args[1:]); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Builders now receive inputs through three well-defined channels:

* Builder arguments (before --) are interpreted directly by
  builders. These arguments may or may not be passed on to underlying
  tools.
* Tool arguments (after --) are passed on to underlying
  tools. Builders may add additional arguments before or after these.
* Environment variables are passed on to underlying tools. Builders
  will usually not modify these.

Fixes #1456