### PR TITLE
Fix deprecated skylark

### DIFF
--- a/go/private/actions/binary.bzl
+++ b/go/private/actions/binary.bzl
@@ -57,7 +57,7 @@ def emit_binary(
     )
     cgo_dynamic_deps = [
         d
-        for d in archive.cgo_deps
+        for d in archive.cgo_deps.to_list()
         if any([d.basename.endswith(ext) for ext in SHARED_LIB_EXTENSIONS])
     ]
     runfiles = go._ctx.runfiles(files = cgo_dynamic_deps).merge(archive.runfiles)

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -94,7 +94,7 @@ def emit_link(
     base_rpath = origin + "../" * pkg_depth
     cgo_dynamic_deps = [
         d
-        for d in archive.cgo_deps
+        for d in archive.cgo_deps.to_list()
         if any([d.basename.endswith(ext) for ext in SHARED_LIB_EXTENSIONS])
     ]
     cgo_rpaths = []
@@ -148,12 +148,12 @@ def emit_link(
 def _bootstrap_link(go, archive, executable, gc_linkopts):
     """See go/toolchains.rst#link for full documentation."""
 
-    inputs = depset([archive.data.file])
+    inputs = [archive.data.file] + go.sdk_files + go.sdk_tools
     args = ["tool", "link", "-s", "-o", executable.path]
     args.extend(gc_linkopts)
     args.append(archive.data.file.path)
     go.actions.run_shell(
-        inputs = inputs + go.sdk_files + go.sdk_tools,
+        inputs = inputs,
         outputs = [executable],
         mnemonic = "GoLink",
         command = "export GOROOT=$(pwd)/{} && export GOROOT_FINAL=GOROOT && {} {}".format(go.root, go.go.path, " ".join(args)),

--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -62,14 +62,6 @@ objc_exts = [
     ".hxx",
 ]
 
-go_filetype = FileType(go_exts + asm_exts)
-
-cc_hdr_filetype = FileType(hdr_exts)
-
-# Extensions of files we can build with the Go compiler or with cc_library.
-# This is a subset of the extensions recognized by go/build.
-cgo_filetype = FileType(go_exts + asm_exts + c_exts + cxx_exts + objc_exts)
-
 def pkg_dir(workspace_root, package_name):
     """Returns a relative path to a package directory from the root of the
     sandbox. Useful at execution-time or run-time."""

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -18,7 +18,8 @@ load(
 )
 load(
     "@io_bazel_rules_go//go/private:common.bzl",
-    "go_filetype",
+    "asm_exts",
+    "go_exts",
 )
 load(
     "@io_bazel_rules_go//go/private:rules/aspect.bzl",
@@ -89,7 +90,7 @@ go_binary = go_rule(
             allow_files = True,
             cfg = "data",
         ),
-        "srcs": attr.label_list(allow_files = go_filetype),
+        "srcs": attr.label_list(allow_files = go_exts + asm_exts),
         "deps": attr.label_list(
             providers = [GoLibrary],
             aspects = [go_archive_aspect],
@@ -158,7 +159,7 @@ go_tool_binary = go_rule(
             allow_files = True,
             cfg = "data",
         ),
-        "srcs": attr.label_list(allow_files = go_filetype),
+        "srcs": attr.label_list(allow_files = go_exts + asm_exts),
         "deps": attr.label_list(providers = [GoLibrary]),
         "embed": attr.label_list(providers = [GoLibrary]),
         "gc_goopts": attr.string_list(),

--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -92,7 +92,7 @@ def _select_archive(files):
     # list of file extensions in descending order or preference.
     exts = [".pic.lo", ".lo", ".a"]
     for ext in exts:
-        for f in files:
+        for f in as_iterable(files):
             if f.basename.endswith(ext):
                 return f
 
@@ -132,9 +132,9 @@ def _cgo_codegen_impl(ctx):
     cgo_types = go.declare_file(go, path = "_cgo_gotypes.go")
     out_dir = cgo_main.dirname
 
-    builder_args = go.args(go)     # interpreted by builder
-    tool_args = ctx.actions.args() # interpreted by cgo
-    cc_args = ctx.actions.args()   # interpreted by C compiler
+    builder_args = go.args(go)  # interpreted by builder
+    tool_args = ctx.actions.args()  # interpreted by cgo
+    cc_args = ctx.actions.args()  # interpreted by C compiler
 
     c_outs = [cgo_export_h, cgo_export_c]
     cxx_outs = [cgo_export_h]
@@ -415,9 +415,10 @@ def setup_cgo_library(name, srcs, cdeps, copts, cxxopts, cppopts, clinkopts, obj
 
     # Run cgo on the filtered Go files. This will split them into pure Go files
     # and pure C files, plus a few other glue files.
+    repo_name = native.repository_name()
     base_dir = pkg_dir(
-        "external/" + REPOSITORY_NAME[1:] if len(REPOSITORY_NAME) > 1 else "",
-        PACKAGE_NAME,
+        "external/" + repo_name[1:] if len(repo_name) > 1 else "",
+        native.package_name(),
     )
     copts = copts
     cxxopts = cxxopts

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -18,7 +18,8 @@ load(
 )
 load(
     "@io_bazel_rules_go//go/private:common.bzl",
-    "go_filetype",
+    "asm_exts",
+    "go_exts",
     "pkg_dir",
     "split_srcs",
 )
@@ -168,7 +169,7 @@ go_test = go_rule(
             allow_files = True,
             cfg = "data",
         ),
-        "srcs": attr.label_list(allow_files = go_filetype),
+        "srcs": attr.label_list(allow_files = go_exts + asm_exts),
         "deps": attr.label_list(
             providers = [GoLibrary],
             aspects = [go_archive_aspect],

--- a/go/private/skylib/README.rst
+++ b/go/private/skylib/README.rst
@@ -1,5 +1,5 @@
 This directory is a copy of github.com/bazelbuild/bazel-skylib/lib.
-Commit 2169ae1, retrieved on 2018-01-12
+Version 0.4.0, retrieved on 2018-06-11
 
 This is needed only until nested workspaces works.
 It has to be copied in because we use the functionality inside code that 

--- a/go/private/skylib/lib/collections.bzl
+++ b/go/private/skylib/lib/collections.bzl
@@ -21,6 +21,7 @@ def _after_each(separator, iterable):
   Args:
     separator: The value to insert after each item in `iterable`.
     iterable: The list into which to intersperse the separator.
+
   Returns:
     A new list with `separator` after each item in `iterable`.
   """
@@ -38,6 +39,7 @@ def _before_each(separator, iterable):
   Args:
     separator: The value to insert before each item in `iterable`.
     iterable: The list into which to intersperse the separator.
+
   Returns:
     A new list with `separator` before each item in `iterable`.
   """
@@ -56,6 +58,7 @@ def _uniq(iterable):
 
   Args:
     iterable: An iterable to filter.
+
   Returns:
     A new list with all unique elements from `iterable`.
   """

--- a/go/private/skylib/lib/dicts.bzl
+++ b/go/private/skylib/lib/dicts.bzl
@@ -28,6 +28,7 @@ def _add(*dictionaries):
 
   Args:
     *dictionaries: Zero or more dictionaries to be added.
+
   Returns:
     A new `dict` that has all the entries of the given dictionaries.
   """

--- a/go/private/skylib/lib/new_sets.bzl
+++ b/go/private/skylib/lib/new_sets.bzl
@@ -1,0 +1,251 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skylib module containing common hash-set algorithms.
+
+  An empty set can be created using: `sets.make()`, or it can be created with some starting values
+  if you pass it an sequence: `sets.make([1, 2, 3])`. This returns a struct containing all of the
+  values as keys in a dictionary - this means that all passed in values must be hashable.  The
+  values in the set can be retrieved using `sets.to_list(my_set)`.
+"""
+
+load(":dicts.bzl", "dicts")
+
+
+def _make(elements=None):
+  """Creates a new set.
+
+  All elements must be hashable.
+
+  Args:
+    elements: Optional sequence to construct the set out of.
+
+  Returns:
+    A set containing the passed in values.
+  """
+  elements = elements if elements else []
+  return struct(_values = {e: None for e in elements})
+
+
+def _copy(s):
+  """Creates a new set from another set.
+
+  Args:
+    s: A set, as returned by `sets.make()`.
+
+  Returns:
+    A new set containing the same elements as `s`.
+  """
+  return struct(_values = dict(s._values))
+
+
+def _to_list(s):
+  """Creates a list from the values in the set.
+
+  Args:
+    s: A set, as returned by `sets.make()`.
+
+  Returns:
+    A list of values inserted into the set.
+  """
+  return s._values.keys()
+
+
+def _insert(s, e):
+  """Inserts an element into the set.
+
+  Element must be hashable.  This mutates the orginal set.
+
+  Args:
+    s: A set, as returned by `sets.make()`.
+    e: The element to be inserted.
+
+  Returns:
+     The set `s` with `e` included.
+  """
+  s._values[e] = None
+  return s
+
+
+def _remove(s, e):
+  """Removes an element from the set.
+
+  Element must be hashable.  This mutates the orginal set.
+
+  Args:
+    s: A set, as returned by `sets.make()`.
+    e: The element to be removed.
+
+  Returns:
+     The set `s` with `e` removed.
+  """
+  s._values.pop(e)
+  return s
+
+
+def _contains(a, e):
+  """Checks for the existence of an element in a set.
+
+  Args:
+    a: A set, as returned by `sets.make()`.
+    e: The element to look for.
+
+  Returns:
+    True if the element exists in the set, False if the element does not.
+  """
+  return e in a._values
+
+
+def _get_shorter_and_longer(a, b):
+  """Returns two sets in the order of shortest and longest.
+
+  Args:
+    a: A set, as returned by `sets.make()`.
+    b: A set, as returned by `sets.make()`.
+
+  Returns:
+    `a`, `b` if `a` is shorter than `b` - or `b`, `a` if `b` is shorter than `a`.
+  """
+  if _length(a) < _length(b):
+    return a, b
+  return b, a
+
+
+def _is_equal(a, b):
+  """Returns whether two sets are equal.
+
+  Args:
+    a: A set, as returned by `sets.make()`.
+    b: A set, as returned by `sets.make()`.
+
+  Returns:
+    True if `a` is equal to `b`, False otherwise.
+  """
+  return a._values == b._values
+
+
+def _is_subset(a, b):
+  """Returns whether `a` is a subset of `b`.
+
+  Args:
+    a: A set, as returned by `sets.make()`.
+    b: A set, as returned by `sets.make()`.
+
+  Returns:
+    True if `a` is a subset of `b`, False otherwise.
+  """
+  for e in  a._values.keys():
+    if e not in b._values:
+      return False
+  return True
+
+
+def _disjoint(a, b):
+  """Returns whether two sets are disjoint.
+
+  Two sets are disjoint if they have no elements in common.
+
+  Args:
+    a: A set, as returned by `sets.make()`.
+    b: A set, as returned by `sets.make()`.
+
+  Returns:
+    True if `a` and `b` are disjoint, False otherwise.
+  """
+  shorter, longer = _get_shorter_and_longer(a, b)
+  for e in shorter._values.keys():
+    if e in longer._values:
+      return False
+  return True
+
+
+def _intersection(a, b):
+  """Returns the intersection of two sets.
+
+  Args:
+    a: A set, as returned by `sets.make()`.
+    b: A set, as returned by `sets.make()`.
+
+  Returns:
+    A set containing the elements that are in both `a` and `b`.
+  """
+  shorter, longer = _get_shorter_and_longer(a, b)
+  return struct(_values = {e: None for e in shorter._values.keys() if e in longer._values})
+
+
+def _union(*args):
+  """Returns the union of several sets.
+
+  Args:
+    *args: An arbitrary number of sets or lists.
+
+  Returns:
+    The set union of all sets or lists in `*args`.
+  """
+  return struct(_values = dicts.add(*[s._values for s in args]))
+
+
+def _difference(a, b):
+  """Returns the elements in `a` that are not in `b`.
+
+  Args:
+    a: A set, as returned by `sets.make()`.
+    b: A set, as returned by `sets.make()`.
+
+  Returns:
+    A set containing the elements that are in `a` but not in `b`.
+  """
+  return struct(_values = {e: None for e in a._values.keys() if e not in b._values})
+
+
+def _length(s):
+  """Returns the number of elements in a set.
+
+  Args:
+    s: A set, as returned by `sets.make()`.
+
+  Returns:
+    An integer representing the number of elements in the set.
+  """
+  return len(s._values)
+
+def _repr(s):
+  """Returns a string value representing the set.
+
+  Args:
+    s: A set, as returned by `sets.make()`.
+
+  Returns:
+    A string representing the set.
+  """
+  return repr(s._values.keys())
+
+
+sets = struct(
+  make = _make,
+  copy = _copy,
+  to_list = _to_list,
+  insert = _insert,
+  contains = _contains,
+  is_equal = _is_equal,
+  is_subset = _is_subset,
+  disjoint = _disjoint,
+  intersection = _intersection,
+  union = _union,
+  difference = _difference,
+  length = _length,
+  remove = _remove,
+  repr = _repr,
+  str = _repr,
+)

--- a/go/private/skylib/lib/partial.bzl
+++ b/go/private/skylib/lib/partial.bzl
@@ -1,0 +1,130 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skylark module for working with partial function objects.
+
+Partial function objects allow some parameters are bound before the call.
+
+Similar to https://docs.python.org/3/library/functools.html#functools.partial.
+"""
+
+def _call(partial, *args, **kwargs):
+  """Calls a partial created using `make`.
+
+  Args:
+    partial: The partial to be called.
+    *args: Additional positional arguments to be appended to the ones given to
+           make.
+    **kwargs: Additional keyword arguments to augment and override the ones
+              given to make.
+
+  Returns:
+    Whatever the function in the partial returns.
+  """
+  function_args = partial.args + args
+  function_kwargs = dict(partial.kwargs)
+  function_kwargs.update(kwargs)
+  return partial.function(*function_args, **function_kwargs)
+
+def _make(func, *args, **kwargs):
+  """Creates a partial that can be called using `call`.
+
+  A partial can have args assigned to it at the make site, and can have args
+  passed to it at the call sites.
+
+  A partial 'function' can be defined with positional args and kwargs:
+
+    # function with no args
+    def function1():
+      ...
+
+    # function with 2 args
+    def function2(arg1, arg2):
+      ...
+
+    # function with 2 args and keyword args
+    def function3(arg1, arg2, x, y):
+      ...
+
+  The positional args passed to the function are the args passed into make
+  followed by any additional positional args given to call. The below example
+  illustrates a function with two positional arguments where one is supplied by
+  make and the other by call:
+
+    # function demonstrating 1 arg at make site, and 1 arg at call site
+    def _foo(make_arg1, func_arg1):
+    print(make_arg1 + " " + func_arg1 + "!")
+
+  For example:
+
+    hi_func = partial.make(_foo, "Hello")
+    bye_func = partial.make(_foo, "Goodbye")
+    partial.call(hi_func, "Jennifer")
+    partial.call(hi_func, "Dave")
+    partial.call(bye_func, "Jennifer")
+    partial.call(bye_func, "Dave")
+
+  prints:
+
+    "Hello, Jennifer!"
+    "Hello, Dave!"
+    "Goodbye, Jennifer!"
+    "Goodbye, Dave!"
+
+  The keyword args given to the function are the kwargs passed into make
+  unioned with the keyword args given to call. In case of a conflict, the
+  keyword args given to call take precedence. This allows you to set a default
+  value for keyword arguments and override it at the call site.
+
+  Example with a make site arg, a call site arg, a make site kwarg and a
+  call site kwarg:
+
+    def _foo(make_arg1, call_arg1, make_location, call_location):
+      print(make_arg1 + " is from " + make_location + " and " +
+            call_arg1 + " is from " + call_location + "!")
+
+    func = partial.make(_foo, "Ben", make_location="Hollywood")
+    partial.call(func, "Jennifer", call_location="Denver")
+
+  Prints "Ben is from Hollywood and Jennifer is from Denver!".
+
+    partial.call(func, "Jennifer", make_location="LA", call_location="Denver")
+
+  Prints "Ben is from LA and Jennifer is from Denver!".
+
+  Note that keyword args may not overlap with positional args, regardless of
+  whether they are given during the make or call step. For instance, you can't
+  do:
+
+  def foo(x):
+    pass
+
+  func = partial.make(foo, 1)
+  partial.call(func, x=2)
+
+  Args:
+    func: The function to be called.
+    *args: Positional arguments to be passed to function.
+    **kwargs: Keyword arguments to be passed to function. Note that these can
+              be overridden at the call sites.
+
+  Returns:
+    A new `partial` that can be called using `call`
+  """
+  return struct(function=func, args=args, kwargs=kwargs)
+
+partial = struct(
+    make=_make,
+    call=_call,
+)

--- a/go/private/skylib/lib/paths.bzl
+++ b/go/private/skylib/lib/paths.bzl
@@ -30,6 +30,7 @@ def _basename(p):
 
   Args:
     p: The path whose basename should be returned.
+
   Returns:
     The basename of the path, which includes the extension.
   """
@@ -45,6 +46,7 @@ def _dirname(p):
 
   Args:
     p: The path whose dirname should be returned.
+
   Returns:
     The dirname of the path.
   """
@@ -62,10 +64,11 @@ def _is_absolute(path):
 
   Args:
     path: A path (which is a string).
+
   Returns:
     `True` if `path` is an absolute path.
   """
-  return path.startswith("/") or path[1] == ":"
+  return path.startswith("/") or (len(path)>2 and path[1] == ":")
 
 
 def _join(path, *others):
@@ -82,6 +85,7 @@ def _join(path, *others):
   Args:
     path: A path segment.
     *others: Additional path segments.
+
   Returns:
     A string containing the joined paths.
   """
@@ -117,6 +121,7 @@ def _normalize(path):
 
   Args:
     path: A path.
+
   Returns:
     The normalized path.
   """
@@ -162,11 +167,13 @@ def _relativize(path, start):
   will fail if `path` is not beneath `start` (rather than use parent segments to
   walk up to the common file system root).
 
-  Relativizing paths that start with parent directory references is not allowed.
+  Relativizing paths that start with parent directory references only works if
+  the path both start with the same initial parent references.
 
   Args:
     path: The path to relativize.
     start: The ancestor path against which to relativize.
+
   Returns:
     The portion of `path` that is relative to `start`.
   """
@@ -175,9 +182,6 @@ def _relativize(path, start):
   if start_segments == ["."]:
     start_segments = []
   start_length = len(start_segments)
-
-  if (path.startswith("..") or start.startswith("..")):
-    fail("Cannot relativize paths above the current (unknown) directory")
 
   if (path.startswith("/") != start.startswith("/") or
       len(segments) < start_length):
@@ -201,6 +205,7 @@ def _replace_extension(p, new_extension):
     p: The path whose extension should be replaced.
     new_extension: The new extension for the file. The new extension should
         begin with a dot if you want the new filename to have one.
+
   Returns:
     The path with the extension replaced (or added, if it did not have one).
   """
@@ -215,6 +220,7 @@ def _split_extension(p):
 
   Args:
     p: The path whose root and extension should be split.
+
   Returns:
     A tuple `(root, ext)` such that the root is the path without the file
     extension, and `ext` is the file extension (which, if non-empty, contains

--- a/go/private/skylib/lib/selects.bzl
+++ b/go/private/skylib/lib/selects.bzl
@@ -14,7 +14,7 @@
 
 """Skylib module containing convenience interfaces for select()."""
 
-def _with_or(input_dict):
+def _with_or(input_dict, no_match_error=''):
   """Drop-in replacement for `select()` that supports ORed keys.
 
   Args:
@@ -22,6 +22,7 @@ def _with_or(input_dict):
         either the usual form `"//foo:config1"` or
         `("//foo:config1", "//foo:config2", ...)` to signify
         `//foo:config1` OR `//foo:config2` OR `...`.
+    no_match_error: Optional custom error to report if no condition matches.
 
         Example:
 
@@ -48,7 +49,7 @@ def _with_or(input_dict):
     "//configs:three": [":dep2or3"],
     ```
   """
-  return select(_with_or_dict(input_dict))
+  return select(_with_or_dict(input_dict), no_match_error=no_match_error)
 
 
 def _with_or_dict(input_dict):
@@ -72,7 +73,7 @@ def _with_or_dict(input_dict):
         output_dict[config_setting] = value
     else:
       if key in output_dict.keys():
-        fail("key %s appears multiple times" % config_setting)
+        fail("key %s appears multiple times" % key)
       output_dict[key] = value
   return output_dict
 

--- a/go/private/skylib/lib/sets.bzl
+++ b/go/private/skylib/lib/sets.bzl
@@ -48,6 +48,7 @@ def _is_equal(a, b):
   Args:
     a: A depset or a list.
     b: A depset or a list.
+
   Returns:
     True if `a` is equal to `b`, False otherwise.
   """
@@ -115,10 +116,8 @@ def _union(*args):
     The set union of all sets or lists in `*args`.
   """
   _precondition_only_sets_or_lists(*args)
-  r = depset()
-  for a in args:
-    r += a
-  return r
+  args_deps = [depset(x) if type(x) == type([]) else x for x in args]
+  return depset(transitive=args_deps)
 
 
 def _difference(a, b):

--- a/go/private/skylib/lib/shell.bzl
+++ b/go/private/skylib/lib/shell.bzl
@@ -28,6 +28,7 @@ def _array_literal(iterable):
   Args:
     iterable: A sequence of elements. Elements that are not strings will be
         converted to strings first, by calling `str()`.
+
   Returns:
     A string that represents the sequence as a shell array; that is,
     parentheses containing the quoted elements.
@@ -43,6 +44,7 @@ def _quote(s):
 
   Args:
     s: The string to quote.
+
   Returns:
     A quoted version of the string that can be passed to a shell command.
   """

--- a/go/private/skylib/lib/structs.bzl
+++ b/go/private/skylib/lib/structs.bzl
@@ -20,6 +20,7 @@ def _to_dict(s):
 
   Args:
     s: A `struct`.
+
   Returns:
     A `dict` whose keys and values are the same as the fields in `s`. The
     transformation is only applied to the struct's fields and not to any

--- a/go/private/skylib/lib/unittest.bzl
+++ b/go/private/skylib/lib/unittest.bzl
@@ -20,6 +20,7 @@ assertions used to within tests.
 """
 
 load(":sets.bzl", "sets")
+load(":new_sets.bzl", new_sets="sets")
 
 
 def _make(impl, attrs=None):
@@ -52,6 +53,7 @@ def _make(impl, attrs=None):
     impl: The implementation function of the unit test.
     attrs: An optional dictionary to supplement the attrs passed to the
         unit test's `rule()` constructor.
+
   Returns:
     A rule definition that should be stored in a global whose name ends in
     `_test`.
@@ -144,6 +146,7 @@ def _begin(ctx):
   Args:
     ctx: The Skylark context. Pass the implementation function's `ctx` argument
         in verbatim.
+
   Returns:
     A test environment struct that must be passed to assertions and finally to
     `unittest.end`. Do not rely on internal details about the fields in this
@@ -253,11 +256,29 @@ def _assert_set_equals(env, expected, actual, msg=None):
       full_msg = expectation_msg
     _fail(env, full_msg)
 
+def _assert_new_set_equals(env, expected, actual, msg=None):
+  """Asserts that the given `expected` and `actual` sets are equal.
+
+  Args:
+    env: The test environment returned by `unittest.begin`.
+    expected: The expected set resulting from some computation.
+    actual: The actual set returned by some computation.
+    msg: An optional message that will be printed that describes the failure.
+        If omitted, a default will be used.
+  """
+  if not new_sets.is_equal(expected, actual):
+    expectation_msg = "Expected %r, but got %r" % (expected, actual)
+    if msg:
+      full_msg = "%s (%s)" % (msg, expectation_msg)
+    else:
+      full_msg = expectation_msg
+    _fail(env, full_msg)
 
 asserts = struct(
     equals=_assert_equals,
     false=_assert_false,
     set_equals=_assert_set_equals,
+    new_set_equals = _assert_new_set_equals,
     true=_assert_true,
 )
 

--- a/go/private/skylib/lib/versions.bzl
+++ b/go/private/skylib/lib/versions.bzl
@@ -108,7 +108,6 @@ def _check_bazel_version(minimum_bazel_version, maximum_bazel_version=None, baze
         bazel_version, minimum_bazel_version))
 
   if maximum_bazel_version:
-    max_bazel_version = _parse_bazel_version(maximum_bazel_version)
     if not _is_at_most(
         threshold = maximum_bazel_version,
         version = bazel_version):


### PR DESCRIPTION
Fix Skylark deprecation warnings

Fixed several instances of deprecated Skylark behavior

* Used depset.to_list() when iterating
* Avoid depset + operator
* Remove instances of FileType
* Use native.repository_name() and package_name instead of
  REPOSITORY_NAME and PACKAGE_NAME.

Also, upgraded vendored Skylib to 0.4.0, since it had some deprecated
stuff.

This change does not fix deprecated uses of args.add. That will
require more work.

Fixes #1534
Fixes #1535
