### PR TITLE
Expose proto generated sources via OutputGroup

### DIFF
--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -511,7 +511,7 @@ def setup_cgo_library(name, srcs, cdeps, copts, cxxopts, cppopts, clinkopts, obj
         cgo_mode_info[cgo_info_name] = _encode_cgo_mode(goos, goarch, race = False, msan = True)
 
     # Collect everything in a single embedable, aspect-friendly library.
-    cgo_embed_name = name + "%cgo_embed"
+    cgo_embed_name = name + "__cgo_embed"
     _cgo_select_embed(
         name = cgo_embed_name,
         info = cgo_mode_info,

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -100,22 +100,20 @@ def _go_proto_library_impl(ctx):
     )
     source = go.library_to_source(go, ctx.attr, library, False)
     providers = [library, source]
+    output_groups = {
+        "go_generated_srcs": go_srcs,
+    }
     if valid_archive:
         archive = go.archive(go, source)
+        output_groups["compilation_outputs"] = [archive.data.file]
         providers.extend([
             archive,
             DefaultInfo(
                 files = depset([archive.data.file]),
                 runfiles = archive.runfiles,
             ),
-            OutputGroupInfo(
-                compilation_outputs = [archive.data.file],
-            ),
         ])
-    return struct(
-        providers = providers,
-        aspect_proto_go_api_info = struct(files_to_build = go_srcs),
-    )
+    return providers + [OutputGroupInfo(**output_groups)]
 
 go_proto_library = go_rule(
     _go_proto_library_impl,

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -99,21 +99,23 @@ def _go_proto_library_impl(ctx):
         srcs = go_srcs,
     )
     source = go.library_to_source(go, ctx.attr, library, False)
-    if not valid_archive:
-        return [library, source]
-    archive = go.archive(go, source)
-    return [
-        library,
-        source,
-        archive,
-        DefaultInfo(
-            files = depset([archive.data.file]),
-            runfiles = archive.runfiles,
-        ),
-        OutputGroupInfo(
-            compilation_outputs = [archive.data.file],
-        ),
-    ]
+    providers = [library, source]
+    if valid_archive:
+        archive = go.archive(go, source)
+        providers.extend([
+            archive,
+            DefaultInfo(
+                files = depset([archive.data.file]),
+                runfiles = archive.runfiles,
+            ),
+            OutputGroupInfo(
+                compilation_outputs = [archive.data.file],
+            ),
+        ])
+    return struct(
+        providers = providers,
+        aspect_proto_go_api_info = struct(files_to_build = go_srcs),
+    )
 
 go_proto_library = go_rule(
     _go_proto_library_impl,


### PR DESCRIPTION
This PR modifies `go_proto_library` to return the legacy-style provider that the IntelliJ plugin [currently expects](https://github.com/bazelbuild/intellij/blob/54f5b0709e9a74d4cd1c5a0fdcd4f7cf8c76500d/aspect/intellij_info_impl.bzl#L217-L223).