### PR TITLE
go_tool_binary: set GOROOT explicitly

### DIFF
--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -171,10 +171,11 @@ def _go_tool_binary_impl(ctx):
         goroot = shell.quote(sdk.root_file.dirname),
         out = shell.quote(out.path),
     )
-    
+
     ctx.actions.run_shell(
         inputs = sdk.libs + sdk.headers + sdk.tools + ctx.files.srcs + [sdk.go],
         outputs = [out],
+        env = {"GOROOT": sdk.root_file.dirname},  # NOTE(#2005): avoid realpath in sandbox
         command = command,
         arguments = [f.path for f in ctx.files.srcs],
         mnemonic = "GoToolchainBinary",
@@ -207,7 +208,6 @@ just have a main package and only depend on the standard library and don't
 require build constraints.
 """,
 )
-
 
 def gc_linkopts(ctx):
     gc_linkopts = [


### PR DESCRIPTION
Set GOROOT explicitly when invoking "go tool compile" and
"go tool binary". The Go tool determines GOROOT automatically based on
argv[0], but this does not work in some sandbox environments.

Fixes #2005