### PR TITLE
nogo.rst: doc tweaks

### DIFF
--- a/go/nogo.rst
+++ b/go/nogo.rst
@@ -263,9 +263,12 @@ default).
     )
 
 Setting ``vet = True`` is equivalent to adding the ``atomic``, ``bool``,
-``buildtags``, ``nilfunc``, and ``printf`` analyzers from
+``buildtag``, ``nilfunc``, and ``printf`` analyzers from
 ``@org_golang_x_tools//go/analysis/passes`` to the ``deps`` list of your
 ``nogo`` rule.
+
+See the full list of available nogo checks:
+``bazel query 'kind(go_tool_library, @org_golang_x_tools//go/analysis/passes/...)'``
 
 API
 ---

--- a/go/nogo.rst
+++ b/go/nogo.rst
@@ -268,7 +268,11 @@ Setting ``vet = True`` is equivalent to adding the ``atomic``, ``bools``,
 ``nogo`` rule.
 
 See the full list of available nogo checks:
-``bazel query 'kind(go_tool_library, @org_golang_x_tools//go/analysis/passes/...)'``
+
+.. code:: shell
+
+    bazel query 'kind(go_tool_library, @org_golang_x_tools//go/analysis/passes/...)'
+
 
 API
 ---

--- a/go/nogo.rst
+++ b/go/nogo.rst
@@ -262,7 +262,7 @@ default).
         visibility = ["//visibility:public"],
     )
 
-Setting ``vet = True`` is equivalent to adding the ``atomic``, ``bool``,
+Setting ``vet = True`` is equivalent to adding the ``atomic``, ``bools``,
 ``buildtag``, ``nilfunc``, and ``printf`` analyzers from
 ``@org_golang_x_tools//go/analysis/passes`` to the ``deps`` list of your
 ``nogo`` rule.


### PR DESCRIPTION
1. Fix package name to reflect current code (`buildtags` => `buildtag`)
2. Add a copy-paste friendly one-liner to see the list of available built-in passes