### PR TITLE
Re-enable go_path_test and document copy behavior

### DIFF
--- a/go/core.rst
+++ b/go/core.rst
@@ -813,6 +813,11 @@ Attributes
 |   are copied into the tree.                                                                      |
 | * ``"link"``: Source files are symlinked into the tree. All of the symlink                       |
 |   files are provided as separate output files.                                                   |
+|                                                                                                  |
+| **NOTE:** In ``"copy"`` mode, when a ``GoPath`` is consumed as a set of input                    |
+| files or run files, Bazel may provide symbolic links instead of regular files.                   |
+| Any program that consumes these files should dereference links, e.g., if you                     |
+| run ``tar``, use the ``--dereference`` flag.                                                     |
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`include_data`      | :type:`bool`                | :value:`True`                         |
 +----------------------------+-----------------------------+---------------------------------------+

--- a/tests/core/go_path/BUILD.bazel
+++ b/tests/core/go_path/BUILD.bazel
@@ -43,5 +43,4 @@ go_test(
         ":nodata_path",
     ],
     rundir = ".",
-    tags = ["manual"],
 )


### PR DESCRIPTION
go_path_test no longer checks whether files are symbolic links or
regular files. Bazel may provide either.

This is now noted in the documentation for go_path.

We will keep both modes for now to avoid breaking anyone depending on
the API. There is a difference in behavior with file / tree artifacts.

Fixes #1699