### PR TITLE
Fixes and tests for reproducibility

### DIFF
--- a/go/tools/builders/stdlib.go
+++ b/go/tools/builders/stdlib.go
@@ -65,6 +65,9 @@ func run(args []string) error {
 	}
 	os.Setenv("PATH", strings.Join(absPaths, string(os.PathListSeparator)))
 
+	// Strip path prefix from source files in debug information.
+	os.Setenv("CGO_CFLAGS", os.Getenv("CGO_CFLAGS")+" -fdebug-prefix-map="+abs(".")+"=")
+
 	// Build the commands needed to build the std library in the right mode
 	installArgs := goenv.goCmd("install", "-toolexec", abs(*filterBuildid))
 	if len(build.Default.BuildTags) > 0 {

--- a/tests/reproducibility/BUILD.bazel
+++ b/tests/reproducibility/BUILD.bazel
@@ -1,0 +1,51 @@
+load("@io_bazel_rules_go//tests:bazel_tests.bzl", "bazel_test", "md5_sum")
+
+# A test script that, when run, builds the given targets in a clean build state
+# with sandboxed strategy, and outputs their md5 digests from the build with
+# ___MD5___ prefix to each line.
+bazel_test(
+    name = "collect_digests",
+    check = """
+print_digests() {
+  if (( result == 0 )); then
+    echo "#### BEGIN DIGESTS ####"
+    pushd bazel-bin
+    set -o pipefail
+
+    external/io_bazel_rules_go/go/tools/builders/*/md5sum . | \
+      # TODO: Find why .lo files are not reproducible.
+      grep -v '\.lo ' | \
+      grep -v 'MANIFEST ' | \
+      grep -v 'runfiles_manifest ' | \
+      sed -e 's/^/___MD5___ /'
+    result=$?
+
+    set +o pipefail
+    popd
+    echo "#### END DIGESTS ####"
+  fi
+}
+print_digests
+""",
+    clean_build = True,
+    command = "build",
+    standalone = False,
+    targets = [
+        "@io_bazel_rules_go//go/tools/builders:md5sum",
+        "@io_bazel_rules_go//tests/reproducibility/cgo",
+    ],
+)
+
+# A test that runs the above test script twice and diffs the output.
+sh_test(
+    name = "reproducibility",
+    size = "large",
+    timeout = "moderate",
+    srcs = ["test.sh"],
+    data = [":collect_digests"],
+    tags = [
+        "bazel",
+        "exclusive",
+        "local",
+    ],
+)

--- a/tests/reproducibility/cgo/BUILD.bazel
+++ b/tests/reproducibility/cgo/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_binary")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "add.c",
+        "add.cpp",
+        "add.h",
+        "adder.go",
+        "main.go",
+    ],
+    cgo = True,
+    importpath = "github.com/bazelbuild/rules_go/tests/reproducibility/cgo",
+    visibility = ["//tests/reproducibility:__pkg__"],
+)
+
+go_binary(
+    name = "cgo",
+    embed = [":go_default_library"],
+    linkmode = "c-archive",
+    visibility = ["//visibility:public"],
+)

--- a/tests/reproducibility/cgo/add.c
+++ b/tests/reproducibility/cgo/add.c
@@ -1,0 +1,4 @@
+#include "add.h"
+#include "_cgo_export.h"
+
+int add_c(int a, int b) { return add(a, b); }

--- a/tests/reproducibility/cgo/add.cpp
+++ b/tests/reproducibility/cgo/add.cpp
@@ -1,0 +1,4 @@
+#include "add.h"
+#include "_cgo_export.h"
+
+int add_cpp(int a, int b) { return add(a, b); }

--- a/tests/reproducibility/cgo/add.h
+++ b/tests/reproducibility/cgo/add.h
@@ -1,0 +1,10 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int add_c(int a, int b);
+int add_cpp(int a, int b);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/reproducibility/cgo/adder.go
+++ b/tests/reproducibility/cgo/adder.go
@@ -1,0 +1,19 @@
+package main
+
+/*
+#import "add.h"
+*/
+import "C"
+
+func AddC(a, b int32) int32 {
+	return int32(C.add_c(C.int(a), C.int(b)))
+}
+
+func AddCPP(a, b int32) int32 {
+	return int32(C.add_cpp(C.int(a), C.int(b)))
+}
+
+//export add
+func add(a, b int32) int32 {
+	return a + b
+}

--- a/tests/reproducibility/cgo/main.go
+++ b/tests/reproducibility/cgo/main.go
@@ -1,0 +1,9 @@
+package main
+
+import "fmt"
+
+func main() {
+	// Depend on some stdlib function.
+	fmt.Println("In C, 2 + 2 = ", AddC(2, 2))
+	fmt.Println("In C++, 2 + 2 = ", AddCPP(2, 2))
+}

--- a/tests/reproducibility/test.sh
+++ b/tests/reproducibility/test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -eu -o pipefail
+
+function run_bazel() {
+    local out_file="$1"
+
+    ./tests/reproducibility/collect_digests | grep "___MD5___" > "${out_file}"
+}
+
+FILE1=$(mktemp)
+FILE2=$(mktemp)
+
+echo First run
+run_bazel "${FILE1}"
+
+echo Second run
+run_bazel "${FILE2}"
+
+echo Diffing runs
+diff "${FILE1}" "${FILE2}"
+echo Builds are identical!
+
+echo Removing files
+rm "${FILE1}" "${FILE2}"


### PR DESCRIPTION
Includes a reproducibility test in travis, that will test if stdlib and binaries with cgo are reproducible across multiple builds by the same user. This still does not test if the binaries are reproducible across multiple users or machines. I am relying on tests/legacy/reproducible_binary to check that.

There are two fixes included here:
1. Supplying -fdebug-prefix-map to C compiler invocations for cgo.
2. Stripping temp dir path from generated src files (*.cgo2.c).

Resolves #1518.
Resolves #1547.