### PR TITLE
Add srcs attribute to GoStdLib provider

### DIFF
--- a/go/private/rules/stdlib.bzl
+++ b/go/private/rules/stdlib.bzl
@@ -32,6 +32,7 @@ load(
 
 def _stdlib_library_to_source(go, attr, source, merge):
     pkg = go.declare_directory(go, "pkg")
+    src = go.declare_directory(go, "src")
     root_file = go.declare_file(go, "ROOT")
     filter_buildid = attr._filter_buildid_builder.files.to_list()[0]
     files = [root_file, go.go, pkg]
@@ -54,7 +55,7 @@ def _stdlib_library_to_source(go, attr, source, merge):
     })
     go.actions.run(
         inputs = go.sdk_files + go.sdk_tools + go.crosstool + [filter_buildid, go.package_list, root_file],
-        outputs = [pkg],
+        outputs = [pkg, src],
         mnemonic = "GoStdlib",
         executable = attr._stdlib_builder.files.to_list()[0],
         arguments = [args],
@@ -65,6 +66,7 @@ def _stdlib_library_to_source(go, attr, source, merge):
         mode = go.mode,
         libs = [pkg],
         headers = [pkg],
+        srcs = [src],
         files = files,
     )
 


### PR DESCRIPTION
The src directory is not added to the files attribute so it needs to be
explicitly depended upon. Therefore, this change does not have any
effect on downstream rules, and does not add to the sandboxing overhead.

The src directory is useful for some linter invocations which can now
depend on sandboxed stdlib instead of expecting the users to have an
installed stdlib.