### PR TITLE
Migrate for Bazel's --incompatible_require_ctx_in_configure_features

### DIFF
--- a/go/private/compat/compat_repo.bzl
+++ b/go/private/compat/compat_repo.bzl
@@ -38,16 +38,18 @@ _go_rules_compat = repository_rule(
 )
 
 def go_rules_compat(**kwargs):
-    v = native.bazel_version
-    if not v:
+    impls = [18, 22, 23, 26]  # keep sorted
+    if not native.bazel_version:
         # bazel_version is None in development builds, so we can't do a
         # version comparison. Use the newest version of the compat file.
-        stem = "v23"
-    elif versions.is_at_most("0.21.0", v):
-        stem = "v18"
-    elif versions.is_at_most("0.22.0", v):
-        stem = "v22"
+        impl = impls[-1]
     else:
-        stem = "v23"
-    impl = "@io_bazel_rules_go//go/private:compat/{}.bzl".format(stem)
-    _go_rules_compat(impl = impl, **kwargs)
+        bazel_version = versions.parse(native.bazel_version)
+        impl = impls[0]
+        for iv in impls[1:]:
+            next_version = (0, iv, 0)
+            if bazel_version < next_version:
+                break
+            impl = iv
+    impl_label = "@io_bazel_rules_go//go/private:compat/v{}.bzl".format(impl)
+    _go_rules_compat(impl = impl_label, **kwargs)

--- a/go/private/compat/v18.bzl
+++ b/go/private/compat/v18.bzl
@@ -91,3 +91,11 @@ def providers_with_coverage(ctx, source_attributes, dependency_attributes, exten
             dependency_attributes = dependency_attributes,
         ),
     )
+
+# Compatibility for --incompatible_require_ctx_in_configure_features
+def cc_configure_features(ctx, cc_toolchain, requested_features, unsupported_features):
+    return cc_common.configure_features(
+        cc_toolchain = cc_toolchain,
+        requested_features = requested_features,
+        unsupported_features = unsupported_features,
+    )

--- a/go/private/compat/v22.bzl
+++ b/go/private/compat/v22.bzl
@@ -122,3 +122,11 @@ def providers_with_coverage(ctx, source_attributes, dependency_attributes, exten
             dependency_attributes = dependency_attributes,
         ),
     )
+
+# Compatibility for --incompatible_require_ctx_in_configure_features
+def cc_configure_features(ctx, cc_toolchain, requested_features, unsupported_features):
+    return cc_common.configure_features(
+        cc_toolchain = cc_toolchain,
+        requested_features = requested_features,
+        unsupported_features = unsupported_features,
+    )

--- a/go/private/compat/v26.bzl
+++ b/go/private/compat/v26.bzl
@@ -124,6 +124,7 @@ def providers_with_coverage(ctx, source_attributes, dependency_attributes, exten
 # Compatibility for --incompatible_require_ctx_in_configure_features
 def cc_configure_features(ctx, cc_toolchain, requested_features, unsupported_features):
     return cc_common.configure_features(
+        ctx = ctx,
         cc_toolchain = cc_toolchain,
         requested_features = requested_features,
         unsupported_features = unsupported_features,

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -417,6 +417,7 @@ def _go_context_data_impl(ctx):
     # is switched on.
     cc_toolchain = find_cpp_toolchain(ctx)
     feature_configuration = cc_common.configure_features(
+        ctx = ctx,
         cc_toolchain = cc_toolchain,
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -25,6 +25,10 @@ load(
     "C_COMPILE_ACTION_NAME",
 )
 load(
+    "@io_bazel_rules_go_compat//:compat.bzl",
+    "cc_configure_features",
+)
+load(
     "@io_bazel_rules_go//go/private:providers.bzl",
     "EXPLICIT_PATH",
     "EXPORT_PATH",
@@ -416,7 +420,7 @@ def _go_context_data_impl(ctx):
     # ctx.files._cc_toolchain won't work when cc toolchain resolution
     # is switched on.
     cc_toolchain = find_cpp_toolchain(ctx)
-    feature_configuration = cc_common.configure_features(
+    feature_configuration = cc_configure_features(
         ctx = ctx,
         cc_toolchain = cc_toolchain,
         requested_features = ctx.features,

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -590,5 +590,5 @@ go_context_data = rule(
             default = "@bazel_tools//tools/osx:current_xcode_config",
         ),
     },
-    fragments = ["apple"],
+    fragments = ["apple", "cpp"],
 )


### PR DESCRIPTION
This PR migrates rules_go for Bazel's incompatible change https://github.com/bazelbuild/bazel/issues/7793, which is present in 0.25.