### PR TITLE
Use @bazel_tools git_repository and http_archive in boilerplate [skip ci]

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,6 +127,7 @@ Setup
 
   .. code:: bzl
 
+    load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
     http_archive(
         name = "io_bazel_rules_go",
         url = "https://github.com/bazelbuild/rules_go/releases/download/0.12.0/rules_go-0.12.0.tar.gz",
@@ -141,6 +142,7 @@ Setup
 
   .. code:: bzl
 
+    load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
     git_repository(
         name = "io_bazel_rules_go",
         remote = "https://github.com/bazelbuild/rules_go.git",
@@ -174,6 +176,7 @@ build files automatically using gazelle_.
 
   .. code:: bzl
 
+    load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
     http_archive(
         name = "io_bazel_rules_go",
         url = "https://github.com/bazelbuild/rules_go/releases/download/0.12.0/rules_go-0.12.0.tar.gz",


### PR DESCRIPTION
We don't directly use these rules in WORKSPACE or in
go_rules_dependencies, so the boilerplate was the only thing that
needs to be updated.

Fixes #1515