### PR TITLE
Speed up downloading of @go_googleapis by using http_archive.

### DIFF
--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -143,10 +143,12 @@ def go_rules_dependencies():
         # importpath = "google.golang.org/genproto",
     )
     _maybe(
-        git_repository,
+        http_archive,
         name = "go_googleapis",
-        remote = "https://github.com/googleapis/googleapis",
-        commit = "6a3277c0656219174ff7c345f31fb20a90b30b97",  # master as of 2018-07-01
+        # master as of 2018-07-01
+        urls = ["https://codeload.github.com/googleapis/googleapis/zip/6a3277c0656219174ff7c345f31fb20a90b30b97"],
+        strip_prefix = "googleapis-6a3277c0656219174ff7c345f31fb20a90b30b97",
+        type = "zip",
         overlay = manifest["go_googleapis"],
     )
 


### PR DESCRIPTION
The googleapis repository seems to be of such a size that it takes a
long time to clone on a link with lower bandwidth. So long, in fact,
that it causes timeouts in my case.