### PR TITLE
Add more explicit dependencies for bazel_test

### DIFF
--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -156,3 +156,10 @@ go_tool_binary(
     ],
     visibility = ["//visibility:public"],
 )
+
+filegroup(
+    name = "all_builder_srcs",
+    testonly = True,
+    srcs = glob(["*.go"]),
+    visibility = ["//:__subpackages__"],
+)

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -1,6 +1,6 @@
 load("//proto:compiler.bzl", "go_proto_compiler")
 load("//proto:gogo.bzl", "gogo_special_proto")
-load("//proto/wkt:well_known_types.bzl", "WELL_KNOWN_TYPE_RULES", "GOGO_WELL_KNOWN_TYPE_REMAPS")
+load("//proto/wkt:well_known_types.bzl", "GOGO_WELL_KNOWN_TYPE_REMAPS", "WELL_KNOWN_TYPE_RULES")
 
 go_proto_compiler(
     name = "go_proto_bootstrap",
@@ -78,3 +78,10 @@ GOGO_VARIANTS = [
         "@org_golang_x_net//context:go_default_library",
     ] + WELL_KNOWN_TYPE_RULES.values(),
 ) for variant in GOGO_VARIANTS]
+
+filegroup(
+    name = "all_rules",
+    testonly = True,
+    srcs = glob(["*.bzl"]) + ["//proto/wkt:all_rules"],
+    visibility = ["//:__subpackages__"],
+)

--- a/proto/wkt/BUILD.bazel
+++ b/proto/wkt/BUILD.bazel
@@ -1,3 +1,10 @@
 load("//proto/wkt:well_known_types.bzl", "gen_well_known_types")
 
 gen_well_known_types()
+
+filegroup(
+    name = "all_rules",
+    testonly = True,
+    srcs = glob(["*.bzl"]),
+    visibility = ["//:__subpackages__"],
+)

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -2,7 +2,12 @@ load(":bazel_tests.bzl", "md5_sum")
 
 md5_sum(
     name = "all_rules_md5",
-    srcs = ["//go:all_rules"],
+    testonly = True,
+    srcs = [
+        "//go:all_rules",
+        "//go/tools/builders:all_builder_srcs",
+        "//proto:all_rules",
+    ],
     visibility = ["//visibility:private"],
 )
 
@@ -11,6 +16,7 @@ md5_sum(
 # If we wrap it in a filegroup first however it just works.
 filegroup(
     name = "rules_go_deps",
+    testonly = True,
     srcs = [":all_rules_md5"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
//tests:all_rules_md5 now includes .bzl files in //proto, //proto/wkt,
and .go files in //go/tools/builders.

all_rules_md5 is an implicit data dependency of bazel_test
rules. These tests verify the rules_go implementation in an alternate
workspace, so their dependencies on .bzl files in the current
workspace is implicit. When all_rules_md5 changes, it forces them to
run again.