### PR TITLE
fix ios cross compilation with cgo

### DIFF
--- a/go/platform/apple.bzl
+++ b/go/platform/apple.bzl
@@ -41,7 +41,7 @@ def apple_ensure_options(ctx, env, tags, compiler_options, linker_options):
     if system_name.endswith("-ios"):
         tags.append("ios")  # needed for stdlib building
     if platform in [apple_common.platform.ios_device, apple_common.platform.ios_simulator]:
-        min_version = _apple_version_min(platform, "6.1")
+        min_version = _apple_version_min(platform, "7.0")
         compiler_options.append(min_version)
         linker_options.append(min_version)
     xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]

--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -280,6 +280,7 @@ _cgo_codegen = go_rule(
         "cxxopts": attr.string_list(),
         "cppopts": attr.string_list(),
         "linkopts": attr.string_list(),
+        "pure": attr.string(default = "off"),
     },
 )
 


### PR DESCRIPTION
we were unable to compile cgo for ios due to 2 issues:
- the ios minimum version should be higher than 6.1 or an error occurs at compile time with the arguments
- when cgo is called pure should always be set to off to setup the environment the right way