### PR TITLE
Pure mode when using the goos attribute

### DIFF
--- a/go/private/mode.bzl
+++ b/go/private/mode.bzl
@@ -78,8 +78,17 @@ def _ternary(*values):
     fail("_ternary failed to produce a final result from {}".format(values))
 
 def get_mode(ctx, host_only, go_toolchain, go_context_data):
+    goos = getattr(ctx.attr, "goos", None)
+    if goos == None or goos == "auto":
+        goos = go_toolchain.default_goos
+    goarch = getattr(ctx.attr, "goarch", None)
+    if goarch == None or goarch == "auto":
+        goarch = go_toolchain.default_goarch
+
     # We always have to  use the pure stdlib in cross compilation mode
-    force_pure = "on" if go_toolchain.cross_compile else "auto"
+    cross_compile = (goos != go_toolchain.sdk.goos or
+                     goarch != go_toolchain.sdk.goarch)
+    force_pure = "on" if cross_compile else "auto"
     force_race = "off" if host_only else "auto"
 
     linkmode = getattr(ctx.attr, "linkmode", LINKMODE_NORMAL)
@@ -116,12 +125,6 @@ def get_mode(ctx, host_only, go_toolchain, go_context_data):
         strip = True
     elif strip_mode == "sometimes":
         strip = not debug
-    goos = getattr(ctx.attr, "goos", None)
-    if goos == None or goos == "auto":
-        goos = go_toolchain.default_goos
-    goarch = getattr(ctx.attr, "goarch", None)
-    if goarch == None or goarch == "auto":
-        goarch = go_toolchain.default_goarch
 
     return struct(
         static = static,

--- a/tests/core/go_binary/BUILD.bazel
+++ b/tests/core/go_binary/BUILD.bazel
@@ -19,5 +19,14 @@ go_binary(
     srcs = ["custom_bin.go"],
     out = "alt_bin",
 )
-    
+
+go_binary(
+    name = "goos_pure_bin",
+    srcs = [
+        "broken_cgo.go",
+        "hello.go",
+    ],
+    goos = "plan9",
+)
+
 many_deps(name = "many_deps")

--- a/tests/core/go_binary/README.rst
+++ b/tests/core/go_binary/README.rst
@@ -17,6 +17,13 @@ out_test
 Test that a `go_binary`_ rule can write its executable file with a custom name
 in the package directory (not the mode directory).
 
+goos_pure_bin
+-------------
+
+Tests that specifying the `goos` attribute on a `go_binary`_ target to be
+different than the host os forces the pure mode to be on. This is achieved
+by including a broken cgo file in the sources for the build.
+
 many_deps
 ---------
 

--- a/tests/core/go_binary/broken_cgo.go
+++ b/tests/core/go_binary/broken_cgo.go
@@ -1,0 +1,7 @@
+// +build cgo
+
+// This file will not compile and its inclusion in a build is used to ensure
+// that a binary was built in pure mode.
+package main
+
+import "non/existent/pkg"


### PR DESCRIPTION
Currently, the `goos` attribute on a go_binary rule is ignored when determining whether to force pure mode. The only check being performed right now is using the toolchain target.

This change forces pure mode for a binary when the toolchain target is the same as the host, but the specific binary is cross-compiled using the goos attribute. All other cases remain the same.