### PR TITLE
Misc fixes for Windows

### DIFF
--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -112,7 +112,7 @@ def env_execute(ctx, arguments, environment = {}, **kwargs):
     to "arguments" before calling "ctx.execute".
 
     Variables that aren't explicitly mentioned in "environment"
-    are removed from the environment. This should be preferred to "ctx.execut"e
+    are removed from the environment. This should be preferred to "ctx.execute"
     in most situations.
     """
     if ctx.os.name.startswith("windows"):
@@ -126,6 +126,18 @@ def env_execute(ctx, arguments, environment = {}, **kwargs):
         env_args.append("%s=%s" % (k, v))
     arguments = env_args + arguments
     return ctx.execute(arguments, **kwargs)
+
+def os_path(ctx, path):
+    path = str(path)  # maybe convert from path type
+    if ctx.os.name.startswith("windows"):
+        path = path.replace("/", "\\")
+    return path
+
+def executable_path(ctx, path):
+    path = os_path(ctx, path)
+    if ctx.os.name.startswith("windows"):
+        path += ".exe"
+    return path
 
 def executable_extension(ctx):
     extension = ""

--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -615,11 +615,16 @@ def go_binary_c_archive_shared(name, kwargs):
     c_hdrs = name + ".c_hdrs"
     cc_import_name = name + ".cc_import"
     cc_library_name = name + ".cc"
+    tags = kwargs.get("tags", ["manual"])
+    if "manual" not in tags:
+        # These archives can't be built on all platforms, so use "manual" tag.s
+        tags.append("manual")
     native.filegroup(
         name = cgo_exports,
         srcs = [name],
         output_group = "cgo_exports",
         visibility = ["//visibility:private"],
+        tags = tags,
     )
     native.genrule(
         name = c_hdrs,
@@ -627,6 +632,7 @@ def go_binary_c_archive_shared(name, kwargs):
         outs = ["%s.h" % name],
         cmd = "cat $(SRCS) > $(@)",
         visibility = ["//visibility:private"],
+        tags = tags,
     )
     cc_import_kwargs = {}
     if linkmode == LINKMODE_C_SHARED:
@@ -637,6 +643,7 @@ def go_binary_c_archive_shared(name, kwargs):
         name = cc_import_name,
         alwayslink = 1,
         visibility = ["//visibility:private"],
+        tags = tags,
         **cc_import_kwargs
     )
     native.cc_library(
@@ -648,4 +655,5 @@ def go_binary_c_archive_shared(name, kwargs):
         copts = _DEFAULT_PLATFORM_COPTS,
         linkopts = _DEFAULT_PLATFORM_COPTS,
         visibility = ["//visibility:public"],
+        tags = tags,
     )

--- a/go/tools/builders/filter_buildid.go
+++ b/go/tools/builders/filter_buildid.go
@@ -41,7 +41,7 @@ func main() {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
-			fmt.Println("error executing command %v: %v", newArgs[0], err)
+			fmt.Printf("error executing command %v: %v", newArgs[0], err)
 			os.Exit(1)
 		}
 	} else {

--- a/tests/core/c_linkmodes/BUILD.bazel
+++ b/tests/core/c_linkmodes/BUILD.bazel
@@ -1,31 +1,41 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 
-test_suite(
-    name = "c_archive",
-)
-
 go_binary(
     name = "adder_archive",
     srcs = ["add.go"],
     cgo = True,
-    linkmode = "c-archive"
+    linkmode = "c-archive",
+    tags = ["manual"],
 )
 
 cc_test(
     name = "c-archive_test",
-    srcs = ["add_test_archive.c"],
-    deps = [":adder_archive.cc"],
+    srcs = select({
+        "@io_bazel_rules_go//go/platform:windows": ["skip.c"],
+        "//conditions:default": ["add_test_archive.c"],
+    }),
+    deps = select({
+        "@io_bazel_rules_go//go/platform:windows": [],
+        "//conditions:default": [":adder_archive.cc"],
+    }),
 )
 
 go_binary(
     name = "adder_shared",
     srcs = ["add.go"],
     cgo = True,
-    linkmode = "c-shared"
+    linkmode = "c-shared",
+    tags = ["manual"],
 )
 
 cc_test(
     name = "c-shared_test",
-    srcs = ["add_test_shared.c"],
-    deps = [":adder_shared.cc"],
+    srcs = select({
+        "@io_bazel_rules_go//go/platform:windows": ["skip.c"],
+        "//conditions:default": ["add_test_shared.c"],
+    }),
+    deps = select({
+        "@io_bazel_rules_go//go/platform:windows": [],
+        "//conditions:default": [":adder_shared.cc"],
+    }),
 )

--- a/tests/core/c_linkmodes/skip.c
+++ b/tests/core/c_linkmodes/skip.c
@@ -1,0 +1,3 @@
+int main() {
+    return 0;
+}

--- a/tests/legacy/go_embed_data/BUILD.bazel
+++ b/tests/legacy/go_embed_data/BUILD.bazel
@@ -93,6 +93,6 @@ genrule(
     name = "embedded_zip",
     srcs = [":BUILD.bazel"],
     outs = ["embedded_zip.zip"],
-    cmd = "$(location @bazel_tools//tools/zip:zipper/zipper) c $@ from-zip/BUILD.bazel=$(location :BUILD.bazel)",
-    tools = ["@bazel_tools//tools/zip:zipper/zipper"],
+    cmd = "$(location @bazel_tools//tools/zip:zipper) c $@ from-zip/BUILD.bazel=$(location :BUILD.bazel)",
+    tools = ["@bazel_tools//tools/zip:zipper"],
 )


### PR DESCRIPTION
* Tag cgo c_archive and c_shared targets "manual". They won't build on
  Windows.
* Add common functions for converting file and executable paths to
  Windows friendly format.
* Fix a couple targets that wouldn't build.