### PR TITLE
Inherit importmap from embedded libraries

### DIFF
--- a/tests/core/go_test/BUILD.bazel
+++ b/tests/core/go_test/BUILD.bazel
@@ -75,3 +75,25 @@ go_test(
     size = "small",
     srcs = ["only_testmain_test.go"],
 )
+
+go_test(
+    name = "external_importmap_test",
+    size = "small",
+    srcs = ["external_importmap_test.go"],
+    embed = [":external_importmap_lib"],
+    deps = [":external_importmap_dep"],
+)
+
+go_library(
+    name = "external_importmap_lib",
+    srcs = ["external_importmap_lib.go"],
+    importmap = "x/github.com/bazelbuild/rules_go/tests/core/go_test/external_importmap",
+    importpath = "github.com/bazelbuild/rules_go/tests/core/go_test/external_importmap",
+)
+
+go_library(
+    name = "external_importmap_dep",
+    srcs = ["external_importmap_dep.go"],
+    importpath = "github.com/bazelbuild/rules_go/tests/core/go_test/external_importmap_dep",
+    deps = [":external_importmap_lib"],
+)

--- a/tests/core/go_test/README.rst
+++ b/tests/core/go_test/README.rst
@@ -45,3 +45,14 @@ only_testmain_test
 ------------------
 Test that an `go_test`_ that contains a ``TestMain`` function but no tests
 still builds and passes.
+
+external_importmap_test
+----------------------
+
+Test that an external test package in `go_test`_ is compiled with the correct
+``importmap`` for the library under test. This is verified by defining an
+interface in the library under test and implementing it in a separate
+dependency.
+
+Verifies #1538.
+

--- a/tests/core/go_test/external_importmap_dep.go
+++ b/tests/core/go_test/external_importmap_dep.go
@@ -1,0 +1,11 @@
+package external_importmap_dep
+
+import (
+	"github.com/bazelbuild/rules_go/tests/core/go_test/external_importmap"
+)
+
+type Impl struct{}
+
+func (_ *Impl) DeepCopyObject() external_importmap.Object {
+	return nil
+}

--- a/tests/core/go_test/external_importmap_lib.go
+++ b/tests/core/go_test/external_importmap_lib.go
@@ -1,0 +1,5 @@
+package external_importmap
+
+type Object interface {
+	DeepCopyObject() Object
+}

--- a/tests/core/go_test/external_importmap_test.go
+++ b/tests/core/go_test/external_importmap_test.go
@@ -1,0 +1,10 @@
+package external_importmap_test
+
+import (
+	"github.com/bazelbuild/rules_go/tests/core/go_test/external_importmap"
+	"github.com/bazelbuild/rules_go/tests/core/go_test/external_importmap_dep"
+)
+
+var _ external_importmap.Object = &external_importmap_dep.Impl{}
+
+// Test passes if it compiles.


### PR DESCRIPTION
This change allows Go rules to inherit the importmap attribute from
embedded libraries, the same way the importpath attribute is
inherited. This is particularly important for tests, which rely on an
embedded library under test to set the importpath. Test archives are
imported from the generated testmain, so their importmap does matter.

Fixes #1538