### PR TITLE
nogo: pass explicit path to .x output file

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -46,6 +46,8 @@ def emit_archive(go, source = None):
     out_lib = go.declare_file(go, path = lib_name)
     out_export = None
     if go.nogo:
+        # TODO(#1847): write nogo data into a new section in the .a file instead
+        # of writing a separate file.
         out_export = go.declare_file(go, path = lib_name[:-len(".a")] + ".x")
     searchpath = out_lib.path[:-len(lib_name)]
     testfilter = getattr(source.library, "testfilter", None)

--- a/go/private/actions/compile.bzl
+++ b/go/private/actions/compile.bzl
@@ -60,6 +60,7 @@ def emit_compile(
         builder_args.add("-testfilter", testfilter)
     if go.nogo:
         builder_args.add("-nogo", go.nogo)
+        builder_args.add("-x", out_export)
         inputs.append(go.nogo)
         inputs.extend([archive.data.export_file for archive in archives])
         outputs.append(out_export)

--- a/go/tools/builders/compile.go
+++ b/go/tools/builders/compile.go
@@ -50,6 +50,7 @@ func run(args []string) error {
 	flags.Var(&unfiltered, "src", "A source file to be filtered and compiled")
 	flags.Var(&archives, "arc", "Import path, package path, and file name of a direct dependency, separated by '='")
 	nogo := flags.String("nogo", "", "The nogo binary")
+	outExport := flags.String("x", "", "Path to nogo that should be written")
 	output := flags.String("o", "", "The output object file to write")
 	packageList := flags.String("package_list", "", "The file containing the list of standard library packages")
 	testfilter := flags.String("testfilter", "off", "Controls test package filtering")
@@ -150,7 +151,7 @@ func run(args []string) error {
 		for _, imp := range stdImports {
 			nogoargs = append(nogoargs, "-stdimport", imp)
 		}
-		nogoargs = append(nogoargs, "-x", strings.TrimSuffix(*output, ".a")+".x")
+		nogoargs = append(nogoargs, "-x", *outExport)
 		nogoargs = append(nogoargs, filenames...)
 		nogoCmd := exec.Command(*nogo, nogoargs...)
 		nogoCmd.Stdout, nogoCmd.Stderr = &nogoOutput, &nogoOutput

--- a/tests/core/nogo/vet/BUILD.bazel
+++ b/tests/core/nogo/vet/BUILD.bazel
@@ -68,5 +68,6 @@ go_library(
 go_library(
     name = "no_errors",
     srcs = ["no_errors.go"],
+    cgo = True,
     importpath = "noerrors",
 )

--- a/tests/core/nogo/vet/no_errors.go
+++ b/tests/core/nogo/vet/no_errors.go
@@ -1,5 +1,8 @@
 package noerrors
 
+// const int x = 1;
+import "C"
+
 func Foo() bool {
-	return true
+	return bool(C.x == 1)
 }


### PR DESCRIPTION
The compile builder and nogo assume the .x file to be written is in a
location based on the .a file, but analysis generates an .x output
path based on the import path, and the .a output path may vary
slightly from that.

Rather than trying to fix this assumptions, this change makes the
compile builder accept an -x parameter with the output path.

A logical extension of this would be to make paths explicit for .x
files of all dependencies. However, it would be better to get rid of
.x files altogether and store the data in a new section within .a
files instead (#1847).

Fixes #1846