### PR TITLE
Make googleapis work on FreeBSD.

### DIFF
--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -169,7 +169,7 @@ def go_rules_dependencies():
             "@io_bazel_rules_go//third_party:go_googleapis-gazelle.patch",
             "@io_bazel_rules_go//third_party:go_googleapis-fix.patch",
         ],
-        patch_args = ["-p1"],
+        patch_args = ["-E", "-p1"],
     )
 
     # Needed for examples


### PR DESCRIPTION
The patches that are shipped with googleapis have the intent of removing
files from the input. Though GNU patch does this properly, the copy of
patch shipped with FreeBSD does not do this explicitly. It needs the -E
flag to do so.

This makes it possible to build https://github.com/buildbarn on FreeBSD
11.2-STABLE.