### PR TITLE
Fix gRPC cross-compilation for Linux from Darwin

### DIFF
--- a/third_party/org_golang_google_grpc-gazelle.patch
+++ b/third_party/org_golang_google_grpc-gazelle.patch
@@ -2264,6 +2264,7 @@ diff -urN a/internal/syscall/BUILD.bazel b/internal/syscall/BUILD.bazel
 +        ],
 +        "@io_bazel_rules_go//go/platform:darwin": [
 +            "//grpclog:go_default_library",
++            "@org_golang_x_sys//unix:go_default_library",
 +        ],
 +        "@io_bazel_rules_go//go/platform:dragonfly": [
 +            "//grpclog:go_default_library",

--- a/third_party/org_golang_google_grpc-gazelle.patch
+++ b/third_party/org_golang_google_grpc-gazelle.patch
@@ -2247,7 +2247,7 @@ diff -urN a/internal/leakcheck/BUILD.bazel b/internal/leakcheck/BUILD.bazel
 diff -urN a/internal/syscall/BUILD.bazel b/internal/syscall/BUILD.bazel
 --- a/internal/syscall/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ b/internal/syscall/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,48 @@
+@@ -0,0 +1,49 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(


### PR DESCRIPTION
In the same vein as #1991 this appears to fix gRPC cross-compilation for Linux from Darwin.

I suspect the other Unix platforms need the same change, but don't have a way to test them.