### PR TITLE
Add env attribute to go_test rule

### DIFF
--- a/go/core.rst
+++ b/go/core.rst
@@ -3,6 +3,7 @@ Core go rules
 
 .. _test_filter: https://docs.bazel.build/versions/master/user-manual.html#flag--test_filter
 .. _test_arg: https://docs.bazel.build/versions/master/user-manual.html#flag--test_arg
+.. _test_env: https://docs.bazel.build/versions/master/user-manual.html#flag--test_env
 .. _Gazelle: https://github.com/bazelbuild/bazel-gazelle
 .. _GoLibrary: providers.rst#GoLibrary
 .. _GoSource: providers.rst#GoSource
@@ -807,6 +808,11 @@ Attributes
 | shards in a round-robin fashion.                                                                 |
 |                                                                                                  |
 | For more details on this attribute, consult the official Bazel documentation for shard_count_.   |
++----------------------------+-----------------------------+---------------------------------------+
+| :param:`env`               | :type:`string_dict`         | :value:`{}`                           |
++----------------------------+-----------------------------+---------------------------------------+
+| Map of environment variables to set before the test is run.                                      |
+| Equivalent to passing in the `--test_env <test_env_>`_ argument to Bazel.                        |
 +----------------------------+-----------------------------+---------------------------------------+
 
 To write an internal test, reference the library being tested with the :param:`embed`

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -108,6 +108,8 @@ def _go_test_impl(ctx):
         "-import",
         "l_test=" + external_source.library.importpath,
     )
+    for e in ctx.attr.env.items():
+        arguments.add_joined("-env", e, join_with = ":")
     arguments.add_all(go_srcs, before_each = "-src", format_each = "l=%s")
     ctx.actions.run(
         inputs = go_srcs,
@@ -186,6 +188,7 @@ go_test = go_rule(
             providers = [GoLibrary],
             aspects = [go_archive_aspect],
         ),
+        "env": attr.string_dict(),
         "importpath": attr.string(),
         "pure": attr.string(
             values = [

--- a/tests/core/go_test/BUILD.bazel
+++ b/tests/core/go_test/BUILD.bazel
@@ -137,3 +137,10 @@ go_library(
     data = ["z"],
     importpath = "github.com/bazelbuild/rules_go/tests/core/go_test/data_test_dep",
 )
+
+go_test(
+    name = "env_test",
+    size = "small",
+    srcs = ["env_test.go",],
+    env = {"FOO": "BAR",},
+)

--- a/tests/core/go_test/env_test.go
+++ b/tests/core/go_test/env_test.go
@@ -1,0 +1,27 @@
+/* Copyright 2018 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestEnv(t *testing.T) {
+	env := os.Getenv("FOO")
+	if env != "BAR" {
+		t.Error("FOO is not set to BAR")
+	}
+}


### PR DESCRIPTION
This change adds the `env` attribute to the `go_test` rule.

`env` is a map of environment variables that will be set before the test is run.