### PR TITLE
go_sdk: replace globs with generated file lists

### DIFF
--- a/go/private/BUILD.sdk.bazel
+++ b/go/private/BUILD.sdk.bazel
@@ -1,30 +1,28 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_sdk")
 load("@io_bazel_rules_go//go/toolchain:toolchains.bzl", "declare_toolchains")
 load("@io_bazel_rules_go//go/private:rules/sdk.bzl", "package_list")
+load(":globs.bzl", "HEADERS", "LIBS", "SRCS", "TOOLS")
 
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "libs",
-    srcs = glob(
-        ["pkg/{goos}_{goarch}/**/*.a"],
-        exclude = ["pkg/{goos}_{goarch}/**/cmd/**"],
-    ),
+    srcs = LIBS,
 )
 
 filegroup(
     name = "headers",
-    srcs = glob(["pkg/include/*.h"]),
+    srcs = HEADERS,
 )
 
 filegroup(
     name = "srcs",
-    srcs = glob(["src/**"]),
+    srcs = SRCS,
 )
 
 filegroup(
     name = "tools",
-    srcs = glob(["pkg/tool/**", "bin/gofmt*"])
+    srcs = TOOLS,
 )
 
 go_sdk(
@@ -56,9 +54,11 @@ declare_toolchains(
 
 filegroup(
     name = "files",
-    srcs = glob([
-        "bin/go*",
-        "src/**",
-        "pkg/**",
-    ]),
+    srcs = [
+        ":headers",
+        ":libs",
+        ":srcs",
+        ":tools",
+        "bin/go{exe}",
+    ],
 )


### PR DESCRIPTION
When Bazel builds a target that depends on a glob, it traverses a
directory tree, making a list of matching files. This needs to be done
on every build to confirm files haven't been added or removed.

In repository rules, there's no way for files to be added or removed,
so globs are pointless. Instead, we can generate file lists ahead of
time and depend on those.

Fixes #1862