### PR TITLE
Add go_wrap_sdk rule

### DIFF
--- a/go/def.bzl
+++ b/go/def.bzl
@@ -22,8 +22,8 @@ load(
     _GoArchiveData = "GoArchiveData",
     _GoLibrary = "GoLibrary",
     _GoPath = "GoPath",
-    _GoSource = "GoSource",
     _GoSDK = "GoSDK",
+    _GoSource = "GoSource",
 )
 load(
     "@io_bazel_rules_go//go/private:repositories.bzl",
@@ -35,6 +35,7 @@ load(
     "go_download_sdk",
     "go_host_sdk",
     "go_local_sdk",
+    "go_wrap_sdk",
 )
 load(
     "@io_bazel_rules_go//go/private:rules/sdk.bzl",

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -76,6 +76,26 @@ def go_local_sdk(name, **kwargs):
     _go_local_sdk(name = name, **kwargs)
     _register_toolchains(name)
 
+def _go_wrap_sdk_impl(ctx):
+    host = _detect_host_platform(ctx)
+    path = str(ctx.path(ctx.attr.root_file).dirname)
+    _sdk_build_file(ctx, host)
+    _local_sdk(ctx, path)
+
+_go_wrap_sdk = repository_rule(
+    _go_wrap_sdk_impl,
+    attrs = {
+        "root_file": attr.label(
+            mandatory = True,
+            doc = "A file in the SDK root direcotry. Used to determine GOROOT.",
+        ),
+    },
+)
+
+def go_wrap_sdk(name, **kwargs):
+    _go_wrap_sdk(name = name, **kwargs)
+    _register_toolchains(name)
+
 def _register_toolchains(repo):
     labels = ["@{}//:{}".format(repo, name)
               for name in generate_toolchain_names()]


### PR DESCRIPTION
go_wrap_sdk allows you to configure a Go SDK that was downloaded or
located with another repository rule.

Related #1611