### PR TITLE
Make nogo work on Windows (path handling)

### DIFF
--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -56,6 +56,7 @@ go_source(
     name = "nogo_srcs",
     srcs = [
         "flags.go",
+        "env.go",
         "nogo_main.go",
     ],
     # //go/tools/builders:nogo_srcs is considered a different target by

--- a/go/tools/builders/nogo_main.go
+++ b/go/tools/builders/nogo_main.go
@@ -34,6 +34,7 @@ import (
 	"os"
 	"reflect"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -90,6 +91,9 @@ func run(args []string) error {
 		return fmt.Errorf("errors found by nogo during build-time code analysis:\n%s\n", diagnostics)
 	}
 	if *xPath != "" {
+		if runtime.GOOS != "darwin" {
+			*xPath = abs(*xPath)
+		}
 		if err := ioutil.WriteFile(*xPath, facts, 0666); err != nil {
 			return fmt.Errorf("error writing facts: %v", err)
 		}

--- a/go/tools/builders/nogo_main.go
+++ b/go/tools/builders/nogo_main.go
@@ -34,7 +34,6 @@ import (
 	"os"
 	"reflect"
 	"regexp"
-	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -91,10 +90,7 @@ func run(args []string) error {
 		return fmt.Errorf("errors found by nogo during build-time code analysis:\n%s\n", diagnostics)
 	}
 	if *xPath != "" {
-		if runtime.GOOS != "darwin" {
-			*xPath = abs(*xPath)
-		}
-		if err := ioutil.WriteFile(*xPath, facts, 0666); err != nil {
+		if err := ioutil.WriteFile(abs(*xPath), facts, 0666); err != nil {
 			return fmt.Errorf("error writing facts: %v", err)
 		}
 	}


### PR DESCRIPTION
Recently, we tried out using nogo in our Go projects, and it failed on Windows because of too long relative path names. (I'm not surprised about this thing anymore ;))

I don't know if you think this one goes too far, feel free to adapt. This one works for me on Windows and Linux. (Haven't tried macOS)