### PR TITLE
Change crosstool dependency to @bazel_tools//tools/cpp:current_cc_too…

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -337,7 +337,7 @@ go_context_data = rule(
     attrs = {
         "strip": attr.string(mandatory = True),
         # Hidden internal attributes
-        "_crosstool": attr.label(default = Label("//tools/defaults:crosstool")),
+        "_crosstool": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
         "_package_list": attr.label(
             allow_files = True,
             single_file = True,


### PR DESCRIPTION
…lchain

//tools/defaults is a special case which is being removed in Bazel.