### PR TITLE
lcov_merger: workaround for Bazel 0.18.0 coverage

### DIFF
--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -232,6 +232,12 @@ go_test = go_rule(
         "rundir": attr.string(),
         "x_defs": attr.string_dict(),
         "linkmode": attr.string(default = LINKMODE_NORMAL),
+        # Workaround for bazelbuild/bazel#6293. See comment in lcov_merger.sh.
+        "_lcov_merger": attr.label(
+            executable = True,
+            default = "@io_bazel_rules_go//go/tools/builders:lcov_merger",
+            cfg = "target",
+        ),
     },
     executable = True,
     test = True,

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -180,6 +180,12 @@ go_tool_binary(
     visibility = ["//visibility:public"],
 )
 
+sh_binary(
+    name = "lcov_merger",
+    srcs = ["lcov_merger.sh"],
+    visibility = ["//visibility:public"],
+)
+
 filegroup(
     name = "all_builder_srcs",
     testonly = True,

--- a/go/tools/builders/lcov_merger.sh
+++ b/go/tools/builders/lcov_merger.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a workaround for bazelbuild/bazel#6293. Since Bazel 0.18.0, Bazel
+# expects tests to have an "$lcov_merger' or "_lcov_merger" attribute that
+# points to an executable. If this is missing, the test driver fails.
+
+exit 0


### PR DESCRIPTION
When collecting coverage, Bazel now expects test rules to have an
implicit "$lcov_merger" or "_lcov_merger" attribute that points to a
binary to be run by the test driver script.

This change adds a dummy _lcov_merger attribute to go_test. The script
does nothing for now.

Related bazelbuild/bazel#6293