### PR TITLE
Fix some incompatibilities in Bazel 0.22.0

### DIFF
--- a/tests/core/cgo/BUILD.bazel
+++ b/tests/core/cgo/BUILD.bazel
@@ -46,25 +46,23 @@ cc_import(
     tags = ["manual"],
 )
 
-genrule(
-    name = "darwin_gen_imported_dylib",
+cc_binary(
+    name = "libimported.dylib",
     srcs = ["imported.c"],
-    outs = ["libimported.dylib"],
-    cmd = "$(CC) -shared -install_name @rpath/libimported.dylib $< -o $@",
+    linkshared = True,
     tags = ["manual"],
 )
 
 cc_import(
     name = "linux_imported_dylib",
-    shared_library = "libimported.so",
+    shared_library = ":libimported.so",
     tags = ["manual"],
 )
 
-genrule(
-    name = "linux_gen_imported_dylib",
+cc_binary(
+    name = "libimported.so",
     srcs = ["imported.c"],
-    outs = ["libimported.so"],
-    cmd = "$(CC) -shared $< -o $@",
+    linkshared = True,
     tags = ["manual"],
 )
 

--- a/tests/core/cgo/BUILD.bazel
+++ b/tests/core/cgo/BUILD.bazel
@@ -49,6 +49,7 @@ cc_import(
 cc_binary(
     name = "libimported.dylib",
     srcs = ["imported.c"],
+    linkopts = ["-install_name @rpath/libimported.dylib"],
     linkshared = True,
     tags = ["manual"],
 )

--- a/tests/legacy/examples/cgo/cc_dependency/BUILD.bazel
+++ b/tests/legacy/examples/cgo/cc_dependency/BUILD.bazel
@@ -13,7 +13,7 @@ cc_library(
     # See also comments in cxx_version.cc.
     deps = select({
         ":darwin": [],
-        "//conditions:default": [":c_version_wrap"],
+        "//conditions:default": [":c_version_import"],
     }),
 )
 
@@ -30,8 +30,9 @@ filegroup(
     output_group = "dynamic_library",
 )
 
-cc_library(
-    name = "c_version_wrap",
-    srcs = [":c_version_so"],
+cc_import(
+    name = "c_version_import",
     hdrs = ["c_version.h"],
+    shared_library = ":c_version_so",
+    tags = ["manual"],
 )


### PR DESCRIPTION
* go_proto_library now relies on the undocumented ProtoInfo instead of
  the .proto field.
* go_proto_library now uses to_list() when iterating ProtoInfo
  depsets.
* A test in tests/core/cgo now uses cc_binary to generate shared
  libraries.

Updates #1888