### PR TITLE
Wire sdk toolchain

### DIFF
--- a/go/def.bzl
+++ b/go/def.bzl
@@ -23,6 +23,7 @@ load(
     _GoLibrary = "GoLibrary",
     _GoPath = "GoPath",
     _GoSource = "GoSource",
+    _GoSDK = "GoSDK",
 )
 load(
     "@io_bazel_rules_go//go/private:repositories.bzl",
@@ -34,6 +35,10 @@ load(
     "go_download_sdk",
     "go_host_sdk",
     "go_local_sdk",
+)
+load(
+    "@io_bazel_rules_go//go/private:rules/sdk.bzl",
+    "go_sdk",
 )
 load(
     "@io_bazel_rules_go//go/private:go_toolchain.bzl",
@@ -88,6 +93,9 @@ GoArchive = _GoArchive
 
 GoArchiveData = _GoArchiveData
 """See go/providers.rst#GoArchiveData for full documentation."""
+
+GoSDK = _GoSDK
+"""See go/providers.rst#GoSDK for full documentation."""
 
 go_library = _go_library_macro
 """See go/core.rst#go_library for full documentation."""

--- a/go/private/BUILD.sdk.bazel
+++ b/go/private/BUILD.sdk.bazel
@@ -1,4 +1,58 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_sdk")
+load("@io_bazel_rules_go//go/toolchain:toolchains.bzl", "declare_toolchains")
+load("@io_bazel_rules_go//go/private:rules/sdk.bzl", "package_list")
+
 package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "libs",
+    srcs = glob(
+        ["pkg/{goos}_{goarch}/**/*.a"],
+        exclude = ["pkg/{goos}_{goarch}/**/cmd/**"],
+    ),
+)
+
+filegroup(
+    name = "headers",
+    srcs = glob(["pkg/include/*.h"]),
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["src/**"]),
+)
+
+filegroup(
+    name = "tools",
+    srcs = glob(["pkg/tool/**"]),
+)
+
+go_sdk(
+    name = "go_sdk",
+    goos = "{goos}",
+    goarch = "{goarch}",
+    root_file = "ROOT",
+    package_list = ":package_list",
+    libs = [":libs"],
+    headers = [":headers"],
+    srcs = [":srcs"],
+    tools = [":tools"],
+    go = "bin/go{exe}",
+)
+
+# TODO(jayconrod): Gazelle depends on this file directly. This dependency
+# should be broken, and this rule should be folded into go_sdk.
+package_list(
+    name = "package_list",
+    srcs = [":srcs"],
+    root_file = "ROOT",
+    out = "packages.txt",
+)
+
+declare_toolchains(
+    host = "{goos}_{goarch}",
+    sdk = ":go_sdk",
+)
 
 filegroup(
     name = "files",
@@ -8,16 +62,3 @@ filegroup(
         "pkg/**",
     ]),
 )
-
-filegroup(
-    name = "tools",
-    srcs = glob([
-        "bin/go*",
-        "pkg/tool/**",
-    ]) + select({
-        "@io_bazel_rules_go//go/platform:darwin_amd64": ["@local_config_cc//:cc_wrapper"],
-        "//conditions:default": [],
-    }),
-)
-
-exports_files(["packages.txt", "ROOT"])

--- a/go/private/actions/asm.bzl
+++ b/go/private/actions/asm.bzl
@@ -33,11 +33,11 @@ def emit_asm(
         fail("source is a required parameter")
 
     out_obj = go.declare_file(go, path = source.basename[:-2], ext = ".o")
-    inputs = hdrs + go.sdk_tools + go.stdlib.files + [source]
+    inputs = hdrs + go.sdk.tools + go.sdk.headers + go.stdlib.libs + [source]
 
     args = go.args(go)
     args.add_all([source, "--"])
-    includes = ([go.stdlib.root_file.dirname + "/pkg/include"] +
+    includes = ([go.sdk.root_file.dirname + "/pkg/include"] +
                 [f.dirname for f in hdrs])
 
     # TODO(#1463): use uniquify=True when available.

--- a/go/private/actions/compile.bzl
+++ b/go/private/actions/compile.bzl
@@ -55,7 +55,7 @@ def emit_compile(
 
     inputs = (sources + [go.package_list] +
               [archive.data.file for archive in archives] +
-              go.sdk_tools + go.stdlib.files)
+              go.sdk.tools + go.stdlib.libs)
     outputs = [out_lib]
 
     builder_args = go.args(go)
@@ -105,7 +105,7 @@ def _bootstrap_compile(go, sources, out_lib, gc_goopts):
     args.extend(gc_goopts)
     args.extend([s.path for s in sources])
     go.actions.run_shell(
-        inputs = sources + go.sdk_files + go.sdk_tools,
+        inputs = sources + go.sdk.libs + go.sdk.tools + [go.go],
         outputs = [out_lib],
         mnemonic = "GoCompile",
         command = "export GOROOT=$(pwd)/{} && export GOROOT_FINAL=GOROOT && {} {}".format(go.root, go.go.path, " ".join(args)),

--- a/go/private/actions/cover.bzl
+++ b/go/private/actions/cover.bzl
@@ -56,7 +56,7 @@ def emit_cover(go, source):
             "-mode=set",
         ])
         go.actions.run(
-            inputs = [src] + go.sdk_tools,
+            inputs = [src] + go.sdk.tools,
             outputs = [out],
             mnemonic = "GoCover",
             executable = go.builders.cover,

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -141,8 +141,8 @@ def emit_link(
             archive.cgo_deps,
             go.crosstool,
             stamp_inputs,
-            go.sdk_tools,
-            go.stdlib.files,
+            go.sdk.tools,
+            go.stdlib.libs,
         ),
         outputs = [executable],
         mnemonic = "GoLink",
@@ -154,7 +154,7 @@ def emit_link(
 def _bootstrap_link(go, archive, executable, gc_linkopts):
     """See go/toolchains.rst#link for full documentation."""
 
-    inputs = [archive.data.file] + go.sdk_files + go.sdk_tools
+    inputs = [archive.data.file] + go.sdk.libs + go.sdk.tools + [go.go]
     args = ["tool", "link", "-s", "-o", executable.path]
     args.extend(gc_linkopts)
     args.append(archive.data.file.path)

--- a/go/private/actions/pack.bzl
+++ b/go/private/actions/pack.bzl
@@ -25,7 +25,7 @@ def emit_pack(
     if out_lib == None:
         fail("out_lib is a required parameter")
 
-    inputs = [in_lib] + go.sdk_tools + objects + archives
+    inputs = [in_lib] + go.sdk.tools + objects + archives
 
     args = go.args(go)
     args.add_all(["-in", in_lib])

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -79,7 +79,7 @@ def _declare_directory(go, path = "", ext = "", name = ""):
 
 def _new_args(go):
     args = go.actions.args()
-    args.add_all(["-sdk", go.sdk_root.dirname])
+    args.add_all(["-sdk", go.sdk.root_file.dirname])
     if go.tags:
         args.add("-tags")
         args.add_joined(go.tags, join_with = ",")
@@ -192,20 +192,6 @@ def _infer_importpath(ctx):
         importpath = importpath[1:]
     return importpath, importpath, INFERRED_PATH
 
-def _get_go_binary(context_data):
-    for f in context_data.sdk_tools:
-        parent = paths.dirname(f.path)
-        sdk = paths.dirname(parent)
-        parent = paths.basename(parent)
-        if parent != "bin":
-            continue
-        basename = paths.basename(f.path)
-        name, ext = paths.split_extension(basename)
-        if name != "go":
-            continue
-        return f
-    fail("Could not find go executable in go_sdk")
-
 def go_context(ctx, attr = None):
     toolchain = ctx.toolchains["@io_bazel_rules_go//go:toolchain"]
 
@@ -230,14 +216,14 @@ def go_context(ctx, attr = None):
         tags.append("race")
     if mode.msan:
         tags.append("msan")
-    binary = _get_go_binary(context_data)
+    binary = toolchain.sdk.go
 
     stdlib = getattr(attr, "_stdlib", None)
     if stdlib:
         stdlib = get_source(stdlib).stdlib
         goroot = stdlib.root_file.dirname
     else:
-        goroot = context_data.sdk_root.dirname
+        goroot = toolchain.sdk.root_file.dirname
 
     env = dict(context_data.env)
     env.update({
@@ -249,22 +235,31 @@ def go_context(ctx, attr = None):
         "PATH": context_data.cgo_tools.compiler_path,
     })
 
+    # TODO(jayconrod): remove this. It's way too broad. Everything should
+    # depend on more specific lists.
+    sdk_files = ([toolchain.sdk.go] +
+                 toolchain.sdk.srcs +
+                 toolchain.sdk.headers +
+                 toolchain.sdk.libs +
+                 toolchain.sdk.tools)
+
     importpath, importmap, pathtype = _infer_importpath(ctx)
     return GoContext(
         # Fields
         toolchain = toolchain,
+        sdk = toolchain.sdk,
         mode = mode,
         root = goroot,
         go = binary,
         stdlib = stdlib,
-        sdk_root = context_data.sdk_root,
-        sdk_files = context_data.sdk_files,
-        sdk_tools = context_data.sdk_tools,
+        sdk_root = toolchain.sdk.root_file,
+        sdk_files = sdk_files,
+        sdk_tools = toolchain.sdk.tools,
         actions = ctx.actions,
         exe_extension = goos_to_extension(mode.goos),
         shared_extension = goos_to_shared_extension(mode.goos),
         crosstool = context_data.crosstool,
-        package_list = context_data.package_list,
+        package_list = toolchain.sdk.package_list,
         importpath = importpath,
         importmap = importmap,
         pathtype = pathtype,
@@ -316,10 +311,6 @@ def _go_context_data(ctx):
     return struct(
         strip = ctx.attr.strip,
         crosstool = ctx.files._crosstool,
-        package_list = ctx.file._package_list,
-        sdk_root = ctx.file._sdk_root,
-        sdk_files = ctx.files._sdk_files,
-        sdk_tools = ctx.files._sdk_tools,
         tags = tags,
         env = env,
         cgo_tools = struct(
@@ -337,26 +328,7 @@ go_context_data = rule(
     _go_context_data,
     attrs = {
         "strip": attr.string(mandatory = True),
-        # Hidden internal attributes
         "_crosstool": attr.label(default = Label("//tools/defaults:crosstool")),
-        "_package_list": attr.label(
-            allow_files = True,
-            single_file = True,
-            default = "@go_sdk//:packages.txt",
-        ),
-        "_sdk_root": attr.label(
-            allow_single_file = True,
-            default = "@go_sdk//:ROOT",
-        ),
-        "_sdk_files": attr.label(
-            allow_files = True,
-            default = "@go_sdk//:files",
-        ),
-        "_sdk_tools": attr.label(
-            allow_files = True,
-            cfg = "host",
-            default = "@go_sdk//:tools",
-        ),
         "_xcode_config": attr.label(
             default = Label("@bazel_tools//tools/osx:current_xcode_config"),
         ),

--- a/go/private/providers.bzl
+++ b/go/private/providers.bzl
@@ -48,6 +48,27 @@ GoAspectProviders = provider()
 
 GoPath = provider()
 
+GoSDK = provider(
+    doc = "Contains information about the Go SDK used in the toolchain",
+    fields = {
+        "goos": "The host OS the SDK was built for.",
+        "goarch": "The host architecture the SDK was built for.",
+        "root_file": "A file in the SDK root directory",
+        "libs": ("List of pre-compiled .a files for the standard library " +
+                 "built for the execution platform."),
+        "headers": ("List of .h files from pkg/include that may be included " +
+                    "in assembly sources."),
+        "srcs": ("List of source files for importable packages in the " +
+                 "standard library. Internal, vendored, and tool packages " +
+                 "may not be included."),
+        "package_list": ("A file containing a list of importable packages " +
+                         "in the standard library."),
+        "tools": ("List of executable files from pkg/tool " +
+                  "built for the execution platform."),
+        "go": "The go binary file",
+    },
+)
+
 GoStdLib = provider()
 
 GoBuilders = provider()

--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -190,7 +190,7 @@ def _cgo_codegen_impl(ctx):
 
     tool_args.add_all(["-objdir", out_dir])
 
-    inputs = sets.union(ctx.files.srcs, go.crosstool, go.sdk_tools, go.stdlib.files)
+    inputs = sets.union(ctx.files.srcs, go.crosstool, go.sdk.tools, go.stdlib.libs)
     deps = depset()
     runfiles = ctx.runfiles(collect_data = True)
     for d in ctx.attr.deps:
@@ -310,7 +310,7 @@ def _cgo_import_impl(ctx):
         inputs = [
             ctx.file.cgo_o,
             ctx.files.sample_go_srcs[0],
-        ] + go.sdk_tools,
+        ] + go.sdk.tools,
         outputs = [out],
         executable = go.builders.cgo,
         arguments = [args],

--- a/go/private/rules/info.bzl
+++ b/go/private/rules/info.bzl
@@ -27,7 +27,7 @@ def _go_info_impl(ctx):
     args = go.args(go)
     args.add_all(["-out", report])
     go.actions.run(
-        inputs = go.stdlib.files,
+        inputs = [go.go],
         outputs = [report],
         mnemonic = "GoInfo",
         executable = ctx.executable._go_info,

--- a/go/private/rules/sdk.bzl
+++ b/go/private/rules/sdk.bzl
@@ -1,0 +1,124 @@
+# Copyright 2014 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load(
+    "@io_bazel_rules_go//go/private:providers.bzl",
+    "GoSDK",
+)
+
+def _go_sdk_impl(ctx):
+    return [GoSDK(
+        goos = ctx.attr.goos,
+        goarch = ctx.attr.goarch,
+        root_file = ctx.file.root_file,
+        package_list = ctx.file.package_list,
+        libs = ctx.files.libs,
+        headers = ctx.files.headers,
+        srcs = ctx.files.srcs,
+        tools = ctx.files.tools,
+        go = ctx.file.go,
+    )]
+
+go_sdk = rule(
+    _go_sdk_impl,
+    attrs = {
+        "goos": attr.string(
+            mandatory = True,
+            doc = "The host OS the SDK was built for",
+        ),
+        "goarch": attr.string(
+            mandatory = True,
+            doc = "The host architecture the SDK was built for",
+        ),
+        "root_file": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+            doc = "A file in the SDK root directory. Used to determine GOROOT.",
+        ),
+        "package_list": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+            doc = ("A text file containing a list of packages in the " +
+                   "standard library that may be imported."),
+        ),
+        "libs": attr.label_list(
+            allow_files = [".a"],
+            doc = ("Pre-compiled .a files for the standard library, " +
+                   "built for the execution platform"),
+        ),
+        "headers": attr.label_list(
+            allow_files = [".h"],
+            doc = (".h files from pkg/include that may be included in " +
+                   "assembly sources"),
+        ),
+        "srcs": attr.label_list(
+            allow_files = True,
+            doc = "Source files for packages in the standard library",
+        ),
+        "tools": attr.label_list(
+            allow_files = True,
+            cfg = "host",
+            doc = ("List of executable files from pkg/tool " +
+                   "built for the execution platform"),
+        ),
+        "go": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+            executable = True,
+            cfg = "host",
+            doc = "The go binary",
+        ),
+    },
+    doc = ("Collects information about a Go SDK. The SDK must have a normal " +
+           "GOROOT directory structure."),
+    provides = [GoSDK],
+)
+
+def _package_list_impl(ctx):
+    packages = {}
+    src_dir = ctx.file.root_file.dirname + "/src/"
+    for src in ctx.files.srcs:
+        pkg_src_dir = src.dirname
+        if not pkg_src_dir.startswith(src_dir):
+            continue
+        pkg_name = pkg_src_dir[len(src_dir):]
+        if any([prefix in pkg_name for prefix in ("vendor/", "cmd/")]):
+            continue
+        packages[pkg_name] = None
+    content = "\n".join(sorted(packages.keys())) + "\n"
+    ctx.actions.write(ctx.outputs.out, content)
+    return [DefaultInfo(files = depset([ctx.outputs.out]))]
+
+package_list = rule(
+    _package_list_impl,
+    attrs = {
+        "srcs": attr.label_list(
+            allow_files = True,
+            doc = "Source files for packages in the standard library",
+        ),
+        "root_file": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+            doc = "A file in the SDK root directory. Used to determine GOROOT.",
+        ),
+        "out": attr.output(
+            mandatory = True,
+            doc = "File to write. Must be 'packages.txt'.",
+            # Gazelle depends on this file directly. It has to be an output
+            # attribute because Bazel has no other way of knowing what rule
+            # produces this file.
+            # TODO(jayconrod): Update Gazelle and simplify this.
+        ),
+    },
+)

--- a/go/private/tools/vet.bzl
+++ b/go/private/tools/vet.bzl
@@ -37,6 +37,8 @@ Please do not rely on it for production use, but feel free to use it and file is
         files = ctx.files.data + go.stdlib.libs + go.sdk.tools + [go.go],
         collect_data = True,
     )
+    root_file = go.stdlib.root_file.short_path
+    goroot, _, _ = root_file.rpartition("/")
     gopath = []
     packages = []
     for data in ctx.attr.data:
@@ -45,10 +47,12 @@ Please do not rely on it for production use, but feel free to use it and file is
         packages += [entry.gopath + "/" + package.dir for package in entry.packages]
     ctx.actions.write(output = script_file, is_executable = True, content = """
 export GOPATH="{gopath}"
+export GOROOT="$(pwd)/{goroot}"
 {go} tool vet {packages}
 """.format(
         go = go.go.short_path,
-        gopath = ":".join(["$(pwd)/{})".format(entry) for entry in gopath]),
+        goroot = goroot,
+        gopath = ":".join(["$(pwd)/{}".format(entry) for entry in gopath]),
         packages = " ".join(packages),
     ))
     return [DefaultInfo(

--- a/go/private/tools/vet.bzl
+++ b/go/private/tools/vet.bzl
@@ -33,7 +33,10 @@ Please do not rely on it for production use, but feel free to use it and file is
     go = go_context(ctx)
     script_file = go.declare_file(go, ext = ".bash")
     gopath = []
-    files = ctx.files.data + go.stdlib.files
+    runfiles = ctx.runfiles(
+        files = ctx.files.data + go.stdlib.libs + go.sdk.tools + [go.go],
+        collect_data = True,
+    )
     gopath = []
     packages = []
     for data in ctx.attr.data:
@@ -48,10 +51,10 @@ export GOPATH="{gopath}"
         gopath = ":".join(["$(pwd)/{})".format(entry) for entry in gopath]),
         packages = " ".join(packages),
     ))
-    return struct(
+    return [DefaultInfo(
         files = depset([script_file]),
-        runfiles = ctx.runfiles(files, collect_data = True),
-    )
+        runfiles = runfiles,
+    )]
 
 _go_vet_generate = go_rule(
     _go_vet_generate_impl,

--- a/go/toolchain/BUILD.bazel
+++ b/go/toolchain/BUILD.bazel
@@ -1,11 +1,8 @@
 load(
     ":toolchains.bzl",
     "declare_constraints",
-    "declare_toolchains",
 )
 
 package(default_visibility = ["//visibility:public"])
-
-declare_toolchains()
 
 declare_constraints()

--- a/tests/core/stdlib/stdlib_files.bzl
+++ b/tests/core/stdlib/stdlib_files.bzl
@@ -12,19 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@io_bazel_rules_go//go:def.bzl", "go_context", "go_rule")
 load("@io_bazel_rules_go//go/private:providers.bzl", "GoSource")
 
 def _stdlib_files_impl(ctx):
-    files = ctx.attr._stdlib[GoSource].stdlib.files
-    runfiles = ctx.runfiles(files = files)
+    go = go_context(ctx)
+    libs = go.stdlib.libs
+    runfiles = ctx.runfiles(files = libs + go.sdk.tools)
     return [DefaultInfo(
-        files = depset(files),
+        files = depset(libs),
         runfiles = runfiles,
     )]
 
-stdlib_files = rule(
+stdlib_files = go_rule(
     _stdlib_files_impl,
     attrs = {
-        "_stdlib": attr.label(default = "@io_bazel_rules_go//:stdlib"),
+        "pure": attr.string(default = "on"),  # force recompilation
+        "static": attr.string(default = "off"),
+        "msan": attr.string(default = "off"),
+        "race": attr.string(default = "off"),
     },
 )

--- a/tests/legacy/custom_go_toolchain/BUILD.bazel
+++ b/tests/legacy/custom_go_toolchain/BUILD.bazel
@@ -10,11 +10,6 @@ go_test(
 
 bazel_test(
     name = "custom_go_toolchain",
-    build = """
-load("@io_bazel_rules_go//go:def.bzl", "go_toolchain")
-go_toolchain(name="my_linux_toolchain", target="linux_amd64")
-go_toolchain(name="my_darwin_toolchain", target="darwin_amd64")
-""",
     command = "test",
     config = "fetch",
     go_version = "",
@@ -31,10 +26,6 @@ go_download_sdk(
         "linux_amd64":       ("go1.10.1.linux-amd64.tar.gz", "72d820dec546752e5a8303b33b009079c15c2390ce76d67cf514991646c6127b"),
         "darwin_amd64":      ("go1.10.1.darwin-amd64.tar.gz", "0a5bbcbbb0d150338ba346151d2864fd326873beaedf964e2057008c8a4dc557"),
     },
-)
-register_toolchains(
-    "@//:my_linux_toolchain",
-    "@//:my_darwin_toolchain",
 )
 
 go_rules_dependencies()


### PR DESCRIPTION
* go_toolchain has a new mandatory attribute, "sdk", which be
  something that provides GoSDK.
* go_host_sdk, go_local_sdk, and go_download_sdk are now macros that
  wrap the old rules. Each rule declares toolchains in its BUILD.bazel
  file that work on the host architecture. The macro calls
  register_toolchains with these.
* go_register_toolchains no longer calls register_toolchains, but it
  will an SDK rule if "go_sdk" isn't defined. This is a step toward
  allowing multiple SDKs to support multiple execution platforms.
* Action inputs are narrowed to use go.sdk.tools and go.stdlib.libs
  rather than larger sets of files.