### PR TITLE
Use add_all(), add_joined() instead of deprecated functionality of add()

### DIFF
--- a/extras/bindata.bzl
+++ b/extras/bindata.bzl
@@ -25,7 +25,7 @@ def _bindata_impl(ctx):
     go = go_context(ctx)
     out = go.declare_file(go, ext = ".go")
     arguments = ctx.actions.args()
-    arguments.add([
+    arguments.add_all([
         "-o",
         out.path,
         "-pkg",
@@ -40,10 +40,10 @@ def _bindata_impl(ctx):
     if not ctx.attr.memcopy:
         arguments.add("-nomemcopy")
     if not ctx.attr.modtime:
-        arguments.add(["-modtime", "0"])
+        arguments.add_all(["-modtime", "0"])
     if ctx.attr.extra_args:
-        arguments.add(ctx.attr.extra_args)
-    arguments.add(ctx.files.srcs)
+        arguments.add_all(ctx.attr.extra_args)
+    arguments.add_all(ctx.files.srcs)
     ctx.actions.run(
         inputs = ctx.files.srcs,
         outputs = [out],

--- a/extras/embed_data.bzl
+++ b/extras/embed_data.bzl
@@ -43,7 +43,7 @@ def _go_embed_data_impl(ctx):
             fail("%s: must provide package attribute for go_embed_data rules in the repository root directory" % ctx.label)
 
     out = go.declare_file(go, ext = ".go")
-    args.add([
+    args.add_all([
         "-workspace",
         ctx.workspace_name,
         "-label",
@@ -62,7 +62,7 @@ def _go_embed_data_impl(ctx):
     if ctx.attr.unpack:
         args.add("-unpack")
         args.add("-multi")
-    args.add(srcs)
+    args.add_all(srcs)
 
     library = go.new_library(go, srcs = srcs)
     source = go.library_to_source(go, ctx.attr, library, ctx.coverage_instrumented())

--- a/go/private/actions/asm.bzl
+++ b/go/private/actions/asm.bzl
@@ -36,14 +36,14 @@ def emit_asm(
     inputs = hdrs + go.sdk_tools + go.stdlib.files + [source]
 
     args = go.args(go)
-    args.add([source, "--"])
+    args.add_all([source, "--"])
     includes = ([go.stdlib.root_file.dirname + "/pkg/include"] +
                 [f.dirname for f in hdrs])
 
     # TODO(#1463): use uniquify=True when available.
     includes = sorted({i: None for i in includes}.keys())
-    args.add(includes, before_each = "-I")
-    args.add(["-trimpath", ".", "-o", out_obj])
+    args.add_all(includes, before_each = "-I")
+    args.add_all(["-trimpath", ".", "-o", out_obj])
     if go.mode.link in [LINKMODE_C_ARCHIVE, LINKMODE_C_SHARED]:
         args.add("-shared")
     if go.mode.link == LINKMODE_PLUGIN:

--- a/go/private/actions/compile.bzl
+++ b/go/private/actions/compile.bzl
@@ -23,14 +23,14 @@ load(
     "LINKMODE_PLUGIN",
 )
 
-def _importpath(l):
-    return [v.data.importpath for v in l]
+def _importpath(v):
+    return v.data.importpath
 
-def _searchpath(l):
-    return [v.data.searchpath for v in l]
+def _searchpath(v):
+    return v.data.searchpath
 
-def _importmap(l):
-    return ["{}={}".format(v.data.importpath, v.data.importmap) for v in l]
+def _importmap(v):
+    return "{}={}".format(v.data.importpath, v.data.importmap)
 
 def emit_compile(
         go,
@@ -59,25 +59,25 @@ def emit_compile(
     outputs = [out_lib]
 
     builder_args = go.args(go)
-    builder_args.add(sources, before_each = "-src")
-    builder_args.add(archives, before_each = "-dep", map_fn = _importpath)
-    builder_args.add(archives, before_each = "-importmap", map_fn = _importmap)
-    builder_args.add(["-o", out_lib])
-    builder_args.add(["-package_list", go.package_list])
+    builder_args.add_all(sources, before_each = "-src")
+    builder_args.add_all(archives, before_each = "-dep", map_each = _importpath)
+    builder_args.add_all(archives, before_each = "-importmap", map_each = _importmap)
+    builder_args.add_all(["-o", out_lib])
+    builder_args.add_all(["-package_list", go.package_list])
     if testfilter:
-        builder_args.add(["-testfilter", testfilter])
+        builder_args.add_all(["-testfilter", testfilter])
 
     tool_args = go.actions.args()
     if asmhdr:
-        tool_args.add(["-asmhdr", asmhdr.path])
+        tool_args.add_all(["-asmhdr", asmhdr.path])
         outputs.append(asmhdr)
-    tool_args.add(archives, before_each = "-I", map_fn = _searchpath)
-    tool_args.add(["-trimpath", ".", "-I", "."])
+    tool_args.add_all(archives, before_each = "-I", map_each = _searchpath)
+    tool_args.add_all(["-trimpath", ".", "-I", "."])
 
     #TODO: Check if we really need this expand make variables in here
     #TODO: If we really do then it needs to be moved all the way back out to the rule
     gc_goopts = [go._ctx.expand_make_variables("gc_goopts", f, {}) for f in gc_goopts]
-    tool_args.add(gc_goopts)
+    tool_args.add_all(gc_goopts)
     if go.mode.race:
         tool_args.add("-race")
     if go.mode.msan:
@@ -87,10 +87,10 @@ def emit_compile(
     if go.mode.link == LINKMODE_PLUGIN:
         tool_args.add("-dynlink")
     if importpath:
-        tool_args.add(["-p", importpath])
+        tool_args.add_all(["-p", importpath])
     if go.mode.debug:
-        tool_args.add(["-N", "-l"])
-    tool_args.add(go.toolchain.flags.compile)
+        tool_args.add_all(["-N", "-l"])
+    tool_args.add_all(go.toolchain.flags.compile)
     go.actions.run(
         inputs = inputs,
         outputs = outputs,

--- a/go/private/actions/pack.bzl
+++ b/go/private/actions/pack.bzl
@@ -28,10 +28,10 @@ def emit_pack(
     inputs = [in_lib] + go.sdk_tools + objects + archives
 
     args = go.args(go)
-    args.add(["-in", in_lib])
-    args.add(["-out", out_lib])
-    args.add(objects, before_each = "-obj")
-    args.add(archives, before_each = "-arc")
+    args.add_all(["-in", in_lib])
+    args.add_all(["-out", out_lib])
+    args.add_all(objects, before_each = "-obj")
+    args.add_all(archives, before_each = "-arc")
 
     go.actions.run(
         inputs = inputs,

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -79,9 +79,10 @@ def _declare_directory(go, path = "", ext = "", name = ""):
 
 def _new_args(go):
     args = go.actions.args()
-    args.add(["-sdk", go.sdk_root.dirname])
+    args.add_all(["-sdk", go.sdk_root.dirname])
     if go.tags:
-        args.add(["-tags", ",".join(go.tags)])
+        args.add("-tags")
+        args.add_joined(go.tags, join_with = ",")
     return args
 
 def _new_library(go, name = None, importpath = None, resolver = None, importable = True, testfilter = None, **kwargs):

--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -165,30 +165,30 @@ def _cgo_codegen_impl(ctx):
         transformed_go_outs.append(gen_go_file)
         transformed_go_map[gen_go_file] = src
         c_outs.append(gen_c_file)
-        builder_args.add(["-src", gen_go_file.path + "=" + src.path])
+        builder_args.add_all(["-src", gen_go_file.path + "=" + src.path])
     for src in source.asm:
         mangled_stem, src_ext = _mangle(src, stems)
         gen_file = go.declare_file(go, path = mangled_stem + ".cgo1." + src_ext)
         transformed_go_outs.append(gen_file)
         transformed_go_map[gen_go_file] = src
-        builder_args.add(["-src", gen_file.path + "=" + src.path])
+        builder_args.add_all(["-src", gen_file.path + "=" + src.path])
     for src in source.c:
         mangled_stem, src_ext = _mangle(src, stems)
         gen_file = go.declare_file(go, path = mangled_stem + ".cgo1." + src_ext)
         c_outs.append(gen_file)
-        builder_args.add(["-src", gen_file.path + "=" + src.path])
+        builder_args.add_all(["-src", gen_file.path + "=" + src.path])
     for src in source.cxx:
         mangled_stem, src_ext = _mangle(src, stems)
         gen_file = go.declare_file(go, path = mangled_stem + ".cgo1." + src_ext)
         cxx_outs.append(gen_file)
-        builder_args.add(["-src", gen_file.path + "=" + src.path])
+        builder_args.add_all(["-src", gen_file.path + "=" + src.path])
     for src in source.objc:
         mangled_stem, src_ext = _mangle(src, stems)
         gen_file = go.declare_file(go, path = mangled_stem + ".cgo1." + src_ext)
         objc_outs.append(gen_file)
-        builder_args.add(["-src", gen_file.path + "=" + src.path])
+        builder_args.add_all(["-src", gen_file.path + "=" + src.path])
 
-    tool_args.add(["-objdir", out_dir])
+    tool_args.add_all(["-objdir", out_dir])
 
     inputs = sets.union(ctx.files.srcs, go.crosstool, go.sdk_tools, go.stdlib.files)
     deps = depset()
@@ -245,7 +245,8 @@ def _cgo_codegen_impl(ctx):
     env["CC"] = go.cgo_tools.compiler_executable
     env["CGO_LDFLAGS"] = " ".join(linkopts)
 
-    cc_args.add(cppopts + copts)
+    cc_args.add_all(cppopts)
+    cc_args.add_all(copts)
 
     ctx.actions.run(
         inputs = inputs,
@@ -295,7 +296,7 @@ def _cgo_import_impl(ctx):
     go = go_context(ctx)
     out = go.declare_file(go, path = "_cgo_import.go")
     args = go.args(go)
-    args.add([
+    args.add_all([
         "-import",
         "-src",
         ctx.files.sample_go_srcs[0],

--- a/go/private/rules/info.bzl
+++ b/go/private/rules/info.bzl
@@ -25,7 +25,7 @@ def _go_info_impl(ctx):
     go = go_context(ctx)
     report = go.declare_file(go, "go_info_report")
     args = go.args(go)
-    args.add(["-out", report])
+    args.add_all(["-out", report])
     go.actions.run(
         inputs = go.stdlib.files,
         outputs = [report],

--- a/go/private/rules/stdlib.bzl
+++ b/go/private/rules/stdlib.bzl
@@ -38,14 +38,14 @@ def _stdlib_library_to_source(go, attr, source, merge):
     filter_buildid = attr._filter_buildid_builder.files.to_list()[0]
     files = [root_file, go.go, pkg]
     args = go.args(go)
-    args.add(["-out", root_file.dirname])
+    args.add_all(["-out", root_file.dirname])
     if go.mode.race:
         args.add("-race")
     if go.mode.link in [LINKMODE_C_ARCHIVE, LINKMODE_C_SHARED]:
         args.add("-shared")
     if go.mode.link == LINKMODE_PLUGIN:
         args.add("-dynlink")
-    args.add(["-filter_buildid", filter_buildid.path])
+    args.add_all(["-filter_buildid", filter_buildid.path])
     go.actions.write(root_file, "")
     env = go.env
     env.update({

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -94,10 +94,10 @@ def _go_test_impl(ctx):
 
     main_go = go.declare_file(go, "testmain.go")
     arguments = go.args(go)
-    arguments.add(["-rundir", run_dir, "-output", main_go])
+    arguments.add_all(["-rundir", run_dir, "-output", main_go])
     if ctx.configuration.coverage_enabled:
-        arguments.add(["-coverage"])
-    arguments.add([
+        arguments.add("-coverage")
+    arguments.add_all([
         # the l is the alias for the package under test, the l_test must be the
         # same with the test suffix
         "-import",
@@ -105,7 +105,7 @@ def _go_test_impl(ctx):
         "-import",
         "l_test=" + external_source.library.importpath,
     ])
-    arguments.add(go_srcs, before_each = "-src", format = "l=%s")
+    arguments.add_all(go_srcs, before_each = "-src", format_each = "l=%s")
     ctx.actions.run(
         inputs = go_srcs,
         outputs = [main_go],

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -37,7 +37,7 @@ def go_proto_compile(go, compiler, proto, imports, importpath):
         if outpath == None:
             outpath = out.dirname[:-len(importpath)]
     args = go.actions.args()
-    args.add([
+    args.add_all([
         "--protoc",
         compiler.protoc,
         "--importpath",
@@ -49,14 +49,13 @@ def go_proto_compile(go, compiler, proto, imports, importpath):
         "--compiler_path",
         go.cgo_tools.compiler_path,
     ])
-    options = compiler.options
+    args.add_all(compiler.options, before_each = "--option")
     if compiler.import_path_option:
-        options = options + ["import_path={}".format(importpath)]
-    args.add(options, before_each = "--option")
-    args.add(proto.transitive_descriptor_sets, before_each = "--descriptor_set")
-    args.add(go_srcs, before_each = "--expected")
-    args.add(imports, before_each = "--import")
-    args.add(proto.direct_sources, map_fn = _all_proto_paths)
+        args.add_all([importpath], before_each = "--option", format_each = "import_path=%s")
+    args.add_all(proto.transitive_descriptor_sets, before_each = "--descriptor_set")
+    args.add_all(go_srcs, before_each = "--expected")
+    args.add_all(imports, before_each = "--import")
+    args.add_all(proto.direct_sources, map_each = proto_path)
     go.actions.run(
         inputs = sets.union([
             compiler.go_protoc,
@@ -70,9 +69,6 @@ def go_proto_compile(go, compiler, proto, imports, importpath):
         arguments = [args],
     )
     return go_srcs
-
-def _all_proto_paths(protos):
-    return [proto_path(proto) for proto in protos]
 
 def proto_path(proto):
     """

--- a/tests/bazel_tests.bzl
+++ b/tests/bazel_tests.bzl
@@ -274,8 +274,8 @@ def _md5_sum_impl(ctx):
     go = go_context(ctx)
     out = go.declare_file(go, ext = ".md5")
     arguments = ctx.actions.args()
-    arguments.add(["-output", out.path])
-    arguments.add(ctx.files.srcs)
+    arguments.add_all(["-output", out.path])
+    arguments.add_all(ctx.files.srcs)
     ctx.actions.run(
         inputs = ctx.files.srcs,
         outputs = [out],


### PR DESCRIPTION
Some of the parameters of `args.add()` are deprecated - see https://docs.bazel.build/versions/master/skylark/lib/Args.html#add. This PR changes their usage to non-deprecated analogs.

This passes `bazel test //...` on my machine, I haven't done any additional changes.

This is my first rules_go PR, let me know if something is not right.