### PR TITLE
Move repository definitions from //go:def.bzl to //go:deps.bzl

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,8 +2,7 @@ workspace(name = "io_bazel_rules_go")
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")
-load("@io_bazel_rules_go//proto:def.bzl", "proto_register_toolchains")
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 
@@ -12,7 +11,7 @@ go_register_toolchains()
 # Needed for tests
 git_repository(
     name = "bazel_gazelle",
-    commit = "f9428739d9a72ab9c9255ada38403856d4521ab2",  # master as of 2019-01-11
+    commit = "aa1a9cfe4845bc83482af92addbfcd41f8dc51f0",  # master as of 2019-01-27
     remote = "https://github.com/bazelbuild/bazel-gazelle",
 )
 

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -26,27 +26,12 @@ load(
     _GoSource = "GoSource",
 )
 load(
-    "@io_bazel_rules_go//go/private:repositories.bzl",
-    _go_rules_dependencies = "go_rules_dependencies",
-)
-load(
-    "@io_bazel_rules_go//go/toolchain:toolchains.bzl",
-    _go_register_toolchains = "go_register_toolchains",
-)
-load(
-    "@io_bazel_rules_go//go/private:sdk.bzl",
-    "go_download_sdk",
-    "go_host_sdk",
-    "go_local_sdk",
-    "go_wrap_sdk",
-)
-load(
     "@io_bazel_rules_go//go/private:rules/sdk.bzl",
     _go_sdk = "go_sdk",
 )
 load(
     "@io_bazel_rules_go//go/private:go_toolchain.bzl",
-    "go_toolchain",
+    _go_toolchain = "go_toolchain",
 )
 load(
     "@io_bazel_rules_go//go/private:rules/wrappers.bzl",
@@ -88,12 +73,11 @@ load(
 RULES_GO_VERSION = "0.16.0"
 
 go_context = _go_context
-go_rules_dependencies = _go_rules_dependencies
-go_register_toolchains = _go_register_toolchains
 go_tool_library = _go_tool_library
 nogo = _nogo
 go_embed_data = _go_embed_data
 go_sdk = _go_sdk
+go_toolchain = _go_toolchain
 
 GoLibrary = _GoLibrary
 """See go/providers.rst#GoLibrary for full documentation."""
@@ -140,3 +124,25 @@ go_vet_test = _go_vet_test
 """
     go_vet_test
 """
+
+def go_rules_dependencies():
+    _moved("go_rules_dependencies")
+
+def go_register_toolchains(**kwargs):
+    _moved("go_register_toolchains")
+
+def go_download_sdk(**kwargs):
+    _moved("go_download_sdk")
+
+def go_host_sdk(**kwargs):
+    _moved("go_host_sdk")
+
+def go_local_sdk(**kwargs):
+    _moved("go_local_sdk")
+
+def go_wrap_sdk(**kwargs):
+    _moved("go_wrap_sdK")
+
+def _moved(name):
+    fail(name + " has moved. Please load from " +
+         " @io_bazel_rules_go//go:deps.bzl instead of def.bzl.")

--- a/go/deps.bzl
+++ b/go/deps.bzl
@@ -12,13 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# deps.bzl loads definitions for use in WORKSPACE files. It's important
+# to keep this file and the .bzl files it loads separate from the files
+# loaded by def.bzl. def.bzl and its dependencies may depend on repositories
+# declared here, but at the time this file is loaded, we can't assume
+# anything has been declared.
+
 load(
-    "@io_bazel_rules_go//go:def.bzl",
+    "@io_bazel_rules_go//go/private:repositories.bzl",
+    _go_rules_dependencies = "go_rules_dependencies",
+)
+load(
+    "@io_bazel_rules_go//go/toolchain:toolchains.bzl",
+    _go_register_toolchains = "go_register_toolchains",
+)
+load(
+    "@io_bazel_rules_go//go/private:sdk.bzl",
     _go_download_sdk = "go_download_sdk",
     _go_host_sdk = "go_host_sdk",
     _go_local_sdk = "go_local_sdk",
-    _go_register_toolchains = "go_register_toolchains",
-    _go_rules_dependencies = "go_rules_dependencies",
     _go_wrap_sdk = "go_wrap_sdk",
 )
 

--- a/tests/bazel_tests.bzl
+++ b/tests/bazel_tests.bzl
@@ -49,7 +49,7 @@ build:fetch --fetch=True
 # _basic_workspace is the content appended to all test workspace files
 # it contains the calls required to make the go rules work
 _basic_workspace = """
-load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
 go_rules_dependencies()
 """
 

--- a/tests/legacy/custom_go_toolchain/BUILD.bazel
+++ b/tests/legacy/custom_go_toolchain/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test", "go_binary")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_test")
 load("@io_bazel_rules_go//tests:bazel_tests.bzl", "bazel_test")
 
 go_test(
@@ -17,8 +17,8 @@ bazel_test(
     targets = [":go_default_test"],
     workspace = """
 
-load("@io_bazel_rules_go//go:def.bzl", "go_download_sdk")
-load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies")
+load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk")
+load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies")
 
 go_download_sdk(
     name = "go_sdk",


### PR DESCRIPTION
All definitions used in WORKSPACE must now be loaded from deps.bzl
instead of def.bzl.

Files loaded from def.bzl (but not deps.bzl) may refer to repositories
declared in go_rules_dependencies() and go_register_toolchains().

This will allow us to set up a private compatibility repository, which
will have different implementations depending on the Bazel
version. That will allow us to support a wider range of Bazel
versions. We'll also be able to reference Skylib directly instead of
vendoring it.

Fixes #1924