### PR TITLE
Upgrade github.com/golang/protobuf from v1.2.0 to v1.3.0

### DIFF
--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -55,7 +55,7 @@ def go_rules_dependencies():
         git_repository,
         name = "com_github_golang_protobuf",
         remote = "https://github.com/golang/protobuf",
-        commit = "aa810b61a9c79d51363740d207bb46cf8e620ed5",  # v1.2.0, as of 2018-09-28
+        commit = "c823c79ea1570fb5ff454033735a8e68575d1d0f",  # v1.3.0, as of 2019-02-26
         patches = [
             "@io_bazel_rules_go//third_party:com_github_golang_protobuf-gazelle.patch",
             "@io_bazel_rules_go//third_party:com_github_golang_protobuf-extras.patch",

--- a/go/workspace.rst
+++ b/go/workspace.rst
@@ -143,7 +143,7 @@ Gazelle. You can provide the additional patches to `go_repository`_.
     go_repository(
         name = "com_github_golang_protobuf",
         build_file_proto_mode = "disable_global",
-        commit = "7011d38ac0d201eeddff4a4085a657c3da322d75",
+        commit = "c823c79ea1570fb5ff454033735a8e68575d1d0f",
         importpath = "github.com/golang/protobuf",
         patch_args = ["-p1"],
         patches = ["@io_bazel_rules_go//third_party:com_github_golang_protobuf-extras.patch"],


### PR DESCRIPTION
This is necessary because https://github.com/golang/protobuf/releases/tag/v1.3.0 resulted in a new `ProtoPackageIsVersion3` https://github.com/golang/protobuf/blob/v1.3.0/proto/lib.go#L946 meaning that code generated with v1.3.0 will not build against a dependency of v1.2.0. There's a bit of a chicken-and-egg problem that `go_rules_dependencies` depends on v1.2.0, but some use `go_repository` from Gazelle to depend on `com_github_golang_protobuf`, but `go_rules_dependencies` needs to be loaded before `go_repository` can be loaded from Gazelle.

I've verified this is a drop-in, I am using this in https://github.com/uber/prototool/blob/3c3a6dbdc3f490a385928221a8b6606f14ac1aa5/WORKSPACE#L15

It would probably be worthwhile to upgrade gogo/protobuf to v1.2.1 as well, but this isn't required.

`bazel test //...` passes locally using Bazel v0.22.0.