### PR TITLE
Fix `gofast` `go_proto_compiler` dependencies.

### DIFF
--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -42,7 +42,6 @@ go_proto_compiler(
 
 GOGO_VARIANTS = [
     "combo",
-    "gofast",
     "gogo",
     "gogofast",
     "gogofaster",
@@ -64,6 +63,15 @@ GOGO_VARIANTS = [
     ] + WELL_KNOWN_TYPE_RULES.values(),
 ) for variant in GOGO_VARIANTS]
 
+go_proto_compiler(
+    name = "gofast_proto",
+    plugin = "@com_github_gogo_protobuf//protoc-gen-gofast",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_golang_protobuf//proto:go_default_library",
+    ] + WELL_KNOWN_TYPE_RULES.values(),
+)
+
 [go_proto_compiler(
     name = variant + "_grpc",
     options = ["plugins=grpc"] + GOGO_WELL_KNOWN_TYPE_REMAPS,
@@ -78,6 +86,18 @@ GOGO_VARIANTS = [
         "@org_golang_x_net//context:go_default_library",
     ] + WELL_KNOWN_TYPE_RULES.values(),
 ) for variant in GOGO_VARIANTS]
+
+go_proto_compiler(
+    name = "gofast_grpc",
+    options = ["plugins=grpc"],
+    plugin = "@com_github_gogo_protobuf//protoc-gen-gofast",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_golang_protobuf//proto:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_x_net//context:go_default_library",
+    ] + WELL_KNOWN_TYPE_RULES.values(),
+)
 
 filegroup(
     name = "all_rules",

--- a/tests/core/go_proto_library/BUILD.bazel
+++ b/tests/core/go_proto_library/BUILD.bazel
@@ -26,6 +26,11 @@ go_proto_library(
     deps = [":foo_go_proto"],
 )
 
+proto_library(
+    name = "grpc_proto",
+    srcs = ["grpc.proto"],
+)
+
 # embed_test
 go_proto_library(
     name = "embed_go_proto",
@@ -128,6 +133,62 @@ proto_library(
 proto_library(
     name = "protos_b_proto",
     srcs = ["protos_b.proto"],
+)
+
+# gofast test
+go_test(
+    name = "gofast_test",
+    srcs = ["gofast_test.go"],
+    deps = [":gofast_proto"],
+)
+
+go_proto_library(
+    name = "gofast_proto",
+    importpath = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/foo",
+    compilers = ["@io_bazel_rules_go//proto:gofast_proto"],
+    protos = [":foo_proto"],
+)
+
+# gofast gRPC test
+go_test(
+    name = "gofast_grpc_test",
+    srcs = ["gofast_grpc_test.go"],
+    deps = [":gofast_grpc"],
+)
+
+go_proto_library(
+    name = "gofast_grpc",
+    importpath = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/grpc",
+    compilers = ["@io_bazel_rules_go//proto:gofast_grpc"],
+    protos = [":grpc_proto"],
+)
+
+# gogofast test
+go_test(
+    name = "gogofast_test",
+    srcs = ["gogofast_test.go"],
+    deps = [":gogofast_proto"],
+)
+
+go_proto_library(
+    name = "gogofast_proto",
+    importpath = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/foo",
+    compilers = ["@io_bazel_rules_go//proto:gogofast_proto"],
+    protos = [":foo_proto"],
+)
+
+# gogofast gRPC test
+go_test(
+    name = "gogofast_grpc_test",
+    srcs = ["gogofast_grpc_test.go"],
+    deps = [":gogofast_grpc"],
+)
+
+go_proto_library(
+    name = "gogofast_grpc",
+    importpath = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/grpc",
+    compilers = ["@io_bazel_rules_go//proto:gogofast_grpc"],
+    protos = [":grpc_proto"],
 )
 
 # adjusted_import_test

--- a/tests/core/go_proto_library/README.rst
+++ b/tests/core/go_proto_library/README.rst
@@ -24,3 +24,16 @@ adjusted_import_test
 
 Checks that `go_proto_library`_ can build ``proto_library`` with
 ``import_prefix`` and ``strip_import_prefix``.
+
+gofast_test and gofast_grpc_test
+--------------------------------
+
+Checks that the gogo `gofast` compiler plugins build and link.  In
+particular, these plugins only depoend on `github.com/golang/protobuf`.
+
+gogofast_test and gogofast_grpc_test
+------------------------------------
+
+Checks that the `gogofast` compiler plugins build and link.  In
+particular, these plugins depend on both `github.com/gogo/protobuf`
+and `github.com/golang/protobuf`.

--- a/tests/core/go_proto_library/gofast_grpc_test.go
+++ b/tests/core/go_proto_library/gofast_grpc_test.go
@@ -1,0 +1,32 @@
+/* Copyright 2019 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gofast_grpc_test
+
+import (
+	"testing"
+
+	"github.com/bazelbuild/rules_go/tests/core/go_proto_library/grpc"
+)
+
+func use(interface{}) {}
+
+func TestGoFastGrpc(t *testing.T) {
+	// just make sure types and generated functions exist
+	use(grpc.RPCServer(nil))
+	use(grpc.RPCClient(nil))
+	(&grpc.HelloRequest{}).Marshal()
+	(&grpc.HelloReply{}).Marshal()
+}

--- a/tests/core/go_proto_library/gofast_test.go
+++ b/tests/core/go_proto_library/gofast_test.go
@@ -1,0 +1,30 @@
+/* Copyright 2019 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gofast_test
+
+import (
+	"testing"
+
+	"github.com/bazelbuild/rules_go/tests/core/go_proto_library/foo"
+)
+
+func use(interface{}) {}
+
+func TestGoFast(t *testing.T) {
+	// just make sure types and generated functions exist
+	use(foo.Foo{Value: 42})
+	(&foo.Foo{}).Marshal()
+}

--- a/tests/core/go_proto_library/gogofast_grpc_test.go
+++ b/tests/core/go_proto_library/gogofast_grpc_test.go
@@ -1,0 +1,32 @@
+/* Copyright 2019 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gogofast_grpc_test
+
+import (
+	"testing"
+
+	"github.com/bazelbuild/rules_go/tests/core/go_proto_library/grpc"
+)
+
+func use(interface{}) {}
+
+func TestGoGoFastGrpc(t *testing.T) {
+	// just make sure types and generated functions exist
+	use(grpc.RPCServer(nil))
+	use(grpc.RPCClient(nil))
+	(&grpc.HelloRequest{}).Marshal()
+	(&grpc.HelloReply{}).Marshal()
+}

--- a/tests/core/go_proto_library/gogofast_test.go
+++ b/tests/core/go_proto_library/gogofast_test.go
@@ -1,0 +1,30 @@
+/* Copyright 2019 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gogofast_test
+
+import (
+	"testing"
+
+	"github.com/bazelbuild/rules_go/tests/core/go_proto_library/foo"
+)
+
+func use(interface{}) {}
+
+func TestGoGoFast(t *testing.T) {
+	// just make sure types and generated functions exist
+	use(foo.Foo{Value: 42})
+	(&foo.Foo{}).Marshal()
+}

--- a/tests/core/go_proto_library/grpc.proto
+++ b/tests/core/go_proto_library/grpc.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package tests.core.go_proto_library.grpc;
+option go_package = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/grpc";
+
+message HelloRequest {
+}
+
+message HelloReply {
+}
+
+service RPC {
+    rpc Hello (HelloRequest) returns (HelloReply) {}
+}


### PR DESCRIPTION
Unlike the other plugins, `gofast` does not generate `.pb.go` files that depend on `gogo`; instead, they depend on the standard `github.com/golang/protobuf`.