### PR TITLE
go/tools/builders/pack: preserve file extensions

### DIFF
--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -188,7 +188,6 @@ def _cgo_codegen_impl(ctx):
         mangled_stem, src_ext = _mangle(src, stems)
         gen_file = go.declare_file(go, path = mangled_stem + ".cgo1." + src_ext)
         transformed_go_outs.append(gen_file)
-        transformed_go_map[gen_go_file] = src
         builder_args.add("-src", gen_file.path + "=" + src.path)
     for src in source.c:
         mangled_stem, src_ext = _mangle(src, stems)


### PR DESCRIPTION
The .a format limits file names to 16 characters. There are various
extensions to this format which support longer names, but Go doesn't
recognize them and generally doesn't need them. Before Go 1.12, the
linker passed all extra files (other than the compiled Go code and the
export data) to the external link.

In Go 1.12, the linker only passes on .o files. The GoPack action
simply truncated long file names, which meant .o files were sometimes
ignored. GoPack will now preserve file extensions.

Updates #1896