### PR TITLE
Add iOS as a platform

### DIFF
--- a/go/platform/list.bzl
+++ b/go/platform/list.bzl
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 GOOS = {
-    "android": None,
+    "android": "@bazel_tools//platforms:android",
     "darwin": "@bazel_tools//platforms:osx",
+    "ios": "@bazel_tools//platforms:ios",
     "dragonfly": None,
     "freebsd": "@bazel_tools//platforms:freebsd",
     "linux": "@bazel_tools//platforms:linux",
@@ -52,6 +53,10 @@ GOOS_GOARCH = (
     ("darwin", "amd64"),
     ("darwin", "arm"),
     ("darwin", "arm64"),
+    ("ios", "386"),
+    ("ios", "amd64"),
+    ("ios", "arm"),
+    ("ios", "arm64"),
     ("dragonfly", "amd64"),
     ("freebsd", "386"),
     ("freebsd", "amd64"),

--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -31,12 +31,15 @@ load("@io_bazel_rules_go//go/private:actions/stdlib.bzl", "emit_stdlib")
 
 def _go_toolchain_impl(ctx):
     sdk = ctx.attr.sdk[GoSDK]
-    cross_compile = ctx.attr.goos != sdk.goos or ctx.attr.goarch != sdk.goarch
+    goos = ctx.attr.goos
+    if goos == "ios":
+        goos = "darwin"
+    cross_compile = goos != sdk.goos or ctx.attr.goarch != sdk.goarch
     return [platform_common.ToolchainInfo(
         # Public fields
         name = ctx.label.name,
         cross_compile = cross_compile,
-        default_goos = ctx.attr.goos,
+        default_goos = goos,
         default_goarch = ctx.attr.goarch,
         actions = struct(
             archive = emit_archive,


### PR DESCRIPTION
Opening in draft for now.

iOS is a special variant of GOOS=darwin. In order to support the new
CC toolchain constraints that come with bazel 0.26, we need to propagate
the same OS that what bazel expects, or else CGo won't work because it
can't find a toolchain.

This needs Bazel 0.26.1 as 0.26.0 has a bug regarding this [1].

1. https://github.com/bazelbuild/bazel/pull/8522

Also, this might require gazelle to handle the ios case, too.