### PR TITLE
Don't compile cgo code with --coverage

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -65,7 +65,13 @@ _GoContextData = provider()
 _COMPILER_OPTIONS_BLACKLIST = {
     "-fcolor-diagnostics": None,
     "-Wall": None,
-    "-g0": None,  # symbols are needed by Go, so keep them
+
+    # Symbols are needed by Go, so keep them
+    "-g0": None,
+
+    # Don't compile generated cgo code with coverage. If we do an internal
+    # link, we may have undefined references to coverage functions.
+    "--coverage": None,
 }
 
 _LINKER_OPTIONS_BLACKLIST = {

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -72,6 +72,8 @@ _COMPILER_OPTIONS_BLACKLIST = {
     # Don't compile generated cgo code with coverage. If we do an internal
     # link, we may have undefined references to coverage functions.
     "--coverage": None,
+    "-ftest-coverage": None,
+    "-fprofile-arcs": None,
 }
 
 _LINKER_OPTIONS_BLACKLIST = {

--- a/tests/core/race/BUILD.bazel
+++ b/tests/core/race/BUILD.bazel
@@ -60,7 +60,10 @@ else
   result=0
 fi
 """,
-    command = "test",
+    # NOTE(#1801): we use "coverage" instead of "test" here to verify that
+    # race binaries can link when coverage is enabled. Adding a new
+    # bazel_test, so we piggy-back on this one.
+    command = "coverage",
     targets = [":race_auto_test"],
 )
 


### PR DESCRIPTION
If we do an internal link, we may have undefined references to
coverage functions.

Fixes #1801