### PR TITLE
nogo: make fact files optional for dependencies

### DIFF
--- a/go/private/actions/compile.bzl
+++ b/go/private/actions/compile.bzl
@@ -22,7 +22,12 @@ load(
 )
 
 def _archive(v):
-    return "{}={}={}".format(v.data.importpath, v.data.importmap, v.data.file.path)
+    return "{}={}={}={}".format(
+        v.data.importpath,
+        v.data.importmap,
+        v.data.file.path,
+        v.data.export_file.path if v.data.export_file else "",
+    )
 
 def emit_compile(
         go,
@@ -62,7 +67,7 @@ def emit_compile(
         builder_args.add("-nogo", go.nogo)
         builder_args.add("-x", out_export)
         inputs.append(go.nogo)
-        inputs.extend([archive.data.export_file for archive in archives])
+        inputs.extend([archive.data.export_file for archive in archives if archive.data.export_file])
         outputs.append(out_export)
 
     tool_args = go.tool_args(go)

--- a/go/tools/builders/compile.go
+++ b/go/tools/builders/compile.go
@@ -35,7 +35,7 @@ import (
 )
 
 type archive struct {
-	importPath, importMap, file string
+	importPath, importMap, file, xFile string
 }
 
 func run(args []string) error {
@@ -180,6 +180,11 @@ func run(args []string) error {
 		nogoargs = append(nogoargs, "-importcfg", importcfgName)
 		for _, imp := range stdImports {
 			nogoargs = append(nogoargs, "-stdimport", imp)
+		}
+		for _, arc := range archives {
+			if arc.xFile != "" {
+				nogoargs = append(nogoargs, "-fact", fmt.Sprintf("%s=%s", arc.importPath, arc.xFile))
+			}
 		}
 		nogoargs = append(nogoargs, "-x", *outExport)
 		nogoargs = append(nogoargs, filenames...)
@@ -385,14 +390,18 @@ func (m *archiveMultiFlag) String() string {
 
 func (m *archiveMultiFlag) Set(v string) error {
 	parts := strings.Split(v, "=")
-	if len(parts) != 3 {
+	if len(parts) != 4 {
 		return fmt.Errorf("badly formed -arc flag: %s", v)
 	}
-	*m = append(*m, archive{
+	a := archive{
 		importPath: parts[0],
 		importMap:  parts[1],
 		file:       abs(parts[2]),
-	})
+	}
+	if parts[3] != "" {
+		a.xFile = abs(parts[3])
+	}
+	*m = append(*m, a)
 	return nil
 }
 

--- a/tests/core/nogo/coverage/BUILD.bazel
+++ b/tests/core/nogo/coverage/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test", "go_tool_library")
+load("@io_bazel_rules_go//tests:bazel_tests.bzl", "bazel_test")
+
+COVERAGE_BUILD_FILE = """
+load("@io_bazel_rules_go//go:def.bzl", "nogo")
+
+nogo(
+    name = "nogo",
+    deps = ["@org_golang_x_tools//go/analysis/passes/printf:go_tool_library"],
+    visibility = ["//visibility:public"],
+)
+"""
+
+bazel_test(
+    name = "coverage_test",
+    build = COVERAGE_BUILD_FILE,
+    command = "coverage",
+    nogo = "@//:nogo",
+    targets = [":coverage_target"],
+)
+
+go_test(
+    name = "coverage_target",
+    srcs = ["coverage_target_test.go"],
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+    deps = [":coverage_target_dep"],
+)
+
+go_tool_library(
+    name = "coverage_target_dep",
+    importmap = "mapped/coverage_target/dep",
+    importpath = "coverage_target/dep",
+)

--- a/tests/core/nogo/coverage/README.rst
+++ b/tests/core/nogo/coverage/README.rst
@@ -1,0 +1,14 @@
+nogo test with coverage
+=======================
+
+.. _nogo: /go/nogo.rst
+.. _go_tool_library: /go/core.rst#_go_tool_library
+
+Tests to ensure that `nogo`_ works with coverage.
+
+coverage_target_test
+--------------------
+Checks that `nogo`_ works when coverage is enabled. All covered libraries gain
+an implicit dependencies on ``//go/tools/coverdata``, which is a
+`go_tool_library`_, which isn't built with `nogo`_. We should be able to
+handle libraries like this that do not have serialized facts. Verifies #1940.

--- a/tests/core/nogo/coverage/coverage_target_test.go
+++ b/tests/core/nogo/coverage/coverage_target_test.go
@@ -1,0 +1,1 @@
+package coverage_target_test


### PR DESCRIPTION
nogo now allows imported archives not to have fact files (.x
files). Fact files are produced for libraries analyzed by nogo. We
already had a special case for standard libraries (which are not
analyzed by nogo), but we also need to support go_tool_library
dependencies, especially //go/tools/coverdata, which is an implicit
dependency when coverage is enabled.

Fixes #1940