### PR TITLE
Allow bazel version to be empty if bazel is built from source

### DIFF
--- a/go/private/skylib/lib/versions.bzl
+++ b/go/private/skylib/lib/versions.bzl
@@ -53,7 +53,7 @@ def _parse_bazel_version(bazel_version):
   """
 
   version = _extract_version_number(bazel_version)
-  return tuple([int(n) for n in version.split(".")])
+  return tuple([int(n or "0") for n in version.split(".")])
 
 
 def _is_at_most(threshold, version):
@@ -64,8 +64,12 @@ def _is_at_most(threshold, version):
     version: the version string to be compared to the threshold
 
   Returns:
-    True if version <= threshold.
+    True if version <= threshold, or if version is falsy.
   """
+
+  if not version:
+      return True    
+    
   return _parse_bazel_version(version) <= _parse_bazel_version(threshold)
 
 
@@ -77,8 +81,11 @@ def _is_at_least(threshold, version):
     version: the version string to be compared to the threshold
 
   Returns:
-    True if version >= threshold.
+    True if version >= threshold, or if version is falsy.
   """
+    
+  if not version:
+      return True
 
   return _parse_bazel_version(version) >= _parse_bazel_version(threshold)
 


### PR DESCRIPTION
Follow-up to https://github.com/bazelbuild/rules_go/pull/1703. Sorry @jayconrod, I tested this slightly better this time.