### PR TITLE
protoc import should not conflict with option override anymore

### DIFF
--- a/go/tools/builders/protoc.go
+++ b/go/tools/builders/protoc.go
@@ -71,7 +71,17 @@ func run(args []string) error {
 	pluginBase := filepath.Base(*plugin)
 	pluginName := strings.TrimSuffix(
 		strings.TrimPrefix(filepath.Base(*plugin), "protoc-gen-"), ".exe")
+imports_loop:
 	for _, m := range imports {
+		importName := m[:strings.Index(m, "=")+1]
+		for _, option := range options {
+			if option[0] != 'M' {
+				continue
+			}
+			if strings.HasPrefix(option[1:], importName) {
+				continue imports_loop
+			}
+		}
 		options = append(options, fmt.Sprintf("M%v", m))
 	}
 	protoc_args := []string{


### PR DESCRIPTION
Problem:
Protoc is appending the "-import" as "-option M". But with gogofaster compiler some "-option M" are added and will be override by the default import, which is not what we want.

Solution:
append the "-import" as "-option M" only if the "-option M" is not already set. This should avoid overriding compiler options.