### PR TITLE
Change base URL that SDKs are downloaded from

### DIFF
--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -55,7 +55,7 @@ go_download_sdk = repository_rule(
     _go_download_sdk_impl,
     attrs = {
         "sdks": attr.string_list_dict(),
-        "urls": attr.string_list(default = ["https://storage.googleapis.com/golang/{}"]),
+        "urls": attr.string_list(default = ["https://dl.google.com/go/{}"]),
         "strip_prefix": attr.string(default = "go"),
     },
 )


### PR DESCRIPTION
https://dl.google.com/go is now the official base linked from golang.org.

Related #1501