### PR TITLE
Use find_cpp_toolchain instead of ctx.fragments.cpp

### DIFF
--- a/go/platform/apple.bzl
+++ b/go/platform/apple.bzl
@@ -29,14 +29,13 @@ PLATFORMS = {
 def _apple_version_min(platform, version):
     return "-m" + platform.name_in_plist.lower() + "-version-min=" + version
 
-def apple_ensure_options(ctx, env, tags, compiler_options, linker_options):
+def apple_ensure_options(ctx, env, tags, compiler_options, linker_options, target_gnu_system_name):
     """apple_ensure_options ensures that, when building an Apple target, the
     proper environment, compiler flags and Go tags are correctly set."""
-    system_name = ctx.fragments.cpp.target_gnu_system_name
-    platform = PLATFORMS.get(system_name)
+    platform = PLATFORMS.get(target_gnu_system_name)
     if platform == None:
         return
-    if system_name.endswith("-ios"):
+    if target_gnu_system_name.endswith("-ios"):
         tags.append("ios")  # needed for stdlib building
     if platform in [apple_common.platform.ios_device, apple_common.platform.ios_simulator]:
         min_version = _apple_version_min(platform, "7.0")

--- a/tests/bazel_tests.bzl
+++ b/tests/bazel_tests.bzl
@@ -230,10 +230,7 @@ _bazel_test_script = go_rule(
         "check": attr.string(),
         "config": attr.string(default = "isolate"),
         "extra_files": attr.label_list(allow_files = True),
-        "data": attr.label_list(
-            allow_files = True,
-            cfg = "data",
-        ),
+        "data": attr.label_list(allow_files = True),
         "clean_build": attr.bool(default = False),
         "bazelrc": attr.label(
             allow_single_file = True,


### PR DESCRIPTION
ctx.fragments.cpp is deprecated.

This doesn't fully get us away from deprecated APIs. We should use
cc_common for flags and C/C++ compilation command lines.

Related #1744