### PR TITLE
bazel_test: fix load of generate_toolchain_names

### DIFF
--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -18,7 +18,6 @@ Toolchain rules used by go.
 load(
     "@io_bazel_rules_go//go/platform:list.bzl",
     "GOOS_GOARCH",
-    "generate_toolchain_names",
 )
 load("@io_bazel_rules_go//go/private:providers.bzl", "GoSDK")
 load("@io_bazel_rules_go//go/private:actions/archive.bzl", "emit_archive")

--- a/tests/bazel_tests.bzl
+++ b/tests/bazel_tests.bzl
@@ -1,14 +1,14 @@
 load(
+    "@io_bazel_rules_go//go/platform:list.bzl",
+    "generate_toolchain_names",
+)
+load(
     "@io_bazel_rules_go//go/private:context.bzl",
     "go_context",
 )
 load(
     "@io_bazel_rules_go//go/private:common.bzl",
     "env_execute",
-)
-load(
-    "@io_bazel_rules_go//go/private:go_toolchain.bzl",
-    "generate_toolchain_names",
 )
 load(
     "@io_bazel_rules_go//go/private:rules/rule.bzl",


### PR DESCRIPTION
This is broken by a Bazel incompatible flag flip. With this change, we
load generate_toolchain_names from the correct file.

Fixes #2039