### PR TITLE
Fix nogo example import path in nogo.rst

### DIFF
--- a/go/nogo.rst
+++ b/go/nogo.rst
@@ -103,7 +103,7 @@ already been run. For example:
     import (
       "strconv"
 
-      "github.com/bazelbuild/rules_go/go/tools/analysis"
+      "golang.org/x/tools/go/analysis"
     )
 
     var Analyzer = &analysis.Analyzer{


### PR DESCRIPTION
It seems that `github.com/bazelbuild/rules_go/go/tools/analysis` has been moved to `golang.org/x/tools/go/analysis`