### PR TITLE
Fix gRPC cross-compilation for Android

### DIFF
--- a/third_party/org_golang_google_grpc-crosscompile.patch
+++ b/third_party/org_golang_google_grpc-crosscompile.patch
@@ -27,3 +27,14 @@ diff -urN b/internal/channelz/BUILD.bazel c/internal/channelz/BUILD.bazel
          "@io_bazel_rules_go//go/platform:linux": [
              "@org_golang_x_sys//unix:go_default_library",
          ],
+diff -urN a/internal/syscall/BUILD.bazel b/internal/syscall/BUILD.bazel
+--- a/internal/syscall/BUILD.bazel
++++ b/internal/syscall/BUILD.bazel
+@@ -11,6 +11,7 @@ go_library(
+     deps = select({
+         "@io_bazel_rules_go//go/platform:android": [
+             "//grpclog:go_default_library",
++            "@org_golang_x_sys//unix:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:darwin": [
+             "//grpclog:go_default_library",


### PR DESCRIPTION
This was an internal patch that I should have upstreamed a long time ago.