### PR TITLE
Fix cgo build failures with specific GCC flags

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -69,9 +69,15 @@ GoContext = provider()
 _GoContextData = provider()
 
 _COMPILER_OPTIONS_BLACKLIST = {
+    # cgo parses the error messages from the compiler.  It can't handle colors.
+    # Ignore both variants of the diagnostics color flag.
     "-fcolor-diagnostics": None,
     "-fdiagnostics-color": None,
-    "-fmax-errors=20": None,
+
+    # cgo also wants to see all the errors when it is testing the compiler.
+    # fmax-errors limits that and causes build failures.
+    "-fmax-errors=": None,
+
     "-Wall": None,
 
     # Symbols are needed by Go, so keep them
@@ -88,8 +94,18 @@ _LINKER_OPTIONS_BLACKLIST = {
     "-Wl,--gc-sections": None,
 }
 
+def _match_option(option, pattern):
+    if pattern.endswith("="):
+        return option.startswith(pattern)
+    else:
+        return option == pattern
+
 def _filter_options(options, blacklist):
-    return [option for option in options if option not in blacklist]
+    return [
+        option
+        for option in options
+        if not any([_match_option(option, pattern) for pattern in blacklist])
+    ]
 
 def _child_name(go, path, ext, name):
     childname = mode_string(go.mode) + "/"

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -70,6 +70,8 @@ _GoContextData = provider()
 
 _COMPILER_OPTIONS_BLACKLIST = {
     "-fcolor-diagnostics": None,
+    "-fdiagnostics-color": None,
+    "-fmax-errors=20": None,
     "-Wall": None,
 
     # Symbols are needed by Go, so keep them

--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -795,7 +795,10 @@ def setup_cgo_library_for_mode(name, srcs, cdeps, copts, cxxopts, cppopts, clink
         name = cgo_o_name,
         srcs = [select_main_c],
         deps = cdeps + cgo_o_deps,
-        copts = copts + cppopts,
+        copts = copts + cppopts + [
+            # The generated thunks often contain unused variables.
+            "-Wno-unused-variable",
+        ],
         linkopts = clinkopts,
         visibility = ["//visibility:private"],
         **common_attrs


### PR DESCRIPTION
cgo runs the compiler over a test file as part of the build process.  It then parses the compiler errors.  This requires the compiler to be configured well enough to work for cgo.

-fdiagnostics-color is another way to enable color support on GCC.  This adds colors unconditionally to the output (bazel doesn't present a TTY, so to get colors with bazel, you need to force them on).

-fmax-errors=... is a way to prevent GCC from completely flooding your terminal when something goes wrong.  A missed semicolon or misplaced {} can cause thousands of lines of errors.  This can stop showing errors before cgo sees all the errors it is looking for.  We want to strip it out too.