### PR TITLE
Fix incompatibility warning in bazel_test

### DIFF
--- a/tests/bazel_tests.bzl
+++ b/tests/bazel_tests.bzl
@@ -176,7 +176,7 @@ def _bazel_test_script_impl(ctx):
         workspace_content += 'local_repository(name="{name}", path="{exec_root}/{root}")\n'.format(
             name = name,
             root = root,
-            exec_root = ctx.attr._settings.exec_root,
+            exec_root = ctx.attr._settings[BazelTestSettings].exec_root,
         )
     if ctx.attr.workspace:
         workspace_content += ctx.attr.workspace
@@ -199,9 +199,9 @@ def _bazel_test_script_impl(ctx):
         logs = [_testlog_path(t) for t in targets]
 
     script_content = _bazel_test_script_template.format(
-        bazelrc = shell.quote(ctx.attr._settings.exec_root + "/" + ctx.file.bazelrc.path),
+        bazelrc = shell.quote(ctx.attr._settings[BazelTestSettings].exec_root + "/" + ctx.file.bazelrc.path),
         config = ctx.attr.config,
-        extra_files = " ".join([shell.quote(paths.join(ctx.attr._settings.exec_root, "execroot", "io_bazel_rules_go", file.path)) for file in ctx.files.extra_files]),
+        extra_files = " ".join([shell.quote(paths.join(ctx.attr._settings[BazelTestSettings].exec_root, "execroot", "io_bazel_rules_go", file.path)) for file in ctx.files.extra_files]),
         command = ctx.attr.command,
         args = " ".join(ctx.attr.args),
         target = " ".join([str(t) for t in targets]),
@@ -210,9 +210,9 @@ def _bazel_test_script_impl(ctx):
         workspace = shell.quote(workspace_file.short_path),
         build = shell.quote(build_file.short_path),
         output = shell.quote(output),
-        bazel = ctx.attr._settings.bazel,
-        work_dir = shell.quote(ctx.attr._settings.scratch_dir + "/" + ctx.attr.config),
-        cache_dir = shell.quote(ctx.attr._settings.scratch_dir + "/cache"),
+        bazel = ctx.attr._settings[BazelTestSettings].bazel,
+        work_dir = shell.quote(ctx.attr._settings[BazelTestSettings].scratch_dir + "/" + ctx.attr.config),
+        cache_dir = shell.quote(ctx.attr._settings[BazelTestSettings].scratch_dir + "/cache"),
         clean_build = "1" if ctx.attr.clean_build else "0",
     )
     ctx.actions.write(output = script_file, is_executable = True, content = script_content)
@@ -366,12 +366,14 @@ _test_environment = repository_rule(
     implementation = _test_environment_impl,
 )
 
+BazelTestSettings = provider()
+
 def _bazel_test_settings_impl(ctx):
-    return struct(
+    return [BazelTestSettings(
         bazel = ctx.attr.bazel,
         exec_root = ctx.attr.exec_root,
         scratch_dir = ctx.attr.scratch_dir,
-    )
+    )]
 
 bazel_test_settings = rule(
     _bazel_test_settings_impl,

--- a/tests/bazel_tests.bzl
+++ b/tests/bazel_tests.bzl
@@ -136,6 +136,10 @@ filegroup(
 
 CURRENT_VERSION = "current"
 
+# BazelTestSettings holds information about the test environment, gathered by
+# the bazel_test_settings rule.
+BazelTestSettings = provider()
+
 def _bazel_test_script_impl(ctx):
     base_label = ctx.label
     if not base_label.workspace_root:
@@ -365,8 +369,6 @@ _test_environment = repository_rule(
     ],
     implementation = _test_environment_impl,
 )
-
-BazelTestSettings = provider()
 
 def _bazel_test_settings_impl(ctx):
     return [BazelTestSettings(


### PR DESCRIPTION
--incompatible_disallow_struct_provider_syntax shows an error in the
bazel_test rule. This fixes it, but there are other errors in
@bazel_tools, so it's hard to be sure if there aren't more instances
of this.