### PR TITLE
Windows fixes

### DIFF
--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -132,6 +132,8 @@ def emit_link(
     if extldflags:
         tool_args.add(["-extldflags", " ".join(extldflags)])
 
+    builder_args.use_param_file("@%s")
+    builder_args.set_param_file_format("multiline")
     go.actions.run(
         inputs = sets.union(
             archive.libs,

--- a/go/private/tools/overlay_repository.bzl
+++ b/go/private/tools/overlay_repository.bzl
@@ -93,7 +93,7 @@ def _apply_overlay(ctx, overlay):
 
     # TODO(jayconrod): sanitize destination paths.
     for src_path, dst_rel in overlay:
-        _check_execute(ctx, ["cp", src_path, dst_rel], "failed to copy file from %s" % src_path)
+        ctx.template(dst_rel, src_path)
 
 def _check_execute(ctx, arguments, message):
     res = ctx.execute(arguments)

--- a/go/tools/builders/filter_buildid.go
+++ b/go/tools/builders/filter_buildid.go
@@ -18,7 +18,10 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
+	"runtime"
 	"syscall"
 )
 
@@ -33,5 +36,15 @@ func main() {
 		}
 		newArgs = append(newArgs, arg)
 	}
-	syscall.Exec(newArgs[0], newArgs, os.Environ())
+	if runtime.GOOS == "windows" {
+		cmd := exec.Command(newArgs[0], newArgs[1:]...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Println("error executing command %v: %v", newArgs[0], err)
+			os.Exit(1)
+		}
+	} else {
+		syscall.Exec(newArgs[0], newArgs, os.Environ())
+	}
 }

--- a/go/tools/builders/link.go
+++ b/go/tools/builders/link.go
@@ -98,7 +98,7 @@ This will be an error in the future.`, pkgPath, label, conflictLabel)
 			return fmt.Errorf("package file name %q must have searchable suffix %q", pkgFile, pkgSuffix)
 		}
 		searchPath := pkgFile[:len(pkgFile)-len(pkgSuffix)]
-		goargs = append(goargs, "-L", searchPath)
+		goargs = append(goargs, "-L", abs(searchPath))
 	}
 	for _, xdef := range xstamps {
 		split := strings.SplitN(xdef, "=", 2)

--- a/go/tools/builders/link.go
+++ b/go/tools/builders/link.go
@@ -94,7 +94,7 @@ This will be an error in the future.`, pkgPath, label, conflictLabel)
 		depsSeen[pkgPath] = label
 
 		pkgSuffix := string(os.PathSeparator) + filepath.FromSlash(pkgPath) + ".a"
-		if !strings.HasSuffix(pkgFile, pkgSuffix) {
+		if !strings.HasSuffix(filepath.FromSlash(pkgFile), pkgSuffix) {
 			return fmt.Errorf("package file name %q must have searchable suffix %q", pkgFile, pkgSuffix)
 		}
 		searchPath := pkgFile[:len(pkgFile)-len(pkgSuffix)]

--- a/go/tools/builders/pack.go
+++ b/go/tools/builders/pack.go
@@ -29,7 +29,9 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
+	"path/filepath"
 	"os"
 	"strconv"
 	"strings"
@@ -55,9 +57,15 @@ func run(args []string) error {
 		return err
 	}
 
+	dir, err := ioutil.TempDir("", "go-pack")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(dir)
+
 	names := map[string]struct{}{}
 	for _, archive := range archives {
-		archiveObjects, err := extractFiles(archive, names)
+		archiveObjects, err := extractFiles(archive, dir, names)
 		if err != nil {
 			return err
 		}
@@ -100,7 +108,7 @@ const (
 	entryLength = 60
 )
 
-func extractFiles(archive string, names map[string]struct{}) (files []string, err error) {
+func extractFiles(archive, dir string, names map[string]struct{}) (files []string, err error) {
 	f, err := os.Open(archive)
 	if err != nil {
 		return nil, err
@@ -130,6 +138,7 @@ func extractFiles(archive string, names map[string]struct{}) (files []string, er
 		}
 		name = simpleName(name, names)
 		names[name] = struct{}{}
+		name = filepath.Join(dir, name)
 		if err := extractFile(r, name, size); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
- Don't expect a `cp` command on Windows
- `syscall.Exec` on Windows always returns an error
- Fix path comparison in the linker
- Allow passing deps to the linker in a file rather than the command line, to allow for complex projects with lots of packages
- Fix a race condition in pack.go (doesn't affect other platforms due to sandboxes)