### PR TITLE
turn relative path to absolute path in environment's cgo's flags

### DIFF
--- a/go/tools/builders/asm.go
+++ b/go/tools/builders/asm.go
@@ -52,7 +52,7 @@ func run(args []string) error {
 	// Build source with the assembler.
 	goargs := goenv.goTool("asm", toolArgs...)
 	goargs = append(goargs, source)
-	absArgs(goargs, []string{"I", "o", "trimpath"})
+	absArgs(goargs, []string{"-I", "-o", "-trimpath"})
 	return goenv.runCommand(goargs)
 }
 

--- a/go/tools/builders/compile.go
+++ b/go/tools/builders/compile.go
@@ -118,7 +118,7 @@ func run(args []string) error {
 	for _, f := range files {
 		goargs = append(goargs, f.filename)
 	}
-	absArgs(goargs, []string{"I", "o", "trimpath"})
+	absArgs(goargs, []string{"-I", "-o", "-trimpath"})
 	return goenv.runCommand(goargs)
 }
 

--- a/go/tools/builders/stdlib.go
+++ b/go/tools/builders/stdlib.go
@@ -87,6 +87,12 @@ func run(args []string) error {
 	installArgs = append(installArgs, "-ldflags="+allSlug+strings.Join(ldflags, " "))
 	installArgs = append(installArgs, "-asmflags="+allSlug+strings.Join(asmflags, " "))
 
+	// Modifying CGO flags to use only absolute path
+	// because go is having its own sandbox, all CGO flags must use absolute path
+	if err := absEnv(cgoEnvVars, cgoAbsEnvFlags); err != nil {
+		return fmt.Errorf("error modifying cgo environment to absolute path: %v", err)
+	}
+
 	for _, target := range []string{"std", "runtime/cgo"} {
 		if err := goenv.runCommand(append(installArgs, target)); err != nil {
 			return err


### PR DESCRIPTION
This pr can be merge as it, but it s main focus is to discuss a "rules_go" way to fix the problem.

Problem:
cgo flags will sometime be setup with relative path in the environment but Go will make its own sandbox and wont be able to use those path.

Solution:
make all the path absolute in cgo environment variable.

I have no better solution than to embbed shlex in rules_go and use it on the environmnet variables.
