### PR TITLE
Remove spurious newlines from print messages

### DIFF
--- a/go/private/rules/wrappers.bzl
+++ b/go/private/rules/wrappers.bzl
@@ -55,7 +55,7 @@ _COMMON_ATTRS = {
 def _deprecate(attr, name, ruletype, kwargs, message):
     value = kwargs.pop(attr, None)
     if value and native.repository_name() == "@":
-        print("\nDEPRECATED: //{}:{} : the {} attribute on {} is deprecated. {}".format(native.package_name(), name, attr, ruletype, message))
+        print("DEPRECATED: //{}:{} : the {} attribute on {} is deprecated. {}".format(native.package_name(), name, attr, ruletype, message))
     return value
 
 def _objc(name, kwargs):


### PR DESCRIPTION
The print() primitive should not take strings with newlines at the beginning
nor at the end: messages are automatically prefixed with their severity and
suffixed with the necessary newline.