### PR TITLE
Add importpath back to go_binary, go_test for use in go_path

### DIFF
--- a/go/core.rst
+++ b/go/core.rst
@@ -299,12 +299,6 @@ Attributes
 |                                                                                                  |
 | This should be named the same as the desired name of the generated binary .                      |
 +----------------------------+-----------------------------+---------------------------------------+
-| :param:`importpath`        | :type:`string`              | :value:`""`                           |
-+----------------------------+-----------------------------+---------------------------------------+
-| The import path of this binary. If unspecified, the binary will have an implicit                 |
-| dependency on ``//:go_prefix``, and the import path will be derived from the prefix              |
-| and the binary's label.                                                                          |
-+----------------------------+-----------------------------+---------------------------------------+
 | :param:`srcs`              | :type:`label_list`          | :value:`None`                         |
 +----------------------------+-----------------------------+---------------------------------------+
 | The list of Go source files that are compiled to create the binary.                              |
@@ -330,6 +324,12 @@ Attributes
 | appear in the *.runfiles area of this rule, if it has one. This may include data files needed    |
 | by the binary, or other programs needed by it. See `data dependencies`_ for more information     |
 | about how to depend on and use data files.                                                       |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`importpath`        | :type:`string`              | :value:`""`                           |
++----------------------------+-----------------------------+---------------------------------------+
+| The import path of this binary. Binaries can't actually be imported, but this                    |
+| may be used by `go_path`_ and other tools to report the location of source                       |
+| files. This may be inferred from embedded libraries.                                             |
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`pure`              | :type:`string`              | :value:`auto`                         |
 +----------------------------+-----------------------------+---------------------------------------+
@@ -491,6 +491,12 @@ Attributes
 | appear in the *.runfiles area of this rule, if it has one. This may include data files needed    |
 | by the binary, or other programs needed by it. See `data dependencies`_ for more information     |
 | about how to depend on and use data files.                                                       |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`importpath`        | :type:`string`              | :value:`""`                           |
++----------------------------+-----------------------------+---------------------------------------+
+| The import path of this test. Tests can't actually be imported, but this                         |
+| may be used by `go_path`_ and other tools to report the location of source                       |
+| files. This may be inferred from embedded libraries.                                             |
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`gc_goopts`         | :type:`string_list`         | :value:`[]`                           |
 +----------------------------+-----------------------------+---------------------------------------+

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -90,12 +90,16 @@ def _new_library(go, name=None, importpath=None, resolver=None, importable=True,
   importmap = getattr(go._ctx.attr, "importmap", "")
   if not importmap:
     importmap = importpath
+  pathtype = go.pathtype
+  if not importable and pathtype == EXPLICIT_PATH:
+    pathtype = EXPORT_PATH
+
   return GoLibrary(
       name = go._ctx.label.name if not name else name,
       label = go._ctx.label,
       importpath = importpath,
       importmap = importmap,
-      pathtype = go.pathtype,
+      pathtype = pathtype,
       resolve = resolver,
       testfilter = testfilter,
       **kwargs

--- a/go/private/providers.bzl
+++ b/go/private/providers.bzl
@@ -93,7 +93,7 @@ def effective_importpath_pkgpath(lib):
     A tuple of effective import path and effective package path. Both are ""
     for synthetic archives (e.g., generated testmain).
   """
-  if lib.pathtype != EXPLICIT_PATH:
+  if lib.pathtype not in (EXPLICIT_PATH, EXPORT_PATH):
     return "", ""
   importpath = lib.importpath
   importmap = lib.importmap

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -99,6 +99,7 @@ go_binary = go_rule(
             providers = [GoLibrary],
             aspects = [go_archive_aspect],
         ),
+        "importpath": attr.string(),
         "pure": attr.string(
             values = [
                 "on",

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -32,7 +32,7 @@ load(
 )
 load(
     "@io_bazel_rules_go//go/private:providers.bzl",
-    "EXPORT_PATH",
+    "INFERRED_PATH",
     "GoLibrary",
     "get_archive",
 )
@@ -117,7 +117,7 @@ def _go_test_impl(ctx):
       label = go._ctx.label,
       importpath = "testmain",
       importmap = "testmain",
-      pathtype = EXPORT_PATH,
+      pathtype = INFERRED_PATH,
       resolve = None,
   )
   test_deps = external_archive.direct + [external_archive]
@@ -177,6 +177,7 @@ go_test = go_rule(
             providers = [GoLibrary],
             aspects = [go_archive_aspect],
         ),
+        "importpath": attr.string(),
         "pure": attr.string(
             values = [
                 "on",

--- a/go/private/tools/path.bzl
+++ b/go/private/tools/path.bzl
@@ -18,7 +18,6 @@ load(
 )
 load(
     "@io_bazel_rules_go//go/private:providers.bzl",
-    "EXPLICIT_PATH",
     "GoArchive",
     "GoPath",
     "get_archive",

--- a/go/providers.rst
+++ b/go/providers.rst
@@ -86,8 +86,8 @@ This is a non build mode specific provider.
 +--------------------------------+-----------------------------------------------------------------+
 | :param:`pathtype`              | :type:`string`                                                  |
 +--------------------------------+-----------------------------------------------------------------+
-| Information about the source of the importpath.                                                  |
-| It's values can be                                                                               |
+| Information about the source of the importpath. Possible values are:                             |
+|                                                                                                  |
 | :value:`explicit`                                                                                |
 |     The importpath was explicitly supplied by the user and the library is importable.            |
 |     This is the normal case.                                                                     |
@@ -97,10 +97,9 @@ This is a non build mode specific provider.
 |     This is normally true for rules that do not expect to be compiled directly to a library,     |
 |     embeded into another rule instead (source generators)                                        |
 | :value:`export`                                                                                  |
-|     The importpath is used for generated file names, but the library should not be imported by   |
-|     that name.                                                                                   |
-|     This is the case for the implied "main" library of a binary or test, where the import path   |
-|     is not relevant as the package cannot be imported.                                           |
+|     The importpath was explicitly supplied by the user, but the library is                       |
+|     not importable. This is the case for binaries and tests. The importpath                      |
+|     may still be useful for `go_path`_ and other rules.                                          |
 +--------------------------------+-----------------------------------------------------------------+
 | :param:`resolve`               | :type:`function`                                                |
 +--------------------------------+-----------------------------------------------------------------+

--- a/tests/core/go_path/cmd/bin/BUILD.bazel
+++ b/tests/core/go_path/cmd/bin/BUILD.bazel
@@ -1,15 +1,9 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-
-go_library(
-    name = "go_default_library",
-    srcs = ["bin.go"],
-    data = ["bin.go"],  # test duplicate
-    importpath = "example.com/repo/cmd/bin",
-    visibility = ["//visibility:public"],
-)
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 
 go_binary(
     name = "bin",
-    embed = [":go_default_library"],
+    srcs = ["bin.go"],
+    data = ["bin.go"],  # test duplicate
+    importpath = "example.com/repo/cmd/bin",
     visibility = ["//visibility:public"],
 )

--- a/tests/core/go_path/go_path_test.go
+++ b/tests/core/go_path/go_path_test.go
@@ -36,9 +36,8 @@ var files = []string{
 	"src/example.com/repo/cmd/bin/bin.go",
 	"src/example.com/repo/pkg/lib/lib.go",
 	"src/example.com/repo/pkg/lib/embed_test.go",
-	// TODO: how about go_test without embed?
-	// "src/example.com/repo/pkg/lib/internal_test.go",
-	// "src/example.com/repo/pkg/lib/external_test.go",
+	"src/example.com/repo/pkg/lib/internal_test.go",
+	"src/example.com/repo/pkg/lib/external_test.go",
 	"-src/example.com/repo/pkg/lib_test/embed_test.go",
 	"src/example.com/repo/pkg/lib/data.txt",
 	"src/example.com/repo/pkg/lib/testdata/testdata.txt",

--- a/tests/core/go_path/pkg/lib/BUILD.bazel
+++ b/tests/core/go_path/pkg/lib/BUILD.bazel
@@ -18,6 +18,7 @@ go_test(
         "external_test.go",
         "internal_test.go",
     ],
+    importpath = "example.com/repo/pkg/lib",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
go_binary and go_test once again support the importpath
attribute. This is used by go_path to place binary and test sources in
the output tree. It may also be used by coverage for reporting sources
in a GOPATH-like format (though test sources are normally excluded
from coverage).