### PR TITLE
fix README.rst indentation for gazelle

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ Announcements
 December 20, 2018
   Gazelle
   `0.16.0 <https://github.com/bazelbuild/bazel-gazelle/releases/tag/0.16.0>`_
-   is now available.
+  is now available.
 December 15, 2018
   Releases
   `0.16.5 <https://github.com/bazelbuild/rules_go/releases/tag/0.16.5>`_,


### PR DESCRIPTION
before:
<img width="220" alt="screen shot 2018-12-28 at 11 22 52 pm" src="https://user-images.githubusercontent.com/1469579/50534849-9edd1680-0af7-11e9-8fd8-03281a6e8b28.png">

after:
<img width="292" alt="screen shot 2018-12-28 at 11 23 51 pm" src="https://user-images.githubusercontent.com/1469579/50534853-adc3c900-0af7-11e9-9222-786040736779.png">
