### PR TITLE
Fix mismatching version and hash in gazelle sec

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -192,7 +192,7 @@ build files automatically using gazelle_.
     load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
     http_archive(
         name = "io_bazel_rules_go",
-        urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.16.1/rules_go-0.16.1.tar.gz"],
+        urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.16.2/rules_go-0.16.2.tar.gz"],
         sha256 = "f87fa87475ea107b3c69196f39c82b7bbf58fe27c62a338684c20ca17d1d8613",
     )
     http_archive(


### PR DESCRIPTION
Gazelle section has WORKSPACE commands that provide for version 0.16.1 with a hash for 0.16.2, which doesn't work. Just changed it to 0.16.2 for consistency. Tried on my computer, and it works.