### PR TITLE
Update and fix go_googleapis and org_golang_google_genproto

### DIFF
--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -129,7 +129,7 @@ def go_rules_dependencies():
         git_repository,
         name = "org_golang_google_genproto",
         remote = "https://github.com/google/go-genproto",
-        commit = "0e822944c569bf5c9afd034adaa56208bd2906ac",  # master as of 2018-09-28
+        commit = "c7e5094acea1ca1b899e2259d80a6b0f882f81f8",  # master as of 2018-09-28
         patches = ["//third_party:org_golang_google_genproto-gazelle.patch"],
         patch_args = ["-p1"],
         # gazelle args: -go_prefix google.golang.org/genproto -proto disable_global
@@ -137,13 +137,14 @@ def go_rules_dependencies():
     _maybe(
         http_archive,
         name = "go_googleapis",
-        # master as of 2018-08-08
-        urls = ["https://codeload.github.com/googleapis/googleapis/zip/071efb9af05d831205787108e163235db6b763e4"],
-        strip_prefix = "googleapis-071efb9af05d831205787108e163235db6b763e4",
+        # master as of 2018-09-28
+        urls = ["https://codeload.github.com/googleapis/googleapis/zip/b71d0c74de0b84f2f10a2c61cd66fbb48873709f"],
+        strip_prefix = "googleapis-b71d0c74de0b84f2f10a2c61cd66fbb48873709f",
         type = "zip",
         patches = [
             "//third_party:go_googleapis-directives.patch",
             "//third_party:go_googleapis-gazelle.patch",
+            "//third_party:go_googleapis-fix.patch",
         ],
         patch_args = ["-p1"],
     )

--- a/third_party/go_googleapis-fix.patch
+++ b/third_party/go_googleapis-fix.patch
@@ -1,0 +1,72 @@
+diff -urN c/google/api/BUILD.bazel d/google/api/BUILD.bazel
+--- c/google/api/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
++++ d/google/api/BUILD.bazel	2018-10-01 11:17:12.582705780 -0400
+@@ -12,8 +12,13 @@
+ 
+ proto_library(
+     name = "api_proto",
+-    srcs = ["launch_stage.proto"],
++    srcs = [
++        "experimental/authorization_config.proto",
++        "experimental/experimental.proto",
++        "launch_stage.proto",
++    ],
+     visibility = ["//visibility:public"],
++    deps = [":annotations_proto"],
+ )
+ 
+ proto_library(
+@@ -90,10 +95,10 @@
+     visibility = ["//visibility:public"],
+     deps = [
+         ":annotations_proto",
++        ":api_proto",
+         ":label_proto",
+         ":metric_proto",
+         ":monitoredres_proto",
+-        "//google/api/experimental:api_proto",
+         "@com_google_protobuf//:any_proto",
+         "@com_google_protobuf//:api_proto",
+         "@com_google_protobuf//:type_proto",
+@@ -113,6 +118,7 @@
+     importpath = "google.golang.org/genproto/googleapis/api",
+     proto = ":api_proto",
+     visibility = ["//visibility:public"],
++    deps = [":annotations_go_proto"],
+ )
+ 
+ go_proto_library(
+@@ -171,9 +177,9 @@
+     visibility = ["//visibility:public"],
+     deps = [
+         ":annotations_go_proto",
++        ":api_go_proto",
+         ":label_go_proto",
+         ":metric_go_proto",
+         ":monitoredres_go_proto",
+-        "//google/api/experimental:api_go_proto",
+     ],
+ )
+diff -urN c/google/api/experimental/BUILD.bazel d/google/api/experimental/BUILD.bazel
+--- c/google/api/experimental/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
++++ d/google/api/experimental/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
+@@ -1,19 +0,0 @@
+-load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+-
+-proto_library(
+-    name = "api_proto",
+-    srcs = [
+-        "authorization_config.proto",
+-        "experimental.proto",
+-    ],
+-    visibility = ["//visibility:public"],
+-    deps = ["//google/api:annotations_proto"],
+-)
+-
+-go_proto_library(
+-    name = "api_go_proto",
+-    importpath = "google.golang.org/genproto/googleapis/api",
+-    proto = ":api_proto",
+-    visibility = ["//visibility:public"],
+-    deps = ["//google/api:annotations_go_proto"],
+-)

--- a/third_party/go_googleapis-gazelle.patch
+++ b/third_party/go_googleapis-gazelle.patch
@@ -1,7 +1,6 @@
-Binary files b/.git/index and c/.git/index differ
 diff -urN b/google/ads/googleads/v0/common/BUILD.bazel c/google/ads/googleads/v0/common/BUILD.bazel
 --- b/google/ads/googleads/v0/common/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/ads/googleads/v0/common/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/ads/googleads/v0/common/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -32,7 +31,7 @@ diff -urN b/google/ads/googleads/v0/common/BUILD.bazel c/google/ads/googleads/v0
 +)
 diff -urN b/google/ads/googleads/v0/enums/BUILD.bazel c/google/ads/googleads/v0/enums/BUILD.bazel
 --- b/google/ads/googleads/v0/enums/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/ads/googleads/v0/enums/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/ads/googleads/v0/enums/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,43 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -79,7 +78,7 @@ diff -urN b/google/ads/googleads/v0/enums/BUILD.bazel c/google/ads/googleads/v0/
 +)
 diff -urN b/google/ads/googleads/v0/errors/BUILD.bazel c/google/ads/googleads/v0/errors/BUILD.bazel
 --- b/google/ads/googleads/v0/errors/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/ads/googleads/v0/errors/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/ads/googleads/v0/errors/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,72 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -155,7 +154,7 @@ diff -urN b/google/ads/googleads/v0/errors/BUILD.bazel c/google/ads/googleads/v0
 +)
 diff -urN b/google/ads/googleads/v0/resources/BUILD.bazel c/google/ads/googleads/v0/resources/BUILD.bazel
 --- b/google/ads/googleads/v0/resources/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/ads/googleads/v0/resources/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/ads/googleads/v0/resources/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,37 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -196,7 +195,7 @@ diff -urN b/google/ads/googleads/v0/resources/BUILD.bazel c/google/ads/googleads
 +)
 diff -urN b/google/ads/googleads/v0/services/BUILD.bazel c/google/ads/googleads/v0/services/BUILD.bazel
 --- b/google/ads/googleads/v0/services/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/ads/googleads/v0/services/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/ads/googleads/v0/services/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,46 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -246,7 +245,7 @@ diff -urN b/google/ads/googleads/v0/services/BUILD.bazel c/google/ads/googleads/
 +)
 diff -urN b/google/api/BUILD.bazel c/google/api/BUILD.bazel
 --- b/google/api/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/api/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/api/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,179 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -429,7 +428,7 @@ diff -urN b/google/api/BUILD.bazel c/google/api/BUILD.bazel
 +)
 diff -urN b/google/api/experimental/BUILD.bazel c/google/api/experimental/BUILD.bazel
 --- b/google/api/experimental/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/api/experimental/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/api/experimental/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -452,7 +451,7 @@ diff -urN b/google/api/experimental/BUILD.bazel c/google/api/experimental/BUILD.
 +)
 diff -urN b/google/api/expr/v1alpha1/BUILD.bazel c/google/api/expr/v1alpha1/BUILD.bazel
 --- b/google/api/expr/v1alpha1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/api/expr/v1alpha1/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/api/expr/v1alpha1/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -487,7 +486,7 @@ diff -urN b/google/api/expr/v1alpha1/BUILD.bazel c/google/api/expr/v1alpha1/BUIL
 +)
 diff -urN b/google/api/expr/v1beta1/BUILD.bazel c/google/api/expr/v1beta1/BUILD.bazel
 --- b/google/api/expr/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/api/expr/v1beta1/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/api/expr/v1beta1/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -517,7 +516,7 @@ diff -urN b/google/api/expr/v1beta1/BUILD.bazel c/google/api/expr/v1beta1/BUILD.
 +)
 diff -urN b/google/api/servicecontrol/v1/BUILD.bazel c/google/api/servicecontrol/v1/BUILD.bazel
 --- b/google/api/servicecontrol/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/api/servicecontrol/v1/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/api/servicecontrol/v1/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -559,7 +558,7 @@ diff -urN b/google/api/servicecontrol/v1/BUILD.bazel c/google/api/servicecontrol
 +)
 diff -urN b/google/api/servicemanagement/v1/BUILD.bazel c/google/api/servicemanagement/v1/BUILD.bazel
 --- b/google/api/servicemanagement/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/api/servicemanagement/v1/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/api/servicemanagement/v1/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -601,7 +600,7 @@ diff -urN b/google/api/servicemanagement/v1/BUILD.bazel c/google/api/servicemana
 +)
 diff -urN b/google/appengine/legacy/BUILD.bazel c/google/appengine/legacy/BUILD.bazel
 --- b/google/appengine/legacy/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/appengine/legacy/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/appengine/legacy/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -619,7 +618,7 @@ diff -urN b/google/appengine/legacy/BUILD.bazel c/google/appengine/legacy/BUILD.
 +)
 diff -urN b/google/appengine/logging/v1/BUILD.bazel c/google/appengine/logging/v1/BUILD.bazel
 --- b/google/appengine/logging/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/appengine/logging/v1/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/appengine/logging/v1/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -643,7 +642,7 @@ diff -urN b/google/appengine/logging/v1/BUILD.bazel c/google/appengine/logging/v
 +)
 diff -urN b/google/appengine/v1/BUILD.bazel c/google/appengine/v1/BUILD.bazel
 --- b/google/appengine/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/appengine/v1/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/appengine/v1/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,42 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -689,7 +688,7 @@ diff -urN b/google/appengine/v1/BUILD.bazel c/google/appengine/v1/BUILD.bazel
 +)
 diff -urN b/google/assistant/embedded/v1alpha1/BUILD.bazel c/google/assistant/embedded/v1alpha1/BUILD.bazel
 --- b/google/assistant/embedded/v1alpha1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/assistant/embedded/v1alpha1/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/assistant/embedded/v1alpha1/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -716,7 +715,7 @@ diff -urN b/google/assistant/embedded/v1alpha1/BUILD.bazel c/google/assistant/em
 +)
 diff -urN b/google/assistant/embedded/v1alpha2/BUILD.bazel c/google/assistant/embedded/v1alpha2/BUILD.bazel
 --- b/google/assistant/embedded/v1alpha2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/assistant/embedded/v1alpha2/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/assistant/embedded/v1alpha2/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -743,7 +742,7 @@ diff -urN b/google/assistant/embedded/v1alpha2/BUILD.bazel c/google/assistant/em
 +)
 diff -urN b/google/bigtable/admin/cluster/v1/BUILD.bazel c/google/bigtable/admin/cluster/v1/BUILD.bazel
 --- b/google/bigtable/admin/cluster/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/bigtable/admin/cluster/v1/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/bigtable/admin/cluster/v1/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,29 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -776,7 +775,7 @@ diff -urN b/google/bigtable/admin/cluster/v1/BUILD.bazel c/google/bigtable/admin
 +)
 diff -urN b/google/bigtable/admin/table/v1/BUILD.bazel c/google/bigtable/admin/table/v1/BUILD.bazel
 --- b/google/bigtable/admin/table/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/bigtable/admin/table/v1/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/bigtable/admin/table/v1/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,29 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -809,7 +808,7 @@ diff -urN b/google/bigtable/admin/table/v1/BUILD.bazel c/google/bigtable/admin/t
 +)
 diff -urN b/google/bigtable/admin/v2/BUILD.bazel c/google/bigtable/admin/v2/BUILD.bazel
 --- b/google/bigtable/admin/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/bigtable/admin/v2/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/bigtable/admin/v2/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -848,7 +847,7 @@ diff -urN b/google/bigtable/admin/v2/BUILD.bazel c/google/bigtable/admin/v2/BUIL
 +)
 diff -urN b/google/bigtable/v1/BUILD.bazel c/google/bigtable/v1/BUILD.bazel
 --- b/google/bigtable/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/bigtable/v1/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/bigtable/v1/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -880,7 +879,7 @@ diff -urN b/google/bigtable/v1/BUILD.bazel c/google/bigtable/v1/BUILD.bazel
 +)
 diff -urN b/google/bigtable/v2/BUILD.bazel c/google/bigtable/v2/BUILD.bazel
 --- b/google/bigtable/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/bigtable/v2/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/bigtable/v2/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -911,7 +910,7 @@ diff -urN b/google/bigtable/v2/BUILD.bazel c/google/bigtable/v2/BUILD.bazel
 +)
 diff -urN b/google/bytestream/BUILD.bazel c/google/bytestream/BUILD.bazel
 --- b/google/bytestream/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/bytestream/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/bytestream/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -935,7 +934,7 @@ diff -urN b/google/bytestream/BUILD.bazel c/google/bytestream/BUILD.bazel
 +)
 diff -urN b/google/cloud/asset/v1beta1/BUILD.bazel c/google/cloud/asset/v1beta1/BUILD.bazel
 --- b/google/cloud/asset/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/asset/v1beta1/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/cloud/asset/v1beta1/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -970,7 +969,7 @@ diff -urN b/google/cloud/asset/v1beta1/BUILD.bazel c/google/cloud/asset/v1beta1/
 +)
 diff -urN b/google/cloud/audit/BUILD.bazel c/google/cloud/audit/BUILD.bazel
 --- b/google/cloud/audit/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/audit/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/cloud/audit/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -999,7 +998,7 @@ diff -urN b/google/cloud/audit/BUILD.bazel c/google/cloud/audit/BUILD.bazel
 +)
 diff -urN b/google/cloud/automl/v1beta1/BUILD.bazel c/google/cloud/automl/v1beta1/BUILD.bazel
 --- b/google/cloud/automl/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/automl/v1beta1/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/cloud/automl/v1beta1/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,42 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1045,7 +1044,7 @@ diff -urN b/google/cloud/automl/v1beta1/BUILD.bazel c/google/cloud/automl/v1beta
 +)
 diff -urN b/google/cloud/bigquery/datatransfer/v1/BUILD.bazel c/google/cloud/bigquery/datatransfer/v1/BUILD.bazel
 --- b/google/cloud/bigquery/datatransfer/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/bigquery/datatransfer/v1/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/cloud/bigquery/datatransfer/v1/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,32 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1081,7 +1080,7 @@ diff -urN b/google/cloud/bigquery/datatransfer/v1/BUILD.bazel c/google/cloud/big
 +)
 diff -urN b/google/cloud/bigquery/logging/v1/BUILD.bazel c/google/cloud/bigquery/logging/v1/BUILD.bazel
 --- b/google/cloud/bigquery/logging/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/bigquery/logging/v1/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/cloud/bigquery/logging/v1/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1109,7 +1108,7 @@ diff -urN b/google/cloud/bigquery/logging/v1/BUILD.bazel c/google/cloud/bigquery
 +)
 diff -urN b/google/cloud/bigquery/storage/v1beta1/BUILD.bazel c/google/cloud/bigquery/storage/v1beta1/BUILD.bazel
 --- b/google/cloud/bigquery/storage/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/bigquery/storage/v1beta1/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/cloud/bigquery/storage/v1beta1/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1137,7 +1136,7 @@ diff -urN b/google/cloud/bigquery/storage/v1beta1/BUILD.bazel c/google/cloud/big
 +)
 diff -urN b/google/cloud/billing/v1/BUILD.bazel c/google/cloud/billing/v1/BUILD.bazel
 --- b/google/cloud/billing/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/billing/v1/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/cloud/billing/v1/BUILD.bazel	2018-10-01 11:16:42.874328344 -0400
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1158,7 +1157,7 @@ diff -urN b/google/cloud/billing/v1/BUILD.bazel c/google/cloud/billing/v1/BUILD.
 +)
 diff -urN b/google/cloud/dataproc/v1/BUILD.bazel c/google/cloud/dataproc/v1/BUILD.bazel
 --- b/google/cloud/dataproc/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/dataproc/v1/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/cloud/dataproc/v1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1193,7 +1192,7 @@ diff -urN b/google/cloud/dataproc/v1/BUILD.bazel c/google/cloud/dataproc/v1/BUIL
 +)
 diff -urN b/google/cloud/dataproc/v1beta2/BUILD.bazel c/google/cloud/dataproc/v1beta2/BUILD.bazel
 --- b/google/cloud/dataproc/v1beta2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/dataproc/v1beta2/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/cloud/dataproc/v1beta2/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1230,7 +1229,7 @@ diff -urN b/google/cloud/dataproc/v1beta2/BUILD.bazel c/google/cloud/dataproc/v1
 +)
 diff -urN b/google/cloud/dialogflow/v2/BUILD.bazel c/google/cloud/dialogflow/v2/BUILD.bazel
 --- b/google/cloud/dialogflow/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/dialogflow/v2/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/cloud/dialogflow/v2/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1272,7 +1271,7 @@ diff -urN b/google/cloud/dialogflow/v2/BUILD.bazel c/google/cloud/dialogflow/v2/
 +)
 diff -urN b/google/cloud/dialogflow/v2beta1/BUILD.bazel c/google/cloud/dialogflow/v2beta1/BUILD.bazel
 --- b/google/cloud/dialogflow/v2beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/dialogflow/v2beta1/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/cloud/dialogflow/v2beta1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,41 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1317,7 +1316,7 @@ diff -urN b/google/cloud/dialogflow/v2beta1/BUILD.bazel c/google/cloud/dialogflo
 +)
 diff -urN b/google/cloud/functions/v1beta2/BUILD.bazel c/google/cloud/functions/v1beta2/BUILD.bazel
 --- b/google/cloud/functions/v1beta2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/functions/v1beta2/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/cloud/functions/v1beta2/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1352,7 +1351,7 @@ diff -urN b/google/cloud/functions/v1beta2/BUILD.bazel c/google/cloud/functions/
 +)
 diff -urN b/google/cloud/iot/v1/BUILD.bazel c/google/cloud/iot/v1/BUILD.bazel
 --- b/google/cloud/iot/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/iot/v1/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/cloud/iot/v1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,32 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1388,7 +1387,7 @@ diff -urN b/google/cloud/iot/v1/BUILD.bazel c/google/cloud/iot/v1/BUILD.bazel
 +)
 diff -urN b/google/cloud/kms/v1/BUILD.bazel c/google/cloud/kms/v1/BUILD.bazel
 --- b/google/cloud/kms/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/kms/v1/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/cloud/kms/v1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1419,7 +1418,7 @@ diff -urN b/google/cloud/kms/v1/BUILD.bazel c/google/cloud/kms/v1/BUILD.bazel
 +)
 diff -urN b/google/cloud/language/v1/BUILD.bazel c/google/cloud/language/v1/BUILD.bazel
 --- b/google/cloud/language/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/language/v1/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/cloud/language/v1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1440,7 +1439,7 @@ diff -urN b/google/cloud/language/v1/BUILD.bazel c/google/cloud/language/v1/BUIL
 +)
 diff -urN b/google/cloud/language/v1beta1/BUILD.bazel c/google/cloud/language/v1beta1/BUILD.bazel
 --- b/google/cloud/language/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/language/v1beta1/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/cloud/language/v1beta1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1461,7 +1460,7 @@ diff -urN b/google/cloud/language/v1beta1/BUILD.bazel c/google/cloud/language/v1
 +)
 diff -urN b/google/cloud/language/v1beta2/BUILD.bazel c/google/cloud/language/v1beta2/BUILD.bazel
 --- b/google/cloud/language/v1beta2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/language/v1beta2/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/cloud/language/v1beta2/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1491,7 +1490,7 @@ diff -urN b/google/cloud/language/v1beta2/BUILD.bazel c/google/cloud/language/v1
 +)
 diff -urN b/google/cloud/location/BUILD.bazel c/google/cloud/location/BUILD.bazel
 --- b/google/cloud/location/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/location/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/cloud/location/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1515,7 +1514,7 @@ diff -urN b/google/cloud/location/BUILD.bazel c/google/cloud/location/BUILD.baze
 +)
 diff -urN b/google/cloud/ml/v1/BUILD.bazel c/google/cloud/ml/v1/BUILD.bazel
 --- b/google/cloud/ml/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/ml/v1/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/cloud/ml/v1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1554,7 +1553,7 @@ diff -urN b/google/cloud/ml/v1/BUILD.bazel c/google/cloud/ml/v1/BUILD.bazel
 +)
 diff -urN b/google/cloud/oslogin/common/BUILD.bazel c/google/cloud/oslogin/common/BUILD.bazel
 --- b/google/cloud/oslogin/common/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/oslogin/common/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/cloud/oslogin/common/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,16 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1574,7 +1573,7 @@ diff -urN b/google/cloud/oslogin/common/BUILD.bazel c/google/cloud/oslogin/commo
 +)
 diff -urN b/google/cloud/oslogin/v1/BUILD.bazel c/google/cloud/oslogin/v1/BUILD.bazel
 --- b/google/cloud/oslogin/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/oslogin/v1/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/cloud/oslogin/v1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1603,7 +1602,7 @@ diff -urN b/google/cloud/oslogin/v1/BUILD.bazel c/google/cloud/oslogin/v1/BUILD.
 +)
 diff -urN b/google/cloud/oslogin/v1alpha/BUILD.bazel c/google/cloud/oslogin/v1alpha/BUILD.bazel
 --- b/google/cloud/oslogin/v1alpha/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/oslogin/v1alpha/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/cloud/oslogin/v1alpha/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1632,7 +1631,7 @@ diff -urN b/google/cloud/oslogin/v1alpha/BUILD.bazel c/google/cloud/oslogin/v1al
 +)
 diff -urN b/google/cloud/oslogin/v1beta/BUILD.bazel c/google/cloud/oslogin/v1beta/BUILD.bazel
 --- b/google/cloud/oslogin/v1beta/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/oslogin/v1beta/BUILD.bazel	2018-09-28 13:47:29.060884604 -0400
++++ c/google/cloud/oslogin/v1beta/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1661,7 +1660,7 @@ diff -urN b/google/cloud/oslogin/v1beta/BUILD.bazel c/google/cloud/oslogin/v1bet
 +)
 diff -urN b/google/cloud/redis/v1/BUILD.bazel c/google/cloud/redis/v1/BUILD.bazel
 --- b/google/cloud/redis/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/redis/v1/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/cloud/redis/v1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1690,7 +1689,7 @@ diff -urN b/google/cloud/redis/v1/BUILD.bazel c/google/cloud/redis/v1/BUILD.baze
 +)
 diff -urN b/google/cloud/redis/v1beta1/BUILD.bazel c/google/cloud/redis/v1beta1/BUILD.bazel
 --- b/google/cloud/redis/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/redis/v1beta1/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/cloud/redis/v1beta1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1719,7 +1718,7 @@ diff -urN b/google/cloud/redis/v1beta1/BUILD.bazel c/google/cloud/redis/v1beta1/
 +)
 diff -urN b/google/cloud/resourcemanager/v2/BUILD.bazel c/google/cloud/resourcemanager/v2/BUILD.bazel
 --- b/google/cloud/resourcemanager/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/resourcemanager/v2/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/cloud/resourcemanager/v2/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1750,7 +1749,7 @@ diff -urN b/google/cloud/resourcemanager/v2/BUILD.bazel c/google/cloud/resourcem
 +)
 diff -urN b/google/cloud/runtimeconfig/v1beta1/BUILD.bazel c/google/cloud/runtimeconfig/v1beta1/BUILD.bazel
 --- b/google/cloud/runtimeconfig/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/runtimeconfig/v1beta1/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/cloud/runtimeconfig/v1beta1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1785,7 +1784,7 @@ diff -urN b/google/cloud/runtimeconfig/v1beta1/BUILD.bazel c/google/cloud/runtim
 +)
 diff -urN b/google/cloud/speech/v1/BUILD.bazel c/google/cloud/speech/v1/BUILD.bazel
 --- b/google/cloud/speech/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/speech/v1/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/cloud/speech/v1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,29 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1818,7 +1817,7 @@ diff -urN b/google/cloud/speech/v1/BUILD.bazel c/google/cloud/speech/v1/BUILD.ba
 +)
 diff -urN b/google/cloud/speech/v1p1beta1/BUILD.bazel c/google/cloud/speech/v1p1beta1/BUILD.bazel
 --- b/google/cloud/speech/v1p1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/speech/v1p1beta1/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/cloud/speech/v1p1beta1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1850,7 +1849,7 @@ diff -urN b/google/cloud/speech/v1p1beta1/BUILD.bazel c/google/cloud/speech/v1p1
 +)
 diff -urN b/google/cloud/support/BUILD.bazel c/google/cloud/support/BUILD.bazel
 --- b/google/cloud/support/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/support/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/cloud/support/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1873,7 +1872,7 @@ diff -urN b/google/cloud/support/BUILD.bazel c/google/cloud/support/BUILD.bazel
 +)
 diff -urN b/google/cloud/support/v1alpha1/BUILD.bazel c/google/cloud/support/v1alpha1/BUILD.bazel
 --- b/google/cloud/support/v1alpha1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/support/v1alpha1/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/cloud/support/v1alpha1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1902,7 +1901,7 @@ diff -urN b/google/cloud/support/v1alpha1/BUILD.bazel c/google/cloud/support/v1a
 +)
 diff -urN b/google/cloud/tasks/v2beta2/BUILD.bazel c/google/cloud/tasks/v2beta2/BUILD.bazel
 --- b/google/cloud/tasks/v2beta2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/tasks/v2beta2/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/cloud/tasks/v2beta2/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1942,7 +1941,7 @@ diff -urN b/google/cloud/tasks/v2beta2/BUILD.bazel c/google/cloud/tasks/v2beta2/
 +)
 diff -urN b/google/cloud/tasks/v2beta3/BUILD.bazel c/google/cloud/tasks/v2beta3/BUILD.bazel
 --- b/google/cloud/tasks/v2beta3/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/tasks/v2beta3/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/cloud/tasks/v2beta3/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1982,7 +1981,7 @@ diff -urN b/google/cloud/tasks/v2beta3/BUILD.bazel c/google/cloud/tasks/v2beta3/
 +)
 diff -urN b/google/cloud/texttospeech/v1/BUILD.bazel c/google/cloud/texttospeech/v1/BUILD.bazel
 --- b/google/cloud/texttospeech/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/texttospeech/v1/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/cloud/texttospeech/v1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2003,7 +2002,7 @@ diff -urN b/google/cloud/texttospeech/v1/BUILD.bazel c/google/cloud/texttospeech
 +)
 diff -urN b/google/cloud/texttospeech/v1beta1/BUILD.bazel c/google/cloud/texttospeech/v1beta1/BUILD.bazel
 --- b/google/cloud/texttospeech/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/texttospeech/v1beta1/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/cloud/texttospeech/v1beta1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2024,7 +2023,7 @@ diff -urN b/google/cloud/texttospeech/v1beta1/BUILD.bazel c/google/cloud/texttos
 +)
 diff -urN b/google/cloud/videointelligence/v1/BUILD.bazel c/google/cloud/videointelligence/v1/BUILD.bazel
 --- b/google/cloud/videointelligence/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/videointelligence/v1/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/cloud/videointelligence/v1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2055,7 +2054,7 @@ diff -urN b/google/cloud/videointelligence/v1/BUILD.bazel c/google/cloud/videoin
 +)
 diff -urN b/google/cloud/videointelligence/v1beta1/BUILD.bazel c/google/cloud/videointelligence/v1beta1/BUILD.bazel
 --- b/google/cloud/videointelligence/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/videointelligence/v1beta1/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/cloud/videointelligence/v1beta1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2085,7 +2084,7 @@ diff -urN b/google/cloud/videointelligence/v1beta1/BUILD.bazel c/google/cloud/vi
 +)
 diff -urN b/google/cloud/videointelligence/v1beta2/BUILD.bazel c/google/cloud/videointelligence/v1beta2/BUILD.bazel
 --- b/google/cloud/videointelligence/v1beta2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/videointelligence/v1beta2/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/cloud/videointelligence/v1beta2/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2116,7 +2115,7 @@ diff -urN b/google/cloud/videointelligence/v1beta2/BUILD.bazel c/google/cloud/vi
 +)
 diff -urN b/google/cloud/videointelligence/v1p1beta1/BUILD.bazel c/google/cloud/videointelligence/v1p1beta1/BUILD.bazel
 --- b/google/cloud/videointelligence/v1p1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/videointelligence/v1p1beta1/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/cloud/videointelligence/v1p1beta1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2147,7 +2146,7 @@ diff -urN b/google/cloud/videointelligence/v1p1beta1/BUILD.bazel c/google/cloud/
 +)
 diff -urN b/google/cloud/videointelligence/v1p2beta1/BUILD.bazel c/google/cloud/videointelligence/v1p2beta1/BUILD.bazel
 --- b/google/cloud/videointelligence/v1p2beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/videointelligence/v1p2beta1/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/cloud/videointelligence/v1p2beta1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2178,7 +2177,7 @@ diff -urN b/google/cloud/videointelligence/v1p2beta1/BUILD.bazel c/google/cloud/
 +)
 diff -urN b/google/cloud/vision/v1/BUILD.bazel c/google/cloud/vision/v1/BUILD.bazel
 --- b/google/cloud/vision/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/vision/v1/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/cloud/vision/v1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2217,7 +2216,7 @@ diff -urN b/google/cloud/vision/v1/BUILD.bazel c/google/cloud/vision/v1/BUILD.ba
 +)
 diff -urN b/google/cloud/vision/v1p1beta1/BUILD.bazel c/google/cloud/vision/v1p1beta1/BUILD.bazel
 --- b/google/cloud/vision/v1p1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/vision/v1p1beta1/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/cloud/vision/v1p1beta1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,32 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2253,7 +2252,7 @@ diff -urN b/google/cloud/vision/v1p1beta1/BUILD.bazel c/google/cloud/vision/v1p1
 +)
 diff -urN b/google/cloud/vision/v1p2beta1/BUILD.bazel c/google/cloud/vision/v1p2beta1/BUILD.bazel
 --- b/google/cloud/vision/v1p2beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/vision/v1p2beta1/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/cloud/vision/v1p2beta1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2292,7 +2291,7 @@ diff -urN b/google/cloud/vision/v1p2beta1/BUILD.bazel c/google/cloud/vision/v1p2
 +)
 diff -urN b/google/cloud/vision/v1p3beta1/BUILD.bazel c/google/cloud/vision/v1p3beta1/BUILD.bazel
 --- b/google/cloud/vision/v1p3beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/vision/v1p3beta1/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/cloud/vision/v1p3beta1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,39 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2335,7 +2334,7 @@ diff -urN b/google/cloud/vision/v1p3beta1/BUILD.bazel c/google/cloud/vision/v1p3
 +)
 diff -urN b/google/cloud/websecurityscanner/v1alpha/BUILD.bazel c/google/cloud/websecurityscanner/v1alpha/BUILD.bazel
 --- b/google/cloud/websecurityscanner/v1alpha/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/cloud/websecurityscanner/v1alpha/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/cloud/websecurityscanner/v1alpha/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2369,7 +2368,7 @@ diff -urN b/google/cloud/websecurityscanner/v1alpha/BUILD.bazel c/google/cloud/w
 +)
 diff -urN b/google/container/v1/BUILD.bazel c/google/container/v1/BUILD.bazel
 --- b/google/container/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/container/v1/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/container/v1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2393,7 +2392,7 @@ diff -urN b/google/container/v1/BUILD.bazel c/google/container/v1/BUILD.bazel
 +)
 diff -urN b/google/container/v1alpha1/BUILD.bazel c/google/container/v1alpha1/BUILD.bazel
 --- b/google/container/v1alpha1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/container/v1alpha1/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/container/v1alpha1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2417,7 +2416,7 @@ diff -urN b/google/container/v1alpha1/BUILD.bazel c/google/container/v1alpha1/BU
 +)
 diff -urN b/google/container/v1beta1/BUILD.bazel c/google/container/v1beta1/BUILD.bazel
 --- b/google/container/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/container/v1beta1/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/container/v1beta1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2441,7 +2440,7 @@ diff -urN b/google/container/v1beta1/BUILD.bazel c/google/container/v1beta1/BUIL
 +)
 diff -urN b/google/datastore/admin/v1/BUILD.bazel c/google/datastore/admin/v1/BUILD.bazel
 --- b/google/datastore/admin/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/datastore/admin/v1/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/datastore/admin/v1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2472,7 +2471,7 @@ diff -urN b/google/datastore/admin/v1/BUILD.bazel c/google/datastore/admin/v1/BU
 +)
 diff -urN b/google/datastore/admin/v1beta1/BUILD.bazel c/google/datastore/admin/v1beta1/BUILD.bazel
 --- b/google/datastore/admin/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/datastore/admin/v1beta1/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/datastore/admin/v1beta1/BUILD.bazel	2018-10-01 11:16:42.878328395 -0400
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2500,7 +2499,7 @@ diff -urN b/google/datastore/admin/v1beta1/BUILD.bazel c/google/datastore/admin/
 +)
 diff -urN b/google/datastore/v1/BUILD.bazel c/google/datastore/v1/BUILD.bazel
 --- b/google/datastore/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/datastore/v1/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/datastore/v1/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2534,7 +2533,7 @@ diff -urN b/google/datastore/v1/BUILD.bazel c/google/datastore/v1/BUILD.bazel
 +)
 diff -urN b/google/datastore/v1beta3/BUILD.bazel c/google/datastore/v1beta3/BUILD.bazel
 --- b/google/datastore/v1beta3/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/datastore/v1beta3/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/datastore/v1beta3/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2568,7 +2567,7 @@ diff -urN b/google/datastore/v1beta3/BUILD.bazel c/google/datastore/v1beta3/BUIL
 +)
 diff -urN b/google/devtools/build/v1/BUILD.bazel c/google/devtools/build/v1/BUILD.bazel
 --- b/google/devtools/build/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/devtools/build/v1/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/devtools/build/v1/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,32 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2604,7 +2603,7 @@ diff -urN b/google/devtools/build/v1/BUILD.bazel c/google/devtools/build/v1/BUIL
 +)
 diff -urN b/google/devtools/cloudbuild/v1/BUILD.bazel c/google/devtools/cloudbuild/v1/BUILD.bazel
 --- b/google/devtools/cloudbuild/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/devtools/cloudbuild/v1/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/devtools/cloudbuild/v1/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2638,7 +2637,7 @@ diff -urN b/google/devtools/cloudbuild/v1/BUILD.bazel c/google/devtools/cloudbui
 +)
 diff -urN b/google/devtools/clouddebugger/v2/BUILD.bazel c/google/devtools/clouddebugger/v2/BUILD.bazel
 --- b/google/devtools/clouddebugger/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/devtools/clouddebugger/v2/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/devtools/clouddebugger/v2/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2672,7 +2671,7 @@ diff -urN b/google/devtools/clouddebugger/v2/BUILD.bazel c/google/devtools/cloud
 +)
 diff -urN b/google/devtools/clouderrorreporting/v1beta1/BUILD.bazel c/google/devtools/clouderrorreporting/v1beta1/BUILD.bazel
 --- b/google/devtools/clouderrorreporting/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/devtools/clouderrorreporting/v1beta1/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/devtools/clouderrorreporting/v1beta1/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2706,7 +2705,7 @@ diff -urN b/google/devtools/clouderrorreporting/v1beta1/BUILD.bazel c/google/dev
 +)
 diff -urN b/google/devtools/cloudprofiler/v2/BUILD.bazel c/google/devtools/cloudprofiler/v2/BUILD.bazel
 --- b/google/devtools/cloudprofiler/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/devtools/cloudprofiler/v2/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/devtools/cloudprofiler/v2/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2732,7 +2731,7 @@ diff -urN b/google/devtools/cloudprofiler/v2/BUILD.bazel c/google/devtools/cloud
 +)
 diff -urN b/google/devtools/cloudtrace/v1/BUILD.bazel c/google/devtools/cloudtrace/v1/BUILD.bazel
 --- b/google/devtools/cloudtrace/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/devtools/cloudtrace/v1/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/devtools/cloudtrace/v1/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2757,7 +2756,7 @@ diff -urN b/google/devtools/cloudtrace/v1/BUILD.bazel c/google/devtools/cloudtra
 +)
 diff -urN b/google/devtools/cloudtrace/v2/BUILD.bazel c/google/devtools/cloudtrace/v2/BUILD.bazel
 --- b/google/devtools/cloudtrace/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/devtools/cloudtrace/v2/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/devtools/cloudtrace/v2/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,29 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2790,7 +2789,7 @@ diff -urN b/google/devtools/cloudtrace/v2/BUILD.bazel c/google/devtools/cloudtra
 +)
 diff -urN b/google/devtools/containeranalysis/v1alpha1/BUILD.bazel c/google/devtools/containeranalysis/v1alpha1/BUILD.bazel
 --- b/google/devtools/containeranalysis/v1alpha1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/devtools/containeranalysis/v1alpha1/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/devtools/containeranalysis/v1alpha1/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2832,7 +2831,7 @@ diff -urN b/google/devtools/containeranalysis/v1alpha1/BUILD.bazel c/google/devt
 +)
 diff -urN b/google/devtools/containeranalysis/v1beta1/attestation/BUILD.bazel c/google/devtools/containeranalysis/v1beta1/attestation/BUILD.bazel
 --- b/google/devtools/containeranalysis/v1beta1/attestation/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/devtools/containeranalysis/v1beta1/attestation/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/devtools/containeranalysis/v1beta1/attestation/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2850,7 +2849,7 @@ diff -urN b/google/devtools/containeranalysis/v1beta1/attestation/BUILD.bazel c/
 +)
 diff -urN b/google/devtools/containeranalysis/v1beta1/build/BUILD.bazel c/google/devtools/containeranalysis/v1beta1/build/BUILD.bazel
 --- b/google/devtools/containeranalysis/v1beta1/build/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/devtools/containeranalysis/v1beta1/build/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/devtools/containeranalysis/v1beta1/build/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,16 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2870,7 +2869,7 @@ diff -urN b/google/devtools/containeranalysis/v1beta1/build/BUILD.bazel c/google
 +)
 diff -urN b/google/devtools/containeranalysis/v1beta1/BUILD.bazel c/google/devtools/containeranalysis/v1beta1/BUILD.bazel
 --- b/google/devtools/containeranalysis/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/devtools/containeranalysis/v1beta1/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/devtools/containeranalysis/v1beta1/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2898,7 +2897,7 @@ diff -urN b/google/devtools/containeranalysis/v1beta1/BUILD.bazel c/google/devto
 +)
 diff -urN b/google/devtools/containeranalysis/v1beta1/common/BUILD.bazel c/google/devtools/containeranalysis/v1beta1/common/BUILD.bazel
 --- b/google/devtools/containeranalysis/v1beta1/common/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/devtools/containeranalysis/v1beta1/common/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/devtools/containeranalysis/v1beta1/common/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2916,7 +2915,7 @@ diff -urN b/google/devtools/containeranalysis/v1beta1/common/BUILD.bazel c/googl
 +)
 diff -urN b/google/devtools/containeranalysis/v1beta1/deployment/BUILD.bazel c/google/devtools/containeranalysis/v1beta1/deployment/BUILD.bazel
 --- b/google/devtools/containeranalysis/v1beta1/deployment/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/devtools/containeranalysis/v1beta1/deployment/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/devtools/containeranalysis/v1beta1/deployment/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2935,7 +2934,7 @@ diff -urN b/google/devtools/containeranalysis/v1beta1/deployment/BUILD.bazel c/g
 +)
 diff -urN b/google/devtools/containeranalysis/v1beta1/discovery/BUILD.bazel c/google/devtools/containeranalysis/v1beta1/discovery/BUILD.bazel
 --- b/google/devtools/containeranalysis/v1beta1/discovery/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/devtools/containeranalysis/v1beta1/discovery/BUILD.bazel	2018-09-28 13:47:29.064884658 -0400
++++ c/google/devtools/containeranalysis/v1beta1/discovery/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2962,7 +2961,7 @@ diff -urN b/google/devtools/containeranalysis/v1beta1/discovery/BUILD.bazel c/go
 +)
 diff -urN b/google/devtools/containeranalysis/v1beta1/grafeas/BUILD.bazel c/google/devtools/containeranalysis/v1beta1/grafeas/BUILD.bazel
 --- b/google/devtools/containeranalysis/v1beta1/grafeas/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/devtools/containeranalysis/v1beta1/grafeas/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/devtools/containeranalysis/v1beta1/grafeas/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,42 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3008,7 +3007,7 @@ diff -urN b/google/devtools/containeranalysis/v1beta1/grafeas/BUILD.bazel c/goog
 +)
 diff -urN b/google/devtools/containeranalysis/v1beta1/image/BUILD.bazel c/google/devtools/containeranalysis/v1beta1/image/BUILD.bazel
 --- b/google/devtools/containeranalysis/v1beta1/image/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/devtools/containeranalysis/v1beta1/image/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/devtools/containeranalysis/v1beta1/image/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3026,7 +3025,7 @@ diff -urN b/google/devtools/containeranalysis/v1beta1/image/BUILD.bazel c/google
 +)
 diff -urN b/google/devtools/containeranalysis/v1beta1/package/BUILD.bazel c/google/devtools/containeranalysis/v1beta1/package/BUILD.bazel
 --- b/google/devtools/containeranalysis/v1beta1/package/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/devtools/containeranalysis/v1beta1/package/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/devtools/containeranalysis/v1beta1/package/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3044,7 +3043,7 @@ diff -urN b/google/devtools/containeranalysis/v1beta1/package/BUILD.bazel c/goog
 +)
 diff -urN b/google/devtools/containeranalysis/v1beta1/provenance/BUILD.bazel c/google/devtools/containeranalysis/v1beta1/provenance/BUILD.bazel
 --- b/google/devtools/containeranalysis/v1beta1/provenance/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/devtools/containeranalysis/v1beta1/provenance/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/devtools/containeranalysis/v1beta1/provenance/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3067,7 +3066,7 @@ diff -urN b/google/devtools/containeranalysis/v1beta1/provenance/BUILD.bazel c/g
 +)
 diff -urN b/google/devtools/containeranalysis/v1beta1/source/BUILD.bazel c/google/devtools/containeranalysis/v1beta1/source/BUILD.bazel
 --- b/google/devtools/containeranalysis/v1beta1/source/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/devtools/containeranalysis/v1beta1/source/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/devtools/containeranalysis/v1beta1/source/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3085,7 +3084,7 @@ diff -urN b/google/devtools/containeranalysis/v1beta1/source/BUILD.bazel c/googl
 +)
 diff -urN b/google/devtools/containeranalysis/v1beta1/vulnerability/BUILD.bazel c/google/devtools/containeranalysis/v1beta1/vulnerability/BUILD.bazel
 --- b/google/devtools/containeranalysis/v1beta1/vulnerability/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/devtools/containeranalysis/v1beta1/vulnerability/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/devtools/containeranalysis/v1beta1/vulnerability/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3111,7 +3110,7 @@ diff -urN b/google/devtools/containeranalysis/v1beta1/vulnerability/BUILD.bazel 
 +)
 diff -urN b/google/devtools/remoteexecution/v1test/BUILD.bazel c/google/devtools/remoteexecution/v1test/BUILD.bazel
 --- b/google/devtools/remoteexecution/v1test/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/devtools/remoteexecution/v1test/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/devtools/remoteexecution/v1test/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3141,7 +3140,7 @@ diff -urN b/google/devtools/remoteexecution/v1test/BUILD.bazel c/google/devtools
 +)
 diff -urN b/google/devtools/remoteworkers/v1test2/BUILD.bazel c/google/devtools/remoteworkers/v1test2/BUILD.bazel
 --- b/google/devtools/remoteworkers/v1test2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/devtools/remoteworkers/v1test2/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/devtools/remoteworkers/v1test2/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3178,7 +3177,7 @@ diff -urN b/google/devtools/remoteworkers/v1test2/BUILD.bazel c/google/devtools/
 +)
 diff -urN b/google/devtools/resultstore/v2/BUILD.bazel c/google/devtools/resultstore/v2/BUILD.bazel
 --- b/google/devtools/resultstore/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/devtools/resultstore/v2/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/devtools/resultstore/v2/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3218,7 +3217,7 @@ diff -urN b/google/devtools/resultstore/v2/BUILD.bazel c/google/devtools/results
 +)
 diff -urN b/google/devtools/source/v1/BUILD.bazel c/google/devtools/source/v1/BUILD.bazel
 --- b/google/devtools/source/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/devtools/source/v1/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/devtools/source/v1/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,16 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3238,7 +3237,7 @@ diff -urN b/google/devtools/source/v1/BUILD.bazel c/google/devtools/source/v1/BU
 +)
 diff -urN b/google/devtools/sourcerepo/v1/BUILD.bazel c/google/devtools/sourcerepo/v1/BUILD.bazel
 --- b/google/devtools/sourcerepo/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/devtools/sourcerepo/v1/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/devtools/sourcerepo/v1/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3266,7 +3265,7 @@ diff -urN b/google/devtools/sourcerepo/v1/BUILD.bazel c/google/devtools/sourcere
 +)
 diff -urN b/google/example/library/v1/BUILD.bazel c/google/example/library/v1/BUILD.bazel
 --- b/google/example/library/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/example/library/v1/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/example/library/v1/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3290,7 +3289,7 @@ diff -urN b/google/example/library/v1/BUILD.bazel c/google/example/library/v1/BU
 +)
 diff -urN b/google/firestore/admin/v1beta1/BUILD.bazel c/google/firestore/admin/v1beta1/BUILD.bazel
 --- b/google/firestore/admin/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/firestore/admin/v1beta1/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/firestore/admin/v1beta1/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3322,7 +3321,7 @@ diff -urN b/google/firestore/admin/v1beta1/BUILD.bazel c/google/firestore/admin/
 +)
 diff -urN b/google/firestore/admin/v1beta2/BUILD.bazel c/google/firestore/admin/v1beta2/BUILD.bazel
 --- b/google/firestore/admin/v1beta2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/firestore/admin/v1beta2/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/firestore/admin/v1beta2/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3357,7 +3356,7 @@ diff -urN b/google/firestore/admin/v1beta2/BUILD.bazel c/google/firestore/admin/
 +)
 diff -urN b/google/firestore/v1beta1/BUILD.bazel c/google/firestore/v1beta1/BUILD.bazel
 --- b/google/firestore/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/firestore/v1beta1/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/firestore/v1beta1/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3396,7 +3395,7 @@ diff -urN b/google/firestore/v1beta1/BUILD.bazel c/google/firestore/v1beta1/BUIL
 +)
 diff -urN b/google/genomics/v1/BUILD.bazel c/google/genomics/v1/BUILD.bazel
 --- b/google/genomics/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/genomics/v1/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/genomics/v1/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,46 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3446,7 +3445,7 @@ diff -urN b/google/genomics/v1/BUILD.bazel c/google/genomics/v1/BUILD.bazel
 +)
 diff -urN b/google/genomics/v1alpha2/BUILD.bazel c/google/genomics/v1alpha2/BUILD.bazel
 --- b/google/genomics/v1alpha2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/genomics/v1alpha2/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/genomics/v1alpha2/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3478,7 +3477,7 @@ diff -urN b/google/genomics/v1alpha2/BUILD.bazel c/google/genomics/v1alpha2/BUIL
 +)
 diff -urN b/google/home/graph/v1/BUILD.bazel c/google/home/graph/v1/BUILD.bazel
 --- b/google/home/graph/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/home/graph/v1/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/home/graph/v1/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3506,7 +3505,7 @@ diff -urN b/google/home/graph/v1/BUILD.bazel c/google/home/graph/v1/BUILD.bazel
 +)
 diff -urN b/google/iam/admin/v1/BUILD.bazel c/google/iam/admin/v1/BUILD.bazel
 --- b/google/iam/admin/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/iam/admin/v1/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/iam/admin/v1/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3536,7 +3535,7 @@ diff -urN b/google/iam/admin/v1/BUILD.bazel c/google/iam/admin/v1/BUILD.bazel
 +)
 diff -urN b/google/iam/credentials/v1/BUILD.bazel c/google/iam/credentials/v1/BUILD.bazel
 --- b/google/iam/credentials/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/iam/credentials/v1/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/iam/credentials/v1/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3564,7 +3563,7 @@ diff -urN b/google/iam/credentials/v1/BUILD.bazel c/google/iam/credentials/v1/BU
 +)
 diff -urN b/google/iam/v1/BUILD.bazel c/google/iam/v1/BUILD.bazel
 --- b/google/iam/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/iam/v1/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/iam/v1/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3588,7 +3587,7 @@ diff -urN b/google/iam/v1/BUILD.bazel c/google/iam/v1/BUILD.bazel
 +)
 diff -urN b/google/iam/v1/logging/BUILD.bazel c/google/iam/v1/logging/BUILD.bazel
 --- b/google/iam/v1/logging/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/iam/v1/logging/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/iam/v1/logging/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3614,7 +3613,7 @@ diff -urN b/google/iam/v1/logging/BUILD.bazel c/google/iam/v1/logging/BUILD.baze
 +)
 diff -urN b/google/logging/type/BUILD.bazel c/google/logging/type/BUILD.bazel
 --- b/google/logging/type/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/logging/type/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/logging/type/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3640,7 +3639,7 @@ diff -urN b/google/logging/type/BUILD.bazel c/google/logging/type/BUILD.bazel
 +)
 diff -urN b/google/logging/v2/BUILD.bazel c/google/logging/v2/BUILD.bazel
 --- b/google/logging/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/logging/v2/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/logging/v2/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,42 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3686,7 +3685,7 @@ diff -urN b/google/logging/v2/BUILD.bazel c/google/logging/v2/BUILD.bazel
 +)
 diff -urN b/google/longrunning/BUILD.bazel c/google/longrunning/BUILD.bazel
 --- b/google/longrunning/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/longrunning/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/longrunning/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3715,7 +3714,7 @@ diff -urN b/google/longrunning/BUILD.bazel c/google/longrunning/BUILD.bazel
 +)
 diff -urN b/google/monitoring/v3/BUILD.bazel c/google/monitoring/v3/BUILD.bazel
 --- b/google/monitoring/v3/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/monitoring/v3/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/monitoring/v3/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,51 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3770,7 +3769,7 @@ diff -urN b/google/monitoring/v3/BUILD.bazel c/google/monitoring/v3/BUILD.bazel
 +)
 diff -urN b/google/privacy/dlp/v2/BUILD.bazel c/google/privacy/dlp/v2/BUILD.bazel
 --- b/google/privacy/dlp/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/privacy/dlp/v2/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/privacy/dlp/v2/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3810,7 +3809,7 @@ diff -urN b/google/privacy/dlp/v2/BUILD.bazel c/google/privacy/dlp/v2/BUILD.baze
 +)
 diff -urN b/google/pubsub/v1/BUILD.bazel c/google/pubsub/v1/BUILD.bazel
 --- b/google/pubsub/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/pubsub/v1/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/pubsub/v1/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3837,7 +3836,7 @@ diff -urN b/google/pubsub/v1/BUILD.bazel c/google/pubsub/v1/BUILD.bazel
 +)
 diff -urN b/google/pubsub/v1beta2/BUILD.bazel c/google/pubsub/v1beta2/BUILD.bazel
 --- b/google/pubsub/v1beta2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/pubsub/v1beta2/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/pubsub/v1beta2/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,16 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3857,7 +3856,7 @@ diff -urN b/google/pubsub/v1beta2/BUILD.bazel c/google/pubsub/v1beta2/BUILD.baze
 +)
 diff -urN b/google/rpc/BUILD.bazel c/google/rpc/BUILD.bazel
 --- b/google/rpc/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/rpc/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/rpc/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,42 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3903,7 +3902,7 @@ diff -urN b/google/rpc/BUILD.bazel c/google/rpc/BUILD.bazel
 +)
 diff -urN b/google/spanner/admin/database/v1/BUILD.bazel c/google/spanner/admin/database/v1/BUILD.bazel
 --- b/google/spanner/admin/database/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/spanner/admin/database/v1/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/spanner/admin/database/v1/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3934,7 +3933,7 @@ diff -urN b/google/spanner/admin/database/v1/BUILD.bazel c/google/spanner/admin/
 +)
 diff -urN b/google/spanner/admin/instance/v1/BUILD.bazel c/google/spanner/admin/instance/v1/BUILD.bazel
 --- b/google/spanner/admin/instance/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/spanner/admin/instance/v1/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/spanner/admin/instance/v1/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3966,7 +3965,7 @@ diff -urN b/google/spanner/admin/instance/v1/BUILD.bazel c/google/spanner/admin/
 +)
 diff -urN b/google/spanner/v1/BUILD.bazel c/google/spanner/v1/BUILD.bazel
 --- b/google/spanner/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/spanner/v1/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/spanner/v1/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -4001,7 +4000,7 @@ diff -urN b/google/spanner/v1/BUILD.bazel c/google/spanner/v1/BUILD.bazel
 +)
 diff -urN b/google/storagetransfer/v1/BUILD.bazel c/google/storagetransfer/v1/BUILD.bazel
 --- b/google/storagetransfer/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/storagetransfer/v1/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/storagetransfer/v1/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,34 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -4039,7 +4038,7 @@ diff -urN b/google/storagetransfer/v1/BUILD.bazel c/google/storagetransfer/v1/BU
 +)
 diff -urN b/google/streetview/publish/v1/BUILD.bazel c/google/streetview/publish/v1/BUILD.bazel
 --- b/google/streetview/publish/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/streetview/publish/v1/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/streetview/publish/v1/BUILD.bazel	2018-10-01 11:16:42.882328446 -0400
 @@ -0,0 +1,32 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -4075,7 +4074,7 @@ diff -urN b/google/streetview/publish/v1/BUILD.bazel c/google/streetview/publish
 +)
 diff -urN b/google/type/BUILD.bazel c/google/type/BUILD.bazel
 --- b/google/type/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/type/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/type/BUILD.bazel	2018-10-01 11:16:42.886328496 -0400
 @@ -0,0 +1,93 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -4172,7 +4171,7 @@ diff -urN b/google/type/BUILD.bazel c/google/type/BUILD.bazel
 +)
 diff -urN b/google/watcher/v1/BUILD.bazel c/google/watcher/v1/BUILD.bazel
 --- b/google/watcher/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/google/watcher/v1/BUILD.bazel	2018-09-28 13:47:29.068884711 -0400
++++ c/google/watcher/v1/BUILD.bazel	2018-10-01 11:16:42.886328496 -0400
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +

--- a/third_party/org_golang_google_genproto-gazelle.patch
+++ b/third_party/org_golang_google_genproto-gazelle.patch
@@ -1,6 +1,6 @@
 diff -urN a/googleapis/api/annotations/BUILD.bazel b/googleapis/api/annotations/BUILD.bazel
 --- a/googleapis/api/annotations/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/api/annotations/BUILD.bazel	2018-09-28 13:00:41.147203943 -0400
++++ b/googleapis/api/annotations/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -19,7 +19,7 @@ diff -urN a/googleapis/api/annotations/BUILD.bazel b/googleapis/api/annotations/
 +)
 diff -urN a/googleapis/api/BUILD.bazel b/googleapis/api/BUILD.bazel
 --- a/googleapis/api/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/api/BUILD.bazel	2018-09-28 13:00:41.147203943 -0400
++++ b/googleapis/api/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,16 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -39,7 +39,7 @@ diff -urN a/googleapis/api/BUILD.bazel b/googleapis/api/BUILD.bazel
 +)
 diff -urN a/googleapis/api/configchange/BUILD.bazel b/googleapis/api/configchange/BUILD.bazel
 --- a/googleapis/api/configchange/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/api/configchange/BUILD.bazel	2018-09-28 13:00:41.147203943 -0400
++++ b/googleapis/api/configchange/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,9 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -52,7 +52,7 @@ diff -urN a/googleapis/api/configchange/BUILD.bazel b/googleapis/api/configchang
 +)
 diff -urN a/googleapis/api/distribution/BUILD.bazel b/googleapis/api/distribution/BUILD.bazel
 --- a/googleapis/api/distribution/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/api/distribution/BUILD.bazel	2018-09-28 13:00:41.147203943 -0400
++++ b/googleapis/api/distribution/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,12 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -68,7 +68,7 @@ diff -urN a/googleapis/api/distribution/BUILD.bazel b/googleapis/api/distributio
 +)
 diff -urN a/googleapis/api/expr/v1alpha1/BUILD.bazel b/googleapis/api/expr/v1alpha1/BUILD.bazel
 --- a/googleapis/api/expr/v1alpha1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/api/expr/v1alpha1/BUILD.bazel	2018-09-28 13:00:41.147203943 -0400
++++ b/googleapis/api/expr/v1alpha1/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -98,7 +98,7 @@ diff -urN a/googleapis/api/expr/v1alpha1/BUILD.bazel b/googleapis/api/expr/v1alp
 +)
 diff -urN a/googleapis/api/expr/v1beta/BUILD.bazel b/googleapis/api/expr/v1beta/BUILD.bazel
 --- a/googleapis/api/expr/v1beta/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/api/expr/v1beta/BUILD.bazel	2018-09-28 13:00:41.147203943 -0400
++++ b/googleapis/api/expr/v1beta/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,13 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -115,7 +115,7 @@ diff -urN a/googleapis/api/expr/v1beta/BUILD.bazel b/googleapis/api/expr/v1beta/
 +)
 diff -urN a/googleapis/api/expr/v1beta1/BUILD.bazel b/googleapis/api/expr/v1beta1/BUILD.bazel
 --- a/googleapis/api/expr/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/api/expr/v1beta1/BUILD.bazel	2018-09-28 13:00:41.147203943 -0400
++++ b/googleapis/api/expr/v1beta1/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -138,7 +138,7 @@ diff -urN a/googleapis/api/expr/v1beta1/BUILD.bazel b/googleapis/api/expr/v1beta
 +)
 diff -urN a/googleapis/api/httpbody/BUILD.bazel b/googleapis/api/httpbody/BUILD.bazel
 --- a/googleapis/api/httpbody/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/api/httpbody/BUILD.bazel	2018-09-28 13:00:41.147203943 -0400
++++ b/googleapis/api/httpbody/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,12 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -154,7 +154,7 @@ diff -urN a/googleapis/api/httpbody/BUILD.bazel b/googleapis/api/httpbody/BUILD.
 +)
 diff -urN a/googleapis/api/label/BUILD.bazel b/googleapis/api/label/BUILD.bazel
 --- a/googleapis/api/label/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/api/label/BUILD.bazel	2018-09-28 13:00:41.147203943 -0400
++++ b/googleapis/api/label/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,9 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -167,7 +167,7 @@ diff -urN a/googleapis/api/label/BUILD.bazel b/googleapis/api/label/BUILD.bazel
 +)
 diff -urN a/googleapis/api/metric/BUILD.bazel b/googleapis/api/metric/BUILD.bazel
 --- a/googleapis/api/metric/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/api/metric/BUILD.bazel	2018-09-28 13:00:41.147203943 -0400
++++ b/googleapis/api/metric/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,12 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -183,7 +183,7 @@ diff -urN a/googleapis/api/metric/BUILD.bazel b/googleapis/api/metric/BUILD.baze
 +)
 diff -urN a/googleapis/api/monitoredres/BUILD.bazel b/googleapis/api/monitoredres/BUILD.bazel
 --- a/googleapis/api/monitoredres/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/api/monitoredres/BUILD.bazel	2018-09-28 13:00:41.147203943 -0400
++++ b/googleapis/api/monitoredres/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,13 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -200,7 +200,7 @@ diff -urN a/googleapis/api/monitoredres/BUILD.bazel b/googleapis/api/monitoredre
 +)
 diff -urN a/googleapis/api/serviceconfig/BUILD.bazel b/googleapis/api/serviceconfig/BUILD.bazel
 --- a/googleapis/api/serviceconfig/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/api/serviceconfig/BUILD.bazel	2018-09-28 13:00:41.147203943 -0400
++++ b/googleapis/api/serviceconfig/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -240,7 +240,7 @@ diff -urN a/googleapis/api/serviceconfig/BUILD.bazel b/googleapis/api/servicecon
 +)
 diff -urN a/googleapis/api/servicecontrol/v1/BUILD.bazel b/googleapis/api/servicecontrol/v1/BUILD.bazel
 --- a/googleapis/api/servicecontrol/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/api/servicecontrol/v1/BUILD.bazel	2018-09-28 13:00:41.147203943 -0400
++++ b/googleapis/api/servicecontrol/v1/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -272,7 +272,7 @@ diff -urN a/googleapis/api/servicecontrol/v1/BUILD.bazel b/googleapis/api/servic
 +)
 diff -urN a/googleapis/api/servicemanagement/v1/BUILD.bazel b/googleapis/api/servicemanagement/v1/BUILD.bazel
 --- a/googleapis/api/servicemanagement/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/api/servicemanagement/v1/BUILD.bazel	2018-09-28 13:00:41.147203943 -0400
++++ b/googleapis/api/servicemanagement/v1/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -302,7 +302,7 @@ diff -urN a/googleapis/api/servicemanagement/v1/BUILD.bazel b/googleapis/api/ser
 +)
 diff -urN a/googleapis/appengine/legacy/BUILD.bazel b/googleapis/appengine/legacy/BUILD.bazel
 --- a/googleapis/appengine/legacy/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/appengine/legacy/BUILD.bazel	2018-09-28 13:00:41.147203943 -0400
++++ b/googleapis/appengine/legacy/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,9 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -315,7 +315,7 @@ diff -urN a/googleapis/appengine/legacy/BUILD.bazel b/googleapis/appengine/legac
 +)
 diff -urN a/googleapis/appengine/logging/v1/BUILD.bazel b/googleapis/appengine/logging/v1/BUILD.bazel
 --- a/googleapis/appengine/logging/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/appengine/logging/v1/BUILD.bazel	2018-09-28 13:00:41.147203943 -0400
++++ b/googleapis/appengine/logging/v1/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -333,7 +333,7 @@ diff -urN a/googleapis/appengine/logging/v1/BUILD.bazel b/googleapis/appengine/l
 +)
 diff -urN a/googleapis/appengine/v1/BUILD.bazel b/googleapis/appengine/v1/BUILD.bazel
 --- a/googleapis/appengine/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/appengine/v1/BUILD.bazel	2018-09-28 13:00:41.147203943 -0400
++++ b/googleapis/appengine/v1/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,32 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -369,7 +369,7 @@ diff -urN a/googleapis/appengine/v1/BUILD.bazel b/googleapis/appengine/v1/BUILD.
 +)
 diff -urN a/googleapis/assistant/embedded/v1alpha1/BUILD.bazel b/googleapis/assistant/embedded/v1alpha1/BUILD.bazel
 --- a/googleapis/assistant/embedded/v1alpha1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/assistant/embedded/v1alpha1/BUILD.bazel	2018-09-28 13:00:41.147203943 -0400
++++ b/googleapis/assistant/embedded/v1alpha1/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -388,7 +388,7 @@ diff -urN a/googleapis/assistant/embedded/v1alpha1/BUILD.bazel b/googleapis/assi
 +)
 diff -urN a/googleapis/assistant/embedded/v1alpha2/BUILD.bazel b/googleapis/assistant/embedded/v1alpha2/BUILD.bazel
 --- a/googleapis/assistant/embedded/v1alpha2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/assistant/embedded/v1alpha2/BUILD.bazel	2018-09-28 13:00:41.147203943 -0400
++++ b/googleapis/assistant/embedded/v1alpha2/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -407,7 +407,7 @@ diff -urN a/googleapis/assistant/embedded/v1alpha2/BUILD.bazel b/googleapis/assi
 +)
 diff -urN a/googleapis/bigtable/admin/cluster/v1/BUILD.bazel b/googleapis/bigtable/admin/cluster/v1/BUILD.bazel
 --- a/googleapis/bigtable/admin/cluster/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/bigtable/admin/cluster/v1/BUILD.bazel	2018-09-28 13:00:41.147203943 -0400
++++ b/googleapis/bigtable/admin/cluster/v1/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -432,7 +432,7 @@ diff -urN a/googleapis/bigtable/admin/cluster/v1/BUILD.bazel b/googleapis/bigtab
 +)
 diff -urN a/googleapis/bigtable/admin/table/v1/BUILD.bazel b/googleapis/bigtable/admin/table/v1/BUILD.bazel
 --- a/googleapis/bigtable/admin/table/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/bigtable/admin/table/v1/BUILD.bazel	2018-09-28 13:00:41.147203943 -0400
++++ b/googleapis/bigtable/admin/table/v1/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -457,7 +457,7 @@ diff -urN a/googleapis/bigtable/admin/table/v1/BUILD.bazel b/googleapis/bigtable
 +)
 diff -urN a/googleapis/bigtable/admin/v2/BUILD.bazel b/googleapis/bigtable/admin/v2/BUILD.bazel
 --- a/googleapis/bigtable/admin/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/bigtable/admin/v2/BUILD.bazel	2018-09-28 13:00:41.147203943 -0400
++++ b/googleapis/bigtable/admin/v2/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -487,7 +487,7 @@ diff -urN a/googleapis/bigtable/admin/v2/BUILD.bazel b/googleapis/bigtable/admin
 +)
 diff -urN a/googleapis/bigtable/v1/BUILD.bazel b/googleapis/bigtable/v1/BUILD.bazel
 --- a/googleapis/bigtable/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/bigtable/v1/BUILD.bazel	2018-09-28 13:00:41.147203943 -0400
++++ b/googleapis/bigtable/v1/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -511,7 +511,7 @@ diff -urN a/googleapis/bigtable/v1/BUILD.bazel b/googleapis/bigtable/v1/BUILD.ba
 +)
 diff -urN a/googleapis/bigtable/v2/BUILD.bazel b/googleapis/bigtable/v2/BUILD.bazel
 --- a/googleapis/bigtable/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/bigtable/v2/BUILD.bazel	2018-09-28 13:00:41.147203943 -0400
++++ b/googleapis/bigtable/v2/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -534,7 +534,7 @@ diff -urN a/googleapis/bigtable/v2/BUILD.bazel b/googleapis/bigtable/v2/BUILD.ba
 +)
 diff -urN a/googleapis/bytestream/BUILD.bazel b/googleapis/bytestream/BUILD.bazel
 --- a/googleapis/bytestream/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/bytestream/BUILD.bazel	2018-09-28 13:00:41.147203943 -0400
++++ b/googleapis/bytestream/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -553,7 +553,7 @@ diff -urN a/googleapis/bytestream/BUILD.bazel b/googleapis/bytestream/BUILD.baze
 +)
 diff -urN a/googleapis/cloud/asset/v1beta1/BUILD.bazel b/googleapis/cloud/asset/v1beta1/BUILD.bazel
 --- a/googleapis/cloud/asset/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/asset/v1beta1/BUILD.bazel	2018-09-28 13:00:41.147203943 -0400
++++ b/googleapis/cloud/asset/v1beta1/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -579,7 +579,7 @@ diff -urN a/googleapis/cloud/asset/v1beta1/BUILD.bazel b/googleapis/cloud/asset/
 +)
 diff -urN a/googleapis/cloud/audit/BUILD.bazel b/googleapis/cloud/audit/BUILD.bazel
 --- a/googleapis/cloud/audit/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/audit/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/audit/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -598,7 +598,7 @@ diff -urN a/googleapis/cloud/audit/BUILD.bazel b/googleapis/cloud/audit/BUILD.ba
 +)
 diff -urN a/googleapis/cloud/automl/v1beta1/BUILD.bazel b/googleapis/cloud/automl/v1beta1/BUILD.bazel
 --- a/googleapis/cloud/automl/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/automl/v1beta1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/automl/v1beta1/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -635,7 +635,7 @@ diff -urN a/googleapis/cloud/automl/v1beta1/BUILD.bazel b/googleapis/cloud/autom
 +)
 diff -urN a/googleapis/cloud/bigquery/datatransfer/v1/BUILD.bazel b/googleapis/cloud/bigquery/datatransfer/v1/BUILD.bazel
 --- a/googleapis/cloud/bigquery/datatransfer/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/bigquery/datatransfer/v1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/bigquery/datatransfer/v1/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -663,7 +663,7 @@ diff -urN a/googleapis/cloud/bigquery/datatransfer/v1/BUILD.bazel b/googleapis/c
 +)
 diff -urN a/googleapis/cloud/bigquery/logging/v1/BUILD.bazel b/googleapis/cloud/bigquery/logging/v1/BUILD.bazel
 --- a/googleapis/cloud/bigquery/logging/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/bigquery/logging/v1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/bigquery/logging/v1/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -680,9 +680,33 @@ diff -urN a/googleapis/cloud/bigquery/logging/v1/BUILD.bazel b/googleapis/cloud/
 +        "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
 +    ],
 +)
+diff -urN a/googleapis/cloud/bigquery/storage/v1beta1/BUILD.bazel b/googleapis/cloud/bigquery/storage/v1beta1/BUILD.bazel
+--- a/googleapis/cloud/bigquery/storage/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/googleapis/cloud/bigquery/storage/v1beta1/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
+@@ -0,0 +1,20 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "avro.pb.go",
++        "read_options.pb.go",
++        "storage.pb.go",
++        "table_reference.pb.go",
++    ],
++    importpath = "google.golang.org/genproto/googleapis/cloud/bigquery/storage/v1beta1",
++    visibility = ["//visibility:public"],
++    deps = [
++        "@com_github_golang_protobuf//proto:go_default_library",
++        "@com_github_golang_protobuf//ptypes/empty:go_default_library",
++        "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
++        "@org_golang_google_grpc//:go_default_library",
++        "@org_golang_x_net//context:go_default_library",
++    ],
++)
 diff -urN a/googleapis/cloud/billing/v1/BUILD.bazel b/googleapis/cloud/billing/v1/BUILD.bazel
 --- a/googleapis/cloud/billing/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/billing/v1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/billing/v1/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -700,7 +724,7 @@ diff -urN a/googleapis/cloud/billing/v1/BUILD.bazel b/googleapis/cloud/billing/v
 +)
 diff -urN a/googleapis/cloud/dataproc/v1/BUILD.bazel b/googleapis/cloud/dataproc/v1/BUILD.bazel
 --- a/googleapis/cloud/dataproc/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/dataproc/v1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/dataproc/v1/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -727,7 +751,7 @@ diff -urN a/googleapis/cloud/dataproc/v1/BUILD.bazel b/googleapis/cloud/dataproc
 +)
 diff -urN a/googleapis/cloud/dataproc/v1beta2/BUILD.bazel b/googleapis/cloud/dataproc/v1beta2/BUILD.bazel
 --- a/googleapis/cloud/dataproc/v1beta2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/dataproc/v1beta2/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/dataproc/v1beta2/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -756,7 +780,7 @@ diff -urN a/googleapis/cloud/dataproc/v1beta2/BUILD.bazel b/googleapis/cloud/dat
 +)
 diff -urN a/googleapis/cloud/dialogflow/v2/BUILD.bazel b/googleapis/cloud/dialogflow/v2/BUILD.bazel
 --- a/googleapis/cloud/dialogflow/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/dialogflow/v2/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/dialogflow/v2/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -788,7 +812,7 @@ diff -urN a/googleapis/cloud/dialogflow/v2/BUILD.bazel b/googleapis/cloud/dialog
 +)
 diff -urN a/googleapis/cloud/dialogflow/v2beta1/BUILD.bazel b/googleapis/cloud/dialogflow/v2beta1/BUILD.bazel
 --- a/googleapis/cloud/dialogflow/v2beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/dialogflow/v2beta1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/dialogflow/v2beta1/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -823,7 +847,7 @@ diff -urN a/googleapis/cloud/dialogflow/v2beta1/BUILD.bazel b/googleapis/cloud/d
 +)
 diff -urN a/googleapis/cloud/functions/v1beta2/BUILD.bazel b/googleapis/cloud/functions/v1beta2/BUILD.bazel
 --- a/googleapis/cloud/functions/v1beta2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/functions/v1beta2/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/functions/v1beta2/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -849,7 +873,7 @@ diff -urN a/googleapis/cloud/functions/v1beta2/BUILD.bazel b/googleapis/cloud/fu
 +)
 diff -urN a/googleapis/cloud/iot/v1/BUILD.bazel b/googleapis/cloud/iot/v1/BUILD.bazel
 --- a/googleapis/cloud/iot/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/iot/v1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/iot/v1/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -876,7 +900,7 @@ diff -urN a/googleapis/cloud/iot/v1/BUILD.bazel b/googleapis/cloud/iot/v1/BUILD.
 +)
 diff -urN a/googleapis/cloud/kms/v1/BUILD.bazel b/googleapis/cloud/kms/v1/BUILD.bazel
 --- a/googleapis/cloud/kms/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/kms/v1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/kms/v1/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -902,7 +926,7 @@ diff -urN a/googleapis/cloud/kms/v1/BUILD.bazel b/googleapis/cloud/kms/v1/BUILD.
 +)
 diff -urN a/googleapis/cloud/language/v1/BUILD.bazel b/googleapis/cloud/language/v1/BUILD.bazel
 --- a/googleapis/cloud/language/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/language/v1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/language/v1/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -920,7 +944,7 @@ diff -urN a/googleapis/cloud/language/v1/BUILD.bazel b/googleapis/cloud/language
 +)
 diff -urN a/googleapis/cloud/language/v1beta1/BUILD.bazel b/googleapis/cloud/language/v1beta1/BUILD.bazel
 --- a/googleapis/cloud/language/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/language/v1beta1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/language/v1beta1/BUILD.bazel	2018-10-01 12:28:40.122580585 -0400
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -938,7 +962,7 @@ diff -urN a/googleapis/cloud/language/v1beta1/BUILD.bazel b/googleapis/cloud/lan
 +)
 diff -urN a/googleapis/cloud/language/v1beta2/BUILD.bazel b/googleapis/cloud/language/v1beta2/BUILD.bazel
 --- a/googleapis/cloud/language/v1beta2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/language/v1beta2/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/language/v1beta2/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -959,7 +983,7 @@ diff -urN a/googleapis/cloud/language/v1beta2/BUILD.bazel b/googleapis/cloud/lan
 +)
 diff -urN a/googleapis/cloud/location/BUILD.bazel b/googleapis/cloud/location/BUILD.bazel
 --- a/googleapis/cloud/location/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/location/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/location/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -978,7 +1002,7 @@ diff -urN a/googleapis/cloud/location/BUILD.bazel b/googleapis/cloud/location/BU
 +)
 diff -urN a/googleapis/cloud/ml/v1/BUILD.bazel b/googleapis/cloud/ml/v1/BUILD.bazel
 --- a/googleapis/cloud/ml/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/ml/v1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/ml/v1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1007,7 +1031,7 @@ diff -urN a/googleapis/cloud/ml/v1/BUILD.bazel b/googleapis/cloud/ml/v1/BUILD.ba
 +)
 diff -urN a/googleapis/cloud/oslogin/common/BUILD.bazel b/googleapis/cloud/oslogin/common/BUILD.bazel
 --- a/googleapis/cloud/oslogin/common/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/oslogin/common/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/oslogin/common/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,12 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1023,7 +1047,7 @@ diff -urN a/googleapis/cloud/oslogin/common/BUILD.bazel b/googleapis/cloud/oslog
 +)
 diff -urN a/googleapis/cloud/oslogin/v1/BUILD.bazel b/googleapis/cloud/oslogin/v1/BUILD.bazel
 --- a/googleapis/cloud/oslogin/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/oslogin/v1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/oslogin/v1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1044,7 +1068,7 @@ diff -urN a/googleapis/cloud/oslogin/v1/BUILD.bazel b/googleapis/cloud/oslogin/v
 +)
 diff -urN a/googleapis/cloud/oslogin/v1alpha/BUILD.bazel b/googleapis/cloud/oslogin/v1alpha/BUILD.bazel
 --- a/googleapis/cloud/oslogin/v1alpha/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/oslogin/v1alpha/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/oslogin/v1alpha/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1065,7 +1089,7 @@ diff -urN a/googleapis/cloud/oslogin/v1alpha/BUILD.bazel b/googleapis/cloud/oslo
 +)
 diff -urN a/googleapis/cloud/oslogin/v1beta/BUILD.bazel b/googleapis/cloud/oslogin/v1beta/BUILD.bazel
 --- a/googleapis/cloud/oslogin/v1beta/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/oslogin/v1beta/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/oslogin/v1beta/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1086,7 +1110,7 @@ diff -urN a/googleapis/cloud/oslogin/v1beta/BUILD.bazel b/googleapis/cloud/oslog
 +)
 diff -urN a/googleapis/cloud/redis/v1/BUILD.bazel b/googleapis/cloud/redis/v1/BUILD.bazel
 --- a/googleapis/cloud/redis/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/redis/v1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/redis/v1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1107,7 +1131,7 @@ diff -urN a/googleapis/cloud/redis/v1/BUILD.bazel b/googleapis/cloud/redis/v1/BU
 +)
 diff -urN a/googleapis/cloud/redis/v1beta1/BUILD.bazel b/googleapis/cloud/redis/v1beta1/BUILD.bazel
 --- a/googleapis/cloud/redis/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/redis/v1beta1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/redis/v1beta1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1128,7 +1152,7 @@ diff -urN a/googleapis/cloud/redis/v1beta1/BUILD.bazel b/googleapis/cloud/redis/
 +)
 diff -urN a/googleapis/cloud/resourcemanager/v2/BUILD.bazel b/googleapis/cloud/resourcemanager/v2/BUILD.bazel
 --- a/googleapis/cloud/resourcemanager/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/resourcemanager/v2/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/resourcemanager/v2/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1150,7 +1174,7 @@ diff -urN a/googleapis/cloud/resourcemanager/v2/BUILD.bazel b/googleapis/cloud/r
 +)
 diff -urN a/googleapis/cloud/runtimeconfig/v1beta1/BUILD.bazel b/googleapis/cloud/runtimeconfig/v1beta1/BUILD.bazel
 --- a/googleapis/cloud/runtimeconfig/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/runtimeconfig/v1beta1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/runtimeconfig/v1beta1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1176,7 +1200,7 @@ diff -urN a/googleapis/cloud/runtimeconfig/v1beta1/BUILD.bazel b/googleapis/clou
 +)
 diff -urN a/googleapis/cloud/speech/v1/BUILD.bazel b/googleapis/cloud/speech/v1/BUILD.bazel
 --- a/googleapis/cloud/speech/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/speech/v1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/speech/v1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1200,7 +1224,7 @@ diff -urN a/googleapis/cloud/speech/v1/BUILD.bazel b/googleapis/cloud/speech/v1/
 +)
 diff -urN a/googleapis/cloud/speech/v1p1beta1/BUILD.bazel b/googleapis/cloud/speech/v1p1beta1/BUILD.bazel
 --- a/googleapis/cloud/speech/v1p1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/speech/v1p1beta1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/speech/v1p1beta1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1223,7 +1247,7 @@ diff -urN a/googleapis/cloud/speech/v1p1beta1/BUILD.bazel b/googleapis/cloud/spe
 +)
 diff -urN a/googleapis/cloud/support/common/BUILD.bazel b/googleapis/cloud/support/common/BUILD.bazel
 --- a/googleapis/cloud/support/common/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/support/common/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/support/common/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,13 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1240,7 +1264,7 @@ diff -urN a/googleapis/cloud/support/common/BUILD.bazel b/googleapis/cloud/suppo
 +)
 diff -urN a/googleapis/cloud/support/v1alpha1/BUILD.bazel b/googleapis/cloud/support/v1alpha1/BUILD.bazel
 --- a/googleapis/cloud/support/v1alpha1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/support/v1alpha1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/support/v1alpha1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1261,7 +1285,7 @@ diff -urN a/googleapis/cloud/support/v1alpha1/BUILD.bazel b/googleapis/cloud/sup
 +)
 diff -urN a/googleapis/cloud/tasks/v2beta2/BUILD.bazel b/googleapis/cloud/tasks/v2beta2/BUILD.bazel
 --- a/googleapis/cloud/tasks/v2beta2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/tasks/v2beta2/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/tasks/v2beta2/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1291,7 +1315,7 @@ diff -urN a/googleapis/cloud/tasks/v2beta2/BUILD.bazel b/googleapis/cloud/tasks/
 +)
 diff -urN a/googleapis/cloud/tasks/v2beta3/BUILD.bazel b/googleapis/cloud/tasks/v2beta3/BUILD.bazel
 --- a/googleapis/cloud/tasks/v2beta3/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/tasks/v2beta3/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/tasks/v2beta3/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1321,7 +1345,7 @@ diff -urN a/googleapis/cloud/tasks/v2beta3/BUILD.bazel b/googleapis/cloud/tasks/
 +)
 diff -urN a/googleapis/cloud/texttospeech/v1/BUILD.bazel b/googleapis/cloud/texttospeech/v1/BUILD.bazel
 --- a/googleapis/cloud/texttospeech/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/texttospeech/v1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/texttospeech/v1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1339,7 +1363,7 @@ diff -urN a/googleapis/cloud/texttospeech/v1/BUILD.bazel b/googleapis/cloud/text
 +)
 diff -urN a/googleapis/cloud/texttospeech/v1beta1/BUILD.bazel b/googleapis/cloud/texttospeech/v1beta1/BUILD.bazel
 --- a/googleapis/cloud/texttospeech/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/texttospeech/v1beta1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/texttospeech/v1beta1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1357,7 +1381,7 @@ diff -urN a/googleapis/cloud/texttospeech/v1beta1/BUILD.bazel b/googleapis/cloud
 +)
 diff -urN a/googleapis/cloud/videointelligence/v1/BUILD.bazel b/googleapis/cloud/videointelligence/v1/BUILD.bazel
 --- a/googleapis/cloud/videointelligence/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/videointelligence/v1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/videointelligence/v1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1379,7 +1403,7 @@ diff -urN a/googleapis/cloud/videointelligence/v1/BUILD.bazel b/googleapis/cloud
 +)
 diff -urN a/googleapis/cloud/videointelligence/v1beta1/BUILD.bazel b/googleapis/cloud/videointelligence/v1beta1/BUILD.bazel
 --- a/googleapis/cloud/videointelligence/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/videointelligence/v1beta1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/videointelligence/v1beta1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1400,7 +1424,7 @@ diff -urN a/googleapis/cloud/videointelligence/v1beta1/BUILD.bazel b/googleapis/
 +)
 diff -urN a/googleapis/cloud/videointelligence/v1beta2/BUILD.bazel b/googleapis/cloud/videointelligence/v1beta2/BUILD.bazel
 --- a/googleapis/cloud/videointelligence/v1beta2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/videointelligence/v1beta2/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/videointelligence/v1beta2/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1422,7 +1446,7 @@ diff -urN a/googleapis/cloud/videointelligence/v1beta2/BUILD.bazel b/googleapis/
 +)
 diff -urN a/googleapis/cloud/videointelligence/v1p1beta1/BUILD.bazel b/googleapis/cloud/videointelligence/v1p1beta1/BUILD.bazel
 --- a/googleapis/cloud/videointelligence/v1p1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/videointelligence/v1p1beta1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/videointelligence/v1p1beta1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1444,7 +1468,7 @@ diff -urN a/googleapis/cloud/videointelligence/v1p1beta1/BUILD.bazel b/googleapi
 +)
 diff -urN a/googleapis/cloud/videointelligence/v1p2beta1/BUILD.bazel b/googleapis/cloud/videointelligence/v1p2beta1/BUILD.bazel
 --- a/googleapis/cloud/videointelligence/v1p2beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/videointelligence/v1p2beta1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/videointelligence/v1p2beta1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1466,7 +1490,7 @@ diff -urN a/googleapis/cloud/videointelligence/v1p2beta1/BUILD.bazel b/googleapi
 +)
 diff -urN a/googleapis/cloud/vision/v1/BUILD.bazel b/googleapis/cloud/vision/v1/BUILD.bazel
 --- a/googleapis/cloud/vision/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/vision/v1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/vision/v1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1494,7 +1518,7 @@ diff -urN a/googleapis/cloud/vision/v1/BUILD.bazel b/googleapis/cloud/vision/v1/
 +)
 diff -urN a/googleapis/cloud/vision/v1p1beta1/BUILD.bazel b/googleapis/cloud/vision/v1p1beta1/BUILD.bazel
 --- a/googleapis/cloud/vision/v1p1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/vision/v1p1beta1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/vision/v1p1beta1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1520,7 +1544,7 @@ diff -urN a/googleapis/cloud/vision/v1p1beta1/BUILD.bazel b/googleapis/cloud/vis
 +)
 diff -urN a/googleapis/cloud/vision/v1p2beta1/BUILD.bazel b/googleapis/cloud/vision/v1p2beta1/BUILD.bazel
 --- a/googleapis/cloud/vision/v1p2beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/vision/v1p2beta1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/vision/v1p2beta1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1548,7 +1572,7 @@ diff -urN a/googleapis/cloud/vision/v1p2beta1/BUILD.bazel b/googleapis/cloud/vis
 +)
 diff -urN a/googleapis/cloud/vision/v1p3beta1/BUILD.bazel b/googleapis/cloud/vision/v1p3beta1/BUILD.bazel
 --- a/googleapis/cloud/vision/v1p3beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/vision/v1p3beta1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/vision/v1p3beta1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1580,7 +1604,7 @@ diff -urN a/googleapis/cloud/vision/v1p3beta1/BUILD.bazel b/googleapis/cloud/vis
 +)
 diff -urN a/googleapis/cloud/websecurityscanner/v1alpha/BUILD.bazel b/googleapis/cloud/websecurityscanner/v1alpha/BUILD.bazel
 --- a/googleapis/cloud/websecurityscanner/v1alpha/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/cloud/websecurityscanner/v1alpha/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/cloud/websecurityscanner/v1alpha/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1609,7 +1633,7 @@ diff -urN a/googleapis/cloud/websecurityscanner/v1alpha/BUILD.bazel b/googleapis
 +)
 diff -urN a/googleapis/container/v1/BUILD.bazel b/googleapis/container/v1/BUILD.bazel
 --- a/googleapis/container/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/container/v1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/container/v1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1628,7 +1652,7 @@ diff -urN a/googleapis/container/v1/BUILD.bazel b/googleapis/container/v1/BUILD.
 +)
 diff -urN a/googleapis/container/v1alpha1/BUILD.bazel b/googleapis/container/v1alpha1/BUILD.bazel
 --- a/googleapis/container/v1alpha1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/container/v1alpha1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/container/v1alpha1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1647,7 +1671,7 @@ diff -urN a/googleapis/container/v1alpha1/BUILD.bazel b/googleapis/container/v1a
 +)
 diff -urN a/googleapis/container/v1beta1/BUILD.bazel b/googleapis/container/v1beta1/BUILD.bazel
 --- a/googleapis/container/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/container/v1beta1/BUILD.bazel	2018-09-28 13:00:41.151203996 -0400
++++ b/googleapis/container/v1beta1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1666,7 +1690,7 @@ diff -urN a/googleapis/container/v1beta1/BUILD.bazel b/googleapis/container/v1be
 +)
 diff -urN a/googleapis/datastore/admin/v1/BUILD.bazel b/googleapis/datastore/admin/v1/BUILD.bazel
 --- a/googleapis/datastore/admin/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/datastore/admin/v1/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/datastore/admin/v1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1689,7 +1713,7 @@ diff -urN a/googleapis/datastore/admin/v1/BUILD.bazel b/googleapis/datastore/adm
 +)
 diff -urN a/googleapis/datastore/admin/v1beta1/BUILD.bazel b/googleapis/datastore/admin/v1beta1/BUILD.bazel
 --- a/googleapis/datastore/admin/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/datastore/admin/v1beta1/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/datastore/admin/v1beta1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,16 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1709,7 +1733,7 @@ diff -urN a/googleapis/datastore/admin/v1beta1/BUILD.bazel b/googleapis/datastor
 +)
 diff -urN a/googleapis/datastore/v1/BUILD.bazel b/googleapis/datastore/v1/BUILD.bazel
 --- a/googleapis/datastore/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/datastore/v1/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/datastore/v1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1735,7 +1759,7 @@ diff -urN a/googleapis/datastore/v1/BUILD.bazel b/googleapis/datastore/v1/BUILD.
 +)
 diff -urN a/googleapis/datastore/v1beta3/BUILD.bazel b/googleapis/datastore/v1beta3/BUILD.bazel
 --- a/googleapis/datastore/v1beta3/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/datastore/v1beta3/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/datastore/v1beta3/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1761,7 +1785,7 @@ diff -urN a/googleapis/datastore/v1beta3/BUILD.bazel b/googleapis/datastore/v1be
 +)
 diff -urN a/googleapis/devtools/build/v1/BUILD.bazel b/googleapis/devtools/build/v1/BUILD.bazel
 --- a/googleapis/devtools/build/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/devtools/build/v1/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/devtools/build/v1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1789,7 +1813,7 @@ diff -urN a/googleapis/devtools/build/v1/BUILD.bazel b/googleapis/devtools/build
 +)
 diff -urN a/googleapis/devtools/cloudbuild/v1/BUILD.bazel b/googleapis/devtools/cloudbuild/v1/BUILD.bazel
 --- a/googleapis/devtools/cloudbuild/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/devtools/cloudbuild/v1/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/devtools/cloudbuild/v1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1813,7 +1837,7 @@ diff -urN a/googleapis/devtools/cloudbuild/v1/BUILD.bazel b/googleapis/devtools/
 +)
 diff -urN a/googleapis/devtools/clouddebugger/v2/BUILD.bazel b/googleapis/devtools/clouddebugger/v2/BUILD.bazel
 --- a/googleapis/devtools/clouddebugger/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/devtools/clouddebugger/v2/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/devtools/clouddebugger/v2/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1839,7 +1863,7 @@ diff -urN a/googleapis/devtools/clouddebugger/v2/BUILD.bazel b/googleapis/devtoo
 +)
 diff -urN a/googleapis/devtools/clouderrorreporting/v1beta1/BUILD.bazel b/googleapis/devtools/clouderrorreporting/v1beta1/BUILD.bazel
 --- a/googleapis/devtools/clouderrorreporting/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/devtools/clouderrorreporting/v1beta1/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/devtools/clouderrorreporting/v1beta1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1865,7 +1889,7 @@ diff -urN a/googleapis/devtools/clouderrorreporting/v1beta1/BUILD.bazel b/google
 +)
 diff -urN a/googleapis/devtools/cloudprofiler/v2/BUILD.bazel b/googleapis/devtools/cloudprofiler/v2/BUILD.bazel
 --- a/googleapis/devtools/cloudprofiler/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/devtools/cloudprofiler/v2/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/devtools/cloudprofiler/v2/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1886,7 +1910,7 @@ diff -urN a/googleapis/devtools/cloudprofiler/v2/BUILD.bazel b/googleapis/devtoo
 +)
 diff -urN a/googleapis/devtools/cloudtrace/v1/BUILD.bazel b/googleapis/devtools/cloudtrace/v1/BUILD.bazel
 --- a/googleapis/devtools/cloudtrace/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/devtools/cloudtrace/v1/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/devtools/cloudtrace/v1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,16 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1906,7 +1930,7 @@ diff -urN a/googleapis/devtools/cloudtrace/v1/BUILD.bazel b/googleapis/devtools/
 +)
 diff -urN a/googleapis/devtools/cloudtrace/v2/BUILD.bazel b/googleapis/devtools/cloudtrace/v2/BUILD.bazel
 --- a/googleapis/devtools/cloudtrace/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/devtools/cloudtrace/v2/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/devtools/cloudtrace/v2/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1931,7 +1955,7 @@ diff -urN a/googleapis/devtools/cloudtrace/v2/BUILD.bazel b/googleapis/devtools/
 +)
 diff -urN a/googleapis/devtools/containeranalysis/v1alpha1/BUILD.bazel b/googleapis/devtools/containeranalysis/v1alpha1/BUILD.bazel
 --- a/googleapis/devtools/containeranalysis/v1alpha1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/devtools/containeranalysis/v1alpha1/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/devtools/containeranalysis/v1alpha1/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1963,7 +1987,7 @@ diff -urN a/googleapis/devtools/containeranalysis/v1alpha1/BUILD.bazel b/googlea
 +)
 diff -urN a/googleapis/devtools/containeranalysis/v1beta1/attestation/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/attestation/BUILD.bazel
 --- a/googleapis/devtools/containeranalysis/v1beta1/attestation/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/devtools/containeranalysis/v1beta1/attestation/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/devtools/containeranalysis/v1beta1/attestation/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,9 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1976,7 +2000,7 @@ diff -urN a/googleapis/devtools/containeranalysis/v1beta1/attestation/BUILD.baze
 +)
 diff -urN a/googleapis/devtools/containeranalysis/v1beta1/build/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/build/BUILD.bazel
 --- a/googleapis/devtools/containeranalysis/v1beta1/build/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/devtools/containeranalysis/v1beta1/build/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/devtools/containeranalysis/v1beta1/build/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,12 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -1992,7 +2016,7 @@ diff -urN a/googleapis/devtools/containeranalysis/v1beta1/build/BUILD.bazel b/go
 +)
 diff -urN a/googleapis/devtools/containeranalysis/v1beta1/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/BUILD.bazel
 --- a/googleapis/devtools/containeranalysis/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/devtools/containeranalysis/v1beta1/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/devtools/containeranalysis/v1beta1/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,16 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2012,7 +2036,7 @@ diff -urN a/googleapis/devtools/containeranalysis/v1beta1/BUILD.bazel b/googleap
 +)
 diff -urN a/googleapis/devtools/containeranalysis/v1beta1/common/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/common/BUILD.bazel
 --- a/googleapis/devtools/containeranalysis/v1beta1/common/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/devtools/containeranalysis/v1beta1/common/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/devtools/containeranalysis/v1beta1/common/BUILD.bazel	2018-10-01 12:28:40.126580635 -0400
 @@ -0,0 +1,9 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2025,7 +2049,7 @@ diff -urN a/googleapis/devtools/containeranalysis/v1beta1/common/BUILD.bazel b/g
 +)
 diff -urN a/googleapis/devtools/containeranalysis/v1beta1/deployment/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/deployment/BUILD.bazel
 --- a/googleapis/devtools/containeranalysis/v1beta1/deployment/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/devtools/containeranalysis/v1beta1/deployment/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/devtools/containeranalysis/v1beta1/deployment/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,12 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2041,7 +2065,7 @@ diff -urN a/googleapis/devtools/containeranalysis/v1beta1/deployment/BUILD.bazel
 +)
 diff -urN a/googleapis/devtools/containeranalysis/v1beta1/discovery/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/discovery/BUILD.bazel
 --- a/googleapis/devtools/containeranalysis/v1beta1/discovery/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/devtools/containeranalysis/v1beta1/discovery/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/devtools/containeranalysis/v1beta1/discovery/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2059,7 +2083,7 @@ diff -urN a/googleapis/devtools/containeranalysis/v1beta1/discovery/BUILD.bazel 
 +)
 diff -urN a/googleapis/devtools/containeranalysis/v1beta1/grafeas/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/grafeas/BUILD.bazel
 --- a/googleapis/devtools/containeranalysis/v1beta1/grafeas/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/devtools/containeranalysis/v1beta1/grafeas/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/devtools/containeranalysis/v1beta1/grafeas/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2089,7 +2113,7 @@ diff -urN a/googleapis/devtools/containeranalysis/v1beta1/grafeas/BUILD.bazel b/
 +)
 diff -urN a/googleapis/devtools/containeranalysis/v1beta1/image/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/image/BUILD.bazel
 --- a/googleapis/devtools/containeranalysis/v1beta1/image/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/devtools/containeranalysis/v1beta1/image/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/devtools/containeranalysis/v1beta1/image/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,9 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2102,7 +2126,7 @@ diff -urN a/googleapis/devtools/containeranalysis/v1beta1/image/BUILD.bazel b/go
 +)
 diff -urN a/googleapis/devtools/containeranalysis/v1beta1/package/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/package/BUILD.bazel
 --- a/googleapis/devtools/containeranalysis/v1beta1/package/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/devtools/containeranalysis/v1beta1/package/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/devtools/containeranalysis/v1beta1/package/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,9 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2115,7 +2139,7 @@ diff -urN a/googleapis/devtools/containeranalysis/v1beta1/package/BUILD.bazel b/
 +)
 diff -urN a/googleapis/devtools/containeranalysis/v1beta1/provenance/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/provenance/BUILD.bazel
 --- a/googleapis/devtools/containeranalysis/v1beta1/provenance/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/devtools/containeranalysis/v1beta1/provenance/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/devtools/containeranalysis/v1beta1/provenance/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,13 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2132,7 +2156,7 @@ diff -urN a/googleapis/devtools/containeranalysis/v1beta1/provenance/BUILD.bazel
 +)
 diff -urN a/googleapis/devtools/containeranalysis/v1beta1/source/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/source/BUILD.bazel
 --- a/googleapis/devtools/containeranalysis/v1beta1/source/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/devtools/containeranalysis/v1beta1/source/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/devtools/containeranalysis/v1beta1/source/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,9 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2145,7 +2169,7 @@ diff -urN a/googleapis/devtools/containeranalysis/v1beta1/source/BUILD.bazel b/g
 +)
 diff -urN a/googleapis/devtools/containeranalysis/v1beta1/vulnerability/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/vulnerability/BUILD.bazel
 --- a/googleapis/devtools/containeranalysis/v1beta1/vulnerability/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/devtools/containeranalysis/v1beta1/vulnerability/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/devtools/containeranalysis/v1beta1/vulnerability/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,13 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2162,7 +2186,7 @@ diff -urN a/googleapis/devtools/containeranalysis/v1beta1/vulnerability/BUILD.ba
 +)
 diff -urN a/googleapis/devtools/remoteexecution/v1test/BUILD.bazel b/googleapis/devtools/remoteexecution/v1test/BUILD.bazel
 --- a/googleapis/devtools/remoteexecution/v1test/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/devtools/remoteexecution/v1test/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/devtools/remoteexecution/v1test/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2183,7 +2207,7 @@ diff -urN a/googleapis/devtools/remoteexecution/v1test/BUILD.bazel b/googleapis/
 +)
 diff -urN a/googleapis/devtools/remoteworkers/v1test2/BUILD.bazel b/googleapis/devtools/remoteworkers/v1test2/BUILD.bazel
 --- a/googleapis/devtools/remoteworkers/v1test2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/devtools/remoteworkers/v1test2/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/devtools/remoteworkers/v1test2/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2212,7 +2236,7 @@ diff -urN a/googleapis/devtools/remoteworkers/v1test2/BUILD.bazel b/googleapis/d
 +)
 diff -urN a/googleapis/devtools/resultstore/v2/BUILD.bazel b/googleapis/devtools/resultstore/v2/BUILD.bazel
 --- a/googleapis/devtools/resultstore/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/devtools/resultstore/v2/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/devtools/resultstore/v2/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2247,7 +2271,7 @@ diff -urN a/googleapis/devtools/resultstore/v2/BUILD.bazel b/googleapis/devtools
 +)
 diff -urN a/googleapis/devtools/source/v1/BUILD.bazel b/googleapis/devtools/source/v1/BUILD.bazel
 --- a/googleapis/devtools/source/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/devtools/source/v1/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/devtools/source/v1/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,12 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2263,7 +2287,7 @@ diff -urN a/googleapis/devtools/source/v1/BUILD.bazel b/googleapis/devtools/sour
 +)
 diff -urN a/googleapis/devtools/sourcerepo/v1/BUILD.bazel b/googleapis/devtools/sourcerepo/v1/BUILD.bazel
 --- a/googleapis/devtools/sourcerepo/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/devtools/sourcerepo/v1/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/devtools/sourcerepo/v1/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,16 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2283,7 +2307,7 @@ diff -urN a/googleapis/devtools/sourcerepo/v1/BUILD.bazel b/googleapis/devtools/
 +)
 diff -urN a/googleapis/example/library/v1/BUILD.bazel b/googleapis/example/library/v1/BUILD.bazel
 --- a/googleapis/example/library/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/example/library/v1/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/example/library/v1/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2302,7 +2326,7 @@ diff -urN a/googleapis/example/library/v1/BUILD.bazel b/googleapis/example/libra
 +)
 diff -urN a/googleapis/firestore/admin/v1beta1/BUILD.bazel b/googleapis/firestore/admin/v1beta1/BUILD.bazel
 --- a/googleapis/firestore/admin/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/firestore/admin/v1beta1/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/firestore/admin/v1beta1/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2326,7 +2350,7 @@ diff -urN a/googleapis/firestore/admin/v1beta1/BUILD.bazel b/googleapis/firestor
 +)
 diff -urN a/googleapis/firestore/admin/v1beta2/BUILD.bazel b/googleapis/firestore/admin/v1beta2/BUILD.bazel
 --- a/googleapis/firestore/admin/v1beta2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/firestore/admin/v1beta2/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/firestore/admin/v1beta2/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2353,7 +2377,7 @@ diff -urN a/googleapis/firestore/admin/v1beta2/BUILD.bazel b/googleapis/firestor
 +)
 diff -urN a/googleapis/firestore/v1beta1/BUILD.bazel b/googleapis/firestore/v1beta1/BUILD.bazel
 --- a/googleapis/firestore/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/firestore/v1beta1/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/firestore/v1beta1/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2383,7 +2407,7 @@ diff -urN a/googleapis/firestore/v1beta1/BUILD.bazel b/googleapis/firestore/v1be
 +)
 diff -urN a/googleapis/genomics/v1/BUILD.bazel b/googleapis/genomics/v1/BUILD.bazel
 --- a/googleapis/genomics/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/genomics/v1/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/genomics/v1/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2423,7 +2447,7 @@ diff -urN a/googleapis/genomics/v1/BUILD.bazel b/googleapis/genomics/v1/BUILD.ba
 +)
 diff -urN a/googleapis/genomics/v1alpha2/BUILD.bazel b/googleapis/genomics/v1alpha2/BUILD.bazel
 --- a/googleapis/genomics/v1alpha2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/genomics/v1alpha2/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/genomics/v1alpha2/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2446,7 +2470,7 @@ diff -urN a/googleapis/genomics/v1alpha2/BUILD.bazel b/googleapis/genomics/v1alp
 +)
 diff -urN a/googleapis/home/graph/v1/BUILD.bazel b/googleapis/home/graph/v1/BUILD.bazel
 --- a/googleapis/home/graph/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/home/graph/v1/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/home/graph/v1/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2469,7 +2493,7 @@ diff -urN a/googleapis/home/graph/v1/BUILD.bazel b/googleapis/home/graph/v1/BUIL
 +)
 diff -urN a/googleapis/iam/admin/v1/BUILD.bazel b/googleapis/iam/admin/v1/BUILD.bazel
 --- a/googleapis/iam/admin/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/iam/admin/v1/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/iam/admin/v1/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2491,7 +2515,7 @@ diff -urN a/googleapis/iam/admin/v1/BUILD.bazel b/googleapis/iam/admin/v1/BUILD.
 +)
 diff -urN a/googleapis/iam/credentials/v1/BUILD.bazel b/googleapis/iam/credentials/v1/BUILD.bazel
 --- a/googleapis/iam/credentials/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/iam/credentials/v1/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/iam/credentials/v1/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2514,7 +2538,7 @@ diff -urN a/googleapis/iam/credentials/v1/BUILD.bazel b/googleapis/iam/credentia
 +)
 diff -urN a/googleapis/iam/v1/BUILD.bazel b/googleapis/iam/v1/BUILD.bazel
 --- a/googleapis/iam/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/iam/v1/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/iam/v1/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2535,7 +2559,7 @@ diff -urN a/googleapis/iam/v1/BUILD.bazel b/googleapis/iam/v1/BUILD.bazel
 +)
 diff -urN a/googleapis/iam/v1/logging/BUILD.bazel b/googleapis/iam/v1/logging/BUILD.bazel
 --- a/googleapis/iam/v1/logging/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/iam/v1/logging/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/iam/v1/logging/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,13 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2552,7 +2576,7 @@ diff -urN a/googleapis/iam/v1/logging/BUILD.bazel b/googleapis/iam/v1/logging/BU
 +)
 diff -urN a/googleapis/logging/type/BUILD.bazel b/googleapis/logging/type/BUILD.bazel
 --- a/googleapis/logging/type/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/logging/type/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/logging/type/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,16 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2572,7 +2596,7 @@ diff -urN a/googleapis/logging/type/BUILD.bazel b/googleapis/logging/type/BUILD.
 +)
 diff -urN a/googleapis/logging/v2/BUILD.bazel b/googleapis/logging/v2/BUILD.bazel
 --- a/googleapis/logging/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/logging/v2/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/logging/v2/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2606,7 +2630,7 @@ diff -urN a/googleapis/logging/v2/BUILD.bazel b/googleapis/logging/v2/BUILD.baze
 +)
 diff -urN a/googleapis/longrunning/BUILD.bazel b/googleapis/longrunning/BUILD.bazel
 --- a/googleapis/longrunning/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/longrunning/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/longrunning/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2627,7 +2651,7 @@ diff -urN a/googleapis/longrunning/BUILD.bazel b/googleapis/longrunning/BUILD.ba
 +)
 diff -urN a/googleapis/monitoring/v3/BUILD.bazel b/googleapis/monitoring/v3/BUILD.bazel
 --- a/googleapis/monitoring/v3/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/monitoring/v3/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/monitoring/v3/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,39 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2670,7 +2694,7 @@ diff -urN a/googleapis/monitoring/v3/BUILD.bazel b/googleapis/monitoring/v3/BUIL
 +)
 diff -urN a/googleapis/privacy/dlp/v2/BUILD.bazel b/googleapis/privacy/dlp/v2/BUILD.bazel
 --- a/googleapis/privacy/dlp/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/privacy/dlp/v2/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/privacy/dlp/v2/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2699,7 +2723,7 @@ diff -urN a/googleapis/privacy/dlp/v2/BUILD.bazel b/googleapis/privacy/dlp/v2/BU
 +)
 diff -urN a/googleapis/pubsub/v1/BUILD.bazel b/googleapis/pubsub/v1/BUILD.bazel
 --- a/googleapis/pubsub/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/pubsub/v1/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/pubsub/v1/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2721,7 +2745,7 @@ diff -urN a/googleapis/pubsub/v1/BUILD.bazel b/googleapis/pubsub/v1/BUILD.bazel
 +)
 diff -urN a/googleapis/pubsub/v1beta2/BUILD.bazel b/googleapis/pubsub/v1beta2/BUILD.bazel
 --- a/googleapis/pubsub/v1beta2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/pubsub/v1beta2/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/pubsub/v1beta2/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2739,7 +2763,7 @@ diff -urN a/googleapis/pubsub/v1beta2/BUILD.bazel b/googleapis/pubsub/v1beta2/BU
 +)
 diff -urN a/googleapis/rpc/code/BUILD.bazel b/googleapis/rpc/code/BUILD.bazel
 --- a/googleapis/rpc/code/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/rpc/code/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/rpc/code/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,9 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2752,7 +2776,7 @@ diff -urN a/googleapis/rpc/code/BUILD.bazel b/googleapis/rpc/code/BUILD.bazel
 +)
 diff -urN a/googleapis/rpc/errdetails/BUILD.bazel b/googleapis/rpc/errdetails/BUILD.bazel
 --- a/googleapis/rpc/errdetails/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/rpc/errdetails/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/rpc/errdetails/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,12 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2768,7 +2792,7 @@ diff -urN a/googleapis/rpc/errdetails/BUILD.bazel b/googleapis/rpc/errdetails/BU
 +)
 diff -urN a/googleapis/rpc/status/BUILD.bazel b/googleapis/rpc/status/BUILD.bazel
 --- a/googleapis/rpc/status/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/rpc/status/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/rpc/status/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,12 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2784,7 +2808,7 @@ diff -urN a/googleapis/rpc/status/BUILD.bazel b/googleapis/rpc/status/BUILD.baze
 +)
 diff -urN a/googleapis/spanner/admin/database/v1/BUILD.bazel b/googleapis/spanner/admin/database/v1/BUILD.bazel
 --- a/googleapis/spanner/admin/database/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/spanner/admin/database/v1/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/spanner/admin/database/v1/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2806,7 +2830,7 @@ diff -urN a/googleapis/spanner/admin/database/v1/BUILD.bazel b/googleapis/spanne
 +)
 diff -urN a/googleapis/spanner/admin/instance/v1/BUILD.bazel b/googleapis/spanner/admin/instance/v1/BUILD.bazel
 --- a/googleapis/spanner/admin/instance/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/spanner/admin/instance/v1/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/spanner/admin/instance/v1/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2829,7 +2853,7 @@ diff -urN a/googleapis/spanner/admin/instance/v1/BUILD.bazel b/googleapis/spanne
 +)
 diff -urN a/googleapis/spanner/v1/BUILD.bazel b/googleapis/spanner/v1/BUILD.bazel
 --- a/googleapis/spanner/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/spanner/v1/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/spanner/v1/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2859,7 +2883,7 @@ diff -urN a/googleapis/spanner/v1/BUILD.bazel b/googleapis/spanner/v1/BUILD.baze
 +)
 diff -urN a/googleapis/storagetransfer/v1/BUILD.bazel b/googleapis/storagetransfer/v1/BUILD.bazel
 --- a/googleapis/storagetransfer/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/storagetransfer/v1/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/storagetransfer/v1/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2887,7 +2911,7 @@ diff -urN a/googleapis/storagetransfer/v1/BUILD.bazel b/googleapis/storagetransf
 +)
 diff -urN a/googleapis/streetview/publish/v1/BUILD.bazel b/googleapis/streetview/publish/v1/BUILD.bazel
 --- a/googleapis/streetview/publish/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/streetview/publish/v1/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/streetview/publish/v1/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2914,7 +2938,7 @@ diff -urN a/googleapis/streetview/publish/v1/BUILD.bazel b/googleapis/streetview
 +)
 diff -urN a/googleapis/type/color/BUILD.bazel b/googleapis/type/color/BUILD.bazel
 --- a/googleapis/type/color/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/type/color/BUILD.bazel	2018-09-28 13:00:41.155204052 -0400
++++ b/googleapis/type/color/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,12 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2930,7 +2954,7 @@ diff -urN a/googleapis/type/color/BUILD.bazel b/googleapis/type/color/BUILD.baze
 +)
 diff -urN a/googleapis/type/date/BUILD.bazel b/googleapis/type/date/BUILD.bazel
 --- a/googleapis/type/date/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/type/date/BUILD.bazel	2018-09-28 13:00:41.159204106 -0400
++++ b/googleapis/type/date/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,9 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2943,7 +2967,7 @@ diff -urN a/googleapis/type/date/BUILD.bazel b/googleapis/type/date/BUILD.bazel
 +)
 diff -urN a/googleapis/type/dayofweek/BUILD.bazel b/googleapis/type/dayofweek/BUILD.bazel
 --- a/googleapis/type/dayofweek/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/type/dayofweek/BUILD.bazel	2018-09-28 13:00:41.159204106 -0400
++++ b/googleapis/type/dayofweek/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,9 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2956,7 +2980,7 @@ diff -urN a/googleapis/type/dayofweek/BUILD.bazel b/googleapis/type/dayofweek/BU
 +)
 diff -urN a/googleapis/type/latlng/BUILD.bazel b/googleapis/type/latlng/BUILD.bazel
 --- a/googleapis/type/latlng/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/type/latlng/BUILD.bazel	2018-09-28 13:00:41.159204106 -0400
++++ b/googleapis/type/latlng/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,9 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2969,7 +2993,7 @@ diff -urN a/googleapis/type/latlng/BUILD.bazel b/googleapis/type/latlng/BUILD.ba
 +)
 diff -urN a/googleapis/type/money/BUILD.bazel b/googleapis/type/money/BUILD.bazel
 --- a/googleapis/type/money/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/type/money/BUILD.bazel	2018-09-28 13:00:41.159204106 -0400
++++ b/googleapis/type/money/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,9 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2982,7 +3006,7 @@ diff -urN a/googleapis/type/money/BUILD.bazel b/googleapis/type/money/BUILD.baze
 +)
 diff -urN a/googleapis/type/postaladdress/BUILD.bazel b/googleapis/type/postaladdress/BUILD.bazel
 --- a/googleapis/type/postaladdress/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/type/postaladdress/BUILD.bazel	2018-09-28 13:00:41.159204106 -0400
++++ b/googleapis/type/postaladdress/BUILD.bazel	2018-10-01 12:28:40.130580686 -0400
 @@ -0,0 +1,9 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -2995,7 +3019,7 @@ diff -urN a/googleapis/type/postaladdress/BUILD.bazel b/googleapis/type/postalad
 +)
 diff -urN a/googleapis/type/timeofday/BUILD.bazel b/googleapis/type/timeofday/BUILD.bazel
 --- a/googleapis/type/timeofday/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/type/timeofday/BUILD.bazel	2018-09-28 13:00:41.159204106 -0400
++++ b/googleapis/type/timeofday/BUILD.bazel	2018-10-01 12:28:40.134580737 -0400
 @@ -0,0 +1,9 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -3008,7 +3032,7 @@ diff -urN a/googleapis/type/timeofday/BUILD.bazel b/googleapis/type/timeofday/BU
 +)
 diff -urN a/googleapis/watcher/v1/BUILD.bazel b/googleapis/watcher/v1/BUILD.bazel
 --- a/googleapis/watcher/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/googleapis/watcher/v1/BUILD.bazel	2018-09-28 13:00:41.159204106 -0400
++++ b/googleapis/watcher/v1/BUILD.bazel	2018-10-01 12:28:40.134580737 -0400
 @@ -0,0 +1,16 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -3028,7 +3052,7 @@ diff -urN a/googleapis/watcher/v1/BUILD.bazel b/googleapis/watcher/v1/BUILD.baze
 +)
 diff -urN a/protobuf/api/BUILD.bazel b/protobuf/api/BUILD.bazel
 --- a/protobuf/api/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/protobuf/api/BUILD.bazel	2018-09-28 13:00:41.159204106 -0400
++++ b/protobuf/api/BUILD.bazel	2018-10-01 12:28:40.134580737 -0400
 @@ -0,0 +1,13 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -3045,7 +3069,7 @@ diff -urN a/protobuf/api/BUILD.bazel b/protobuf/api/BUILD.bazel
 +)
 diff -urN a/protobuf/field_mask/BUILD.bazel b/protobuf/field_mask/BUILD.bazel
 --- a/protobuf/field_mask/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/protobuf/field_mask/BUILD.bazel	2018-09-28 13:00:41.159204106 -0400
++++ b/protobuf/field_mask/BUILD.bazel	2018-10-01 12:28:40.134580737 -0400
 @@ -0,0 +1,9 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -3058,7 +3082,7 @@ diff -urN a/protobuf/field_mask/BUILD.bazel b/protobuf/field_mask/BUILD.bazel
 +)
 diff -urN a/protobuf/ptype/BUILD.bazel b/protobuf/ptype/BUILD.bazel
 --- a/protobuf/ptype/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/protobuf/ptype/BUILD.bazel	2018-09-28 13:00:41.159204106 -0400
++++ b/protobuf/ptype/BUILD.bazel	2018-10-01 12:28:40.134580737 -0400
 @@ -0,0 +1,13 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
@@ -3075,7 +3099,7 @@ diff -urN a/protobuf/ptype/BUILD.bazel b/protobuf/ptype/BUILD.bazel
 +)
 diff -urN a/protobuf/source_context/BUILD.bazel b/protobuf/source_context/BUILD.bazel
 --- a/protobuf/source_context/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/protobuf/source_context/BUILD.bazel	2018-09-28 13:00:41.159204106 -0400
++++ b/protobuf/source_context/BUILD.bazel	2018-10-01 12:28:40.134580737 -0400
 @@ -0,0 +1,9 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +


### PR DESCRIPTION
* Both repositories should now be generated from googleapis at the
  same commit.
* Removed the build file for @go_googleapis//google/api/experimental
  and incorporated the protos into
  @go_googleapis//google/api:api_proto and api_go_proto. Ideally,
  there should be an alias for the old targets, but proto_library
  requires proto srcs to be in the same Bazel package.