### PR TITLE
Propagate mode aspect on "_coverdata" edges

### DIFF
--- a/go/private/rules/aspect.bzl
+++ b/go/private/rules/aspect.bzl
@@ -73,6 +73,7 @@ go_archive_aspect = aspect(
         "compiler",
         "compilers",
         "_stdlib",
+        "_coverdata",
     ],
     attrs = {
         "pure": attr.string(values = [

--- a/go/private/rules/rule.bzl
+++ b/go/private/rules/rule.bzl
@@ -18,6 +18,9 @@ load(
 )
 
 _ASPECT_ATTRS = ["pure", "static", "msan", "race"]
+
+# Keep in sync with attr_aspects in go_archive_aspect. Any implicit dependency
+# that is built in the target configuration should go there.
 _BOOTSTRAP_ATTRS = ["_builders", "_coverdata", "_stdlib"]
 
 def go_rule(implementation, attrs = {}, toolchains = [], bootstrap = False, bootstrap_attrs = _BOOTSTRAP_ATTRS, **kwargs):

--- a/tests/core/coverage/BUILD.bazel
+++ b/tests/core/coverage/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//tests:bazel_tests.bzl", "bazel_test")
 
 bazel_test(
     name = "coverage_test_test",
+    args = ["--instrumentation_filter=-coverage:b"],
     check = """
 if ! grep -q '^coverage: 50.0% of statements' "bazel-testlogs/$RULES_GO_OUTPUT/coverage_test/test.log"; then
   echo "error: no coverage output found in test log file" >&2
@@ -48,7 +49,6 @@ for i in "${excluded_files[@]}"; do
 done
     """,
     command = "coverage",
-    args = ["--instrumentation_filter=-coverage:b"],
     targets = [":coverage_test"],
 )
 
@@ -62,19 +62,38 @@ go_test(
 go_library(
     name = "a",
     srcs = ["a.go"],
-    deps = [":b"],
     importpath = "github.com/bazelbuild/rules_go/tests/core/coverage/a",
+    deps = [":b"],
 )
 
 go_library(
     name = "b",
     srcs = ["b.go"],
-    deps = [":c"],
     importpath = "github.com/bazelbuild/rules_go/tests/core/coverage/b",
+    deps = [":c"],
 )
 
 go_library(
     name = "c",
     srcs = ["c.go"],
     importpath = "github.com/bazelbuild/rules_go/tests/core/coverage/c",
+)
+
+bazel_test(
+    name = "cross_cover_test_test",
+    args = [
+        "--collect_code_coverage",
+        "--instrumentation_filter=-coverage:b",
+    ],
+    command = "build",
+    targets = [":cross_cover_test"],
+)
+
+go_test(
+    name = "cross_cover_test",
+    srcs = ["coverage_test.go"],
+    embed = [":a"],
+    goarch = "386",
+    goos = "linux",
+    tags = ["manual"],
 )

--- a/tests/core/coverage/README.rst
+++ b/tests/core/coverage/README.rst
@@ -8,3 +8,9 @@ Checks that ``bazel coverage`` on a ``go_test`` produces reasonable output.
 Libraries referenced by the test that pass ``--instrumentation_filter`` should
 have coverage data. Library excluded with ``--instrumentatiuon_filter`` should
 not have coverage data.
+
+coverdata_aspect_test_test
+--------------------------
+
+Checks that the ``coverdata`` library is compiled in the same mode as the
+test that depends on it.


### PR DESCRIPTION
This ensures the coverdata library is built in the same mode as the
binary that depends on it.

Fixes #1630