### PR TITLE
Update travis.yml to use caches across CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,3 +42,8 @@ script:
 
 notifications:
   email: false
+  
+cache:
+  directories:
+    - $HOME/.bazel_repository_cache
+    - $HOME/.cache


### PR DESCRIPTION
You can specify directories for caching that will be preserved across multiple CI jobs which will reduce time needed to fetch dependencies while executing CI build steps.
More info here: https://docs.travis-ci.com/user/caching