### PR TITLE
Disable GOCACHE and only enable -shared/-dynlink on selected platforms

### DIFF
--- a/go/private/actions/asm.bzl
+++ b/go/private/actions/asm.bzl
@@ -18,9 +18,7 @@ load(
 )
 load(
     "@io_bazel_rules_go//go/private:mode.bzl",
-    "LINKMODE_C_ARCHIVE",
-    "LINKMODE_C_SHARED",
-    "LINKMODE_PLUGIN",
+    "link_mode_args",
 )
 
 def emit_asm(
@@ -44,10 +42,7 @@ def emit_asm(
     includes = sorted({i: None for i in includes}.keys())
     args.add_all(includes, before_each = "-I")
     args.add_all(["-trimpath", ".", "-o", out_obj])
-    if go.mode.link in [LINKMODE_C_ARCHIVE, LINKMODE_C_SHARED]:
-        args.add("-shared")
-    if go.mode.link == LINKMODE_PLUGIN:
-        args.add("-dynlink")
+    args.add_all(link_mode_args(go.mode))
     go.actions.run(
         inputs = inputs,
         outputs = [out_obj],

--- a/go/private/actions/compile.bzl
+++ b/go/private/actions/compile.bzl
@@ -14,9 +14,7 @@
 
 load(
     "@io_bazel_rules_go//go/private:mode.bzl",
-    "LINKMODE_C_ARCHIVE",
-    "LINKMODE_C_SHARED",
-    "LINKMODE_PLUGIN",
+    "link_mode_args",
 )
 load(
     "@io_bazel_rules_go//go/private:skylib/lib/shell.bzl",
@@ -74,10 +72,7 @@ def emit_compile(
         tool_args.add("-race")
     if go.mode.msan:
         tool_args.add("-msan")
-    if go.mode.link in [LINKMODE_C_ARCHIVE, LINKMODE_C_SHARED]:
-        tool_args.add("-shared")
-    if go.mode.link == LINKMODE_PLUGIN:
-        tool_args.add("-dynlink")
+    tool_args.add_all(link_mode_args(go.mode))
     if importpath:
         tool_args.add_all(["-p", importpath])
     if go.mode.debug:

--- a/go/private/mode.bzl
+++ b/go/private/mode.bzl
@@ -150,3 +150,61 @@ def mode_tags_equivalent(l, r):
             l.goarch == r.goarch and
             l.race == r.race and
             l.msan == r.msan)
+
+# Ported from https://github.com/golang/go/blob/master/src/cmd/go/internal/work/init.go#L76
+_LINK_C_ARCHIVE_PLATFORMS = {
+    "darwin/arm": None,
+    "darwin/arm64": None,
+}
+
+_LINK_C_ARCHIVE_GOOS = {
+    "dragonfly": None,
+    "freebsd": None,
+    "linux": None,
+    "netbsd": None,
+    "openbsd": None,
+    "solaris": None,
+}
+
+_LINK_C_SHARED_PLATFORMS = {
+    "linux/amd64": None,
+    "linux/arm": None,
+    "linux/arm64": None,
+    "linux/386": None,
+    "linux/ppc64le": None,
+    "linux/s390x": None,
+    "android/amd64": None,
+    "android/arm": None,
+    "android/arm64": None,
+    "android/386": None,
+}
+
+_LINK_PLUGIN_PLATFORMS = {
+    "linux/amd64": None,
+    "linux/arm": None,
+    "linux/arm64": None,
+    "linux/386": None,
+    "linux/s390x": None,
+    "linux/ppc64le": None,
+    "android/amd64": None,
+    "android/arm": None,
+    "android/arm64": None,
+    "android/386": None,
+    "darwin/amd64": None,
+}
+
+def link_mode_args(mode):
+    platform = mode.goos + "/" + mode.goarch
+    args = []
+    if mode.link == LINKMODE_C_ARCHIVE:
+        if platform in _LINK_C_ARCHIVE_PLATFORMS or mode.goos in _LINK_C_ARCHIVE_GOOS:
+            if platform == "linux/ppc64":
+                return
+            args.append("-shared")
+    elif mode.link == LINKMODE_C_SHARED:
+        if platform in _LINK_C_SHARED_PLATFORMS:
+            args.append("-shared")
+    elif mode.link == LINKMODE_PLUGIN:
+        if platform in _LINK_PLUGIN_PLATFORMS:
+            args.append("-dynlink")
+    return args

--- a/go/private/mode.bzl
+++ b/go/private/mode.bzl
@@ -194,12 +194,12 @@ _LINK_PLUGIN_PLATFORMS = {
 }
 
 def link_mode_args(mode):
+    # based on buildModeInit in cmd/go/internal/work/init.go
     platform = mode.goos + "/" + mode.goarch
     args = []
     if mode.link == LINKMODE_C_ARCHIVE:
-        if platform in _LINK_C_ARCHIVE_PLATFORMS or mode.goos in _LINK_C_ARCHIVE_GOOS:
-            if platform == "linux/ppc64":
-                return
+        if (platform in _LINK_C_ARCHIVE_PLATFORMS or
+            mode.goos in _LINK_C_ARCHIVE_GOOS and platform != "linux/ppc64"):
             args.append("-shared")
     elif mode.link == LINKMODE_C_SHARED:
         if platform in _LINK_C_SHARED_PLATFORMS:

--- a/go/private/rules/stdlib.bzl
+++ b/go/private/rules/stdlib.bzl
@@ -26,10 +26,8 @@ load(
 )
 load(
     "@io_bazel_rules_go//go/private:mode.bzl",
-    "LINKMODE_C_ARCHIVE",
-    "LINKMODE_C_SHARED",
+    "link_mode_args",
     "LINKMODE_NORMAL",
-    "LINKMODE_PLUGIN",
 )
 
 def _stdlib_library_to_source(go, attr, source, merge):
@@ -61,10 +59,7 @@ def _build_stdlib(go, attr):
     args.add_all(["-out", root_file.dirname])
     if go.mode.race:
         args.add("-race")
-    if go.mode.link in [LINKMODE_C_ARCHIVE, LINKMODE_C_SHARED]:
-        args.add("-shared")
-    if go.mode.link == LINKMODE_PLUGIN:
-        args.add("-dynlink")
+    args.add_all(link_mode_args(go.mode))
     args.add_all(["-filter_buildid", filter_buildid])
     go.actions.write(root_file, "")
     env = go.env


### PR DESCRIPTION
Go 1.11 has its own build cache, which is enabled by default. Disable it because it doesn't make sense with bazel. See https://golang.org/cmd/go/#hdr-Build_and_test_caching

Also, only enable `-shared`/`-dynlink` on selected platforms, mimicking what `go build` does.