### PR TITLE
Change the test main function to chdir using an abs path.

### DIFF
--- a/go/tools/builders/generate_test_main.go
+++ b/go/tools/builders/generate_test_main.go
@@ -119,15 +119,15 @@ func testsInShard() []testing.InternalTest {
 
 func main() {
 	// Check if we're being run by Bazel and change directories if so.
-	// TEST_SRCDIR is set by the Bazel test runner, so that makes a decent proxy.
-	if _, ok := os.LookupEnv("TEST_SRCDIR"); ok {
-		abs, absErr := filepath.Abs({{printf "%q" .RunDir}})
-		if err := os.Chdir({{printf "%q" .RunDir}}); err != nil {
+	// TEST_SRCDIR and TEST_WORKSPACE are set by the Bazel test runner, so that makes a decent proxy.
+	testSrcdir := os.Getenv("TEST_SRCDIR")
+	testWorkspace := os.Getenv("TEST_WORKSPACE")
+	if testSrcdir != "" && testWorkspace != "" {
+		abs := filepath.Join(testSrcdir, testWorkspace, {{printf "%q" .RunDir}})
+		if err := os.Chdir(abs); err != nil {
 			log.Fatalf("could not change to test directory: %v", err)
 		}
-		if absErr == nil {
-			os.Setenv("PWD", abs)
-		}
+		os.Setenv("PWD", abs)
 	}
 
 	if filter := os.Getenv("TESTBRIDGE_TEST_ONLY"); filter != "" {


### PR DESCRIPTION
The old code chdirs to a path relative from the
$TEST_SRCDIR/$TEST_WORKSPACE. This creates a problem when a unittest tries to
fork & exec itself to create a clone of itself. The cwd of the forked subprocess
is already at $TEST_SRCDIR/$TEST_WORKSPACE/go/src/something, and its main()
tries to chdir to go/src/something again and crashes.

A unittest trying to fork & execitself might sound strange, but Mapreduce-style
application does this regularly.