### PR TITLE
Add compiled archives to compilation_outputs group

### DIFF
--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -85,6 +85,7 @@ def _go_binary_impl(ctx):
         archive,
         OutputGroupInfo(
             cgo_exports = archive.cgo_exports,
+            compilation_outputs = [archive.data.file],
         ),
         DefaultInfo(
             files = depset([executable]),

--- a/go/private/rules/library.bzl
+++ b/go/private/rules/library.bzl
@@ -44,6 +44,7 @@ def _go_library_impl(ctx):
         ),
         OutputGroupInfo(
             cgo_exports = archive.cgo_exports,
+            compilation_outputs = [archive.data.file],
         ),
     ]
 

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -162,6 +162,9 @@ def _go_test_impl(ctx):
                 runfiles = runfiles,
                 executable = executable,
             ),
+            OutputGroupInfo(
+                compilation_outputs = [internal_archive.data.file],
+            ),
         ],
         instrumented_files = struct(
             extensions = ["go"],

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -110,6 +110,9 @@ def _go_proto_library_impl(ctx):
             files = depset([archive.data.file]),
             runfiles = archive.runfiles,
         ),
+        OutputGroupInfo(
+            compilation_outputs = [archive.data.file],
+        ),
     ]
 
 go_proto_library = go_rule(

--- a/tests/core/README.rst
+++ b/tests/core/README.rst
@@ -22,6 +22,7 @@ Contents
 * `coverage functionality <coverage/README.rst>`_
 * `Import maps <importmap/README.rst>`_
 * `Basic go_path functionality <go_path/README.rst>`_
+* `output_groups functionality <output_groups/README.rst>`_
 
 .. Child list end
 

--- a/tests/core/output_groups/BUILD.bazel
+++ b/tests/core/output_groups/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test", "go_binary")
+
+go_library(
+    name = "lib",
+    srcs = ["lib.go"],
+    importpath = "lib",
+)
+
+go_test(
+    name = "lib_test",
+    srcs = ["lib_test.go"],
+    embed = [":lib"],
+)
+
+go_binary(
+    name = "bin",
+    srcs = ["bin.go"],
+)
+
+filegroup(
+    name = "compilation_outputs",
+    testonly = True,
+    srcs = [
+        ":bin",
+        ":lib",
+        ":lib_test",
+    ],
+    output_group = "compilation_outputs",
+)
+
+go_test(
+    name = "compilation_outputs_test",
+    srcs = ["compilation_outputs_test.go"],
+    data = [":compilation_outputs"],
+)

--- a/tests/core/output_groups/README.rst
+++ b/tests/core/output_groups/README.rst
@@ -1,0 +1,10 @@
+output_groups functionality
+===========================
+
+Tests to ensure the supported `output_groups` are working as expected.
+
+compilation_outputs_test
+------------------------
+
+Checks that the `compilation_outputs` output group is populated with the
+compiled archives from `go_library`, `go_test`, and `go_binary` targets.

--- a/tests/core/output_groups/bin.go
+++ b/tests/core/output_groups/bin.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/tests/core/output_groups/compilation_outputs_test.go
+++ b/tests/core/output_groups/compilation_outputs_test.go
@@ -1,0 +1,42 @@
+package output_groups
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCompilationOutputs(t *testing.T) {
+	expectedFiles := map[string]bool{
+		"compilation_outputs_test": true, // test binary; not relevant
+
+		"lib%/lib.a":                          true, // :lib archive
+		"lib_test%/lib.a":                     true, // :lib_test archive
+		"bin%/tests/core/output_groups/bin.a": true, // :bin archive
+	}
+
+	filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
+		if info.IsDir() {
+			return nil
+		}
+		// Remove first directory of file (e.g. linux_amd64_stripped)
+		if firstSlash := strings.Index(path, "/"); firstSlash >= 0 {
+			path = path[firstSlash+1:]
+		}
+		if expectedFiles[path] {
+			delete(expectedFiles, path)
+		} else {
+			t.Errorf("Runfiles contains an unexpected file: %s", path)
+		}
+		return nil
+	})
+
+	if len(expectedFiles) != 0 {
+		var missingFiles []string
+		for path := range expectedFiles {
+			missingFiles = append(missingFiles, path)
+		}
+		t.Errorf("Could find expected files: %v", missingFiles)
+	}
+}

--- a/tests/core/output_groups/lib.go
+++ b/tests/core/output_groups/lib.go
@@ -1,0 +1,1 @@
+package lib

--- a/tests/core/output_groups/lib_test.go
+++ b/tests/core/output_groups/lib_test.go
@@ -1,0 +1,1 @@
+package lib


### PR DESCRIPTION
This behavior matches the native C++ and Java rules[1] and allows users
to easily verify a target compiles without invoking the linker
unnecessarily.

[1]: https://github.com/bazelbuild/bazel/commit/1dcd8f0f12bb582cc449381f8245f943121031fb