### PR TITLE
Export patches to allow Bazel query to work.

### DIFF
--- a/third_party/BUILD.bazel
+++ b/third_party/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(glob(["*.patch"]))


### PR DESCRIPTION
Otherwise Bazel query fails with:

    ERROR: <BAZEL>/external/io_bazel_rules_go/go/private/repositories.bzl:236:9:
      no such target '@io_bazel_rules_go//third_party:com_github_kevinburke_go_bindata-gazelle.patch':
      target 'com_github_kevinburke_go_bindata-gazelle.patch' not declared in package 'third_party';
      however, a source file of this name exists.
      (Perhaps add 'exports_files(["com_github_kevinburke_go_bindata-gazelle.patch"])' to third_party/BUILD?)
      defined by <BAZEL>/external/io_bazel_rules_go/third_party/BUILD.bazel and referenced by '//external:com_github_kevinburke_go_bindata'

The reason is probably because the patches are referenced from the
root of the remote version of the repository like:

    @io_bazel_rules_go//third_party:org_golang_x_tools-gazelle.patch

Fixes #2043.