### PR TITLE
Disable //tests/core/go_path:go_path_test

### DIFF
--- a/tests/core/go_path/BUILD.bazel
+++ b/tests/core/go_path/BUILD.bazel
@@ -43,4 +43,5 @@ go_test(
         ":nodata_path",
     ],
     rundir = ".",
+    tags = ["manual"],
 )


### PR DESCRIPTION
This is failing for Bazel at master.

Related #1699