### PR TITLE
go_proto_library: support proxy proto_library

### DIFF
--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -22,6 +22,10 @@ load(
     "sets",
 )
 load(
+    "@io_bazel_rules_go//go/private:skylib/lib/paths.bzl",
+    "paths",
+)
+load(
     "@io_bazel_rules_go//go/private:rules/rule.bzl",
     "go_rule",
 )
@@ -44,13 +48,13 @@ def go_proto_compile(go, compiler, proto, imports, importpath):
 
     # TODO(jayconrod): can we just use go.env instead?
     args.add("-compiler_path", go.cgo_tools.c_compiler_path.rpartition("/")[0])
-    args.add_all(compiler.options, before_each = "--option")
+    args.add_all(compiler.options, before_each = "-option")
     if compiler.import_path_option:
-        args.add_all([importpath], before_each = "--option", format_each = "import_path=%s")
-    args.add_all(proto.transitive_descriptor_sets, before_each = "--descriptor_set")
-    args.add_all(go_srcs, before_each = "--expected")
-    args.add_all(imports, before_each = "--import")
-    args.add_all(proto.direct_sources, map_each = proto_path)
+        args.add_all([importpath], before_each = "-option", format_each = "import_path=%s")
+    args.add_all(proto.transitive_descriptor_sets, before_each = "-descriptor_set")
+    args.add_all(go_srcs, before_each = "-expected")
+    args.add_all(imports, before_each = "-import")
+    args.add_all([proto_path(src, proto) for src in proto.direct_sources])
     go.actions.run(
         inputs = sets.union([
             compiler.go_protoc,
@@ -65,23 +69,29 @@ def go_proto_compile(go, compiler, proto, imports, importpath):
     )
     return go_srcs
 
-def proto_path(proto):
+def proto_path(src, proto):
+    """proto_path returns the string used to import the proto. This is the proto
+    source path within its repository, adjusted by import_prefix and
+    strip_import_prefix.
+
+    Args:
+        src: the proto source File.
+        proto: the ProtoInfo provider.
+
+    Returns:
+        An import path string.
     """
-    The proto path is not really a file path
-    It's the path to the proto that was seen when the descriptor file was generated.
-    """
-    path = proto.path
-    root = proto.root.path
-    ws = proto.owner.workspace_root
-    if path.startswith(root):
-        path = path[len(root):]
-    if path.startswith("/"):
-        path = path[1:]
-    if path.startswith(ws):
-        path = path[len(ws):]
-    if path.startswith("/"):
-        path = path[1:]
-    return path
+
+    if proto.proto_source_root.startswith(src.root.path):
+        # sometimes true when import paths are adjusted with import_prefix
+        prefix = proto.proto_source_root + "/"
+    else:
+        # usually true when paths are not adjusted
+        prefix = paths.join(src.root.path, proto.proto_source_root) + "/"
+    if not src.path.startswith(prefix):
+        # sometimes true when importing multiple adjusted protos
+        return src.path
+    return src.path[len(prefix):]
 
 def _go_proto_compiler_impl(ctx):
     go = go_context(ctx)

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -35,7 +35,7 @@ GoProtoCompiler = provider()
 def go_proto_compile(go, compiler, proto, imports, importpath):
     go_srcs = []
     outpath = None
-    for src in proto.direct_sources:
+    for src in proto.check_deps_sources:
         out = go.declare_file(go, path = importpath + "/" + src.basename[:-len(".proto")], ext = compiler.suffix)
         go_srcs.append(out)
         if outpath == None:
@@ -54,7 +54,7 @@ def go_proto_compile(go, compiler, proto, imports, importpath):
     args.add_all(proto.transitive_descriptor_sets, before_each = "-descriptor_set")
     args.add_all(go_srcs, before_each = "-expected")
     args.add_all(imports, before_each = "-import")
-    args.add_all([proto_path(src, proto) for src in proto.direct_sources])
+    args.add_all([proto_path(src, proto) for src in proto.check_deps_sources])
     go.actions.run(
         inputs = sets.union([
             compiler.go_protoc,

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -39,10 +39,11 @@ GoProtoImports = provider()
 
 def get_imports(attr):
     direct = []
-    if hasattr(attr, "proto"):
+    if hasattr(attr, "proto") and hasattr(attr.proto, "proto"):
+        proto = attr.proto.proto
         direct = [
-            "{}={}".format(proto_path(src), attr.importpath)
-            for src in attr.proto.proto.direct_sources
+            "{}={}".format(proto_path(src, proto), attr.importpath)
+            for src in proto.direct_sources
         ]
     deps = getattr(attr, "deps", []) + getattr(attr, "embed", [])
     transitive = [

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -43,7 +43,7 @@ def get_imports(attr):
         proto = attr.proto.proto
         direct = [
             "{}={}".format(proto_path(src, proto), attr.importpath)
-            for src in proto.direct_sources
+            for src in proto.check_deps_sources
         ]
     deps = getattr(attr, "deps", []) + getattr(attr, "embed", [])
     transitive = [

--- a/tests/core/go_proto_library/BUILD.bazel
+++ b/tests/core/go_proto_library/BUILD.bazel
@@ -73,6 +73,37 @@ go_test(
     ],
 )
 
+# proxy_test
+go_test(
+    name = "proxy_test",
+    srcs = ["proxy_test.go"],
+    deps = [":proxy_go_proto"],
+)
+
+go_proto_library(
+    name = "proxy_go_proto",
+    importpath = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/proxy",
+    proto = ":proxy_proto",
+)
+
+proto_library(
+    name = "proxy_proto",
+    deps = [
+        ":proxy_a_proto",
+        ":proxy_b_proto",
+    ],
+)
+
+proto_library(
+    name = "proxy_a_proto",
+    srcs = ["proxy_a.proto"],
+)
+
+proto_library(
+    name = "proxy_b_proto",
+    srcs = ["proxy_b.proto"],
+)
+
 # adjusted_import_test
 # TODO(#1851): uncomment when Bazel 0.22.0 is the minimum version.
 # go_test(

--- a/tests/core/go_proto_library/BUILD.bazel
+++ b/tests/core/go_proto_library/BUILD.bazel
@@ -29,9 +29,9 @@ go_proto_library(
 # embed_test
 go_proto_library(
     name = "embed_go_proto",
-    proto = ":foo_proto",
-    importpath = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/foo",
     embed = [":extra_lib"],
+    importpath = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/foo",
+    proto = ":foo_proto",
 )
 
 go_library(
@@ -52,16 +52,16 @@ go_test(
 # transitive_test
 go_proto_library(
     name = "transitive_go_proto",
-    proto = ":bar_proto",
     importpath = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/bar",
+    proto = ":bar_proto",
     deps = [":wrap_lib"],
 )
 
 go_library(
     name = "wrap_lib",
     srcs = ["extra.go"],
-    importpath = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/foo",
     embed = [":foo_go_proto"],
+    importpath = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/foo",
 )
 
 go_test(
@@ -72,3 +72,70 @@ go_test(
         ":wrap_lib",
     ],
 )
+
+# adjusted_import_test
+# TODO(#1851): uncomment when Bazel 0.22.0 is the minimum version.
+# go_test(
+#     name = "adjusted_import_test",
+#     srcs = ["adjusted_import_test.go"],
+#     deps = [
+#         ":adjusted_a_go_proto",
+#         ":adjusted_b_go_library",
+#         ":adjusted_c_go_proto",
+#     ],
+# )
+
+# go_proto_library(
+#     name = "adjusted_a_go_proto",
+#     importpath = "adjusted/a",
+#     proto = "adjusted_a_proto",
+#     deps = [
+#         ":adjusted_b_go_library",
+#         ":adjusted_c_go_proto",
+#     ],
+# )
+
+# proto_library(
+#     name = "adjusted_a_proto",
+#     srcs = ["adjusted_a.proto"],
+#     import_prefix = "adjusted",
+#     strip_import_prefix = "",
+#     deps = [
+#         ":adjusted_b_proto",
+#         ":adjusted_c_proto",
+#     ],
+# )
+
+# go_library(
+#     name = "adjusted_b_go_library",
+#     embed = [":adjusted_b_go_proto"],
+#     importpath = "adjusted/b",
+# )
+
+# go_proto_library(
+#     name = "adjusted_b_go_proto",
+#     importpath = "adjusted/b",
+#     proto = "adjusted_b_proto",
+#     deps = [":adjusted_c_go_proto"],
+# )
+
+# proto_library(
+#     name = "adjusted_b_proto",
+#     srcs = ["adjusted_b.proto"],
+#     import_prefix = "adjusted",
+#     strip_import_prefix = "",
+#     deps = [":adjusted_c_proto"],
+# )
+
+# go_proto_library(
+#     name = "adjusted_c_go_proto",
+#     importpath = "adjusted/c",
+#     proto = ":adjusted_c_proto",
+# )
+
+# proto_library(
+#     name = "adjusted_c_proto",
+#     srcs = ["adjusted_c.proto"],
+#     import_prefix = "adjusted",
+#     strip_import_prefix = "",
+# )

--- a/tests/core/go_proto_library/README.rst
+++ b/tests/core/go_proto_library/README.rst
@@ -18,3 +18,9 @@ transitive_test
 
 Checks that `go_proto_library`_ can import a proto dependency that is
 embedded in a `go_library`_. Verifies #1422.
+
+adjusted_import_test
+--------------------
+
+Checks that `go_proto_library`_ can build ``proto_library`` with
+``import_prefix`` and ``strip_import_prefix``.

--- a/tests/core/go_proto_library/adjusted_a.proto
+++ b/tests/core/go_proto_library/adjusted_a.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+import "adjusted/adjusted_b.proto";
+import "adjusted/adjusted_c.proto";
+
+package adjusted.a;
+
+option go_package = "adjusted/a";
+
+message A {
+  adjusted.b.B x = 1;
+  adjusted.c.C y = 2;
+}

--- a/tests/core/go_proto_library/adjusted_b.proto
+++ b/tests/core/go_proto_library/adjusted_b.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+import "adjusted/adjusted_c.proto";
+
+package adjusted.b;
+
+option go_package = "adjusted/b";
+
+message B {
+  adjusted.c.C b = 1;
+}

--- a/tests/core/go_proto_library/adjusted_c.proto
+++ b/tests/core/go_proto_library/adjusted_c.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package adjusted.c;
+
+option go_package = "adjusted/c";
+
+message C {
+  int64 c = 1;
+}

--- a/tests/core/go_proto_library/adjusted_import_test.go
+++ b/tests/core/go_proto_library/adjusted_import_test.go
@@ -1,0 +1,31 @@
+/* Copyright 2018 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adjusted_import_test
+
+import (
+	"testing"
+
+	"adjusted/a"
+	"adjusted/b"
+	"adjusted/c"
+)
+
+func use(interface{}) {}
+
+func TestAdjusted(t *testing.T) {
+	// just make sure types exist
+	use(a.A{X: &b.B{B: &c.C{C: 1}}, Y: &c.C{C: 1}})
+}

--- a/tests/core/go_proto_library/proxy_a.proto
+++ b/tests/core/go_proto_library/proxy_a.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+option go_package = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/proxy";
+
+message A {
+  int64 a = 1;
+}

--- a/tests/core/go_proto_library/proxy_b.proto
+++ b/tests/core/go_proto_library/proxy_b.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+option go_package = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/proxy";
+
+message B {
+  int64 b = 1;
+}

--- a/tests/core/go_proto_library/proxy_test.go
+++ b/tests/core/go_proto_library/proxy_test.go
@@ -1,0 +1,30 @@
+/* Copyright 2018 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy_test
+
+import (
+	"testing"
+
+	"github.com/bazelbuild/rules_go/tests/core/go_proto_library/proxy"
+)
+
+func use(interface{}) {}
+
+func TestProxy(t *testing.T) {
+	// just make sure both types exist
+	use(proxy.A{})
+  use(proxy.B{})
+}


### PR DESCRIPTION
In some repositories, a proto_library target will be declared for each
.proto file, even for .proto files in the same package. A
proto_library target with deps and no srcs may be used to combine
several proto_library rules.

With this change, go_proto_library treats a "proxy" proto_library as
if it contained the direct srcs of its deps.

Fixes #1857