### PR TITLE
change import_path_option default value to false

### DIFF
--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -159,7 +159,7 @@ go_proto_compiler = go_rule(
         "options": attr.string_list(),
         "suffix": attr.string(default = ".pb.go"),
         "valid_archive": attr.bool(default = True),
-        "import_path_option": attr.bool(default = True),
+        "import_path_option": attr.bool(default = False),
         "plugin": attr.label(
             allow_single_file = True,
             executable = True,

--- a/tests/core/go_proto_library/BUILD.bazel
+++ b/tests/core/go_proto_library/BUILD.bazel
@@ -144,8 +144,8 @@ go_test(
 
 go_proto_library(
     name = "gofast_proto",
-    importpath = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/foo",
     compilers = ["@io_bazel_rules_go//proto:gofast_proto"],
+    importpath = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/foo",
     protos = [":foo_proto"],
 )
 
@@ -158,8 +158,8 @@ go_test(
 
 go_proto_library(
     name = "gofast_grpc",
-    importpath = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/grpc",
     compilers = ["@io_bazel_rules_go//proto:gofast_grpc"],
+    importpath = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/grpc",
     protos = [":grpc_proto"],
 )
 
@@ -172,8 +172,8 @@ go_test(
 
 go_proto_library(
     name = "gogofast_proto",
-    importpath = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/foo",
     compilers = ["@io_bazel_rules_go//proto:gogofast_proto"],
+    importpath = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/foo",
     protos = [":foo_proto"],
 )
 
@@ -186,8 +186,8 @@ go_test(
 
 go_proto_library(
     name = "gogofast_grpc",
-    importpath = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/grpc",
     compilers = ["@io_bazel_rules_go//proto:gogofast_grpc"],
+    importpath = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/grpc",
     protos = [":grpc_proto"],
 )
 
@@ -257,3 +257,21 @@ go_proto_library(
 #     import_prefix = "adjusted",
 #     strip_import_prefix = "",
 # )
+
+# proto_package_test
+proto_library(
+    name = "no_go_package_proto",
+    srcs = ["no_go_package.proto"],
+)
+
+go_proto_library(
+    name = "no_go_package_go_proto",
+    importpath = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/no_go_package",
+    protos = [":no_go_package_proto"],
+)
+
+go_test(
+    name = "proto_package_test",
+    srcs = ["proto_package_test.go"],
+    deps = [":no_go_package_go_proto"],
+)

--- a/tests/core/go_proto_library/README.rst
+++ b/tests/core/go_proto_library/README.rst
@@ -3,6 +3,8 @@ Basic go_proto_library functionality
 
 .. _go_proto_library: /proto/core.rst#_go_proto_library
 .. _go_library: /go/core.rst#_go_library
+.. _#1422: https://github.com/bazelbuild/rules_go/issues/1422
+.. _#1596: https://github.com/bazelbuild/rules_go/issues/1596
 
 Tests to ensure the basic features of `go_proto_library`_ are working.
 
@@ -17,7 +19,7 @@ transitive_test
 ---------------
 
 Checks that `go_proto_library`_ can import a proto dependency that is
-embedded in a `go_library`_. Verifies #1422.
+embedded in a `go_library`_. Verifies `#1422`_.
 
 adjusted_import_test
 --------------------
@@ -37,3 +39,10 @@ gogofast_test and gogofast_grpc_test
 Checks that the `gogofast` compiler plugins build and link.  In
 particular, these plugins depend on both `github.com/gogo/protobuf`
 and `github.com/golang/protobuf`.
+
+proto_package_test
+------------------
+
+Checks that `go_proto_library`_ generates files with a package name based on
+the proto package, not ``importpath`` when ``option go_package`` is not given.
+Verifies `#1596`_.

--- a/tests/core/go_proto_library/no_go_package.proto
+++ b/tests/core/go_proto_library/no_go_package.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package protopkg;
+
+message Foo {
+  int64 x = 1;
+}

--- a/tests/core/go_proto_library/proto_package_test.go
+++ b/tests/core/go_proto_library/proto_package_test.go
@@ -1,0 +1,28 @@
+/* Copyright 2019 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proto_package_test
+
+import (
+	"testing"
+
+	"github.com/bazelbuild/rules_go/tests/core/go_proto_library/no_go_package"
+)
+
+func use(interface{}) {}
+
+func TestNoGoPackage(t *testing.T) {
+	use(&protopkg.Foo{})
+}


### PR DESCRIPTION
Fixes #1596

`import_path_option` is a `go_proto_compiler` attribute with the following definition:
When true, the `importpath` attribute from `go_proto_library` rules using this compiler will be passed to the compiler on the command line as `--option import_path={}`.

When a proto file does not contain `option go_package`, go_protobuf and gogoprotobuf use the `import_path` parameter to determine the pb.go file's package name. When the `import_path` parameter is not passed in, the proto package name is used to determine the pb.go file's package name.

With the lack of `option go_package`, it appears to be the [expected behaviour](https://developers.google.com/protocol-buffers/docs/reference/go-generated) to use the proto package name for determining the generated go file's package name. Additionally, the `import_path` parameter is [deprecated](https://github.com/golang/protobuf/blob/master/README.md#parameters), and other go proto compilers do not have an `import_path` option. This is leading to package name mismatch compiler errors when a `go_proto_library` rule contains multiple compilers and some are not gogoprotobuf/go_protobuf compilers.

Therefore, I am proposing that the default behavior of the `go_proto_compiler` rule should be to not pass in the `import_path` option. Another solution could be to add a new set of rules for gogoprotobuf and go_protobuf that have the `import_path_option` set to false.

