### PR TITLE
remove -lstdc++ from CGO_LDFLAGS if -static-libstdc++ is present

### DIFF
--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -317,10 +317,11 @@ def _cgo_codegen_impl(ctx):
         objc_outs.append(gen_file)
         builder_args.add("-src", gen_file.path + "=" + src.path)
 
-    # Filter out -lstdc++ in CGO_LDFLAGS if we don't have any C++ code. This
-    # also gets filtered out in link.bzl.
+    # Filter out -lstdc++ in CGO_LDFLAGS if we don't have any C++ code or libstdc++
+    # is statically linked. This also gets filtered out in link.bzl.
     have_cc = len(source.cxx) + len(source.objc) + len(ctx.attr.deps) > 0
-    if not have_cc:
+    static_cc = "-static-libstdc++" in linkopts
+    if not have_cc or static_cc:
         linkopts = [o for o in linkopts if o not in ("-lstdc++", "-lc++")]
 
     tool_args.add("-objdir", out_dir)

--- a/go/tools/builders/cgo2.go
+++ b/go/tools/builders/cgo2.go
@@ -61,17 +61,20 @@ func cgo2(goenv *env, goSrcs, cgoSrcs, cSrcs, cxxSrcs, sSrcs, hSrcs []string, pa
 	// generated sources. The compiler encodes those flags in the compiled .a
 	// file, and the linker passes them on to the external linker.
 	haveCxx := len(cxxSrcs) > 0
+	staticCxx := false
 	if !haveCxx {
 		for _, f := range ldFlags {
 			if strings.HasSuffix(f, ".a") {
 				// These flags come from cdeps options. Assume C++.
 				haveCxx = true
-				break
+			}
+			if strings.Compare(f, "-static-libstdc++") == 0 {
+				staticCxx = true
 			}
 		}
 	}
 	var combinedLdFlags []string
-	if haveCxx {
+	if haveCxx && !staticCxx {
 		combinedLdFlags = append(combinedLdFlags, ldFlags...)
 	} else {
 		for _, f := range ldFlags {


### PR DESCRIPTION
This pull request allows libstdc++ to be statically linked if -static-libstdc++ is specified in the link options.