### PR TITLE
Fix coverage issues around cgo

### DIFF
--- a/go/private/actions/cover.bzl
+++ b/go/private/actions/cover.bzl
@@ -30,23 +30,30 @@ def emit_cover(go, source):
     return source
 
   covered = []
+  covered_src_map = dict(source.orig_src_map)
   for src in source.srcs:
     if not src.basename.endswith(".go") or src not in source.cover:
       covered.append(src)
       continue
+    orig = covered_src_map.get(src, src)
+    _, pkgpath = effective_importpath_pkgpath(source.library)
+    srcname = pkgpath + "/" + orig.basename if pkgpath else orig.path
+
     cover_var = "Cover_" + src.basename[:-3].replace("-", "_").replace(".", "_")
     out = go.declare_file(go, path=cover_var, ext='.cover.go')
+    covered_src_map.pop(src, None)
+    covered_src_map[out] = orig
     covered.append(out)
+
     args = go.args(go)
     args.add([
       "-o=" + out.path,
       "-var=" + cover_var,
       "-src=" + src.path,
+      "-srcname=" + srcname,
+      "--",
+      "-mode=set",
     ])
-    _, pkgpath = effective_importpath_pkgpath(source.library)
-    if pkgpath != "":
-      args.add("-srcname=" + pkgpath + "/" + src.basename)
-    args.add(["--", "-mode=set"])
     go.actions.run(
         inputs = [src] + go.stdlib.files,
         outputs = [out],
@@ -57,4 +64,5 @@ def emit_cover(go, source):
     )
   members = structs.to_dict(source)
   members["srcs"] = covered
+  members["orig_src_map"] = covered_src_map
   return GoSource(**members)

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -42,6 +42,8 @@ def emit_link(go,
   pkg_depth = executable.dirname[config_strip:].count('/') + 1
 
   extldflags = list(go.cgo_tools.linker_options)
+  if go.coverage_enabled:
+    extldflags.append("--coverage")
   gc_linkopts, extldflags = _extract_extldflags(gc_linkopts, extldflags)
   builder_args = go.args(go)
   tool_args = go.actions.args()

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -105,6 +105,7 @@ def _merge_embed(source, embed):
   s = get_source(embed)
   source["srcs"] = s.srcs + source["srcs"]
   source["orig_srcs"] = s.orig_srcs + source["orig_srcs"]
+  source["orig_src_map"].update(s.orig_src_map)
   source["cover"] = source["cover"] + s.cover
   source["deps"] = source["deps"] + s.deps
   source["x_defs"].update(s.x_defs)
@@ -127,6 +128,7 @@ def _library_to_source(go, attr, library, coverage_instrumented):
       "mode": go.mode,
       "srcs": srcs,
       "orig_srcs": srcs,
+      "orig_src_map": {},
       "cover" : [],
       "x_defs" : {},
       "deps" : getattr(attr, "deps", []),
@@ -254,6 +256,8 @@ def go_context(ctx, attr=None):
       cgo_tools = context_data.cgo_tools,
       builders = builders,
       coverdata = coverdata,
+      coverage_enabled = ctx.configuration.coverage_enabled,
+      coverage_instrumented = ctx.coverage_instrumented(),
       env = env,
       tags = context_data.tags,
       # Action generators

--- a/go/providers.rst
+++ b/go/providers.rst
@@ -204,6 +204,12 @@ GoArchiveData represents the compiled form of a package.
 +--------------------------------+-----------------------------------------------------------------+
 | The unmodified sources provided to the rule, including .go, .s, .h, .c files.                    |
 +--------------------------------+-----------------------------------------------------------------+
+| :param:`orig_src_map`          | :type:`dict mapping File to File`                               |
++--------------------------------+-----------------------------------------------------------------+
+| A map from generated source files to the original files (in ``orig_srcs``)                       |
+| they were generated from. Generated sources may be absent if they were not                       |
+| generated from individual files in ``orig_srcs``.                                                |
++--------------------------------+-----------------------------------------------------------------+
 | :param:`data_files`            | :type:`list of File`                                            |
 +--------------------------------+-----------------------------------------------------------------+
 | Data files which should be available at runtime to binaries and tests built                      |

--- a/tests/bazel_tests.bzl
+++ b/tests/bazel_tests.bzl
@@ -80,6 +80,12 @@ def _bazel_test_script_impl(ctx):
   go = go_context(ctx)
   script_file = go.declare_file(go, ext=".bash")
 
+  if not ctx.attr.targets:
+    # Skip test when there are no targets. Targets may be platform-specific,
+    # and we may not have any targets on some platforms.
+    ctx.actions.write(script_file, "", is_executable = True)
+    return [DefaultInfo(files = depset([script_file]))]
+
   if ctx.attr.go_version == CURRENT_VERSION:
     register = 'go_register_toolchains()\n'
   elif ctx.attr.go_version != None:

--- a/tests/core/coverage/BUILD.bazel
+++ b/tests/core/coverage/BUILD.bazel
@@ -4,7 +4,7 @@ load("@io_bazel_rules_go//tests:bazel_tests.bzl", "bazel_test")
 bazel_test(
     name = "coverage_test_test",
     check = """
-if ! grep -q '^coverage: 50.0% of statements' "bazel-testlogs/$RULES_GO_OUTPUT/coverage_test/test.log"; then
+if ! grep -q '^coverage: 50.0% of statements' "bazel-testlogs/$RULES_GO_OUTPUT/"coverage_*_test/test.log; then
   echo "error: no coverage output found in test log file" >&2
   exit 1
 fi
@@ -26,8 +26,13 @@ function check_file_excluded {
 included_files=(
   'github.com/bazelbuild/rules_go/tests/core/coverage/a/a.go:'
   'github.com/bazelbuild/rules_go/tests/core/coverage/c/c.go:'
-  'github.com/bazelbuild/rules_go/tests/core/coverage/c/c_cgo.go:'
 )
+if [ "$(uname -s)" != Darwin ]; then
+  included_files+=(
+    'github.com/bazelbuild/rules_go/tests/core/coverage/a/a_cgo.go:'
+    'github.com/bazelbuild/rules_go/tests/core/coverage/c/c_cgo.go:'
+  )
+fi
 excluded_files=(
   'github.com/bazelbuild/rules_go/tests/core/coverage/b/b.go:'
   'github.com/bazelbuild/rules_go/tests/core/coverage/b/b_cgo.go:'
@@ -42,7 +47,10 @@ done
     """,
     command = "coverage",
     args = ["--instrumentation_filter=-coverage:b"],
-    targets = [":coverage_test"],
+    targets = select({
+        "@io_bazel_rules_go//go/platform:darwin": [],
+        "//conditions:default": [":coverage_test"],
+    }),
 )
 
 go_test(
@@ -63,7 +71,13 @@ fi
 result=0
 """,
     command = "coverage",
-    targets = [":coverage_bin"],
+    targets = select({
+        # TODO(bazelbuild/bazel#5128): skip coverage test on Darwin. The target
+        # includes cgo, which gets instrumented, and Bazel reports link errors
+        # for instrumented C code on Darwin.
+        "@io_bazel_rules_go//go/platform:darwin": [],
+        "//conditions:default": [":coverage_bin"],
+    }),
 )
 
 go_binary(

--- a/tests/core/coverage/BUILD.bazel
+++ b/tests/core/coverage/BUILD.bazel
@@ -4,7 +4,7 @@ load("@io_bazel_rules_go//tests:bazel_tests.bzl", "bazel_test")
 bazel_test(
     name = "coverage_test_test",
     check = """
-if ! grep -q '^coverage: 50.0% of statements' "bazel-testlogs/$RULES_GO_OUTPUT/"coverage_*_test/test.log; then
+if ! grep -q '^coverage: 50.0% of statements' "bazel-testlogs/$RULES_GO_OUTPUT/coverage_test/test.log"; then
   echo "error: no coverage output found in test log file" >&2
   exit 1
 fi
@@ -26,13 +26,8 @@ function check_file_excluded {
 included_files=(
   'github.com/bazelbuild/rules_go/tests/core/coverage/a/a.go:'
   'github.com/bazelbuild/rules_go/tests/core/coverage/c/c.go:'
+  'github.com/bazelbuild/rules_go/tests/core/coverage/c/c_cgo.go:'
 )
-if [ "$(uname -s)" != Darwin ]; then
-  included_files+=(
-    'github.com/bazelbuild/rules_go/tests/core/coverage/a/a_cgo.go:'
-    'github.com/bazelbuild/rules_go/tests/core/coverage/c/c_cgo.go:'
-  )
-fi
 excluded_files=(
   'github.com/bazelbuild/rules_go/tests/core/coverage/b/b.go:'
   'github.com/bazelbuild/rules_go/tests/core/coverage/b/b_cgo.go:'

--- a/tests/core/coverage/BUILD.bazel
+++ b/tests/core/coverage/BUILD.bazel
@@ -10,6 +10,16 @@ if ! grep -q '^coverage: 50.0% of statements' "bazel-testlogs/$RULES_GO_OUTPUT/c
 fi
 
 data_file=bazel-testlogs/$RULES_GO_OUTPUT/coverage_test/coverage.dat
+if [ ! -e "$data_file" ]; then
+  echo "error: $data_file: does not exist" >&2
+  exit 1
+fi
+if [ ! -s "$data_file" ]; then
+  echo "warning: $data_file: has size zero. Bazel may have trashed it with lcov." >&2
+  echo "skipping rest of test" >&2
+  exit 0
+fi
+
 function check_file_included {
   if ! grep -q "$1" "$data_file"; then
     echo "error: coverage data not found for $1" >&2

--- a/tests/core/coverage/BUILD.bazel
+++ b/tests/core/coverage/BUILD.bazel
@@ -51,7 +51,10 @@ for i in "${excluded_files[@]}"; do
 done
     """,
     command = "coverage",
-    args = ["--instrumentation_filter=-coverage:b"],
+    args = [
+        "--instrumentation_filter=-coverage:b",
+        "--nocache_test_results",
+    ],
     targets = select({
         "@io_bazel_rules_go//go/platform:darwin": [],
         "//conditions:default": [":coverage_test"],

--- a/tests/core/coverage/BUILD.bazel
+++ b/tests/core/coverage/BUILD.bazel
@@ -8,14 +8,37 @@ if ! grep -q '^coverage: 50.0% of statements' "bazel-testlogs/$RULES_GO_OUTPUT/c
   echo "error: no coverage output found in test log file" >&2
   exit 1
 fi
-if ! grep -q 'github.com/bazelbuild/rules_go/tests/core/coverage/c/c.go:' "bazel-testlogs/$RULES_GO_OUTPUT/coverage_test/coverage.dat"; then
-  echo "error: coverage data not found for c.go" >&2
-  exit 1
-fi
-if grep -q 'github.com/bazelbuild/rules_go/tests/core/coverage/b/b.go:' "bazel-testlogs/$RULES_GO_OUTPUT/coverage_test/coverage.dat"; then
-  echo "error: coverage data found for b.go, but it should be excluded" >&2
-  exit 1
-fi
+
+data_file=bazel-testlogs/$RULES_GO_OUTPUT/coverage_test/coverage.dat
+function check_file_included {
+  if ! grep -q "$1" "$data_file"; then
+    echo "error: coverage data not found for $1" >&2
+    exit 1
+  fi
+}
+function check_file_excluded {
+  if grep -q "$1" "$data_file"; then
+    echo "error: coverage data found for $1, but it should be excluded" >&2
+    exit 1
+  fi
+}
+
+included_files=(
+  'github.com/bazelbuild/rules_go/tests/core/coverage/a/a.go:'
+  'github.com/bazelbuild/rules_go/tests/core/coverage/c/c.go:'
+  'github.com/bazelbuild/rules_go/tests/core/coverage/c/c_cgo.go:'
+)
+excluded_files=(
+  'github.com/bazelbuild/rules_go/tests/core/coverage/b/b.go:'
+  'github.com/bazelbuild/rules_go/tests/core/coverage/b/b_cgo.go:'
+  '\.cgo1\.go:'
+)
+for i in "${included_files[@]}"; do
+  check_file_included "$i"
+done
+for i in "${excluded_files[@]}"; do
+  check_file_excluded "$i"
+done
     """,
     command = "coverage",
     args = ["--instrumentation_filter=-coverage:b"],
@@ -52,20 +75,32 @@ go_binary(
 
 go_library(
     name = "a",
-    srcs = ["a.go"],
+    srcs = [
+        "a.go",
+        "a_cgo.go",
+    ],
+    cgo = True,
     deps = [":b"],
     importpath = "github.com/bazelbuild/rules_go/tests/core/coverage/a",
 )
 
 go_library(
     name = "b",
-    srcs = ["b.go"],
+    srcs = [
+        "b.go",
+        "b_cgo.go",
+    ],
+    cgo = True,
     deps = [":c"],
     importpath = "github.com/bazelbuild/rules_go/tests/core/coverage/b",
 )
 
 go_library(
     name = "c",
-    srcs = ["c.go"],
+    srcs = [
+        "c.go",
+        "c_cgo.go",
+    ],
+    cgo = True,
     importpath = "github.com/bazelbuild/rules_go/tests/core/coverage/c",
 )

--- a/tests/core/coverage/a_cgo.go
+++ b/tests/core/coverage/a_cgo.go
@@ -1,0 +1,14 @@
+package a
+
+// const int ax = 42;
+import "C"
+
+import "github.com/bazelbuild/rules_go/tests/core/coverage/b"
+
+func ACgoLive() int {
+	return b.BCgoLive() + int(C.ax)
+}
+
+func ACgoDead() int {
+	return b.BCgoDead() + int(C.ax)
+}

--- a/tests/core/coverage/b_cgo.go
+++ b/tests/core/coverage/b_cgo.go
@@ -1,0 +1,14 @@
+package b
+
+// const int bx = 99;
+import "C"
+
+import "github.com/bazelbuild/rules_go/tests/core/coverage/c"
+
+func BCgoLive() int {
+	return c.CCgoLive() + int(C.bx)
+}
+
+func BCgoDead() int {
+	return c.CCgoDead() + int(C.bx)
+}

--- a/tests/core/coverage/c_cgo.go
+++ b/tests/core/coverage/c_cgo.go
@@ -1,0 +1,15 @@
+package c
+
+/*
+int c_live() { return 56; }
+int c_dead() { return 78; }
+*/
+import "C"
+
+func CCgoLive() int {
+	return int(C.c_live())
+}
+
+func CCgoDead() int {
+	return int(C.c_dead())
+}

--- a/tests/core/coverage/coverage_test.go
+++ b/tests/core/coverage/coverage_test.go
@@ -4,4 +4,5 @@ import "testing"
 
 func TestLive(t *testing.T) {
 	ALive()
+	ACgoLive()
 }


### PR DESCRIPTION
* Instrumentation filter is now applied to cgo sources. Previously,
  they were always instrumented if coverage was enabled.
* In coverage data, cgo sources are recorded with their original
  basenames instead of the .cgo1.go generated names.
* If the final binary is linked externally, the --coverage flag is
  passed to the linker. This fixes link errors with gcov functions
  called from instrumented C files.

Also:

* GoSource has a new field: orig_src_map, which is used by coverage to
  find original basenames.

Related #1467