### PR TITLE
Update protobuf

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -150,6 +150,8 @@ Setup
     load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
     go_rules_dependencies()
     go_register_toolchains()
+    load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+    protobuf_deps()
 
   If you want to use a specific commit (for example, something close to
   ``master``), add the following instead:
@@ -165,6 +167,8 @@ Setup
     load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
     go_rules_dependencies()
     go_register_toolchains()
+    load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+    protobuf_deps()
 
   You can add more external dependencies to this file later (see
   `go_repository`_).
@@ -204,6 +208,8 @@ build files automatically using gazelle_.
     load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
     go_rules_dependencies()
     go_register_toolchains()
+    load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+    protobuf_deps()
     load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
     gazelle_dependencies()
 
@@ -318,6 +324,8 @@ a go.mod or Gopkg.lock file.
     load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
     go_rules_dependencies()
     go_register_toolchains()
+    load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+    protobuf_deps()
 
     # Download Gazelle
     http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,6 +8,10 @@ go_rules_dependencies()
 
 go_register_toolchains()
 
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
 # Needed for tests
 git_repository(
     name = "bazel_gazelle",

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -81,24 +81,9 @@ def go_rules_dependencies():
         git_repository,
         name = "com_google_protobuf",
         remote = "https://github.com/protocolbuffers/protobuf",
-        commit = "582743bf40c5d3639a70f98f183914a2c0cd0680",  # v3.7.0, as of 2019-03-03
-        shallow_since = "1551387314 -0800",
+        commit = "09745575a923640154bcf307fba8aedff47f240a",  # v3.8.0, as of 2019-05-28
+        shallow_since = "1558721209 -0700",
     )
-    # Workaround for protocolbuffers/protobuf#5472
-    # At master, they provide a macro that creates this dependency. We can't
-    # load it from here though.
-    if "net_zlib" not in native.existing_rules():
-        native.bind(
-            name = "zlib",
-            actual = "@net_zlib//:zlib",
-        )
-        http_archive(
-            name = "net_zlib",
-            build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
-            sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
-            strip_prefix = "zlib-1.2.11",
-            urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
-        )
 
     _maybe(
         git_repository,


### PR DESCRIPTION
This updates protobuf, which allows us to remove the explicit zlib
dependency. The downside of this is users have to call the
`protobuf_deps` function from their WORKSPACEs.