### PR TITLE
docs/nogo: Use regular expressions in example

### DIFF
--- a/go/nogo.rst
+++ b/go/nogo.rst
@@ -211,16 +211,16 @@ configured, it will emit diagnostics for all Go files built by Bazel.
     {
       "importunsafe": {
         "exclude_files": {
-          "src/foo.go": "manually verified that behavior is working-as-intended",
-          "src/bar.go": "see issue #1337"
+          "src/foo\\.go": "manually verified that behavior is working-as-intended",
+          "src/bar\\.go": "see issue #1337"
         }
       },
       "unsafedom": {
         "only_files": {
-          "src/js/*": ""
+          "src/js/.*": ""
         },
         "exclude_files": {
-          "src/(third_party|vendor)/*": "enforce DOM safety requirements only on first-party code"
+          "src/(third_party|vendor)/.*": "enforce DOM safety requirements only on first-party code"
         }
       }
     }


### PR DESCRIPTION
As per the documentation, the keys in `only_files` and `exclude_files`
are regular expressions, and the code verifies this:
https://github.com/bazelbuild/rules_go/blob/e284e9dafc99aac881970edf760549f5f9daf1e5/go/tools/builders/generate_nogo_main.go#L63

The example in the docs uses globs instead of regular expressions; this
seems to be a typo. This change fixes this by switching the example to
use regular expressions.