### PR TITLE
Exec go tools directly instead of using "go tool"

### DIFF
--- a/go/private/BUILD.sdk.bazel
+++ b/go/private/BUILD.sdk.bazel
@@ -1,20 +1,23 @@
-package(default_visibility = [ "//visibility:public" ])
+package(default_visibility = ["//visibility:public"])
 
 filegroup(
-  name = "files",
-  srcs = glob([
-    "bin/go*",
-    "src/**",
-    "pkg/**",
-  ]),
+    name = "files",
+    srcs = glob([
+        "bin/go*",
+        "src/**",
+        "pkg/**",
+    ]),
 )
 
 filegroup(
-  name = "tools",
-  srcs = select({
-    "@io_bazel_rules_go//go/platform:darwin_amd64": ["@local_config_cc//:cc_wrapper"],
-    "//conditions:default": None,
-  }),
+    name = "tools",
+    srcs = glob([
+        "bin/go*",
+        "pkg/tool/**",
+    ]) + select({
+        "@io_bazel_rules_go//go/platform:darwin_amd64": ["@local_config_cc//:cc_wrapper"],
+        "//conditions:default": [],
+    }),
 )
 
-exports_files(["packages.txt"])
+exports_files(["packages.txt", "ROOT"])

--- a/go/private/actions/asm.bzl
+++ b/go/private/actions/asm.bzl
@@ -28,7 +28,7 @@ def emit_asm(go,
   if source == None: fail("source is a required parameter")
 
   out_obj = go.declare_file(go, path=source.basename[:-2], ext=".o")
-  inputs = hdrs + go.stdlib.files + [source]
+  inputs = hdrs + go.sdk_tools + go.stdlib.files + [source]
 
   args = go.args(go)
   args.add([source, "--"])

--- a/go/private/actions/compile.bzl
+++ b/go/private/actions/compile.bzl
@@ -48,7 +48,7 @@ def emit_compile(go,
 
   inputs = (sources + [go.package_list] +
             [archive.data.file for archive in archives] +
-            go.stdlib.files)
+            go.sdk_tools + go.stdlib.files)
 
   builder_args = go.args(go)
   builder_args.add(sources, before_each="-src")

--- a/go/private/actions/cover.bzl
+++ b/go/private/actions/cover.bzl
@@ -55,7 +55,7 @@ def emit_cover(go, source):
       "-mode=set",
     ])
     go.actions.run(
-        inputs = [src] + go.stdlib.files,
+        inputs = [src] + go.sdk_tools,
         outputs = [out],
         mnemonic = "GoCover",
         executable = go.builders.cover,

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -121,7 +121,7 @@ def emit_link(go,
   
   go.actions.run(
       inputs = sets.union(archive.libs, archive.cgo_deps,
-                go.crosstool, stamp_inputs, go.stdlib.files),
+                go.crosstool, stamp_inputs, go.sdk_tools, go.stdlib.files),
       outputs = [executable],
       mnemonic = "GoLink",
       executable = go.builders.link,

--- a/go/private/actions/pack.bzl
+++ b/go/private/actions/pack.bzl
@@ -22,7 +22,7 @@ def emit_pack(go,
   if in_lib == None: fail("in_lib is a required parameter")
   if out_lib == None: fail("out_lib is a required parameter")
 
-  inputs = [in_lib] + go.stdlib.files + objects + archives
+  inputs = [in_lib] + go.sdk_tools + objects + archives
 
   args = go.args(go)
   args.add(["-in", in_lib])

--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -179,7 +179,7 @@ def _cgo_codegen_impl(ctx):
 
   tool_args.add(["-objdir", out_dir])
 
-  inputs = sets.union(ctx.files.srcs, go.crosstool, go.stdlib.files)
+  inputs = sets.union(ctx.files.srcs, go.crosstool, go.sdk_tools, go.stdlib.files)
   deps = depset()
   runfiles = ctx.runfiles(collect_data = True)
   for d in ctx.attr.deps:
@@ -292,7 +292,7 @@ def _cgo_import_impl(ctx):
       inputs = [
           ctx.file.cgo_o,
           ctx.files.sample_go_srcs[0],
-      ] + go.stdlib.files,
+      ] + go.sdk_tools,
       outputs = [out],
       executable = go.builders.cgo,
       arguments = [args],

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -84,6 +84,7 @@ def _prepare(ctx):
     print(result.stderr)
     fail("failed to list standard packages")
   ctx.file("packages.txt", result.stdout)
+  ctx.file("ROOT", "")
 
 def _remote_sdk(ctx, urls, strip_prefix, sha256):
   ctx.download_and_extract(

--- a/go/tools/builders/asm.go
+++ b/go/tools/builders/asm.go
@@ -50,11 +50,10 @@ func run(args []string) error {
 	}
 
 	// Build source with the assembler.
-	goargs := []string{"tool", "asm"}
-	goargs = append(goargs, toolArgs...)
+	goargs := goenv.goTool("asm", toolArgs...)
 	goargs = append(goargs, source)
 	absArgs(goargs, []string{"I", "o", "trimpath"})
-	return goenv.runGoCommand(goargs)
+	return goenv.runCommand(goargs)
 }
 
 func main() {

--- a/go/tools/builders/cgo.go
+++ b/go/tools/builders/cgo.go
@@ -57,8 +57,9 @@ func run(args []string) error {
 		if err != nil {
 			return err
 		}
-		goargs := append([]string{"tool", "cgo", "-dynpackage", dynpackage}, toolArgs...)
-		return goenv.runGoCommand(goargs)
+		goargs := goenv.goTool("cgo", "-dynpackage", dynpackage)
+		goargs = append(goargs, toolArgs...)
+		return goenv.runCommand(goargs)
 	}
 
 	// create a temporary directory. sources actually passed to cgo will be moved
@@ -180,12 +181,12 @@ func run(args []string) error {
 	}
 
 	// Run cgo.
-	goargs := []string{"tool", "cgo", "-srcdir", srcDir}
+	goargs := goenv.goTool("cgo", "-srcdir", srcDir)
 	goargs = append(goargs, toolArgs...)
 	goargs = append(goargs, "--")
 	goargs = append(goargs, ccArgsSplit...)
 	goargs = append(goargs, cgoSrcs...)
-	if err := goenv.runGoCommand(goargs); err != nil {
+	if err := goenv.runCommand(goargs); err != nil {
 		return err
 	}
 

--- a/go/tools/builders/compile.go
+++ b/go/tools/builders/compile.go
@@ -110,7 +110,7 @@ func run(args []string) error {
 	}
 
 	// Compile the filtered files.
-	goargs := []string{"tool", "compile"}
+	goargs := goenv.goTool("compile")
 	goargs = append(goargs, importmapArgs...)
 	goargs = append(goargs, "-pack", "-o", *output)
 	goargs = append(goargs, toolArgs...)
@@ -119,7 +119,7 @@ func run(args []string) error {
 		goargs = append(goargs, f.filename)
 	}
 	absArgs(goargs, []string{"I", "o", "trimpath"})
-	return goenv.runGoCommand(goargs)
+	return goenv.runCommand(goargs)
 }
 
 func main() {

--- a/go/tools/builders/cover.go
+++ b/go/tools/builders/cover.go
@@ -57,10 +57,10 @@ func run(args []string) error {
 		srcName = origSrc
 	}
 
-	goargs := []string{"tool", "cover", "-var=" + coverVar, "-o=" + coverSrc}
+	goargs := goenv.goTool("cover", "-var", coverVar, "-o", coverSrc)
 	goargs = append(goargs, flags.Args()...)
 	goargs = append(goargs, origSrc)
-	if err := goenv.runGoCommand(goargs); err != nil {
+	if err := goenv.runCommand(goargs); err != nil {
 		return err
 	}
 

--- a/go/tools/builders/info.go
+++ b/go/tools/builders/info.go
@@ -43,10 +43,10 @@ func run(args []string) error {
 		}
 		defer f.Close()
 	}
-	if err := goenv.runGoCommandToFile(f, []string{"version"}); err != nil {
+	if err := goenv.runCommandToFile(f, goenv.goCmd("version")); err != nil {
 		return err
 	}
-	if err := goenv.runGoCommandToFile(f, []string{"env"}); err != nil {
+	if err := goenv.runCommandToFile(f, goenv.goCmd("env")); err != nil {
 		return err
 	}
 	return nil

--- a/go/tools/builders/link.go
+++ b/go/tools/builders/link.go
@@ -73,7 +73,7 @@ func run(args []string) error {
 	}
 
 	// generate any additional link options we need
-	goargs := []string{"tool", "link"}
+	goargs := goenv.goTool("link")
 	depsSeen := make(map[string]string)
 	for _, d := range deps {
 		parts := strings.Split(d, "=")
@@ -120,7 +120,7 @@ This will be an error in the future.`, pkgPath, label, conflictLabel)
 	// add in the unprocess pass through options
 	goargs = append(goargs, toolArgs...)
 	goargs = append(goargs, *main)
-	if err := goenv.runGoCommand(goargs); err != nil {
+	if err := goenv.runCommand(goargs); err != nil {
 		return err
 	}
 

--- a/go/tools/builders/pack.go
+++ b/go/tools/builders/pack.go
@@ -295,6 +295,7 @@ func simpleName(name string, names map[string]struct{}) string {
 }
 
 func appendFiles(goenv *env, archive string, files []string) error {
-	args := append([]string{"tool", "pack", "r", archive}, files...)
-	return goenv.runGoCommand(args)
+	args := goenv.goTool("pack", "r", archive)
+	args = append(args, files...)
+	return goenv.runCommand(args)
 }

--- a/go/tools/builders/stdlib.go
+++ b/go/tools/builders/stdlib.go
@@ -57,7 +57,7 @@ func run(args []string) error {
 	os.Setenv("CC", abs(os.Getenv("CC")))
 
 	// Build the commands needed to build the std library in the right mode
-	installArgs := []string{"install", "-toolexec", abs(*filterBuildid)}
+	installArgs := goenv.goCmd("install", "-toolexec", abs(*filterBuildid))
 	if len(build.Default.BuildTags) > 0 {
 		installArgs = append(installArgs, "-tags", strings.Join(build.Default.BuildTags, ","))
 	}
@@ -88,7 +88,7 @@ func run(args []string) error {
 	installArgs = append(installArgs, "-asmflags="+allSlug+strings.Join(asmflags, " "))
 
 	for _, target := range []string{"std", "runtime/cgo"} {
-		if err := goenv.runGoCommand(append(installArgs, target)); err != nil {
+		if err := goenv.runCommand(append(installArgs, target)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This simplifies and enables use of pre-compiled stdlibs.

* Set location of the SDK and SDK tools in go_context. This may be
  different than GOROOT (currently, it is always different, since the
  standard library is always compiled somewhere else).
* Pass the SDK root directory to builders instead of the path to the
  go tool.
* Execute tools in pkg/tool/goos_goarch/ instead of using "go tool",
  which does the same thing with an extra exec.

Fixes #1491