### PR TITLE
go/tool/compile: generate symabis for assembly

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -78,10 +78,15 @@ def emit_archive(go, source = None):
             testfilter = testfilter,
         )
     else:
+        # Assembly files must be passed to the compiler as sources. We need
+        # to run the assembler to produce a symabis file that gets passed to
+        # the compiler. The compiler builder does all this so it doesn't
+        # need to be a separate action (but individual .o files are still
+        # produced with separate actions).
         partial_lib = go.declare_file(go, path = lib_name + "~partial", ext = ".a")
         go.compile(
             go,
-            sources = split.go,
+            sources = split.go + split.asm + split.headers,
             importpath = source.library.importmap,
             archives = direct,
             out_lib = partial_lib,

--- a/go/private/actions/compile.bzl
+++ b/go/private/actions/compile.bzl
@@ -48,7 +48,7 @@ def emit_compile(
 
     inputs = (sources + [go.package_list] +
               [archive.data.file for archive in archives] +
-              go.sdk.tools + go.stdlib.libs)
+              go.sdk.tools + go.sdk.headers + go.stdlib.libs)
     outputs = [out_lib]
 
     builder_args = go.builder_args(go)
@@ -67,7 +67,7 @@ def emit_compile(
 
     tool_args = go.tool_args(go)
     if asmhdr:
-        tool_args.add("-asmhdr", asmhdr)
+        builder_args.add("-asmhdr", asmhdr)
         outputs.append(asmhdr)
     tool_args.add("-trimpath", ".")
 

--- a/go/tools/builders/compile.go
+++ b/go/tools/builders/compile.go
@@ -27,7 +27,10 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
 )
 
@@ -52,6 +55,7 @@ func run(args []string) error {
 	nogo := flags.String("nogo", "", "The nogo binary")
 	outExport := flags.String("x", "", "Path to nogo that should be written")
 	output := flags.String("o", "", "The output object file to write")
+	asmhdr := flags.String("asmhdr", "", "Path to assembly header file to write")
 	packageList := flags.String("package_list", "", "The file containing the list of standard library packages")
 	testfilter := flags.String("testfilter", "off", "Controls test package filtering")
 	if err := flags.Parse(builderArgs); err != nil {
@@ -61,6 +65,9 @@ func run(args []string) error {
 		return err
 	}
 	*output = abs(*output)
+	if *asmhdr != "" {
+		*asmhdr = abs(*asmhdr)
+	}
 
 	// Filter sources using build constraints.
 	var matcher func(f *goMetadata) bool
@@ -71,11 +78,11 @@ func run(args []string) error {
 		}
 	case "only":
 		matcher = func(f *goMetadata) bool {
-			return strings.HasSuffix(f.pkg, "_test")
+			return strings.HasSuffix(f.filename, ".go") && strings.HasSuffix(f.pkg, "_test")
 		}
 	case "exclude":
 		matcher = func(f *goMetadata) bool {
-			return !strings.HasSuffix(f.pkg, "_test")
+			return !strings.HasSuffix(f.filename, ".go") || !strings.HasSuffix(f.pkg, "_test")
 		}
 	default:
 		return fmt.Errorf("Invalid test filter %q", *testfilter)
@@ -85,13 +92,22 @@ func run(args []string) error {
 	if err != nil {
 		return err
 	}
-	files := []*goMetadata{}
+	var goFiles, sFiles, hFiles []*goMetadata
 	for _, f := range all {
 		if matcher(f) {
-			files = append(files, f)
+			switch path.Ext(f.filename) {
+			case ".go":
+				goFiles = append(goFiles, f)
+			case ".s":
+				sFiles = append(sFiles, f)
+			case ".h":
+				hFiles = append(hFiles, f)
+			default:
+				return fmt.Errorf("unknown file extension: %s", f.filename)
+			}
 		}
 	}
-	if len(files) == 0 {
+	if len(goFiles) == 0 {
 		// We need to run the compiler to create a valid archive, even if there's
 		// nothing in it. GoPack will complain if we try to add assembly or cgo
 		// objects.
@@ -99,16 +115,16 @@ func run(args []string) error {
 		if err := ioutil.WriteFile(emptyPath, []byte("package empty\n"), 0666); err != nil {
 			return err
 		}
-		files = append(files, &goMetadata{filename: emptyPath, pkg: "empty"})
+		goFiles = append(goFiles, &goMetadata{filename: emptyPath, pkg: "empty"})
 	}
 
 	if *packagePath == "" {
-		*packagePath = files[0].pkg
+		*packagePath = goFiles[0].pkg
 	}
 
 	// Check that the filtered sources don't import anything outside of
 	// the standard library and the direct dependencies.
-	_, stdImports, err := checkDirectDeps(files, archives, *packageList)
+	_, stdImports, err := checkDirectDeps(goFiles, archives, *packageList)
 	if err != nil {
 		return err
 	}
@@ -120,15 +136,30 @@ func run(args []string) error {
 	}
 	defer os.Remove(importcfgName)
 
+	// If there are assembly files, and this is go1.12+, generate symbol ABIs.
+	symabisName, err := buildSymabisFile(goenv, sFiles, hFiles, *asmhdr)
+	if symabisName != "" {
+		defer os.Remove(symabisName)
+	}
+	if err != nil {
+		return err
+	}
+
 	// Compile the filtered files.
 	goargs := goenv.goTool("compile")
 	goargs = append(goargs, "-p", *packagePath)
 	goargs = append(goargs, "-importcfg", importcfgName)
 	goargs = append(goargs, "-pack", "-o", *output)
+	if symabisName != "" {
+		goargs = append(goargs, "-symabis", symabisName)
+	}
+	if *asmhdr != "" {
+		goargs = append(goargs, "-asmhdr", *asmhdr)
+	}
 	goargs = append(goargs, toolArgs...)
 	goargs = append(goargs, "--")
-	filenames := make([]string, 0, len(files))
-	for _, f := range files {
+	filenames := make([]string, 0, len(goFiles))
+	for _, f := range goFiles {
 		filenames = append(filenames, f.filename)
 	}
 	goargs = append(goargs, filenames...)
@@ -184,6 +215,78 @@ func main() {
 	if err := run(os.Args[1:]); err != nil {
 		log.Fatal(err)
 	}
+}
+
+// TODO(#1891): consolidate this logic when compile and asm are in the
+// same binary.
+func buildSymabisFile(goenv *env, sFiles, hFiles []*goMetadata, asmhdr string) (string, error) {
+	if len(sFiles) == 0 {
+		return "", nil
+	}
+
+	// Check version. The symabis file is only required and can only be built
+	// starting at go1.12.
+	version := runtime.Version()
+	if strings.HasPrefix(version, "go1.") {
+		minor := version[len("go1."):]
+		if i := strings.IndexByte(minor, '.'); i >= 0 {
+			minor = minor[:i]
+		}
+		n, err := strconv.Atoi(minor)
+		if err == nil && n <= 11 {
+			return "", nil
+		}
+		// Fall through if the version can't be parsed. It's probably a newer
+		// development version.
+	}
+
+	// Create an empty go_asm.h file. The compiler will write this later, but
+	// we need one to exist now.
+	asmhdrFile, err := os.Create(asmhdr)
+	if err != nil {
+		return "", err
+	}
+	if err := asmhdrFile.Close(); err != nil {
+		return "", err
+	}
+	asmhdrDir := filepath.Dir(asmhdr)
+
+	// Create a temporary output file. The caller is responsible for deleting it.
+	var symabisName string
+	symabisFile, err := ioutil.TempFile("", "symabis")
+	if err != nil {
+		return "", err
+	}
+	symabisName = symabisFile.Name()
+	symabisFile.Close()
+
+	// Run the assembler.
+	wd, err := os.Getwd()
+	if err != nil {
+		return symabisName, err
+	}
+	asmargs := goenv.goTool("asm")
+	asmargs = append(asmargs, "-trimpath", wd)
+	asmargs = append(asmargs, "-I", wd)
+	asmargs = append(asmargs, "-I", filepath.Join(os.Getenv("GOROOT"), "pkg", "include"))
+	asmargs = append(asmargs, "-I", asmhdrDir)
+	seenHdrDirs := map[string]bool{wd: true, asmhdrDir: true}
+	for _, hFile := range hFiles {
+		hdrDir := filepath.Dir(abs(hFile.filename))
+		if !seenHdrDirs[hdrDir] {
+			asmargs = append(asmargs, "-I", hdrDir)
+			seenHdrDirs[hdrDir] = true
+		}
+	}
+	// TODO(#1894): define GOOS_goos, GOARCH_goarch, both here and in the
+	// GoAsm action.
+	asmargs = append(asmargs, "-gensymabis", "-o", symabisName, "--")
+	for _, sFile := range sFiles {
+		asmargs = append(asmargs, sFile.filename)
+	}
+
+	err = goenv.runCommand(asmargs)
+	return symabisName, err
 }
 
 func checkDirectDeps(files []*goMetadata, archives []archive, packageList string) (depImports, stdImports []string, err error) {


### PR DESCRIPTION
Go 1.12 requires the assembler to generate a symabis file, which is
passed to the compiler. The compile action will now do this when there
are assembly sources.

In the future, we'll combine GoCompile, GoAsm, and other actions into
a single GoCompile action per package. Because of this plan,
generating the symabis file is not a separate action.

Updates #1896