### PR TITLE
Band-aid gRPC cross-compilation for Linux

### DIFF
--- a/third_party/org_golang_google_grpc-crosscompile.patch
+++ b/third_party/org_golang_google_grpc-crosscompile.patch
@@ -30,11 +30,42 @@ diff -urN b/internal/channelz/BUILD.bazel c/internal/channelz/BUILD.bazel
 diff -urN a/internal/syscall/BUILD.bazel b/internal/syscall/BUILD.bazel
 --- a/internal/syscall/BUILD.bazel
 +++ b/internal/syscall/BUILD.bazel
-@@ -11,6 +11,7 @@ go_library(
+@@ -11,15 +11,19 @@ go_library(
      deps = select({
          "@io_bazel_rules_go//go/platform:android": [
              "//grpclog:go_default_library",
 +            "@org_golang_x_sys//unix:go_default_library",
          ],
          "@io_bazel_rules_go//go/platform:darwin": [
+             "//grpclog:go_default_library",
++            "@org_golang_x_sys//unix:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:dragonfly": [
+             "//grpclog:go_default_library",
++            "@org_golang_x_sys//unix:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:freebsd": [
+             "//grpclog:go_default_library",
++            "@org_golang_x_sys//unix:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:linux": [
+             "//grpclog:go_default_library",
+@@ -30,15 +34,18 @@ go_library(
+         ],
+         "@io_bazel_rules_go//go/platform:netbsd": [
+             "//grpclog:go_default_library",
++            "@org_golang_x_sys//unix:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:openbsd": [
+             "//grpclog:go_default_library",
++            "@org_golang_x_sys//unix:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:plan9": [
+             "//grpclog:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:solaris": [
+             "//grpclog:go_default_library",
++            "@org_golang_x_sys//unix:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:windows": [
              "//grpclog:go_default_library",


### PR DESCRIPTION
This PR replaces #2007. 

As discussed in that PR, we're setting goos="linux" on a go_image rule from rules_docker, which is broken unless `--platforms` flags are specified. This is change is a workaround/quality of life improvement to bring back support for `bazel build //...` and similar invocations to multi-platform repos.