### PR TITLE
Bazel compatibility updates

### DIFF
--- a/go/private/compat/v22.bzl
+++ b/go/private/compat/v22.bzl
@@ -14,6 +14,8 @@
 
 # Compatibility for --incompatible_disable_legacy_cc_provider
 
+load("@io_bazel_rules_go//go/private:common.bzl", "as_iterable")
+
 CC_PROVIDER_NAME = CcInfo
 
 def has_cc(target):
@@ -40,7 +42,7 @@ def cc_link_flags(target):
 def cc_libs(target):
     # Copied from get_libs_for_static_executable in migration instructions
     # from bazelbuild/bazel#7036.
-    libraries_to_link = target[CcInfo].linking_context.libraries_to_link
+    libraries_to_link = as_iterable(target[CcInfo].linking_context.libraries_to_link)
     libs = []
     for library_to_link in libraries_to_link:
         if library_to_link.static_library != None:

--- a/go/private/compat/v23.bzl
+++ b/go/private/compat/v23.bzl
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@io_bazel_rules_go//go/private:common.bzl", "as_iterable")
+
 # Compatibility for --incompatible_disable_legacy_cc_provider
 
 CC_PROVIDER_NAME = CcInfo
@@ -40,7 +42,7 @@ def cc_link_flags(target):
 def cc_libs(target):
     # Copied from get_libs_for_static_executable in migration instructions
     # from bazelbuild/bazel#7036.
-    libraries_to_link = target[CcInfo].linking_context.libraries_to_link
+    libraries_to_link = as_iterable(target[CcInfo].linking_context.libraries_to_link)
     libs = []
     for library_to_link in libraries_to_link:
         if library_to_link.static_library != None:

--- a/go/private/compat/v26.bzl
+++ b/go/private/compat/v26.bzl
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@io_bazel_rules_go//go/private:common.bzl", "as_iterable")
+
 # Compatibility for --incompatible_disable_legacy_cc_provider
 
 CC_PROVIDER_NAME = CcInfo
@@ -40,7 +42,7 @@ def cc_link_flags(target):
 def cc_libs(target):
     # Copied from get_libs_for_static_executable in migration instructions
     # from bazelbuild/bazel#7036.
-    libraries_to_link = target[CcInfo].linking_context.libraries_to_link
+    libraries_to_link = as_iterable(target[CcInfo].linking_context.libraries_to_link)
     libs = []
     for library_to_link in libraries_to_link:
         if library_to_link.static_library != None:


### PR DESCRIPTION
Made tests pass with bazel 0.26.0rc8 --all_incompatible_flags
with a few exceptions.

Flags fixed:

* --incompatible_depset_is_not_iterable: wrapped some things in
  cc_libs with as_iterable.

Broken flags:

* --incompatible_remap_main_repo: breaks toolchain selection.
* --incompatible_disallow_struct_provider_syntax: breaks java
  toolchain in @bazel_tools
* --incompatible_enable_cc_toolchain_resolution: adds UIKit
  to link flags but does not make it available to the linker on macOS.
* --incompatible_use_python_toolchains: requires Python 3 to be
  installed. Breaks native pkg_tar rule if it's not.