### PR TITLE
Explicitly reexport some symbols, reformat the .bzl files with Buildifier

### DIFF
--- a/go/def.bzl
+++ b/go/def.bzl
@@ -14,7 +14,7 @@
 
 load(
     "@io_bazel_rules_go//go/private:context.bzl",
-    "go_context",
+    _go_context = "go_context",
 )
 load(
     "@io_bazel_rules_go//go/private:providers.bzl",
@@ -27,11 +27,11 @@ load(
 )
 load(
     "@io_bazel_rules_go//go/private:repositories.bzl",
-    "go_rules_dependencies",
+    _go_rules_dependencies = "go_rules_dependencies",
 )
 load(
     "@io_bazel_rules_go//go/toolchain:toolchains.bzl",
-    "go_register_toolchains",
+    _go_register_toolchains = "go_register_toolchains",
 )
 load(
     "@io_bazel_rules_go//go/private:sdk.bzl",
@@ -60,7 +60,7 @@ load(
 )
 load(
     "@io_bazel_rules_go//extras:embed_data.bzl",
-    "go_embed_data",
+    _go_embed_data = "go_embed_data",
 )
 load(
     "@io_bazel_rules_go//go/private:tools/path.bzl",
@@ -76,16 +76,23 @@ load(
 )
 load(
     "@io_bazel_rules_go//go/private:rules/library.bzl",
-    "go_tool_library",
+    _go_tool_library = "go_tool_library",
 )
 load(
     "@io_bazel_rules_go//go/private:rules/nogo.bzl",
-    "nogo",
+    _nogo = "nogo",
 )
 
 # Current version or next version to be tagged. Gazelle and other tools may
 # check this to determine compatibility.
 RULES_GO_VERSION = "0.16.0"
+
+go_context = _go_context
+go_rules_dependencies = _go_rules_dependencies
+go_register_toolchains = _go_register_toolchains
+go_tool_library = _go_tool_library
+nogo = _nogo
+go_embed_data = _go_embed_data
 
 GoLibrary = _GoLibrary
 """See go/providers.rst#GoLibrary for full documentation."""

--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 load(
+    "@io_bazel_rules_go//go/private:skylib/lib/sets.bzl",
+    "sets",
+)
+load(
     "@io_bazel_rules_go//go/private:common.bzl",
     "as_tuple",
-    "sets",
     "split_srcs",
 )
 load(

--- a/go/private/actions/asm.bzl
+++ b/go/private/actions/asm.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load(
-    "@io_bazel_rules_go//go/private:common.bzl",
+    "@io_bazel_rules_go//go/private:skylib/lib/sets.bzl",
     "sets",
 )
 load(

--- a/go/private/actions/cover.bzl
+++ b/go/private/actions/cover.bzl
@@ -18,7 +18,7 @@ load(
     "effective_importpath_pkgpath",
 )
 load(
-    "@io_bazel_rules_go//go/private:common.bzl",
+    "@io_bazel_rules_go//go/private:skylib/lib/structs.bzl",
     "structs",
 )
 

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -13,10 +13,13 @@
 # limitations under the License.
 
 load(
+    "@io_bazel_rules_go//go/private:skylib/lib/sets.bzl",
+    "sets",
+)
+load(
     "@io_bazel_rules_go//go/private:common.bzl",
     "SHARED_LIB_EXTENSIONS",
     "as_iterable",
-    "sets",
 )
 load(
     "@io_bazel_rules_go//go/private:mode.bzl",

--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -12,12 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//go/private:skylib/lib/dicts.bzl", "dicts")
-load("//go/private:skylib/lib/paths.bzl", "paths")
-load("//go/private:skylib/lib/sets.bzl", "sets")
-load("//go/private:skylib/lib/shell.bzl", "shell")
-load("//go/private:skylib/lib/structs.bzl", "structs")
-load("@io_bazel_rules_go//go/private:mode.bzl", "mode_string")
+load("//go/private:skylib/lib/dicts.bzl", _dicts = "dicts")
+load("//go/private:skylib/lib/paths.bzl", _paths = "paths")
+load("//go/private:skylib/lib/sets.bzl", _sets = "sets")
+load("//go/private:skylib/lib/shell.bzl", _shell = "shell")
+load("//go/private:skylib/lib/structs.bzl", _structs = "structs")
+load("@io_bazel_rules_go//go/private:mode.bzl", _mode_string = "mode_string")
+
+# re-exports
+dicts = _dicts
+paths = _paths
+sets = _sets
+shell = _shell
+structs = _structs
+mode_string = _mode_string
 
 go_exts = [
     ".go",

--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -12,21 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//go/private:skylib/lib/dicts.bzl", _dicts = "dicts")
-load("//go/private:skylib/lib/paths.bzl", _paths = "paths")
-load("//go/private:skylib/lib/sets.bzl", _sets = "sets")
-load("//go/private:skylib/lib/shell.bzl", _shell = "shell")
-load("//go/private:skylib/lib/structs.bzl", _structs = "structs")
-load("@io_bazel_rules_go//go/private:mode.bzl", _mode_string = "mode_string")
-
-# re-exports
-dicts = _dicts
-paths = _paths
-sets = _sets
-shell = _shell
-structs = _structs
-mode_string = _mode_string
-
 go_exts = [
     ".go",
 ]

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -51,7 +51,13 @@ load(
     "as_iterable",
     "goos_to_extension",
     "goos_to_shared_extension",
+)
+load(
+    "@io_bazel_rules_go//go/private:skylib/lib/paths.bzl",
     "paths",
+)
+load(
+    "@io_bazel_rules_go//go/private:skylib/lib/structs.bzl",
     "structs",
 )
 load(

--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -139,5 +139,7 @@ def generate_toolchains(host, sdk):
 
 def generate_toolchain_names():
     # Keep in sync with generate_toolchains
-    return ["go_{}_{}".format(target_goos, target_goarch)
-            for target_goos, target_goarch in GOOS_GOARCH]
+    return [
+        "go_{}_{}".format(target_goos, target_goarch)
+        for target_goos, target_goarch in GOOS_GOARCH
+    ]

--- a/go/private/rules/aspect.bzl
+++ b/go/private/rules/aspect.bzl
@@ -13,12 +13,15 @@
 # limitations under the License.
 
 load(
+    "@io_bazel_rules_go//go/private:skylib/lib/sets.bzl",
+    "sets",
+)
+load(
     "@io_bazel_rules_go//go/private:context.bzl",
     "go_context",
 )
 load(
     "@io_bazel_rules_go//go/private:common.bzl",
-    "sets",
     "split_srcs",
 )
 load(

--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 load(
+    "@io_bazel_rules_go//go/private:skylib/lib/sets.bzl",
+    "sets",
+)
+load(
     "@io_bazel_rules_go//go/private:context.bzl",
     "go_context",
 )
@@ -24,7 +28,6 @@ load(
     "as_set",
     "join_srcs",
     "pkg_dir",
-    "sets",
     "split_srcs",
 )
 load(

--- a/go/private/rules/nogo.bzl
+++ b/go/private/rules/nogo.bzl
@@ -14,8 +14,11 @@
 
 load(
     "@io_bazel_rules_go//go/private:context.bzl",
-    "EXPORT_PATH",
     "go_context",
+)
+load(
+    "@io_bazel_rules_go//go/private:providers.bzl",
+    "EXPORT_PATH",
 )
 load(
     "@io_bazel_rules_go//go/private:rules/rule.bzl",

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -18,7 +18,7 @@ load(
     "go_context",
 )
 load(
-    "@io_bazel_rules_go//go/private:common.bzl",  # TODO: @skylib?
+    "@io_bazel_rules_go//go/private:skylib/lib/sets.bzl",
     "sets",
 )
 load(

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -18,7 +18,7 @@ load(
     "go_context",
 )
 load(
-    "@io_bazel_rules_go//go/private:common.bzl",
+    "@io_bazel_rules_go//go/private:skylib/lib/sets.bzl",
     "sets",
 )
 load(

--- a/tests/bazel_tests.bzl
+++ b/tests/bazel_tests.bzl
@@ -191,7 +191,7 @@ def _bazel_test_script_impl(ctx):
 
     output = "{workspace_root}/{package}".format(
         workspace_root = base_label.workspace_root,
-        package = base_label.package
+        package = base_label.package,
     )
     targets = [base_label.relative(t) for t in ctx.attr.targets]
     logs = []


### PR DESCRIPTION
In the future, Bazel will not automatically re-export the symbols that come from a load. This PR is fixing that.

This diff is large, because I also reformatted all files with Buildifier. This will allow you to use Buildifier automated fixes in the future.

Progress towards #1829