### PR TITLE
Fix vendored Skylib w/ Windows-native test wrapper

### DIFF
--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -16,6 +16,7 @@
 
 load("@io_bazel_rules_go//go/private:common.bzl", "MINIMUM_BAZEL_VERSION")
 load("@io_bazel_rules_go//go/private:compat/compat_repo.bzl", "go_rules_compat")
+load("@io_bazel_rules_go//go/private:skylib/lib/unittest.bzl", "register_unittest_toolchains")
 load("@io_bazel_rules_go//go/private:skylib/lib/versions.bzl", "versions")
 load("@io_bazel_rules_go//go/private:nogo.bzl", "DEFAULT_NOGO", "go_register_nogo")
 load("@io_bazel_rules_go//go/platform:list.bzl", "GOOS_GOARCH")
@@ -27,6 +28,8 @@ def go_rules_dependencies():
     """See /go/workspace.rst#go-rules-dependencies for full documentation."""
     if getattr(native, "bazel_version", None):
         versions.check(MINIMUM_BAZEL_VERSION, bazel_version = native.bazel_version)
+
+    register_unittest_toolchains()
 
     # Compatibility layer, needed to support older versions of Bazel.
     _maybe(

--- a/go/private/skylib/README.rst
+++ b/go/private/skylib/README.rst
@@ -1,5 +1,8 @@
 This directory is a copy of github.com/bazelbuild/bazel-skylib/lib.
-Version 0.5.0, retrieved on 2018-11-26.
+Version 0.5.0 (retrieved on 2018-11-26) + some changes:
+- cherry-picked Skylib's daf513702286fe211f291675443235e35e79f34f, except for
+  the files in "tests"
+- updated labels in load() statements and toolchain references
 
 This is needed only until nested workspaces works.
 It has to be copied in because we use the functionality inside code that 

--- a/go/private/skylib/toolchains/unittest/BUILD
+++ b/go/private/skylib/toolchains/unittest/BUILD
@@ -1,0 +1,47 @@
+load("@io_bazel_rules_go//go/private:skylib/lib/unittest.bzl", "TOOLCHAIN_TYPE", "unittest_toolchain")
+
+toolchain_type(
+    name = "toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+unittest_toolchain(
+    name = "cmd",
+    failure_templ = """@echo off
+echo %s
+exit /b 1
+""",
+    file_ext = ".bat",
+    join_on = "\necho ",
+    success_templ = "@exit /b 0",
+    visibility = ["//visibility:public"],
+)
+
+unittest_toolchain(
+    name = "bash",
+    failure_templ = """#!/bin/sh
+cat <<'EOF'
+%s
+EOF
+exit 1
+""",
+    file_ext = ".sh",
+    join_on = "\n",
+    success_templ = "#!/bin/sh\nexit 0",
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "cmd_toolchain",
+    exec_compatible_with = [
+        "@bazel_tools//platforms:windows",
+    ],
+    toolchain = ":cmd",
+    toolchain_type = TOOLCHAIN_TYPE,
+)
+
+toolchain(
+    name = "bash_toolchain",
+    toolchain = ":bash",
+    toolchain_type = TOOLCHAIN_TYPE,
+)


### PR DESCRIPTION
Partially back-port a Skylib commit [1] to the
vendored Skylib code, to fix unittest.bzl for
Bazel's native test wrapper on Windows.

The native test wrapper will replace the
Bash-script test wrapper on Windows [2].

I tried updating the current Skylib 0.5.0 sources
to 0.8.0, but tests failed on Travis CI. I suspect
that an older Bazel version is used.

[1] https://github.com/bazelbuild/bazel-skylib/commit/daf513702286fe211f291675443235e35e79f34f
[2] https://github.com/bazelbuild/bazel/issues/6622