### PR TITLE
go_proto_library: support multiple proto dependencies

### DIFF
--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -42,8 +42,14 @@ def go_proto_compile(go, compiler, protos, imports, importpath):
         for src in proto.check_deps_sources.to_list():
             path = proto_path(src, proto)
             if path in proto_paths:
+                if proto_paths[path] != src:
+                    fail("proto files {} and {} have the same import path, {}".format(
+                        src.path,
+                        proto_paths[path].path,
+                        path,
+                    ))
                 continue
-            proto_paths[path] = True
+            proto_paths[path] = src
             out = go.declare_file(
                 go,
                 path = importpath + "/" + src.basename[:-len(".proto")],

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -50,6 +50,7 @@ def go_proto_compile(go, compiler, protos, imports, importpath):
                     ))
                 continue
             proto_paths[path] = src
+
             out = go.declare_file(
                 go,
                 path = importpath + "/" + src.basename[:-len(".proto")],

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -41,7 +41,7 @@ def go_proto_compile(go, compiler, protos, imports, importpath):
         transitive = [proto.transitive_descriptor_sets for proto in protos],
     )
 
-    for src in dep_sources:
+    for src in dep_sources.to_list():
         out = go.declare_file(go, path = importpath + "/" + src.basename[:-len(".proto")], ext = compiler.suffix)
         go_srcs.append(out)
         if outpath == None:

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -36,7 +36,9 @@ def go_proto_compile(go, compiler, protos, imports, importpath):
     go_srcs = []
     outpath = None
     proto_paths = {}
+    desc_sets = []
     for proto in protos:
+        desc_sets.append(proto.transitive_descriptor_sets)
         for src in proto.check_deps_sources.to_list():
             path = proto_path(src, proto)
             if path in proto_paths:
@@ -51,10 +53,7 @@ def go_proto_compile(go, compiler, protos, imports, importpath):
             if outpath == None:
                 outpath = out.dirname[:-len(importpath)]
 
-    transitive_descriptor_sets = depset(
-        direct = [],
-        transitive = [proto.transitive_descriptor_sets for proto in protos],
-    )
+    transitive_descriptor_sets = depset(direct = [], transitive = desc_sets)
 
     args = go.actions.args()
     args.add("-protoc", compiler.protoc)

--- a/proto/core.rst
+++ b/proto/core.rst
@@ -185,7 +185,7 @@ Attributes
 | :param:`proto`      | :type:`label`        | |mandatory|                                     |
 +---------------------+----------------------+-------------------------------------------------+
 | Points to the ``proto_library`` containing the .proto sources this rule                      |
-| should generate code from. Avoid using this argument, use `protos` instead.                  |
+| should generate code from. Avoid using this argument, use ``protos`` instead.                |
 +---------------------+----------------------+-------------------------------------------------+
 | :param:`protos`     | :type:`label`        | |mandatory|                                     |
 +---------------------+----------------------+-------------------------------------------------+

--- a/proto/core.rst
+++ b/proto/core.rst
@@ -190,7 +190,7 @@ Attributes
 | :param:`protos`     | :type:`label`        | |mandatory|                                     |
 +---------------------+----------------------+-------------------------------------------------+
 | List of ``proto_library`` targets containing the .proto sources this rule should generate    |
-| code from. This argument is ignored if the ``proto`` argument is specified.                  |
+| code from. This argument should be used instead of ``proto`` argument.                  |
 +---------------------+----------------------+-------------------------------------------------+
 | :param:`deps`       | :type:`label_list`   | :value:`[]`                                     |
 +---------------------+----------------------+-------------------------------------------------+

--- a/proto/core.rst
+++ b/proto/core.rst
@@ -190,7 +190,7 @@ Attributes
 | :param:`protos`     | :type:`label`        | |mandatory|                                     |
 +---------------------+----------------------+-------------------------------------------------+
 | List of ``proto_library`` targets containing the .proto sources this rule should generate    |
-| code from. This argument is ignored if `proto` argument is specified.                        |
+| code from. This argument is ignored if the ``proto`` argument is specified.                  |
 +---------------------+----------------------+-------------------------------------------------+
 | :param:`deps`       | :type:`label_list`   | :value:`[]`                                     |
 +---------------------+----------------------+-------------------------------------------------+

--- a/proto/core.rst
+++ b/proto/core.rst
@@ -185,7 +185,12 @@ Attributes
 | :param:`proto`      | :type:`label`        | |mandatory|                                     |
 +---------------------+----------------------+-------------------------------------------------+
 | Points to the ``proto_library`` containing the .proto sources this rule                      |
-| should generate code from.                                                                   |
+| should generate code from. Avoid using this argument, use `protos` instead.                  |
++---------------------+----------------------+-------------------------------------------------+
+| :param:`protos`     | :type:`label`        | |mandatory|                                     |
++---------------------+----------------------+-------------------------------------------------+
+| List of ``proto_library``s containing the .proto sources this rule should generate code from.|
+| This argument is ignored if `proto` argument is specified.                                   |
 +---------------------+----------------------+-------------------------------------------------+
 | :param:`deps`       | :type:`label_list`   | :value:`[]`                                     |
 +---------------------+----------------------+-------------------------------------------------+

--- a/proto/core.rst
+++ b/proto/core.rst
@@ -189,8 +189,8 @@ Attributes
 +---------------------+----------------------+-------------------------------------------------+
 | :param:`protos`     | :type:`label`        | |mandatory|                                     |
 +---------------------+----------------------+-------------------------------------------------+
-| List of ``proto_library``s containing the .proto sources this rule should generate code from.|
-| This argument is ignored if `proto` argument is specified.                                   |
+| List of ``proto_library`` targets containing the .proto sources this rule should generate    |
+| code from. This argument is ignored if `proto` argument is specified.                        |
 +---------------------+----------------------+-------------------------------------------------+
 | :param:`deps`       | :type:`label_list`   | :value:`[]`                                     |
 +---------------------+----------------------+-------------------------------------------------+

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -49,7 +49,7 @@ def get_imports(attr):
 
     direct = dict()
     for proto in protos:
-        for src in proto.check_deps_sources:
+        for src in proto.check_deps_sources.to_list():
             direct["{}={}".format(proto_path(src, proto), attr.importpath)] = True
 
     deps = getattr(attr, "deps", []) + getattr(attr, "embed", [])

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -88,16 +88,19 @@ def _go_proto_library_impl(ctx):
         compilers = [ctx.attr.compiler]
     else:
         compilers = ctx.attr.compilers
-    go_srcs = []
-    valid_archive = False
 
     if ctx.attr.proto:
         #TODO: print("DEPRECATED: proto attribute on {}, use protos instead".format(ctx.label))
+        if ctx.attr.protos:
+            fail("Either proto or protos (non-empty) argument must be specified, but not both")
         protos = [ctx.attr.proto]
-    elif not ctx.attr.protos:
-        fail("Either proto or protos (non-empty) argument must be specified")
     else:
+        if not ctx.attr.protos:
+            fail("Either proto or protos (non-empty) argument must be specified")
         protos = ctx.attr.protos
+
+    go_srcs = []
+    valid_archive = False
 
     for c in compilers:
         compiler = c[GoProtoCompiler]

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -90,7 +90,7 @@ def _go_proto_library_impl(ctx):
         compilers = ctx.attr.compilers
 
     if ctx.attr.proto:
-        #TODO: print("DEPRECATED: proto attribute on {}, use protos instead".format(ctx.label))
+        #TODO: print("DEPRECATED: proto attribute on {}, use protos attribute instead".format(ctx.label))
         if ctx.attr.protos:
             fail("Either proto or protos (non-empty) argument must be specified, but not both")
         protos = [ctx.attr.proto]

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -83,6 +83,15 @@ def _go_proto_library_impl(ctx):
         compilers = ctx.attr.compilers
     go_srcs = []
     valid_archive = False
+
+    if ctx.attr.proto:
+        #TODO: print("DEPRECATED: proto attribute on {}, use protos instead".format(ctx.label))
+        protos = [ctx.attr.proto]
+    elif not ctx.attr.protos:
+        fail("Either proto or protos (non-empty) argument must be specified")
+    else:
+        protos = ctx.attr.protos
+
     for c in compilers:
         compiler = c[GoProtoCompiler]
         if compiler.valid_archive:
@@ -90,7 +99,7 @@ def _go_proto_library_impl(ctx):
         go_srcs.extend(compiler.compile(
             go,
             compiler = compiler,
-            proto = ctx.attr.proto.proto,
+            protos = [proto.proto for proto in protos],
             imports = get_imports(ctx.attr),
             importpath = go.importpath,
         ))
@@ -119,9 +128,10 @@ def _go_proto_library_impl(ctx):
 go_proto_library = go_rule(
     _go_proto_library_impl,
     attrs = {
-        "proto": attr.label(
-            mandatory = True,
+        "proto": attr.label(providers = ["proto"]),
+        "protos": attr.label_list(
             providers = ["proto"],
+            default = [],
         ),
         "deps": attr.label_list(
             providers = [GoLibrary],

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -90,7 +90,7 @@ def _go_proto_library_impl(ctx):
         compilers = ctx.attr.compilers
 
     if ctx.attr.proto:
-        #TODO: print("DEPRECATED: proto attribute on {}, use protos attribute instead".format(ctx.label))
+        #TODO: print("DEPRECATED: proto attribute on {}, use protos instead".format(ctx.label))
         if ctx.attr.protos:
             fail("Either proto or protos (non-empty) argument must be specified, but not both")
         protos = [ctx.attr.proto]

--- a/tests/core/go_proto_library/BUILD.bazel
+++ b/tests/core/go_proto_library/BUILD.bazel
@@ -104,6 +104,34 @@ proto_library(
     srcs = ["proxy_b.proto"],
 )
 
+
+# protos_test (multiple entries in protos argument)
+go_test(
+    name = "protos_test",
+    srcs = ["protos_test.go"],
+    deps = [":protos_go_proto"],
+)
+
+go_proto_library(
+    name = "protos_go_proto",
+    importpath = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/protos",
+    protos = [
+        ":protos_a_proto",
+        ":protos_b_proto",
+
+    ]
+)
+
+proto_library(
+    name = "protos_a_proto",
+    srcs = ["protos_a.proto"],
+)
+
+proto_library(
+    name = "protos_b_proto",
+    srcs = ["protos_b.proto"],
+)
+
 # adjusted_import_test
 # TODO(#1851): uncomment when Bazel 0.22.0 is the minimum version.
 # go_test(

--- a/tests/core/go_proto_library/BUILD.bazel
+++ b/tests/core/go_proto_library/BUILD.bazel
@@ -104,7 +104,6 @@ proto_library(
     srcs = ["proxy_b.proto"],
 )
 
-
 # protos_test (multiple entries in protos argument)
 go_test(
     name = "protos_test",
@@ -118,8 +117,7 @@ go_proto_library(
     protos = [
         ":protos_a_proto",
         ":protos_b_proto",
-
-    ]
+    ],
 )
 
 proto_library(

--- a/tests/core/go_proto_library/protos_a.proto
+++ b/tests/core/go_proto_library/protos_a.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+option go_package = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/protos";
+
+message A {
+  int64 a = 1;
+}

--- a/tests/core/go_proto_library/protos_b.proto
+++ b/tests/core/go_proto_library/protos_b.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+option go_package = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/protos";
+
+message B {
+  int64 b = 1;
+}

--- a/tests/core/go_proto_library/protos_test.go
+++ b/tests/core/go_proto_library/protos_test.go
@@ -1,0 +1,30 @@
+/* Copyright 2018 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package protos_test
+
+import (
+	"testing"
+
+	"github.com/bazelbuild/rules_go/tests/core/go_proto_library/protos"
+)
+
+func use(interface{}) {}
+
+func TestProtos(t *testing.T) {
+	// just make sure both types exist
+	use(protos.A{})
+	use(protos.B{})
+}


### PR DESCRIPTION
Add `protos` argument to `go_proto_library` (same as the existing `proto` argument, but supports multiple protos).

`go_proto_compile` changes one of the arguments from `proto` to `protos`, which is considered Ok (even though this is a technically public API there is no detected usages of the method anywhere else on github).

Implements https://github.com/bazelbuild/rules_go/issues/1856