### PR TITLE
Fix coverage bugs

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -34,7 +34,8 @@ def emit_archive(go, source=None):
 
   if source == None: fail("source is a required parameter")
 
-  if go.cover:
+  covered = bool(go.cover and go.coverdata and source.cover)
+  if covered:
     source = go.cover(go, source)
   split = split_srcs(source.srcs)
   lib_name = source.library.importmap + ".a"
@@ -52,7 +53,7 @@ def emit_archive(go, source=None):
   for a in direct:
     runfiles = runfiles.merge(a.runfiles)
     if a.source.mode != go.mode: fail("Archive mode does not match {} is {} expected {}".format(a.data.label, mode_string(a.source.mode), mode_string(go.mode)))
-  if go.cover:
+  if covered:
     direct.append(go.coverdata)
 
   if len(extra_objects) == 0 and not source.cgo_archives:

--- a/go/private/actions/cover.bzl
+++ b/go/private/actions/cover.bzl
@@ -15,6 +15,7 @@
 load(
     "@io_bazel_rules_go//go/private:providers.bzl",
     "GoSource",
+    "effective_importpath_pkgpath",
 )
 load(
     "@io_bazel_rules_go//go/private:common.bzl",
@@ -41,10 +42,11 @@ def emit_cover(go, source):
       "-o=" + out.path,
       "-var=" + cover_var,
       "-src=" + src.path,
-      "-importpath=" + source.library.importpath,
-      "--",
-      "-mode=set",
     ])
+    _, pkgpath = effective_importpath_pkgpath(source.library)
+    if pkgpath != "":
+      args.add("-srcname=" + pkgpath + "/" + src.basename)
+    args.add(["--", "-mode=set"])
     go.actions.run(
         inputs = [src] + go.stdlib.files,
         outputs = [out],

--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_go//go/private:providers.bzl", "GoLibrary")
 load("//go/private:skylib/lib/dicts.bzl", "dicts")
 load("//go/private:skylib/lib/paths.bzl", "paths")
 load("//go/private:skylib/lib/sets.bzl", "sets")

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -14,6 +14,9 @@
 
 load(
     "@io_bazel_rules_go//go/private:providers.bzl",
+    "EXPLICIT_PATH",
+    "INFERRED_PATH",
+    "EXPORT_PATH",
     "GoLibrary",
     "GoSource",
     "GoAspectProviders",
@@ -45,12 +48,6 @@ load(
 )
 
 GoContext = provider()
-
-EXPLICIT_PATH = "explicit"
-
-INFERRED_PATH = "inferred"
-
-EXPORT_PATH = "export"
 
 _COMPILER_OPTIONS_BLACKLIST = {
   "-fcolor-diagnostics": None,
@@ -159,7 +156,7 @@ def _library_to_source(go, attr, library, coverage_instrumented):
       "cgo_deps" : [],
       "cgo_exports" : [],
   }
-  if coverage_instrumented and not attr.testonly:
+  if coverage_instrumented and not getattr(attr, "testonly", False):
     source["cover"] = attr_srcs
   for e in getattr(attr, "embed", []):
     _merge_embed(source, e)
@@ -233,8 +230,6 @@ def go_context(ctx, attr=None):
   coverdata = getattr(attr, "_coverdata", None)
   if coverdata:
     coverdata = get_archive(coverdata)
-  have_cover = (ctx.configuration.coverage_enabled and
-                bool(toolchain.actions.cover) and bool(coverdata))
 
   host_only = getattr(attr, "_hostonly", False)
 
@@ -265,7 +260,7 @@ def go_context(ctx, attr=None):
       pathtype = pathtype,
       cgo_tools = context_data.cgo_tools,
       builders = builders,
-      coverdata = coverdata if have_cover else None,
+      coverdata = coverdata,
       env = context_data.env,
       tags = context_data.tags,
       # Action generators
@@ -273,7 +268,7 @@ def go_context(ctx, attr=None):
       asm = toolchain.actions.asm,
       binary = toolchain.actions.binary,
       compile = toolchain.actions.compile,
-      cover = toolchain.actions.cover if have_cover else None,
+      cover = toolchain.actions.cover,
       link = toolchain.actions.link,
       pack = toolchain.actions.pack,
 

--- a/go/private/providers.bzl
+++ b/go/private/providers.bzl
@@ -52,6 +52,12 @@ GoStdLib = provider()
 
 GoBuilders = provider()
 
+EXPLICIT_PATH = "explicit"
+
+INFERRED_PATH = "inferred"
+
+EXPORT_PATH = "export"
+
 def new_aspect_provider(source = None, archive = None):
   return GoAspectProviders(
       source = source,
@@ -71,3 +77,35 @@ def get_archive(dep):
   if GoAspectProviders in dep:
     return dep[GoAspectProviders].archive
   return dep[GoArchive]
+
+def effective_importpath_pkgpath(lib):
+  """Returns import and package paths for a given lib with some
+  modifications for display.
+
+  This is used when we need to represent sources in a manner compatible with Go
+  build (e.g., for packaging or coverage data listing). _test suffixes are
+  removed, and vendor directories from importmap may be modified.
+
+  Args:
+    lib: GoLibrary or GoArchiveData
+
+  Returns:
+    A tuple of effective import path and effective package path. Both are ""
+    for synthetic archives (e.g., generated testmain).
+  """
+  if lib.pathtype != EXPLICIT_PATH:
+    return "", ""
+  importpath = lib.importpath
+  importmap = lib.importmap
+  if importpath.endswith("_test"): importpath = importpath[:-len("_test")]
+  if importmap.endswith("_test"): importmap = importmap[:-len("_test")]
+  parts = importmap.split("/")
+  if "vendor" not in parts:
+    # Unusual case not handled by go build. Just return importpath.
+    return importpath, importpath
+  elif len(parts) > 2 and lib.label.workspace_root == "external/" + parts[0]:
+    # Common case for importmap set by Gazelle in external repos.
+    return importpath, importmap[len(parts[0]):]
+  else:
+    # Vendor directory somewhere in the main repo. Leave it alone.
+    return importpath, importmap  

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -15,7 +15,6 @@
 load(
     "@io_bazel_rules_go//go/private:context.bzl",
     "go_context",
-    "EXPORT_PATH",
 )
 load(
     "@io_bazel_rules_go//go/private:common.bzl",
@@ -33,6 +32,7 @@ load(
 )
 load(
     "@io_bazel_rules_go//go/private:providers.bzl",
+    "EXPORT_PATH",
     "GoLibrary",
     "get_archive",
 )
@@ -78,7 +78,7 @@ def _go_test_impl(ctx):
       srcs = [struct(files=go_srcs)],
       deps = internal_archive.direct + [internal_archive],
       x_defs = ctx.attr.x_defs,
-  ), external_library, False)
+  ), external_library, ctx.coverage_instrumented())
   external_archive = go.archive(go, external_source)
   external_srcs = split_srcs(external_source.srcs).go
 
@@ -94,7 +94,7 @@ def _go_test_impl(ctx):
   main_go = go.declare_file(go, "testmain.go")
   arguments = go.args(go)
   arguments.add(['-rundir', run_dir, '-output', main_go])
-  if go.cover:
+  if ctx.configuration.coverage_enabled:
     arguments.add(["-coverage"])
   arguments.add([
       # the l is the alias for the package under test, the l_test must be the
@@ -123,7 +123,7 @@ def _go_test_impl(ctx):
       resolve = None,
   )
   test_deps = external_archive.direct + [external_archive]
-  if go.cover:
+  if ctx.configuration.coverage_enabled:
     test_deps.append(go.coverdata)
   test_source = go.library_to_source(go, struct(
       srcs = [struct(files=[main_go])],

--- a/go/tools/builders/cover.go
+++ b/go/tools/builders/cover.go
@@ -28,17 +28,16 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 )
 
 func run(args []string) error {
 	flags := flag.NewFlagSet("cover", flag.ExitOnError)
-	var coverSrc, coverVar, origSrc, importpath string
+	var coverSrc, coverVar, origSrc, srcName string
 	flags.StringVar(&coverSrc, "o", "", "coverage output file")
 	flags.StringVar(&coverVar, "var", "", "name of cover variable")
 	flags.StringVar(&origSrc, "src", "", "original source file")
-	flags.StringVar(&importpath, "importpath", "", "library import path")
+	flags.StringVar(&srcName, "srcname", "", "source name printed in coverage data")
 	goenv := envFlags(flags)
 	if err := flags.Parse(args); err != nil {
 		return err
@@ -55,11 +54,8 @@ func run(args []string) error {
 	if origSrc == "" {
 		return fmt.Errorf("-src was not set")
 	}
-	var srcName string
-	if importpath == "" {
+	if srcName == "" {
 		srcName = origSrc
-	} else {
-		srcName = filepath.Join(filepath.FromSlash(importpath), filepath.Base(origSrc))
 	}
 
 	goargs := []string{"tool", "cover", "-var=" + coverVar, "-o=" + coverSrc}


### PR DESCRIPTION
* In coverage output data, source names are formatted using the same
  function go_path uses to place sources in GOPATH trees. This may not
  correspond to file system locations of sources, but that was already not
  the case. This will probably be configurable in the future.
* Fixed logic that determines whether sources are covered.

Fixes #1466, #1467