### PR TITLE
Warn against depending on / embedding executables

### DIFF
--- a/go/private/providers.bzl
+++ b/go/private/providers.bzl
@@ -79,12 +79,6 @@ INFERRED_PATH = "inferred"
 
 EXPORT_PATH = "export"
 
-def new_aspect_provider(source = None, archive = None):
-    return GoAspectProviders(
-        source = source,
-        archive = archive,
-    )
-
 def get_source(dep):
     if type(dep) == "struct":
         return dep

--- a/go/private/rules/aspect.bzl
+++ b/go/private/rules/aspect.bzl
@@ -31,9 +31,9 @@ load(
     "@io_bazel_rules_go//go/private:providers.bzl",
     "GoArchive",
     "GoArchiveData",
+    "GoAspectProviders",
     "GoLibrary",
     "GoSource",
-    "new_aspect_provider",
 )
 load(
     "@io_bazel_rules_go//go/platform:list.bzl",
@@ -43,14 +43,12 @@ load(
 
 def _go_archive_aspect_impl(target, ctx):
     go = go_context(ctx, ctx.rule.attr)
+
     source = target[GoSource] if GoSource in target else None
     archive = target[GoArchive] if GoArchive in target else None
     if source and source.mode == go.mode:
         # The base layer already built the right mode for us
-        return [new_aspect_provider(
-            source = source,
-            archive = archive,
-        )]
+        return []
     if not GoLibrary in target:
         # Not a rule we can do anything with
         return []
@@ -60,7 +58,7 @@ def _go_archive_aspect_impl(target, ctx):
     source = go.library_to_source(go, ctx.rule.attr, library, ctx.coverage_instrumented())
     if archive:
         archive = go.archive(go, source = source)
-    return [new_aspect_provider(
+    return [GoAspectProviders(
         source = source,
         archive = archive,
     )]


### PR DESCRIPTION
go_binary and go_test apply an aspect for cross-compilation. If they
depend on other go_bianry and go_test targets, GoAspectProviders may
be emitted multiple times, which causes Bazel to report a very opaque
message. With this change, we warn about this situation before the
aspect runs.

Also: stop attaching GoAspectProviders in the default configuration.

Fixes #1733