### PR TITLE
Enable use of FreeBSD SDK

### DIFF
--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -40,6 +40,8 @@ def _go_download_sdk_impl(ctx):
     host = "darwin_amd64"
   elif ctx.os.name.startswith('windows'):
     host = "windows_amd64"
+  elif ctx.os.name == 'freebsd':
+    host = "freebsd_amd64"
   else:
     fail("Unsupported operating system: " + ctx.os.name)
   sdks = ctx.attr.sdks


### PR DESCRIPTION
This allows a simple repo to be used on FreeBSD (amd64).  I manually
tested the change on a toy project and bazel build/test both worked as I
expected them to work based upon what I've come to expect on Linux.

Signed-off-by: Robert Escriva <robert@rescrv.net>