### PR TITLE
Force absolute paths in builders

### DIFF
--- a/go/tools/builders/compile.go
+++ b/go/tools/builders/compile.go
@@ -186,6 +186,7 @@ func buildImportcfgFile(archives []archive, stdImports []string, installSuffix, 
 	if !ok {
 		return "", errors.New("GOROOT not set")
 	}
+	goroot = abs(goroot)
 	for _, imp := range stdImports {
 		path := filepath.Join(goroot, "pkg", installSuffix, filepath.FromSlash(imp))
 		fmt.Fprintf(buf, "packagefile %s=%s.a\n", imp, path)

--- a/go/tools/builders/link.go
+++ b/go/tools/builders/link.go
@@ -143,7 +143,7 @@ func buildImportcfgFile(archives []archive, packageList, installSuffix, dir stri
 	if !ok {
 		return "", errors.New("GOROOT not set")
 	}
-	prefix := filepath.Join(goroot, "pkg", installSuffix)
+	prefix := abs(filepath.Join(goroot, "pkg", installSuffix))
 	packageListFile, err := os.Open(packageList)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
This is a follow-up to https://github.com/bazelbuild/rules_go/pull/1647. `GOROOT` is still injected as relative path, which is considered bad practice anyway elsewhere [1]. This patch converts the importmap paths to absolute paths even if `GOROOT` is relative. (Will this break anything on any platform? E. g. OSX?)

[1] https://github.com/golang/go/issues/26917#issuecomment-412814805