### PR TITLE
Stop passing alwayslink=1 with linkmode="c-shared"

### DIFF
--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -731,9 +731,9 @@ def go_binary_c_archive_shared(name, kwargs):
         cc_import_kwargs["shared_library"] = name
     elif linkmode == LINKMODE_C_ARCHIVE:
         cc_import_kwargs["static_library"] = name
+        cc_import_kwargs["alwayslink"] = 1
     native.cc_import(
         name = cc_import_name,
-        alwayslink = 1,
         visibility = ["//visibility:private"],
         tags = tags,
         **cc_import_kwargs


### PR DESCRIPTION
The cc_import attribute alwayslink should only be set when a static
library is provided. We should only set it when linkmode =
"c-archive".

Fixes #1909