### PR TITLE
Fix for Bazel upcoming change incompatible_string_join_requires_strings

### DIFF
--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -253,7 +253,7 @@ def _include_unique(opts, flag, include, seen):
     opts.extend([flag, include])
 
 def _encode_cgo_mode(goos, goarch, race, msan):
-    return "_".join((goos, goarch, race, msan))
+    return "_".join((goos, goarch, str(race), str(msan)))
 
 def _cgo_codegen_impl(ctx):
     go = go_context(ctx)


### PR DESCRIPTION
The arguments of string.join should be strings. In the future,
Bazel won't perform this implicit conversion.