### PR TITLE
Dependency: Update golang/protobuf to v1.3.0.

### DIFF
--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -55,8 +55,8 @@ def go_rules_dependencies():
         git_repository,
         name = "com_github_golang_protobuf",
         remote = "https://github.com/golang/protobuf",
-        commit = "aa810b61a9c79d51363740d207bb46cf8e620ed5",  # v1.2.0, as of 2018-09-28
-        shallow_since = "1534281267 -0700",
+        commit = "c823c79ea1570fb5ff454033735a8e68575d1d0f",  # v1.3.0, as of 2019-02-26
+        shallow_since = "1551392442 +0500",
         patches = [
             "@io_bazel_rules_go//third_party:com_github_golang_protobuf-gazelle.patch",
             "@io_bazel_rules_go//third_party:com_github_golang_protobuf-extras.patch",


### PR DESCRIPTION
Signed-off-by: Michael Payne <michael@sooper.org>

Update golang/protobuf to recently released version v1.3.0 - [release notes](https://github.com/golang/protobuf/releases/tag/v1.3.0) 

Tests pass with `bazel test //...`

Allows the closure of the TODO in Envoy Proxy at https://github.com/envoyproxy/envoy/blob/master/bazel/repository_locations.bzl#L204-L207 (golang/protobuf just released v1.3.0)