### PR TITLE
Update to newer version of Gazelle for testing

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,7 +12,7 @@ go_register_toolchains()
 # Needed for tests
 git_repository(
     name = "bazel_gazelle",
-    commit = "455e69320ee92c6f3bfb267aa211a4fa6ebc4e5d",  # master as of 2018-11-27
+    commit = "f9428739d9a72ab9c9255ada38403856d4521ab2",  # master as of 2019-01-11
     remote = "https://github.com/bazelbuild/bazel-gazelle",
 )
 


### PR DESCRIPTION
Needed for go_repository that sets GOCACHE correctly, which is needed
for Go 1.12.

Updates #1896