### PR TITLE
Various fixes in GoCompilePkg

### DIFF
--- a/go/tools/builders/cgo2.go
+++ b/go/tools/builders/cgo2.go
@@ -277,14 +277,16 @@ func compileCSources(goenv *env, cSrcs, cxxSrcs, sSrcs, hSrcs []string, cc strin
 }
 
 func cCompile(goenv *env, src, cc string, cFlags []string, out string) error {
-	args := []string{cc, "-c", src, "-o", out}
+	args := []string{cc}
 	args = append(args, cFlags...)
+	args = append(args, "-c", src, "-o", out)
 	return goenv.runCommand(args)
 }
 
 func cxxCompile(goenv *env, src, cc string, cxxFlags []string, out string) error {
-	args := []string{cc, "-x", "c++", "-c", src, "-o", out}
+	args := []string{cc, "-x", "c++"}
 	args = append(args, cxxFlags...)
+	args = append(args, "-c", src, "-o", out)
 	return goenv.runCommand(args)
 }
 

--- a/go/tools/builders/filter.go
+++ b/go/tools/builders/filter.go
@@ -100,7 +100,7 @@ func readFileInfo(bctx build.Context, input string, needPackage bool) (fileInfo,
 			fi.ext = mExt
 		case ".s":
 			fi.ext = sExt
-		case ".h":
+		case ".h", ".hh", ".hpp", ".hxx":
 			fi.ext = hExt
 		default:
 			return fileInfo{}, fmt.Errorf("unrecognized file extension: %s", ext)


### PR DESCRIPTION
- Add support for C++ headers (`hh`, `hxx`, `hpp`)
- Order c/cxx flags properly, ensuring they are before the compiler input and outputs