### PR TITLE
Depend on @bazel_tools//tools/cpp:toolchain_type in go_context_data

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -594,5 +594,6 @@ go_context_data = rule(
             default = "@bazel_tools//tools/osx:current_xcode_config",
         ),
     },
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
     fragments = ["apple", "cpp"],
 )


### PR DESCRIPTION
Declare dependency on `https://github.com/bazelbuild/bazel/issues/7260` so go rules work when C++ rules are using toolchains and platforms.

This is a migration needed for https://github.com/bazelbuild/bazel/issues/7260.
