### PR TITLE
Replace WKT go_library rules with aliases to //proto/wkt

### DIFF
--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -98,6 +98,8 @@ def go_rules_dependencies():
       commit = "1adfc126b41513cc696b209667c8656ea7aac67c",  # v1.0.0, as of 2018-02-16
       overlay = manifest["com_github_gogo_protobuf"],
       # build_file_proto_mode = "legacy",
+      # TODO(jayconrod): incorporate manual changes when regenerating build
+      # files. This repo contains aliases for //proto/wkt targets.
   )
   _maybe(gogo_special_proto,
       name = "gogo_special_proto",
@@ -132,6 +134,8 @@ def go_rules_dependencies():
       overlay = manifest["org_golang_google_genproto"],
       # build_file_proto_mode = "disable",
       # importpath = "google.golang.org/genproto",
+      # TODO(jayconrod): incorporate manual changes when regenerating build
+      # files. This repo contains aliases for //proto/wkt targets.
   )
 
   # Needed for examples

--- a/proto/wkt/well_known_types.bzl
+++ b/proto/wkt/well_known_types.bzl
@@ -3,9 +3,9 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 _proto_library_suffix = "proto"
 _go_proto_library_suffix = "go_proto"
 
-_WELL_KNOWN_TYPE_PACKAGES = {
+WELL_KNOWN_TYPE_PACKAGES = {
     "any": ("github.com/golang/protobuf/ptypes/any", []),
-    "api": ("github.com/golang/protobuf/ptypes/api", ["source_context", "type"]),
+    "api": ("google.golang.org/genproto/protobuf/api", ["source_context", "type"]),
     "compiler_plugin": ("github.com/golang/protobuf/protoc-gen-go/plugin", ["descriptor"]),
     "descriptor": ("github.com/golang/protobuf/protoc-gen-go/descriptor", []),
     "duration": ("github.com/golang/protobuf/ptypes/duration", []),
@@ -20,7 +20,7 @@ _WELL_KNOWN_TYPE_PACKAGES = {
 
 GOGO_WELL_KNOWN_TYPE_REMAPS = [
     "Mgoogle/protobuf/{}.proto=github.com/gogo/protobuf/types".format(wkt)
-    for wkt, (go_package, _) in _WELL_KNOWN_TYPE_PACKAGES.items() if "protoc-gen-go" not in go_package
+    for wkt, (go_package, _) in WELL_KNOWN_TYPE_PACKAGES.items() if "protoc-gen-go" not in go_package
 ] + [
     "Mgoogle/protobuf/descriptor.proto=github.com/gogo/protobuf/protoc-gen-gogo/descriptor",
     "Mgoogle/protobuf/compiler_plugin.proto=github.com/gogo/protobuf/protoc-gen-gogo/plugin",
@@ -28,12 +28,12 @@ GOGO_WELL_KNOWN_TYPE_REMAPS = [
 
 WELL_KNOWN_TYPE_RULES = {
     wkt: "@io_bazel_rules_go//proto/wkt:{}_{}".format(wkt, _go_proto_library_suffix)
-    for wkt in _WELL_KNOWN_TYPE_PACKAGES.keys()
+    for wkt in WELL_KNOWN_TYPE_PACKAGES.keys()
 }
 
 def gen_well_known_types():
     for wkt, rule in WELL_KNOWN_TYPE_RULES.items():
-        (go_package, deps) = _WELL_KNOWN_TYPE_PACKAGES[wkt]
+        (go_package, deps) = WELL_KNOWN_TYPE_PACKAGES[wkt]
         go_proto_library(
             name = rule.rsplit(":", 1)[1],
             compilers = ["@io_bazel_rules_go//proto:go_proto_bootstrap"],

--- a/third_party/com_github_golang_protobuf/protoc-gen-go/descriptor/BUILD.bazel.in
+++ b/third_party/com_github_golang_protobuf/protoc-gen-go/descriptor/BUILD.bazel.in
@@ -6,10 +6,16 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-go_library(
+alias(
     name = "go_default_library",
+    actual = "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "descriptor_bootstrap",
     srcs = ["descriptor.pb.go"],
     importpath = "github.com/golang/protobuf/protoc-gen-go/descriptor",
-    visibility = ["//visibility:public"],
+    visibility = ["//protoc-gen-go:__subpackages__"],
     deps = ["//proto:go_default_library"],
 )

--- a/third_party/com_github_golang_protobuf/protoc-gen-go/generator/BUILD.bazel.in
+++ b/third_party/com_github_golang_protobuf/protoc-gen-go/generator/BUILD.bazel.in
@@ -7,9 +7,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:go_default_library",
-        "//protoc-gen-go/descriptor:go_default_library",
+        "//protoc-gen-go/descriptor:descriptor_bootstrap",
         "//protoc-gen-go/generator/internal/remap:go_default_library",
-        "//protoc-gen-go/plugin:go_default_library",
+        "//protoc-gen-go/plugin:plugin_bootstrap",
     ],
 )
 

--- a/third_party/com_github_golang_protobuf/protoc-gen-go/grpc/BUILD.bazel.in
+++ b/third_party/com_github_golang_protobuf/protoc-gen-go/grpc/BUILD.bazel.in
@@ -6,7 +6,7 @@ go_library(
     importpath = "github.com/golang/protobuf/protoc-gen-go/grpc",
     visibility = ["//visibility:public"],
     deps = [
-        "//protoc-gen-go/descriptor:go_default_library",
+        "//protoc-gen-go/descriptor:descriptor_bootstrap",
         "//protoc-gen-go/generator:go_default_library",
     ],
 )

--- a/third_party/com_github_golang_protobuf/protoc-gen-go/plugin/BUILD.bazel.in
+++ b/third_party/com_github_golang_protobuf/protoc-gen-go/plugin/BUILD.bazel.in
@@ -6,13 +6,19 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-go_library(
+alias(
     name = "go_default_library",
+    actual = "@io_bazel_rules_go//proto/wkt:compiler_plugin_go_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "plugin_bootstrap",
     srcs = ["plugin.pb.go"],
     importpath = "github.com/golang/protobuf/protoc-gen-go/plugin",
-    visibility = ["//visibility:public"],
+    visibility = ["//protoc-gen-go:__subpackages__"],
     deps = [
         "//proto:go_default_library",
-        "//protoc-gen-go/descriptor:go_default_library",
+        "//protoc-gen-go/descriptor:descriptor_bootstrap",
     ],
 )

--- a/third_party/com_github_golang_protobuf/ptypes/any/BUILD.bazel.in
+++ b/third_party/com_github_golang_protobuf/ptypes/any/BUILD.bazel.in
@@ -6,10 +6,8 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-go_library(
+alias(
     name = "go_default_library",
-    srcs = ["any.pb.go"],
-    importpath = "github.com/golang/protobuf/ptypes/any",
+    actual = "@io_bazel_rules_go//proto/wkt:any_go_proto",
     visibility = ["//visibility:public"],
-    deps = ["//proto:go_default_library"],
 )

--- a/third_party/com_github_golang_protobuf/ptypes/duration/BUILD.bazel.in
+++ b/third_party/com_github_golang_protobuf/ptypes/duration/BUILD.bazel.in
@@ -6,10 +6,8 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-go_library(
+alias(
     name = "go_default_library",
-    srcs = ["duration.pb.go"],
-    importpath = "github.com/golang/protobuf/ptypes/duration",
+    actual = "@io_bazel_rules_go//proto/wkt:duration_go_proto",
     visibility = ["//visibility:public"],
-    deps = ["//proto:go_default_library"],
 )

--- a/third_party/com_github_golang_protobuf/ptypes/empty/BUILD.bazel.in
+++ b/third_party/com_github_golang_protobuf/ptypes/empty/BUILD.bazel.in
@@ -6,10 +6,8 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-go_library(
+alias(
     name = "go_default_library",
-    srcs = ["empty.pb.go"],
-    importpath = "github.com/golang/protobuf/ptypes/empty",
+    actual = "@io_bazel_rules_go//proto/wkt:empty_go_proto",
     visibility = ["//visibility:public"],
-    deps = ["//proto:go_default_library"],
 )

--- a/third_party/com_github_golang_protobuf/ptypes/struct/BUILD.bazel.in
+++ b/third_party/com_github_golang_protobuf/ptypes/struct/BUILD.bazel.in
@@ -6,10 +6,8 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-go_library(
+alias(
     name = "go_default_library",
-    srcs = ["struct.pb.go"],
-    importpath = "github.com/golang/protobuf/ptypes/struct",
+    actual = "@io_bazel_rules_go//proto/wkt:struct_go_proto",
     visibility = ["//visibility:public"],
-    deps = ["//proto:go_default_library"],
 )

--- a/third_party/com_github_golang_protobuf/ptypes/timestamp/BUILD.bazel.in
+++ b/third_party/com_github_golang_protobuf/ptypes/timestamp/BUILD.bazel.in
@@ -6,10 +6,8 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-go_library(
+alias(
     name = "go_default_library",
-    srcs = ["timestamp.pb.go"],
-    importpath = "github.com/golang/protobuf/ptypes/timestamp",
+    actual = "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",
     visibility = ["//visibility:public"],
-    deps = ["//proto:go_default_library"],
 )

--- a/third_party/com_github_golang_protobuf/ptypes/wrappers/BUILD.bazel.in
+++ b/third_party/com_github_golang_protobuf/ptypes/wrappers/BUILD.bazel.in
@@ -6,10 +6,8 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-go_library(
+alias(
     name = "go_default_library",
-    srcs = ["wrappers.pb.go"],
-    importpath = "github.com/golang/protobuf/ptypes/wrappers",
+    actual = "@io_bazel_rules_go//proto/wkt:wrappers_go_proto",
     visibility = ["//visibility:public"],
-    deps = ["//proto:go_default_library"],
 )

--- a/third_party/org_golang_google_genproto/protobuf/api/BUILD.bazel.in
+++ b/third_party/org_golang_google_genproto/protobuf/api/BUILD.bazel.in
@@ -1,13 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
-go_library(
+alias(
     name = "go_default_library",
-    srcs = ["api.pb.go"],
-    importpath = "google.golang.org/genproto/protobuf/api",
+    actual = "@io_bazel_rules_go//proto/wkt:api_go_proto",
     visibility = ["//visibility:public"],
-    deps = [
-        "@com_github_golang_protobuf//proto:go_default_library",
-        "@io_bazel_rules_go//proto/wkt:source_context_go_proto",
-        "@io_bazel_rules_go//proto/wkt:type_go_proto",
-    ],
 )

--- a/third_party/org_golang_google_genproto/protobuf/field_mask/BUILD.bazel.in
+++ b/third_party/org_golang_google_genproto/protobuf/field_mask/BUILD.bazel.in
@@ -1,9 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
-go_library(
+alias(
     name = "go_default_library",
-    srcs = ["field_mask.pb.go"],
-    importpath = "google.golang.org/genproto/protobuf/field_mask",
+    actual = "@io_bazel_rules_go//proto/wkt:field_mask_go_proto",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_golang_protobuf//proto:go_default_library"],
 )

--- a/third_party/org_golang_google_genproto/protobuf/ptype/BUILD.bazel.in
+++ b/third_party/org_golang_google_genproto/protobuf/ptype/BUILD.bazel.in
@@ -1,13 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
-go_library(
+alias(
     name = "go_default_library",
-    srcs = ["type.pb.go"],
-    importpath = "google.golang.org/genproto/protobuf/ptype",
+    actual = "@io_bazel_rules_go//proto/wkt:type_go_proto",
     visibility = ["//visibility:public"],
-    deps = [
-        "@com_github_golang_protobuf//proto:go_default_library",
-        "@io_bazel_rules_go//proto/wkt:any_go_proto",
-        "@io_bazel_rules_go//proto/wkt:source_context_go_proto",
-    ],
 )

--- a/third_party/org_golang_google_genproto/protobuf/source_context/BUILD.bazel.in
+++ b/third_party/org_golang_google_genproto/protobuf/source_context/BUILD.bazel.in
@@ -1,9 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
-go_library(
+alias(
     name = "go_default_library",
-    srcs = ["source_context.pb.go"],
-    importpath = "google.golang.org/genproto/protobuf/source_context",
+    actual = "@io_bazel_rules_go//proto/wkt:source_context_go_proto",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_golang_protobuf//proto:go_default_library"],
 )


### PR DESCRIPTION
There are a significant number of existing rules that depend on WKT
go_library rules directly (for example,
@com_github_golang_protobuf//ptypes/any:go_default_library). Gazelle
resolves now Go imports to @io_bazel_rules_go//proto/wkt, so it's very
easy to end up with conflicting dependencies.

With this change, WKT go_library rules are replaced with aliases
pointing to the equivalent @io_bazel_rules_go//proto/wkt rules.

protoc-gen-go itself depends on descriptor and plugin, so two
bootstrap go_library rules are introduced, visible only to
protoc-gen-go.

Related bazelbuild/bazel-gazelle#159