### PR TITLE
Windows: future-proof single_output_test.bzl

### DIFF
--- a/go/private/tools/single_output_test.bzl
+++ b/go/private/tools/single_output_test.bzl
@@ -13,25 +13,45 @@
 # limitations under the License.
 
 def _impl(ctx):
+    exe = ctx.outputs.out
     ctx.actions.write(
         output = ctx.outputs.executable,
-        content = "",
+        # The file must not be empty because running an empty .bat file as a
+        # subprocess fails on Windows, so we write one space to it.
+        content = " ",
         is_executable = True,
     )
+    return [DefaultInfo(files = depset([exe]), executable = exe)]
 
-single_output_test = rule(
+_single_output_test = rule(
     implementation = _impl,
     attrs = {
         "dep": attr.label(allow_single_file = True),
+        "out": attr.output(),
     },
     test = True,
 )
-"""Checks that a dependency produces a single output file.
 
-This test works by setting `allow_single_file = True` on the `dep` attribute.
-If `dep` provides zero or multiple files in its `files` provider, Bazel will
-fail to build this rule during analysis. The actual test does nothing.]
 
-Args:
-  dep: a label for the rule to check.
-"""
+def single_output_test(name, dep, **kwargs):
+    """Checks that a dependency produces a single output file.
+
+    This test works by setting `allow_single_file = True` on the `dep` attribute.
+    If `dep` provides zero or multiple files in its `files` provider, Bazel will
+    fail to build this rule during analysis. The actual test does nothing.
+
+    Args:
+      name: The name of the test rule.
+      dep: a label for the rule to check.
+      **kwargs: The <a href="https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes-tests">common attributes for tests</a>.
+    """
+
+    _single_output_test(
+        name = name,
+        dep = dep,
+        # On Windows we need the ".bat" extension.
+        # On other platforms the extension doesn't matter.
+        # Therefore we can use ".bat" on every platform.
+        out = name + ".bat",
+        **kwargs
+    )

--- a/go/private/tools/single_output_test.bzl
+++ b/go/private/tools/single_output_test.bzl
@@ -15,7 +15,7 @@
 def _impl(ctx):
     exe = ctx.outputs.out
     ctx.actions.write(
-        output = ctx.outputs.executable,
+        output = exe,
         # The file must not be empty because running an empty .bat file as a
         # subprocess fails on Windows, so we write one space to it.
         content = " ",


### PR DESCRIPTION
Fix single_output_test() on Windows with the new
native test wrapper.

Bazel 0.25 introduced the
--incompatible_windows_native_test_wrapper flag.

This flag enables a new test wrapper on Windows
that doesn't require Bash. On other platforms this
flag has no effect.

The new test wrapper is a C++ binary and doesn't
use Bash, but therefore test rules whose
executable is a naked shell script also don't
work with it.

The solution here is to write a special script
that does nothing and is valid both as `.bat` and
as `.sh`.

See https://github.com/bazelbuild/bazel/issues/6622