### PR TITLE
Pass ProtoInfo instead of Target to proto_path

### DIFF
--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -57,7 +57,7 @@ def get_imports(attr):
     direct = dict()
     for dep in proto_deps:
         for src in proto_check_deps_sources(dep).to_list():
-            direct["{}={}".format(proto_path(src, dep), attr.importpath)] = True
+            direct["{}={}".format(proto_path(src, get_proto(dep)), attr.importpath)] = True
 
     deps = getattr(attr, "deps", []) + getattr(attr, "embed", [])
     transitive = [

--- a/tests/core/go_proto_library/adjusted_a.proto
+++ b/tests/core/go_proto_library/adjusted_a.proto
@@ -5,8 +5,6 @@ import "adjusted/adjusted_c.proto";
 
 package adjusted.a;
 
-option go_package = "adjusted/a";
-
 message A {
   adjusted.b.B x = 1;
   adjusted.c.C y = 2;

--- a/tests/core/go_proto_library/adjusted_b.proto
+++ b/tests/core/go_proto_library/adjusted_b.proto
@@ -4,8 +4,6 @@ import "adjusted/adjusted_c.proto";
 
 package adjusted.b;
 
-option go_package = "adjusted/b";
-
 message B {
   adjusted.c.C b = 1;
 }

--- a/tests/core/go_proto_library/adjusted_c.proto
+++ b/tests/core/go_proto_library/adjusted_c.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package adjusted.c;
 
-option go_package = "adjusted/c";
-
 message C {
   int64 c = 1;
 }

--- a/tests/core/go_proto_library/adjusted_import_test.go
+++ b/tests/core/go_proto_library/adjusted_import_test.go
@@ -18,9 +18,9 @@ package adjusted_import_test
 import (
 	"testing"
 
-	"adjusted/a"
-	"adjusted/b"
-	"adjusted/c"
+	a "adjusted/a"
+	b "adjusted/b"
+	c "adjusted/c"
 )
 
 func use(interface{}) {}


### PR DESCRIPTION
During a refactor in 8670623e6e3a18123129173ba667c33631aca006, a `.proto` attribute was missed and now a `Target` gets passed into the `proto_path` function rather than a `ProtoInfo` provider.

When used with `{strip_}import_prefix`, this would result in the `import` flags passed to the `protoc-go` builder to contain incorrect paths:

```
tests/core/go_proto_library/_virtual_imports/adjusted_c_proto/adjusted/adjusted_c.proto=adjusted/c
```
instead of
```
adjusted/adjusted_c.proto=adjusted/c
```

When `go_package` isn't present in a proto file, protoc-gen-go relies in `Mfile.proto=go/importpath` to resolve proto files to import paths. With these passed incorrect packages for dependencies fail to compile.

I made a few modifications to the tests under `tests/core/go_proto_library/` to catch the issue, but have left the test targets uncommented due to the minimum bazel requirement.