### PR TITLE
Don't check bazel version on development builds

### DIFF
--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -24,7 +24,8 @@ load("@io_bazel_rules_go//third_party:manifest.bzl", "manifest")
 
 def go_rules_dependencies():
     """See /go/workspace.rst#go-rules-dependencies for full documentation."""
-    versions.check(MINIMUM_BAZEL_VERSION)
+    if getattr(native, "bazel_version", None):
+        versions.check(MINIMUM_BAZEL_VERSION, bazel_version = native.bazel_version)
 
     # Was needed by Gazelle in the past. Will likely be needed for go/packages
     # and analysis in the future.

--- a/go/private/skylib/lib/versions.bzl
+++ b/go/private/skylib/lib/versions.bzl
@@ -94,6 +94,10 @@ def _check_bazel_version(minimum_bazel_version, maximum_bazel_version=None, baze
   if not bazel_version:
     if "bazel_version" not in dir(native):
       fail("\nCurrent Bazel version is lower than 0.2.1, expected at least %s\n" % minimum_bazel_version)
+    elif not native.bazel_version:
+      print("\nCurrent Bazel is not a release version, cannot check for compatibility.")
+      print("Make sure that you are running at least Bazel %s.\n" % minimum_bazel_version)
+      return
     else:
       bazel_version = native.bazel_version
 


### PR DESCRIPTION
Reverted #1703. This should not have modified the vendored versions.bzl.

We now just avoid calling `versions.check` if no version is defined.

Related #1711.
