### PR TITLE
Ensure nogo is run on libraries compiled with the aspect

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -296,7 +296,11 @@ def go_context(ctx, attr = None):
     if builders:
         builders = builders[GoBuilders]
 
-    nogo = ctx.files._nogo[0] if getattr(ctx.files, "_nogo", None) else None
+    nogo = None
+    if hasattr(attr, "_nogo"):
+        nogo_files = attr._nogo.files.to_list()
+        if nogo_files:
+            nogo = nogo_files[0]
 
     coverdata = getattr(attr, "_coverdata", None)
     if coverdata:

--- a/tests/core/nogo/README.rst
+++ b/tests/core/nogo/README.rst
@@ -8,6 +8,7 @@ Contents
 
 .. Child list start
 
+* `Nogo configuration <config/README.rst>`_
 * `Vet check <vet/README.rst>`_
 * `nogo analyzers with dependencies <deps/README.rst>`_
 * `Custom nogo analyzers <custom/README.rst>`_

--- a/tests/core/nogo/config/BUILD.bazel
+++ b/tests/core/nogo/config/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//tests:bazel_tests.bzl", "bazel_test")
+
+bazel_test(
+    name = "pure_aspect_test",
+    command = "build",
+    nogo = "@io_bazel_rules_go//:tools_nogo",
+    targets = [":pure_bin"],
+)
+
+go_binary(
+    name = "pure_bin",
+    srcs = ["pure_bin.go"],
+    pure = "on",
+    tags = ["manual"],
+    deps = [":pure_lib"],
+)
+
+go_library(
+    name = "pure_lib",
+    srcs = ["pure_lib.go"],
+    importpath = "github.com/bazelbuild/rules_go/tests/core/nogo/config/pure_lib",
+    tags = ["manual"],
+)

--- a/tests/core/nogo/config/README.rst
+++ b/tests/core/nogo/config/README.rst
@@ -1,0 +1,14 @@
+Nogo configuration
+==================
+
+.. _nogo: /go/nogo.rst
+.. _go_binary: /go/core.rst#_go_binary
+
+Tests that verify nogo_ works on targets compiled in non-default configurations.
+
+.. contents::
+
+pure_aspect_test
+----------------
+Verifies that a `go_binary`_ with ``pure = "on"`` (compiled with the aspect)
+builds successfully with nogo. Verifies #1850.

--- a/tests/core/nogo/config/pure_bin.go
+++ b/tests/core/nogo/config/pure_bin.go
@@ -1,0 +1,6 @@
+package main
+
+import _ "github.com/bazelbuild/rules_go/tests/core/nogo/config/pure_lib"
+
+func main() {
+}

--- a/tests/core/nogo/config/pure_lib.go
+++ b/tests/core/nogo/config/pure_lib.go
@@ -1,0 +1,1 @@
+package pure_lib


### PR DESCRIPTION
Previously, when go_context checked whether nogo was enabled, it just
looked at ctx.attr._nogo. When the aspect is used (e.g., when
`pure = "on"` is set on a binary), ctx.attr refers to the aspect's
attributes. We should look at the underlying rule's attributes
instead.

Fixes #1850