### PR TITLE
Remove 'cfg = "data"' from all attributes

### DIFF
--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -46,10 +46,7 @@ load(
 
 _SHARED_ATTRS = {
     "basename": attr.string(),
-    "data": attr.label_list(
-        allow_files = True,
-        cfg = "data",
-    ),
+    "data": attr.label_list(allow_files = True),
     "srcs": attr.label_list(allow_files = go_exts + asm_exts),
     "gc_goopts": attr.string_list(),
     "gc_linkopts": attr.string_list(),

--- a/go/private/rules/library.bzl
+++ b/go/private/rules/library.bzl
@@ -50,10 +50,7 @@ def _go_library_impl(ctx):
 go_library = go_rule(
     _go_library_impl,
     attrs = {
-        "data": attr.label_list(
-            allow_files = True,
-            cfg = "data",
-        ),
+        "data": attr.label_list(allow_files = True),
         "srcs": attr.label_list(allow_files = True),
         "deps": attr.label_list(providers = [GoLibrary]),
         "importpath": attr.string(),
@@ -72,10 +69,7 @@ go_tool_library = go_rule(
         "_stdlib",
     ],
     attrs = {
-        "data": attr.label_list(
-            allow_files = True,
-            cfg = "data",
-        ),
+        "data": attr.label_list(allow_files = True),
         "srcs": attr.label_list(allow_files = True),
         "deps": attr.label_list(providers = [GoLibrary]),
         "importpath": attr.string(),

--- a/go/private/rules/source.bzl
+++ b/go/private/rules/source.bzl
@@ -41,10 +41,7 @@ def _go_source_impl(ctx):
 go_source = go_rule(
     _go_source_impl,
     attrs = {
-        "data": attr.label_list(
-            allow_files = True,
-            cfg = "data",
-        ),
+        "data": attr.label_list(allow_files = True),
         "srcs": attr.label_list(allow_files = True),
         "deps": attr.label_list(providers = [GoLibrary]),
         "embed": attr.label_list(providers = [GoLibrary]),

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -170,10 +170,7 @@ def _go_test_impl(ctx):
 go_test = go_rule(
     _go_test_impl,
     attrs = {
-        "data": attr.label_list(
-            allow_files = True,
-            cfg = "data",
-        ),
+        "data": attr.label_list(allow_files = True),
         "srcs": attr.label_list(allow_files = go_exts + asm_exts),
         "deps": attr.label_list(
             providers = [GoLibrary],

--- a/go/private/tools/path.bzl
+++ b/go/private/tools/path.bzl
@@ -53,7 +53,7 @@ def _go_path_impl(ctx):
             if importpath == "":
                 continue  # synthetic archive or inferred location
             pkg = struct(
-            importpath = importpath,
+                importpath = importpath,
                 dir = "src/" + pkgpath,
                 srcs = as_list(archive.orig_srcs),
                 data = as_list(archive.data_files),
@@ -130,9 +130,12 @@ def _go_path_impl(ctx):
         out_file = tag
     args = ctx.actions.args()
     args.add_all([
-        "-manifest", manifest_file,
-        "-out", out_path,
-        "-mode", ctx.attr.mode,
+        "-manifest",
+        manifest_file,
+        "-out",
+        out_path,
+        "-mode",
+        ctx.attr.mode,
     ])
     ctx.actions.run(
         outputs = outputs,
@@ -158,10 +161,7 @@ go_path = rule(
     _go_path_impl,
     attrs = {
         "deps": attr.label_list(providers = [GoArchive]),
-        "data": attr.label_list(
-            allow_files = True,
-            cfg = "data",
-        ),
+        "data": attr.label_list(allow_files = True),
         "mode": attr.string(
             default = "copy",
             values = [

--- a/go/private/tools/vet.bzl
+++ b/go/private/tools/vet.bzl
@@ -63,10 +63,7 @@ export GOROOT="$(pwd)/{goroot}"
 _go_vet_generate = go_rule(
     _go_vet_generate_impl,
     attrs = {
-        "data": attr.label_list(
-            providers = [GoPath],
-            cfg = "data",
-        ),
+        "data": attr.label_list(providers = [GoPath]),
     },
 )
 


### PR DESCRIPTION
The "data" configuration has been deprecated for a while and has no
effect.