### PR TITLE
Add @com_github_golang_protobuf//protoc-gen-go/generator:go_default_library_gen

### DIFF
--- a/third_party/com_github_golang_protobuf-extras.patch
+++ b/third_party/com_github_golang_protobuf-extras.patch
@@ -1,6 +1,6 @@
 diff -urN b/conformance/internal/conformance_proto/BUILD.bazel c/conformance/internal/conformance_proto/BUILD.bazel
---- b/conformance/internal/conformance_proto/BUILD.bazel	2018-09-28 12:25:59.940105588 -0400
-+++ c/conformance/internal/conformance_proto/BUILD.bazel	2018-09-28 12:28:40.234183077 -0400
+--- b/conformance/internal/conformance_proto/BUILD.bazel	2018-11-07 14:11:49.292167270 -0500
++++ c/conformance/internal/conformance_proto/BUILD.bazel	2018-11-07 14:12:04.200354786 -0500
 @@ -1,5 +1,11 @@
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
  
@@ -14,8 +14,8 @@ diff -urN b/conformance/internal/conformance_proto/BUILD.bazel c/conformance/int
      name = "go_default_library",
      srcs = ["conformance.pb.go"],
 diff -urN b/descriptor/BUILD.bazel c/descriptor/BUILD.bazel
---- b/descriptor/BUILD.bazel	2018-09-28 12:25:59.940105588 -0400
-+++ c/descriptor/BUILD.bazel	2018-09-28 12:28:40.234183077 -0400
+--- b/descriptor/BUILD.bazel	2018-11-07 14:11:49.292167270 -0500
++++ c/descriptor/BUILD.bazel	2018-11-07 14:12:04.200354786 -0500
 @@ -11,6 +11,18 @@
      ],
  )
@@ -36,8 +36,8 @@ diff -urN b/descriptor/BUILD.bazel c/descriptor/BUILD.bazel
      name = "go_default_test",
      srcs = ["descriptor_test.go"],
 diff -urN b/jsonpb/BUILD.bazel c/jsonpb/BUILD.bazel
---- b/jsonpb/BUILD.bazel	2018-09-28 12:25:59.940105588 -0400
-+++ c/jsonpb/BUILD.bazel	2018-09-28 12:28:40.234183077 -0400
+--- b/jsonpb/BUILD.bazel	2018-11-07 14:11:49.292167270 -0500
++++ c/jsonpb/BUILD.bazel	2018-11-07 14:12:04.204354837 -0500
 @@ -11,6 +11,17 @@
      ],
  )
@@ -57,8 +57,8 @@ diff -urN b/jsonpb/BUILD.bazel c/jsonpb/BUILD.bazel
      name = "go_default_test",
      srcs = ["jsonpb_test.go"],
 diff -urN b/jsonpb/jsonpb_test_proto/BUILD.bazel c/jsonpb/jsonpb_test_proto/BUILD.bazel
---- b/jsonpb/jsonpb_test_proto/BUILD.bazel	2018-09-28 12:25:59.940105588 -0400
-+++ c/jsonpb/jsonpb_test_proto/BUILD.bazel	2018-09-28 12:28:40.234183077 -0400
+--- b/jsonpb/jsonpb_test_proto/BUILD.bazel	2018-11-07 14:11:49.292167270 -0500
++++ c/jsonpb/jsonpb_test_proto/BUILD.bazel	2018-11-07 14:12:04.204354837 -0500
 @@ -1,5 +1,14 @@
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
  
@@ -75,8 +75,8 @@ diff -urN b/jsonpb/jsonpb_test_proto/BUILD.bazel c/jsonpb/jsonpb_test_proto/BUIL
      name = "go_default_library",
      srcs = [
 diff -urN b/proto/proto3_proto/BUILD.bazel c/proto/proto3_proto/BUILD.bazel
---- b/proto/proto3_proto/BUILD.bazel	2018-09-28 12:25:59.940105588 -0400
-+++ c/proto/proto3_proto/BUILD.bazel	2018-09-28 12:28:40.234183077 -0400
+--- b/proto/proto3_proto/BUILD.bazel	2018-11-07 14:11:49.292167270 -0500
++++ c/proto/proto3_proto/BUILD.bazel	2018-11-07 14:12:04.204354837 -0500
 @@ -1,5 +1,11 @@
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
  
@@ -90,8 +90,8 @@ diff -urN b/proto/proto3_proto/BUILD.bazel c/proto/proto3_proto/BUILD.bazel
      name = "go_default_library",
      srcs = ["proto3.pb.go"],
 diff -urN b/proto/test_proto/BUILD.bazel c/proto/test_proto/BUILD.bazel
---- b/proto/test_proto/BUILD.bazel	2018-09-28 12:25:59.940105588 -0400
-+++ c/proto/test_proto/BUILD.bazel	2018-09-28 12:28:40.234183077 -0400
+--- b/proto/test_proto/BUILD.bazel	2018-11-07 14:11:49.292167270 -0500
++++ c/proto/test_proto/BUILD.bazel	2018-11-07 14:12:04.204354837 -0500
 @@ -1,5 +1,11 @@
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
  
@@ -105,8 +105,8 @@ diff -urN b/proto/test_proto/BUILD.bazel c/proto/test_proto/BUILD.bazel
      name = "go_default_library",
      srcs = ["test.pb.go"],
 diff -urN b/protoc-gen-go/descriptor/BUILD.bazel c/protoc-gen-go/descriptor/BUILD.bazel
---- b/protoc-gen-go/descriptor/BUILD.bazel	2018-09-28 12:25:59.940105588 -0400
-+++ c/protoc-gen-go/descriptor/BUILD.bazel	2018-09-28 12:28:40.234183077 -0400
+--- b/protoc-gen-go/descriptor/BUILD.bazel	2018-11-07 14:11:49.296167319 -0500
++++ c/protoc-gen-go/descriptor/BUILD.bazel	2018-11-07 14:12:04.204354837 -0500
 @@ -1,5 +1,11 @@
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
  
@@ -119,9 +119,32 @@ diff -urN b/protoc-gen-go/descriptor/BUILD.bazel c/protoc-gen-go/descriptor/BUIL
  go_library(
      name = "go_default_library",
      srcs = ["descriptor.pb.go"],
+diff -urN b/protoc-gen-go/generator/BUILD.bazel c/protoc-gen-go/generator/BUILD.bazel
+--- b/protoc-gen-go/generator/BUILD.bazel	2018-11-07 14:11:49.296167319 -0500
++++ c/protoc-gen-go/generator/BUILD.bazel	2018-11-07 14:18:03.316867833 -0500
+@@ -13,6 +13,19 @@
+     ],
+ )
+ 
++go_library(
++    name = "go_default_library_gen",
++    srcs = ["generator.go"],
++    importpath = "github.com/golang/protobuf/protoc-gen-go/generator",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//proto:go_default_library",
++        "//protoc-gen-go/generator/internal/remap:go_default_library",
++        "@io_bazel_rules_go//proto/wkt:compiler_plugin_go_proto",
++        "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
++    ],
++)
++
+ go_test(
+     name = "go_default_test",
+     srcs = ["name_test.go"],
 diff -urN b/protoc-gen-go/plugin/BUILD.bazel c/protoc-gen-go/plugin/BUILD.bazel
---- b/protoc-gen-go/plugin/BUILD.bazel	2018-09-28 12:25:59.944105639 -0400
-+++ c/protoc-gen-go/plugin/BUILD.bazel	2018-09-28 12:28:40.238183129 -0400
+--- b/protoc-gen-go/plugin/BUILD.bazel	2018-11-07 14:11:49.296167319 -0500
++++ c/protoc-gen-go/plugin/BUILD.bazel	2018-11-07 14:12:04.204354837 -0500
 @@ -1,5 +1,11 @@
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
  
@@ -135,8 +158,8 @@ diff -urN b/protoc-gen-go/plugin/BUILD.bazel c/protoc-gen-go/plugin/BUILD.bazel
      name = "go_default_library",
      srcs = ["plugin.pb.go"],
 diff -urN b/protoc-gen-go/testdata/deprecated/BUILD.bazel c/protoc-gen-go/testdata/deprecated/BUILD.bazel
---- b/protoc-gen-go/testdata/deprecated/BUILD.bazel	2018-09-28 12:25:59.944105639 -0400
-+++ c/protoc-gen-go/testdata/deprecated/BUILD.bazel	2018-09-28 12:28:40.238183129 -0400
+--- b/protoc-gen-go/testdata/deprecated/BUILD.bazel	2018-11-07 14:11:49.296167319 -0500
++++ c/protoc-gen-go/testdata/deprecated/BUILD.bazel	2018-11-07 14:12:04.204354837 -0500
 @@ -1,5 +1,11 @@
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
  
@@ -150,8 +173,8 @@ diff -urN b/protoc-gen-go/testdata/deprecated/BUILD.bazel c/protoc-gen-go/testda
      name = "go_default_library",
      srcs = ["deprecated.pb.go"],
 diff -urN b/protoc-gen-go/testdata/extension_base/BUILD.bazel c/protoc-gen-go/testdata/extension_base/BUILD.bazel
---- b/protoc-gen-go/testdata/extension_base/BUILD.bazel	2018-09-28 12:25:59.944105639 -0400
-+++ c/protoc-gen-go/testdata/extension_base/BUILD.bazel	2018-09-28 12:28:40.238183129 -0400
+--- b/protoc-gen-go/testdata/extension_base/BUILD.bazel	2018-11-07 14:11:49.296167319 -0500
++++ c/protoc-gen-go/testdata/extension_base/BUILD.bazel	2018-11-07 14:12:04.204354837 -0500
 @@ -1,5 +1,11 @@
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
  
@@ -165,8 +188,8 @@ diff -urN b/protoc-gen-go/testdata/extension_base/BUILD.bazel c/protoc-gen-go/te
      name = "go_default_library",
      srcs = ["extension_base.pb.go"],
 diff -urN b/protoc-gen-go/testdata/extension_extra/BUILD.bazel c/protoc-gen-go/testdata/extension_extra/BUILD.bazel
---- b/protoc-gen-go/testdata/extension_extra/BUILD.bazel	2018-09-28 12:25:59.944105639 -0400
-+++ c/protoc-gen-go/testdata/extension_extra/BUILD.bazel	2018-09-28 12:28:40.238183129 -0400
+--- b/protoc-gen-go/testdata/extension_extra/BUILD.bazel	2018-11-07 14:11:49.296167319 -0500
++++ c/protoc-gen-go/testdata/extension_extra/BUILD.bazel	2018-11-07 14:12:04.204354837 -0500
 @@ -1,5 +1,11 @@
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
  
@@ -180,8 +203,8 @@ diff -urN b/protoc-gen-go/testdata/extension_extra/BUILD.bazel c/protoc-gen-go/t
      name = "go_default_library",
      srcs = ["extension_extra.pb.go"],
 diff -urN b/protoc-gen-go/testdata/extension_user/BUILD.bazel c/protoc-gen-go/testdata/extension_user/BUILD.bazel
---- b/protoc-gen-go/testdata/extension_user/BUILD.bazel	2018-09-28 12:25:59.944105639 -0400
-+++ c/protoc-gen-go/testdata/extension_user/BUILD.bazel	2018-09-28 12:28:40.238183129 -0400
+--- b/protoc-gen-go/testdata/extension_user/BUILD.bazel	2018-11-07 14:11:49.296167319 -0500
++++ c/protoc-gen-go/testdata/extension_user/BUILD.bazel	2018-11-07 14:12:04.204354837 -0500
 @@ -1,5 +1,11 @@
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
  
@@ -195,8 +218,8 @@ diff -urN b/protoc-gen-go/testdata/extension_user/BUILD.bazel c/protoc-gen-go/te
      name = "go_default_library",
      srcs = ["extension_user.pb.go"],
 diff -urN b/protoc-gen-go/testdata/grpc/BUILD.bazel c/protoc-gen-go/testdata/grpc/BUILD.bazel
---- b/protoc-gen-go/testdata/grpc/BUILD.bazel	2018-09-28 12:25:59.944105639 -0400
-+++ c/protoc-gen-go/testdata/grpc/BUILD.bazel	2018-09-28 12:28:40.238183129 -0400
+--- b/protoc-gen-go/testdata/grpc/BUILD.bazel	2018-11-07 14:11:49.296167319 -0500
++++ c/protoc-gen-go/testdata/grpc/BUILD.bazel	2018-11-07 14:12:04.208354887 -0500
 @@ -1,5 +1,11 @@
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
  
@@ -210,8 +233,8 @@ diff -urN b/protoc-gen-go/testdata/grpc/BUILD.bazel c/protoc-gen-go/testdata/grp
      name = "go_default_library",
      srcs = ["grpc.pb.go"],
 diff -urN b/protoc-gen-go/testdata/import_public/BUILD.bazel c/protoc-gen-go/testdata/import_public/BUILD.bazel
---- b/protoc-gen-go/testdata/import_public/BUILD.bazel	2018-09-28 12:25:59.944105639 -0400
-+++ c/protoc-gen-go/testdata/import_public/BUILD.bazel	2018-09-28 12:28:40.238183129 -0400
+--- b/protoc-gen-go/testdata/import_public/BUILD.bazel	2018-11-07 14:11:49.296167319 -0500
++++ c/protoc-gen-go/testdata/import_public/BUILD.bazel	2018-11-07 14:12:04.208354887 -0500
 @@ -1,5 +1,14 @@
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
  
@@ -228,8 +251,8 @@ diff -urN b/protoc-gen-go/testdata/import_public/BUILD.bazel c/protoc-gen-go/tes
      name = "go_default_library",
      srcs = [
 diff -urN b/protoc-gen-go/testdata/import_public/sub/BUILD.bazel c/protoc-gen-go/testdata/import_public/sub/BUILD.bazel
---- b/protoc-gen-go/testdata/import_public/sub/BUILD.bazel	2018-09-28 12:25:59.944105639 -0400
-+++ c/protoc-gen-go/testdata/import_public/sub/BUILD.bazel	2018-09-28 12:28:40.238183129 -0400
+--- b/protoc-gen-go/testdata/import_public/sub/BUILD.bazel	2018-11-07 14:11:49.296167319 -0500
++++ c/protoc-gen-go/testdata/import_public/sub/BUILD.bazel	2018-11-07 14:12:04.208354887 -0500
 @@ -1,5 +1,14 @@
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
  
@@ -246,8 +269,8 @@ diff -urN b/protoc-gen-go/testdata/import_public/sub/BUILD.bazel c/protoc-gen-go
      name = "go_default_library",
      srcs = [
 diff -urN b/protoc-gen-go/testdata/imports/BUILD.bazel c/protoc-gen-go/testdata/imports/BUILD.bazel
---- b/protoc-gen-go/testdata/imports/BUILD.bazel	2018-09-28 12:25:59.944105639 -0400
-+++ c/protoc-gen-go/testdata/imports/BUILD.bazel	2018-09-28 12:28:40.238183129 -0400
+--- b/protoc-gen-go/testdata/imports/BUILD.bazel	2018-11-07 14:11:49.296167319 -0500
++++ c/protoc-gen-go/testdata/imports/BUILD.bazel	2018-11-07 14:12:04.208354887 -0500
 @@ -1,5 +1,15 @@
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
  
@@ -265,8 +288,8 @@ diff -urN b/protoc-gen-go/testdata/imports/BUILD.bazel c/protoc-gen-go/testdata/
      name = "go_default_library",
      srcs = [
 diff -urN b/protoc-gen-go/testdata/imports/fmt/BUILD.bazel c/protoc-gen-go/testdata/imports/fmt/BUILD.bazel
---- b/protoc-gen-go/testdata/imports/fmt/BUILD.bazel	2018-09-28 12:25:59.944105639 -0400
-+++ c/protoc-gen-go/testdata/imports/fmt/BUILD.bazel	2018-09-28 12:28:40.238183129 -0400
+--- b/protoc-gen-go/testdata/imports/fmt/BUILD.bazel	2018-11-07 14:11:49.296167319 -0500
++++ c/protoc-gen-go/testdata/imports/fmt/BUILD.bazel	2018-11-07 14:12:04.208354887 -0500
 @@ -1,5 +1,11 @@
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
  
@@ -280,8 +303,8 @@ diff -urN b/protoc-gen-go/testdata/imports/fmt/BUILD.bazel c/protoc-gen-go/testd
      name = "go_default_library",
      srcs = ["m.pb.go"],
 diff -urN b/protoc-gen-go/testdata/imports/test_a_1/BUILD.bazel c/protoc-gen-go/testdata/imports/test_a_1/BUILD.bazel
---- b/protoc-gen-go/testdata/imports/test_a_1/BUILD.bazel	2018-09-28 12:25:59.944105639 -0400
-+++ c/protoc-gen-go/testdata/imports/test_a_1/BUILD.bazel	2018-09-28 12:28:40.242183180 -0400
+--- b/protoc-gen-go/testdata/imports/test_a_1/BUILD.bazel	2018-11-07 14:11:49.296167319 -0500
++++ c/protoc-gen-go/testdata/imports/test_a_1/BUILD.bazel	2018-11-07 14:12:04.208354887 -0500
 @@ -1,5 +1,14 @@
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
  
@@ -298,8 +321,8 @@ diff -urN b/protoc-gen-go/testdata/imports/test_a_1/BUILD.bazel c/protoc-gen-go/
      name = "go_default_library",
      srcs = [
 diff -urN b/protoc-gen-go/testdata/imports/test_a_2/BUILD.bazel c/protoc-gen-go/testdata/imports/test_a_2/BUILD.bazel
---- b/protoc-gen-go/testdata/imports/test_a_2/BUILD.bazel	2018-09-28 12:25:59.944105639 -0400
-+++ c/protoc-gen-go/testdata/imports/test_a_2/BUILD.bazel	2018-09-28 12:28:40.242183180 -0400
+--- b/protoc-gen-go/testdata/imports/test_a_2/BUILD.bazel	2018-11-07 14:11:49.296167319 -0500
++++ c/protoc-gen-go/testdata/imports/test_a_2/BUILD.bazel	2018-11-07 14:12:04.208354887 -0500
 @@ -1,5 +1,14 @@
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
  
@@ -316,8 +339,8 @@ diff -urN b/protoc-gen-go/testdata/imports/test_a_2/BUILD.bazel c/protoc-gen-go/
      name = "go_default_library",
      srcs = [
 diff -urN b/protoc-gen-go/testdata/imports/test_b_1/BUILD.bazel c/protoc-gen-go/testdata/imports/test_b_1/BUILD.bazel
---- b/protoc-gen-go/testdata/imports/test_b_1/BUILD.bazel	2018-09-28 12:25:59.944105639 -0400
-+++ c/protoc-gen-go/testdata/imports/test_b_1/BUILD.bazel	2018-09-28 12:28:40.242183180 -0400
+--- b/protoc-gen-go/testdata/imports/test_b_1/BUILD.bazel	2018-11-07 14:11:49.296167319 -0500
++++ c/protoc-gen-go/testdata/imports/test_b_1/BUILD.bazel	2018-11-07 14:12:04.208354887 -0500
 @@ -1,5 +1,14 @@
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
  
@@ -334,8 +357,8 @@ diff -urN b/protoc-gen-go/testdata/imports/test_b_1/BUILD.bazel c/protoc-gen-go/
      name = "go_default_library",
      srcs = [
 diff -urN b/protoc-gen-go/testdata/multi/BUILD.bazel c/protoc-gen-go/testdata/multi/BUILD.bazel
---- b/protoc-gen-go/testdata/multi/BUILD.bazel	2018-09-28 12:25:59.944105639 -0400
-+++ c/protoc-gen-go/testdata/multi/BUILD.bazel	2018-09-28 12:28:40.242183180 -0400
+--- b/protoc-gen-go/testdata/multi/BUILD.bazel	2018-11-07 14:11:49.296167319 -0500
++++ c/protoc-gen-go/testdata/multi/BUILD.bazel	2018-11-07 14:12:04.208354887 -0500
 @@ -1,5 +1,15 @@
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
  
@@ -353,8 +376,8 @@ diff -urN b/protoc-gen-go/testdata/multi/BUILD.bazel c/protoc-gen-go/testdata/mu
      name = "go_default_library",
      srcs = [
 diff -urN b/protoc-gen-go/testdata/my_test/BUILD.bazel c/protoc-gen-go/testdata/my_test/BUILD.bazel
---- b/protoc-gen-go/testdata/my_test/BUILD.bazel	2018-09-28 12:25:59.944105639 -0400
-+++ c/protoc-gen-go/testdata/my_test/BUILD.bazel	2018-09-28 12:28:40.242183180 -0400
+--- b/protoc-gen-go/testdata/my_test/BUILD.bazel	2018-11-07 14:11:49.296167319 -0500
++++ c/protoc-gen-go/testdata/my_test/BUILD.bazel	2018-11-07 14:12:04.208354887 -0500
 @@ -1,5 +1,11 @@
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
  
@@ -368,8 +391,8 @@ diff -urN b/protoc-gen-go/testdata/my_test/BUILD.bazel c/protoc-gen-go/testdata/
      name = "go_default_library",
      srcs = ["test.pb.go"],
 diff -urN b/protoc-gen-go/testdata/proto3/BUILD.bazel c/protoc-gen-go/testdata/proto3/BUILD.bazel
---- b/protoc-gen-go/testdata/proto3/BUILD.bazel	2018-09-28 12:25:59.944105639 -0400
-+++ c/protoc-gen-go/testdata/proto3/BUILD.bazel	2018-09-28 12:28:40.242183180 -0400
+--- b/protoc-gen-go/testdata/proto3/BUILD.bazel	2018-11-07 14:11:49.296167319 -0500
++++ c/protoc-gen-go/testdata/proto3/BUILD.bazel	2018-11-07 14:12:04.208354887 -0500
 @@ -1,5 +1,11 @@
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
  
@@ -383,8 +406,8 @@ diff -urN b/protoc-gen-go/testdata/proto3/BUILD.bazel c/protoc-gen-go/testdata/p
      name = "go_default_library",
      srcs = ["proto3.pb.go"],
 diff -urN b/ptypes/any/BUILD.bazel c/ptypes/any/BUILD.bazel
---- b/ptypes/any/BUILD.bazel	2018-09-28 12:25:59.944105639 -0400
-+++ c/ptypes/any/BUILD.bazel	2018-09-28 12:28:40.242183180 -0400
+--- b/ptypes/any/BUILD.bazel	2018-11-07 14:11:49.296167319 -0500
++++ c/ptypes/any/BUILD.bazel	2018-11-07 14:12:04.212354937 -0500
 @@ -1,5 +1,11 @@
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
  
@@ -398,8 +421,8 @@ diff -urN b/ptypes/any/BUILD.bazel c/ptypes/any/BUILD.bazel
      name = "go_default_library",
      srcs = ["any.pb.go"],
 diff -urN b/ptypes/BUILD.bazel c/ptypes/BUILD.bazel
---- b/ptypes/BUILD.bazel	2018-09-28 12:25:59.944105639 -0400
-+++ c/ptypes/BUILD.bazel	2018-09-28 12:28:40.242183180 -0400
+--- b/ptypes/BUILD.bazel	2018-11-07 14:11:49.296167319 -0500
++++ c/ptypes/BUILD.bazel	2018-11-07 14:12:04.212354937 -0500
 @@ -18,6 +18,24 @@
      ],
  )
@@ -426,8 +449,8 @@ diff -urN b/ptypes/BUILD.bazel c/ptypes/BUILD.bazel
      name = "go_default_test",
      srcs = [
 diff -urN b/ptypes/duration/BUILD.bazel c/ptypes/duration/BUILD.bazel
---- b/ptypes/duration/BUILD.bazel	2018-09-28 12:25:59.944105639 -0400
-+++ c/ptypes/duration/BUILD.bazel	2018-09-28 12:28:40.242183180 -0400
+--- b/ptypes/duration/BUILD.bazel	2018-11-07 14:11:49.296167319 -0500
++++ c/ptypes/duration/BUILD.bazel	2018-11-07 14:12:04.212354937 -0500
 @@ -1,5 +1,11 @@
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
  
@@ -441,8 +464,8 @@ diff -urN b/ptypes/duration/BUILD.bazel c/ptypes/duration/BUILD.bazel
      name = "go_default_library",
      srcs = ["duration.pb.go"],
 diff -urN b/ptypes/empty/BUILD.bazel c/ptypes/empty/BUILD.bazel
---- b/ptypes/empty/BUILD.bazel	2018-09-28 12:25:59.944105639 -0400
-+++ c/ptypes/empty/BUILD.bazel	2018-09-28 12:28:40.242183180 -0400
+--- b/ptypes/empty/BUILD.bazel	2018-11-07 14:11:49.296167319 -0500
++++ c/ptypes/empty/BUILD.bazel	2018-11-07 14:12:04.212354937 -0500
 @@ -1,5 +1,11 @@
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
  
@@ -456,8 +479,8 @@ diff -urN b/ptypes/empty/BUILD.bazel c/ptypes/empty/BUILD.bazel
      name = "go_default_library",
      srcs = ["empty.pb.go"],
 diff -urN b/ptypes/struct/BUILD.bazel c/ptypes/struct/BUILD.bazel
---- b/ptypes/struct/BUILD.bazel	2018-09-28 12:25:59.944105639 -0400
-+++ c/ptypes/struct/BUILD.bazel	2018-09-28 12:28:40.246183232 -0400
+--- b/ptypes/struct/BUILD.bazel	2018-11-07 14:11:49.296167319 -0500
++++ c/ptypes/struct/BUILD.bazel	2018-11-07 14:12:04.212354937 -0500
 @@ -1,5 +1,11 @@
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
  
@@ -471,8 +494,8 @@ diff -urN b/ptypes/struct/BUILD.bazel c/ptypes/struct/BUILD.bazel
      name = "go_default_library",
      srcs = ["struct.pb.go"],
 diff -urN b/ptypes/timestamp/BUILD.bazel c/ptypes/timestamp/BUILD.bazel
---- b/ptypes/timestamp/BUILD.bazel	2018-09-28 12:25:59.944105639 -0400
-+++ c/ptypes/timestamp/BUILD.bazel	2018-09-28 12:28:40.246183232 -0400
+--- b/ptypes/timestamp/BUILD.bazel	2018-11-07 14:11:49.296167319 -0500
++++ c/ptypes/timestamp/BUILD.bazel	2018-11-07 14:12:04.212354937 -0500
 @@ -1,5 +1,11 @@
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
  
@@ -486,8 +509,8 @@ diff -urN b/ptypes/timestamp/BUILD.bazel c/ptypes/timestamp/BUILD.bazel
      name = "go_default_library",
      srcs = ["timestamp.pb.go"],
 diff -urN b/ptypes/wrappers/BUILD.bazel c/ptypes/wrappers/BUILD.bazel
---- b/ptypes/wrappers/BUILD.bazel	2018-09-28 12:25:59.944105639 -0400
-+++ c/ptypes/wrappers/BUILD.bazel	2018-09-28 12:28:40.246183232 -0400
+--- b/ptypes/wrappers/BUILD.bazel	2018-11-07 14:11:49.296167319 -0500
++++ c/ptypes/wrappers/BUILD.bazel	2018-11-07 14:12:04.212354937 -0500
 @@ -1,5 +1,11 @@
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
  


### PR DESCRIPTION
It's important for go_default_library not to depend on any
go_proto_library because protoc-gen-go depends on it. However, other
binaries may need to depend on generator and go_proto_library targets,
and this helps them avoid conflicts.

Fixes #1817