### PR TITLE
nogo: translate 'vet = True' into appropriate deps

### DIFF
--- a/go/def.bzl
+++ b/go/def.bzl
@@ -80,7 +80,7 @@ load(
 )
 load(
     "@io_bazel_rules_go//go/private:rules/nogo.bzl",
-    _nogo = "nogo",
+    _nogo = "nogo_wrapper",
 )
 
 # Current version or next version to be tagged. Gazelle and other tools may

--- a/go/nogo.rst
+++ b/go/nogo.rst
@@ -29,7 +29,8 @@ contain disallowed coding patterns. In addition, ``nogo`` may report
 compiler-like errors.
 
 ``nogo`` is a powerful tool for preventing bugs and code anti-patterns early
-in the development process.
+in the development process. It may be used to run the same analyses as `vet`_,
+and you can write new analyses for your own code base.
 
 .. contents:: .
   :depth: 2
@@ -244,10 +245,14 @@ Running vet
 -----------
 
 `vet`_ is a tool that examines Go source code and reports correctness issues not
-caught by Go compilers. It is included in the official Go distribution.
+caught by Go compilers. It is included in the official Go distribution. Vet
+runs analyses built with the Go `analysis`_ framework. nogo uses the
+same framework, which means vet checks can be run with nogo.
 
-You can choose to run `vet`_ alongside the Go compiler by setting the ``vet``
-attribute in your `nogo`_ target:
+You can choose to run a safe subset of vet checks alongside the Go compiler by
+setting ``vet = True`` in your `nogo`_ target. This will only run vet checks
+that are believed to be 100% accurate (the same set run by ``go test`` by
+default).
 
 .. code:: bzl
 
@@ -257,15 +262,10 @@ attribute in your `nogo`_ target:
         visibility = ["//visibility:public"],
     )
 
-In the above example, the generated ``nogo`` program will only run `vet`_.
-`vet`_ can also run alongside ``nogo`` analyzers given by the ``deps``
-attribute.
-
-`vet`_ will print error messages and stop the build if any correctness issues
-are found in the source code being compiled. Only a subset of `vet`_ checks
-which are 100% accurate will be executed. This is the same subset of `vet`_
-checks that are run by the ``go`` tool during ``go test``.
-
+Setting ``vet = True`` is equivalent to adding the ``atomic``, ``bool``,
+``buildtags``, ``nilfunc``, and ``printf`` analyzers from
+``@org_golang_x_tools//go/analysis/passes`` to the ``deps`` list of your
+``nogo`` rule.
 
 API
 ---
@@ -304,7 +304,8 @@ Attributes
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`vet`               | :type:`bool`                | :value:`False`                        |
 +----------------------------+-----------------------------+---------------------------------------+
-| Whether to run the `vet`_ tool.                                                                  |
+| If true, a safe subset of vet checks will be run by nogo (the same subset run                    |
+| by ``go test ``).                                                                                |
 +----------------------------+-----------------------------+---------------------------------------+
 
 Example

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -71,7 +71,6 @@ go_source(
     srcs = [
         "flags.go",
         "nogo_main.go",
-        "nogo_vet.go",
     ],
     # //go/tools/builders:nogo_srcs is considered a different target by
     # Bazel's visibility check than

--- a/go/tools/builders/compile.go
+++ b/go/tools/builders/compile.go
@@ -146,7 +146,6 @@ func run(args []string) error {
 	if *nogo != "" {
 		var nogoargs []string
 		nogoargs = append(nogoargs, "-p", *packagePath)
-		nogoargs = append(nogoargs, "-vet_tool", goenv.goTool("vet")[0])
 		nogoargs = append(nogoargs, "-importcfg", importcfgName)
 		for _, imp := range stdImports {
 			nogoargs = append(nogoargs, "-stdimport", imp)

--- a/go/tools/builders/generate_nogo_main.go
+++ b/go/tools/builders/generate_nogo_main.go
@@ -51,8 +51,6 @@ var analyzers = []*analysis.Analyzer{
 {{- end}}
 }
 
-const enableVet = {{.EnableVet}}
-
 // configs maps analysis names to configurations.
 var configs = map[string]config{
 {{- range $name, $config := .Configs}}
@@ -88,7 +86,6 @@ func run(args []string) error {
 	out := flags.String("output", "", "output file to write (defaults to stdout)")
 	flags.Var(&analyzerImportPaths, "analyzer_importpath", "import path of an analyzer library")
 	configFile := flags.String("config", "", "nogo config file")
-	enableVet := flags.Bool("vet", false, "whether to run vet")
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
@@ -131,12 +128,10 @@ func run(args []string) error {
 	data := struct {
 		Imports    []Import
 		Configs    Configs
-		EnableVet  bool
 		NeedRegexp bool
 	}{
-		Imports:   imports,
-		Configs:   config,
-		EnableVet: *enableVet,
+		Imports: imports,
+		Configs: config,
 	}
 	for _, c := range config {
 		if len(c.OnlyFiles) > 0 || len(c.ExcludeFiles) > 0 {

--- a/go/tools/builders/nogo_main.go
+++ b/go/tools/builders/nogo_main.go
@@ -62,7 +62,6 @@ func run(args []string) error {
 	stdImports := multiFlag{}
 	flags := flag.NewFlagSet("nogo", flag.ExitOnError)
 	flags.Var(&stdImports, "stdimport", "A standard library import path")
-	vetTool := flags.String("vet_tool", "", "The vet tool")
 	importcfg := flags.String("importcfg", "", "The import configuration file")
 	packagePath := flags.String("p", "", "The package path (importmap) of the package being compiled")
 	xPath := flags.String("x", "", "The file where serialized facts should be written")
@@ -76,20 +75,6 @@ func run(args []string) error {
 	stdImportSet := make(map[string]bool)
 	for _, i := range stdImports {
 		stdImportSet[i] = true
-	}
-
-	if enableVet {
-		vcfgPath, err := buildVetcfgFile(packageFile, importMap, stdImports, srcs)
-		if err != nil {
-			return fmt.Errorf("error creating vet config: %v", err)
-		}
-		defer os.Remove(vcfgPath)
-		findings, err := runVet(*vetTool, vcfgPath)
-		if err != nil {
-			return fmt.Errorf("error running vet:\n%v\n", err)
-		} else if findings != "" {
-			return fmt.Errorf("errors found by vet:\n%s\n", findings)
-		}
 	}
 
 	diagnostics, facts, err := checkPackage(analyzers, *packagePath, packageFile, importMap, stdImportSet, srcs)

--- a/tests/core/nogo/vet/BUILD.bazel
+++ b/tests/core/nogo/vet/BUILD.bazel
@@ -36,10 +36,10 @@ bazel_test(
     build = BUILD_ENABLE_VET,
     check = BUILD_FAILED_TMPL.format(
         check_err =
-            CONTAINS_ERR_TMPL.format(err = "has_errors.go:3: +build comment must appear before package clause and be followed by a blank line") +
-            CONTAINS_ERR_TMPL.format(err = "has_errors.go:15: comparison of function F == nil is always false") +
-            CONTAINS_ERR_TMPL.format(err = 'has_errors.go:18: Printf format %b has arg "hi" of wrong type strin') +
-            CONTAINS_ERR_TMPL.format(err = "has_errors.go:19: redundant or: true || true"),
+            CONTAINS_ERR_TMPL.format(err = "has_errors.go:3:1: +build comment must appear before package clause and be followed by a blank line") +
+            CONTAINS_ERR_TMPL.format(err = "has_errors.go:15:5: comparison of function F == nil is always false") +
+            CONTAINS_ERR_TMPL.format(err = 'has_errors.go:18:2: Printf format %b has arg "hi" of wrong type strin') +
+            CONTAINS_ERR_TMPL.format(err = "has_errors.go:19:9: redundant or: true || true"),
     ),
     command = "build",
     nogo = NOGO,


### PR DESCRIPTION
nogo no longer invokes vet at all. Setting 'vet = True' is handled by
a wrapper, which adds the equivalent libraries from
@org_golang_x_tools//go/analysis/passes.

'vet = True' was originally needed before the vet analyses had been
migrated to the analysis framework. There is no need for it anymore,
and the command line interface for vet is changing in Go 1.12.

Updates #1896
Fixes #1800