### PR TITLE
remove non-existent Finding from nogo sample

### DIFF
--- a/go/nogo.rst
+++ b/go/nogo.rst
@@ -112,7 +112,6 @@ already been run. For example:
     }
 
     func run(pass *analysis.Pass) (interface{}, error) {
-      var findings []*analysis.Finding
       for _, f := range pass.Files {
         for _, imp := range f.Imports {
           path, err := strconv.Unquote(imp.Path.Value)


### PR DESCRIPTION
The findings variable isn't used and the required type doesn't seem to exist in the package, so I've deleted that line of the sample code.