### PR TITLE
Revert "Replace WKT go_library rules with aliases to //proto/wkt (#1498)"

### DIFF
--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -101,8 +101,6 @@ def go_rules_dependencies():
         commit = "1adfc126b41513cc696b209667c8656ea7aac67c",  # v1.0.0, as of 2018-02-16
         overlay = manifest["com_github_gogo_protobuf"],
         # build_file_proto_mode = "legacy",
-        # TODO(jayconrod): incorporate manual changes when regenerating build
-        # files. This repo contains aliases for //proto/wkt targets.
     )
     _maybe(
         gogo_special_proto,
@@ -142,8 +140,6 @@ def go_rules_dependencies():
         overlay = manifest["org_golang_google_genproto"],
         # build_file_proto_mode = "disable",
         # importpath = "google.golang.org/genproto",
-        # TODO(jayconrod): incorporate manual changes when regenerating build
-        # files. This repo contains aliases for //proto/wkt targets.
     )
     _maybe(
         git_repository,

--- a/tests/legacy/examples/proto/grpc/BUILD.bazel
+++ b/tests/legacy/examples/proto/grpc/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library", "go_grpc_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_grpc_library", "go_proto_library")
 
 proto_library(
     name = "my_svc_proto",
@@ -35,8 +35,8 @@ go_binary(
     deps = [
         ":my_svc_go_proto",
         "//tests/legacy/examples/proto/lib:lib_go_proto",
-        "@com_github_golang_protobuf//ptypes/any:go_default_library",
-        "@com_github_golang_protobuf//ptypes/empty:go_default_library",
+        "@io_bazel_rules_go//proto/wkt:any_go_proto",
+        "@io_bazel_rules_go//proto/wkt:empty_go_proto",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_x_net//context:go_default_library",
     ],

--- a/third_party/com_github_golang_protobuf/protoc-gen-go/descriptor/BUILD.bazel.in
+++ b/third_party/com_github_golang_protobuf/protoc-gen-go/descriptor/BUILD.bazel.in
@@ -6,16 +6,10 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-alias(
-    name = "go_default_library",
-    actual = "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
-    visibility = ["//visibility:public"],
-)
-
 go_library(
-    name = "descriptor_bootstrap",
+    name = "go_default_library",
     srcs = ["descriptor.pb.go"],
     importpath = "github.com/golang/protobuf/protoc-gen-go/descriptor",
-    visibility = ["//protoc-gen-go:__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = ["//proto:go_default_library"],
 )

--- a/third_party/com_github_golang_protobuf/protoc-gen-go/generator/BUILD.bazel.in
+++ b/third_party/com_github_golang_protobuf/protoc-gen-go/generator/BUILD.bazel.in
@@ -7,9 +7,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:go_default_library",
-        "//protoc-gen-go/descriptor:descriptor_bootstrap",
+        "//protoc-gen-go/descriptor:go_default_library",
         "//protoc-gen-go/generator/internal/remap:go_default_library",
-        "//protoc-gen-go/plugin:plugin_bootstrap",
+        "//protoc-gen-go/plugin:go_default_library",
     ],
 )
 

--- a/third_party/com_github_golang_protobuf/protoc-gen-go/grpc/BUILD.bazel.in
+++ b/third_party/com_github_golang_protobuf/protoc-gen-go/grpc/BUILD.bazel.in
@@ -6,7 +6,7 @@ go_library(
     importpath = "github.com/golang/protobuf/protoc-gen-go/grpc",
     visibility = ["//visibility:public"],
     deps = [
-        "//protoc-gen-go/descriptor:descriptor_bootstrap",
+        "//protoc-gen-go/descriptor:go_default_library",
         "//protoc-gen-go/generator:go_default_library",
     ],
 )

--- a/third_party/com_github_golang_protobuf/protoc-gen-go/plugin/BUILD.bazel.in
+++ b/third_party/com_github_golang_protobuf/protoc-gen-go/plugin/BUILD.bazel.in
@@ -6,19 +6,13 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-alias(
-    name = "go_default_library",
-    actual = "@io_bazel_rules_go//proto/wkt:compiler_plugin_go_proto",
-    visibility = ["//visibility:public"],
-)
-
 go_library(
-    name = "plugin_bootstrap",
+    name = "go_default_library",
     srcs = ["plugin.pb.go"],
     importpath = "github.com/golang/protobuf/protoc-gen-go/plugin",
-    visibility = ["//protoc-gen-go:__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = [
         "//proto:go_default_library",
-        "//protoc-gen-go/descriptor:descriptor_bootstrap",
+        "//protoc-gen-go/descriptor:go_default_library",
     ],
 )

--- a/third_party/com_github_golang_protobuf/ptypes/any/BUILD.bazel.in
+++ b/third_party/com_github_golang_protobuf/ptypes/any/BUILD.bazel.in
@@ -6,8 +6,10 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-alias(
+go_library(
     name = "go_default_library",
-    actual = "@io_bazel_rules_go//proto/wkt:any_go_proto",
+    srcs = ["any.pb.go"],
+    importpath = "github.com/golang/protobuf/ptypes/any",
     visibility = ["//visibility:public"],
+    deps = ["//proto:go_default_library"],
 )

--- a/third_party/com_github_golang_protobuf/ptypes/duration/BUILD.bazel.in
+++ b/third_party/com_github_golang_protobuf/ptypes/duration/BUILD.bazel.in
@@ -6,8 +6,10 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-alias(
+go_library(
     name = "go_default_library",
-    actual = "@io_bazel_rules_go//proto/wkt:duration_go_proto",
+    srcs = ["duration.pb.go"],
+    importpath = "github.com/golang/protobuf/ptypes/duration",
     visibility = ["//visibility:public"],
+    deps = ["//proto:go_default_library"],
 )

--- a/third_party/com_github_golang_protobuf/ptypes/empty/BUILD.bazel.in
+++ b/third_party/com_github_golang_protobuf/ptypes/empty/BUILD.bazel.in
@@ -6,8 +6,10 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-alias(
+go_library(
     name = "go_default_library",
-    actual = "@io_bazel_rules_go//proto/wkt:empty_go_proto",
+    srcs = ["empty.pb.go"],
+    importpath = "github.com/golang/protobuf/ptypes/empty",
     visibility = ["//visibility:public"],
+    deps = ["//proto:go_default_library"],
 )

--- a/third_party/com_github_golang_protobuf/ptypes/struct/BUILD.bazel.in
+++ b/third_party/com_github_golang_protobuf/ptypes/struct/BUILD.bazel.in
@@ -6,8 +6,10 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-alias(
+go_library(
     name = "go_default_library",
-    actual = "@io_bazel_rules_go//proto/wkt:struct_go_proto",
+    srcs = ["struct.pb.go"],
+    importpath = "github.com/golang/protobuf/ptypes/struct",
     visibility = ["//visibility:public"],
+    deps = ["//proto:go_default_library"],
 )

--- a/third_party/com_github_golang_protobuf/ptypes/timestamp/BUILD.bazel.in
+++ b/third_party/com_github_golang_protobuf/ptypes/timestamp/BUILD.bazel.in
@@ -6,8 +6,10 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-alias(
+go_library(
     name = "go_default_library",
-    actual = "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",
+    srcs = ["timestamp.pb.go"],
+    importpath = "github.com/golang/protobuf/ptypes/timestamp",
     visibility = ["//visibility:public"],
+    deps = ["//proto:go_default_library"],
 )

--- a/third_party/com_github_golang_protobuf/ptypes/wrappers/BUILD.bazel.in
+++ b/third_party/com_github_golang_protobuf/ptypes/wrappers/BUILD.bazel.in
@@ -6,8 +6,10 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-alias(
+go_library(
     name = "go_default_library",
-    actual = "@io_bazel_rules_go//proto/wkt:wrappers_go_proto",
+    srcs = ["wrappers.pb.go"],
+    importpath = "github.com/golang/protobuf/ptypes/wrappers",
     visibility = ["//visibility:public"],
+    deps = ["//proto:go_default_library"],
 )

--- a/third_party/org_golang_google_genproto/protobuf/api/BUILD.bazel.in
+++ b/third_party/org_golang_google_genproto/protobuf/api/BUILD.bazel.in
@@ -1,7 +1,13 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
-alias(
+go_library(
     name = "go_default_library",
-    actual = "@io_bazel_rules_go//proto/wkt:api_go_proto",
+    srcs = ["api.pb.go"],
+    importpath = "google.golang.org/genproto/protobuf/api",
     visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_golang_protobuf//proto:go_default_library",
+        "@io_bazel_rules_go//proto/wkt:source_context_go_proto",
+        "@io_bazel_rules_go//proto/wkt:type_go_proto",
+    ],
 )

--- a/third_party/org_golang_google_genproto/protobuf/field_mask/BUILD.bazel.in
+++ b/third_party/org_golang_google_genproto/protobuf/field_mask/BUILD.bazel.in
@@ -1,7 +1,9 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
-alias(
+go_library(
     name = "go_default_library",
-    actual = "@io_bazel_rules_go//proto/wkt:field_mask_go_proto",
+    srcs = ["field_mask.pb.go"],
+    importpath = "google.golang.org/genproto/protobuf/field_mask",
     visibility = ["//visibility:public"],
+    deps = ["@com_github_golang_protobuf//proto:go_default_library"],
 )

--- a/third_party/org_golang_google_genproto/protobuf/ptype/BUILD.bazel.in
+++ b/third_party/org_golang_google_genproto/protobuf/ptype/BUILD.bazel.in
@@ -1,7 +1,13 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
-alias(
+go_library(
     name = "go_default_library",
-    actual = "@io_bazel_rules_go//proto/wkt:type_go_proto",
+    srcs = ["type.pb.go"],
+    importpath = "google.golang.org/genproto/protobuf/ptype",
     visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_golang_protobuf//proto:go_default_library",
+        "@io_bazel_rules_go//proto/wkt:any_go_proto",
+        "@io_bazel_rules_go//proto/wkt:source_context_go_proto",
+    ],
 )

--- a/third_party/org_golang_google_genproto/protobuf/source_context/BUILD.bazel.in
+++ b/third_party/org_golang_google_genproto/protobuf/source_context/BUILD.bazel.in
@@ -1,7 +1,9 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
-alias(
+go_library(
     name = "go_default_library",
-    actual = "@io_bazel_rules_go//proto/wkt:source_context_go_proto",
+    srcs = ["source_context.pb.go"],
+    importpath = "google.golang.org/genproto/protobuf/source_context",
     visibility = ["//visibility:public"],
+    deps = ["@com_github_golang_protobuf//proto:go_default_library"],
 )


### PR DESCRIPTION
This reverts commit ca213b3006c8eed6b3f1ea649cab36b817901b46.

Also: Update legacy example to point to //proto/wkt to avoid conflict

Related #1548