### PR TITLE
Link to build-time code analysis documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,7 @@ Documentation
 
 * `Toolchains <go/toolchains.rst>`_
 * `Extra rules <go/extras.rst>`_
+* `Build-time code analysis <go/checks.rst>`_
 * `Deprecated rules <go/deprecated.rst>`_
 * `Build modes <go/modes.rst>`_
 


### PR DESCRIPTION
This adds a link to the documentation for build-time code analysis
to the main README.