### PR TITLE
Change internal filename suffix from '~' to '%'

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -66,7 +66,7 @@ def _child_name(go, path, ext, name):
     childname = mode_string(go.mode) + "/"
     childname += name if name else go._ctx.label.name
     if path:
-        childname += "~/" + path
+        childname += "%/" + path
     if ext:
         childname += ext
     return childname

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -6,10 +6,10 @@ Main test areas
 
 .. Child list start
 
-* `Go rules examples <examples/README.rst>`_
 * `Core Go rules tests <core/README.rst>`_
 * `Integration tests <integration/README.rst>`_
 * `Legacy tests <legacy/README.rst>`_
+* `Go rules examples <examples/README.rst>`_
 
 .. Child list end
 

--- a/tests/core/README.rst
+++ b/tests/core/README.rst
@@ -8,20 +8,20 @@ Contents
 
 .. Child list start
 
-* `Basic go_path functionality <go_path/README.rst>`_
-* `Basic -buildmode=plugin functionality <go_plugin/README.rst>`_
-* `Basic go_binary functionality <go_binary/README.rst>`_
 * `Basic go_library functionality <go_library/README.rst>`_
+* `Basic -buildmode=plugin functionality <go_plugin/README.rst>`_
+* `go_proto_library importmap <go_proto_library_importmap/README.rst>`_
 * `Cross compilation <cross/README.rst>`_
-* `coverage functionality <coverage/README.rst>`_
 * `Basic go_proto_library functionality <go_proto_library/README.rst>`_
 * `c-archive / c-shared linkmodes <c_linkmodes/README.rst>`_
-* `stdlib functionality <stdlib/README.rst>`_
-* `Import maps <importmap/README.rst>`_
 * `Basic go_test functionality <go_test/README.rst>`_
 * `Basic cgo functionality <cgo/README.rst>`_
 * `race instrumentation <race/README.rst>`_
-* `go_proto_library importmap <go_proto_library_importmap/README.rst>`_
+* `stdlib functionality <stdlib/README.rst>`_
+* `Basic go_binary functionality <go_binary/README.rst>`_
+* `coverage functionality <coverage/README.rst>`_
+* `Import maps <importmap/README.rst>`_
+* `Basic go_path functionality <go_path/README.rst>`_
 
 .. Child list end
 

--- a/tests/core/go_binary/BUILD.bazel
+++ b/tests/core/go_binary/BUILD.bazel
@@ -2,6 +2,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_test")
 
 test_suite(name = "go_binary")
 
+go_binary(
+    name = "hello",
+    srcs = ["hello.go"],
+)
+
 go_test(
     name = "go_default_test",
     srcs = ["out_test.go"],

--- a/tests/core/go_binary/README.rst
+++ b/tests/core/go_binary/README.rst
@@ -5,8 +5,14 @@ Basic go_binary functionality
 
 Tests to ensure the basic features of go_binary are working as expected.
 
+hello
+-----
+
+Hello is a basic "hello world" program that doesn't do anything interesting.
+Useful as a primitive smoke test -- if this doesn't build, nothing will.
+
 out_test
 --------
 
-Test that a go_binary_ rule can write its executable file with a custom name
+Test that a `go_binary`_ rule can write its executable file with a custom name
 in the package directory (not the mode directory).

--- a/tests/core/go_binary/hello.go
+++ b/tests/core/go_binary/hello.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, world!")
+}

--- a/tests/integration/README.rst
+++ b/tests/integration/README.rst
@@ -15,6 +15,7 @@ Contents
 .. Child list start
 
 * `Popular repository tests <popular_repos/README.rst>`_
+* `Functionality related to @go_googleapis <googleapis/README.rst>`_
 
 .. Child list end
 


### PR DESCRIPTION
Also: add a "hello world" binary rule for really basic testing, and
update test readmes.

Fixes #1591