### PR TITLE
Update genproto dependencies

### DIFF
--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -155,9 +155,9 @@ def go_rules_dependencies():
     _maybe(
         http_archive,
         name = "go_googleapis",
-        # master as of 2018-07-01
-        urls = ["https://codeload.github.com/googleapis/googleapis/zip/f47204e81e5aee2c1dfc7cc5ea729aa2fbaa7603"],
-        strip_prefix = "googleapis-f47204e81e5aee2c1dfc7cc5ea729aa2fbaa7603",
+        # master as of 2018-08-08
+        urls = ["https://codeload.github.com/googleapis/googleapis/zip/3e68e19410baa7d78cdacc45b034eafe7467b439"],
+        strip_prefix = "googleapis-3e68e19410baa7d78cdacc45b034eafe7467b439",
         type = "zip",
         overlay = manifest["go_googleapis"],
     )

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -147,7 +147,7 @@ def go_rules_dependencies():
         git_repository,
         name = "org_golang_google_genproto",
         remote = "https://github.com/google/go-genproto",
-        commit = "daca94659cb50e9f37c1b834680f2e46358f10b0",  # master as of 2018-08-06
+        commit = "383e8b2c3b9e36c4076b235b32537292176bae20",  # master as of 2018-08-13
         overlay = manifest["org_golang_google_genproto"],
         # build_file_proto_mode = "disable_global",
         # importpath = "google.golang.org/genproto",

--- a/third_party/go_googleapis/google/firestore/admin/v1beta2/BUILD.bazel.in
+++ b/third_party/go_googleapis/google/firestore/admin/v1beta2/BUILD.bazel.in
@@ -3,13 +3,17 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "admin_proto",
     srcs = [
-        "datastore_admin.proto",
+        "field.proto",
+        "firestore_admin.proto",
         "index.proto",
+        "operation.proto",
     ],
     visibility = ["//visibility:public"],
     deps = [
         "//google/api:annotations_proto",
         "//google/longrunning:longrunning_proto",
+        "@com_google_protobuf//:empty_proto",
+        "@com_google_protobuf//:field_mask_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
 )
@@ -17,7 +21,7 @@ proto_library(
 go_proto_library(
     name = "admin_go_proto",
     compilers = ["@io_bazel_rules_go//proto:go_grpc"],
-    importpath = "google.golang.org/genproto/googleapis/datastore/admin/v1",
+    importpath = "google.golang.org/genproto/googleapis/firestore/admin/v1beta2",
     proto = ":admin_proto",
     visibility = ["//visibility:public"],
     deps = [

--- a/third_party/manifest.bzl
+++ b/third_party/manifest.bzl
@@ -339,6 +339,7 @@ manifest = {
         "@io_bazel_rules_go//third_party:go_googleapis/google/devtools/sourcerepo/v1/BUILD.bazel.in": "google/devtools/sourcerepo/v1/BUILD.bazel",
         "@io_bazel_rules_go//third_party:go_googleapis/google/example/library/v1/BUILD.bazel.in": "google/example/library/v1/BUILD.bazel",
         "@io_bazel_rules_go//third_party:go_googleapis/google/firestore/admin/v1beta1/BUILD.bazel.in": "google/firestore/admin/v1beta1/BUILD.bazel",
+        "@io_bazel_rules_go//third_party:go_googleapis/google/firestore/admin/v1beta2/BUILD.bazel.in": "google/firestore/admin/v1beta2/BUILD.bazel",
         "@io_bazel_rules_go//third_party:go_googleapis/google/firestore/v1beta1/BUILD.bazel.in": "google/firestore/v1beta1/BUILD.bazel",
         "@io_bazel_rules_go//third_party:go_googleapis/google/genomics/v1/BUILD.bazel.in": "google/genomics/v1/BUILD.bazel",
         "@io_bazel_rules_go//third_party:go_googleapis/google/genomics/v1alpha2/BUILD.bazel.in": "google/genomics/v1alpha2/BUILD.bazel",


### PR DESCRIPTION
* `org_golang_google_genproto` to master as of 2018-08-13
* `go_googleapis` to master as of 2018-08-13

Fixes #1656 