### PR TITLE
Use absolute paths to make GoPack work on Windows

### DIFF
--- a/go/tools/builders/pack.go
+++ b/go/tools/builders/pack.go
@@ -57,7 +57,7 @@ func run(args []string) error {
 		return err
 	}
 
-	if err := copyFile(*inArchive, *outArchive); err != nil {
+	if err := copyFile(abs(*inArchive), abs(*outArchive)); err != nil {
 		return err
 	}
 
@@ -76,7 +76,7 @@ func run(args []string) error {
 		objects = append(objects, archiveObjects...)
 	}
 
-	return appendFiles(goenv, *outArchive, objects)
+	return appendFiles(goenv, abs(*outArchive), objects)
 }
 
 func main() {


### PR DESCRIPTION
I recently discovered that targets requiring the GoPack builder have a relative path problem on Windows, too (recall #1647). Using absolute paths here fixes the build for targets with a `gonum.org/v1/gonum` dependency.

https://github.com/Xjs/bazel-go-pack-demo is a minimal example to reproduce.
