### PR TITLE
Make go_sdk's package_list optional

### DIFF
--- a/go/toolchains.rst
+++ b/go/toolchains.rst
@@ -379,10 +379,10 @@ usually won't need to declare this rule explicitly.
 +--------------------------------+-----------------------------+-----------------------------------+
 | A file in the SDK root directory. Used to determine GOROOT.                                      |
 +--------------------------------+-----------------------------+-----------------------------------+
-| :param:`package_list`          | :type:`label`               | |mandatory|                       |
+| :param:`package_list`          | :type:`label`               | :value:`None`                     |
 +--------------------------------+-----------------------------+-----------------------------------+
 | A text file containing a list of packages in the standard library that may                       |
-| be imported.                                                                                     |
+| be imported. If unspecified, this will be generated from ``srcs``.                               |
 +--------------------------------+-----------------------------+-----------------------------------+
 | :param:`libs`                  | :type:`label_list`          | :value:`[]`                       |
 +--------------------------------+-----------------------------+-----------------------------------+


### PR DESCRIPTION
This will eventually be removed when old versions of Gazelle are no
longer supported and nothing depends on the file by name.

If not provided as an input, go_sdk will generate the file itself.