### PR TITLE
Use a more unique name for the cover variable

### DIFF
--- a/go/private/actions/cover.bzl
+++ b/go/private/actions/cover.bzl
@@ -22,6 +22,10 @@ load(
     "structs",
 )
 
+def _sanitize(s):
+    """Replaces /, -, and . with _."""
+    return s.replace("/", "_").replace("-", "_").replace(".", "_")
+
 def emit_cover(go, source):
     """See go/toolchains.rst#cover for full documentation."""
 
@@ -40,8 +44,8 @@ def emit_cover(go, source):
         _, pkgpath = effective_importpath_pkgpath(source.library)
         srcname = pkgpath + "/" + orig.basename if pkgpath else orig.path
 
-        cover_var = "Cover_" + src.basename[:-3].replace("-", "_").replace(".", "_")
-        out = go.declare_file(go, path = cover_var, ext = ".cover.go")
+        cover_var = "Cover_%s_%s" % (_sanitize(pkgpath), _sanitize(src.basename[:-3]))
+        out = go.declare_file(go, path = "Cover_%s" % _sanitize(src.basename[:-3]), ext = ".cover.go")
         covered_src_map.pop(src, None)
         covered_src_map[out] = orig
         covered.append(out)


### PR DESCRIPTION
In kubernetes, we get a build failure when running `bazel coverage`:

```console
GoCompile: error running subcommand: exit status 2
pkg/kubelet/container/testing/os.go:143: Cover_os redeclared in this block
        previous declaration during import "k8s.io/kubernetes/pkg/kubelet/container"
pkg/kubelet/container/testing/runtime_mock.go:32: Cover_os redeclared during import "k8s.io/kubernetes/pkg/kubelet/container"
        previous declaration at pkg/kubelet/container/testing/os.go:143
```

The root cause appears to be at least partially self-inflicted; we have a `pkg/kubelet/container/os.go` file (in package `container`), and a `pkg/kubelet/container/testing/os.go` file (in package `testing`).

The existing `rules_go` coverage generator creates a `Cover_os` variable in each package, which would be unique, except that `pkg/kubelet/container/testing/runtime_mock.go` dot-imports `pkg/kubelet/container`, causing the conflict.

I've attempted to fix the issue here by just including the package path in the variable name, e.g. `Cover_k8s_io_kubernetes_pkg_kubelet_container_os` instead of `Cover_os`. This seems to work, though I'm not sure if there are corner cases I'm missing.