### PR TITLE
go_library, go_test, go_binary: accept .m and .mm files

### DIFF
--- a/go/core.rst
+++ b/go/core.rst
@@ -303,8 +303,10 @@ Attributes
 | If :value:`True`, the package uses cgo_.                                                         |
 | The cgo tool permits Go code to call C code and vice-versa.                                      |
 | This does not support calling C++.                                                               |
-| When cgo is set, :param:`srcs` may contain C or assembly files; these files are compiled with    |
-| the normal c compiler and included in the package.                                               |
+| When cgo is set, :param:`srcs` may contain C, C++, Objective-C, Objective-C++,                   |
+| and assembly files. These files will be compiled with the compiler from                          |
+| the configured C/C++ toolchain. The compiled objects are included in                             |
+| the package.                                                                                     |
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`cdeps`             | :type:`label_list`          | :value:`None`                         |
 +----------------------------+-----------------------------+---------------------------------------+
@@ -558,8 +560,10 @@ Attributes
 | If :value:`True`, the binary uses cgo_.                                                          |
 | The cgo tool permits Go code to call C code and vice-versa.                                      |
 | This does not support calling C++.                                                               |
-| When cgo is set, :param:`srcs` may contain C or assembly files; these files are compiled with    |
-| the normal c compiler and included in the package.                                               |
+| When cgo is set, :param:`srcs` may contain C, C++, Objective-C, Objective-C++,                   |
+| and assembly files. These files will be compiled with the compiler from                          |
+| the configured C/C++ toolchain. The compiled objects are included in                             |
+| the package.                                                                                     |
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`cdeps`             | :type:`label_list`          | :value:`None`                         |
 +----------------------------+-----------------------------+---------------------------------------+
@@ -765,8 +769,10 @@ Attributes
 | If :value:`True`, the binary uses cgo_.                                                          |
 | The cgo tool permits Go code to call C code and vice-versa.                                      |
 | This does not support calling C++.                                                               |
-| When cgo is set, :param:`srcs` may contain C or assembly files; these files are compiled with    |
-| the normal c compiler and included in the package.                                               |
+| When cgo is set, :param:`srcs` may contain C, C++, Objective-C, Objective-C++,                   |
+| and assembly files. These files will be compiled with the compiler from                          |
+| the configured C/C++ toolchain. The compiled objects are included in                             |
+| the package.                                                                                     |
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`cdeps`             | :type:`label_list`          | :value:`None`                         |
 +----------------------------+-----------------------------+---------------------------------------+

--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -85,7 +85,7 @@ def emit_archive(go, source = None):
         if source.cgo and not go.mode.pure:
             cgo = cgo_configure(
                 go,
-                srcs = split.go + split.c + split.asm + split.cxx + split.headers,
+                srcs = split.go + split.c + split.asm + split.cxx + split.objc + split.headers,
                 cdeps = source.cdeps,
                 cppopts = cppopts,
                 copts = copts,
@@ -96,7 +96,7 @@ def emit_archive(go, source = None):
             runfiles = runfiles.merge(cgo.runfiles)
             emit_compilepkg(
                 go,
-                sources = split.go + split.c + split.asm + split.cxx + split.headers,
+                sources = split.go + split.c + split.asm + split.cxx + split.objc + split.headers,
                 cover = source.cover,
                 importpath = effective_importpath_pkgpath(source.library)[0],
                 importmap = source.library.importmap,
@@ -109,6 +109,8 @@ def emit_archive(go, source = None):
                 cppopts = cgo.cppopts,
                 copts = cgo.copts,
                 cxxopts = cgo.cxxopts,
+                objcopts = cgo.objcopts,
+                objcxxopts = cgo.objcxxopts,
                 clinkopts = cgo.clinkopts,
                 cgo_archives = source.cgo_archives,
                 testfilter = testfilter,
@@ -117,7 +119,7 @@ def emit_archive(go, source = None):
             cgo_deps = depset()
             emit_compilepkg(
                 go,
-                sources = split.go + split.c + split.asm + split.cxx + split.headers,
+                sources = split.go + split.c + split.asm + split.cxx + split.objc + split.headers,
                 cover = source.cover,
                 importpath = effective_importpath_pkgpath(source.library)[0],
                 importmap = source.library.importmap,

--- a/go/private/actions/compilepkg.bzl
+++ b/go/private/actions/compilepkg.bzl
@@ -43,6 +43,8 @@ def emit_compilepkg(
         cppopts = [],
         copts = [],
         cxxopts = [],
+        objcopts = [],
+        objcxxopts = [],
         clinkopts = [],
         cgo_archives = [],
         out_lib = None,
@@ -116,6 +118,10 @@ def emit_compilepkg(
             args.add("-cflags", _quote_opts(copts))
         if cxxopts:
             args.add("-cxxflags", _quote_opts(cxxopts))
+        if objcopts:
+            args.add("-objcflags", _quote_opts(objcopts))
+        if objcxxopts:
+            args.add("-objcxxflags", _quote_opts(objcxxopts))
         if clinkopts:
             args.add("-ldflags", _quote_opts(clinkopts))
 

--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -55,6 +55,20 @@ objc_exts = [
     ".hxx",
 ]
 
+cgo_exts = [
+    ".c",
+    ".cc",
+    ".cpp",
+    ".cxx",
+    ".h",
+    ".hh",
+    ".hpp",
+    ".hxx",
+    ".inc",
+    ".m",
+    ".mm",
+]
+
 def pkg_dir(workspace_root, package_name):
     """Returns a relative path to a package directory from the root of the
     sandbox. Useful at execution-time or run-time."""

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -23,6 +23,8 @@ load(
     "CPP_LINK_EXECUTABLE_ACTION_NAME",
     "CPP_LINK_STATIC_LIBRARY_ACTION_NAME",
     "C_COMPILE_ACTION_NAME",
+    "OBJC_COMPILE_ACTION_NAME",
+    "OBJCPP_COMPILE_ACTION_NAME",
 )
 load(
     "@io_bazel_rules_go_compat//:compat.bzl",
@@ -567,6 +569,42 @@ def _cgo_context_data_impl(ctx):
         variables = cxx_compile_variables,
     ))
 
+    objc_compile_variables = cc_common.create_compile_variables(
+        feature_configuration = feature_configuration,
+        cc_toolchain = cc_toolchain,
+    )
+    objc_compile_options = _filter_options(
+        cc_common.get_memory_inefficient_command_line(
+            feature_configuration = feature_configuration,
+            action_name = OBJC_COMPILE_ACTION_NAME,
+            variables = objc_compile_variables,
+        ),
+        _COMPILER_OPTIONS_BLACKLIST,
+    )
+    env.update(cc_common.get_environment_variables(
+        feature_configuration = feature_configuration,
+        action_name = OBJC_COMPILE_ACTION_NAME,
+        variables = objc_compile_variables,
+    ))
+
+    objcxx_compile_variables = cc_common.create_compile_variables(
+        feature_configuration = feature_configuration,
+        cc_toolchain = cc_toolchain,
+    )
+    objcxx_compile_options = _filter_options(
+        cc_common.get_memory_inefficient_command_line(
+            feature_configuration = feature_configuration,
+            action_name = OBJCPP_COMPILE_ACTION_NAME,
+            variables = objcxx_compile_variables,
+        ),
+        _COMPILER_OPTIONS_BLACKLIST,
+    )
+    env.update(cc_common.get_environment_variables(
+        feature_configuration = feature_configuration,
+        action_name = OBJCPP_COMPILE_ACTION_NAME,
+        variables = objcxx_compile_variables,
+    ))
+
     ld_executable_variables = cc_common.create_link_variables(
         feature_configuration = feature_configuration,
         cc_toolchain = cc_toolchain,
@@ -638,7 +676,7 @@ def _cgo_context_data_impl(ctx):
         ctx,
         env,
         tags,
-        (c_compile_options, cxx_compile_options),
+        (c_compile_options, cxx_compile_options, objc_compile_options, objcxx_compile_options),
         (ld_executable_options, ld_dynamic_lib_options),
         cc_toolchain.target_gnu_system_name,
     )
@@ -651,6 +689,8 @@ def _cgo_context_data_impl(ctx):
             c_compiler_path = c_compiler_path,
             c_compile_options = c_compile_options,
             cxx_compile_options = cxx_compile_options,
+            objc_compile_options = objc_compile_options,
+            objcxx_compile_options = objcxx_compile_options,
             ld_executable_path = ld_executable_path,
             ld_executable_options = ld_executable_options,
             ld_static_lib_path = ld_static_lib_path,

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -19,10 +19,8 @@ load(
 load(
     "@io_bazel_rules_go//go/private:common.bzl",
     "asm_exts",
-    "c_exts",
-    "cxx_exts",
+    "cgo_exts",
     "go_exts",
-    "hdr_exts",
 )
 load(
     "@io_bazel_rules_go//go/private:rules/aspect.bzl",
@@ -55,7 +53,7 @@ load(
 _SHARED_ATTRS = {
     "basename": attr.string(),
     "data": attr.label_list(allow_files = True),
-    "srcs": attr.label_list(allow_files = go_exts + asm_exts + hdr_exts + c_exts + cxx_exts),
+    "srcs": attr.label_list(allow_files = go_exts + asm_exts + cgo_exts),
     "gc_goopts": attr.string_list(),
     "gc_linkopts": attr.string_list(),
     "x_defs": attr.string_dict(),

--- a/go/private/rules/library.bzl
+++ b/go/private/rules/library.bzl
@@ -15,10 +15,8 @@
 load(
     "@io_bazel_rules_go//go/private:common.bzl",
     "asm_exts",
-    "c_exts",
-    "cxx_exts",
+    "cgo_exts",
     "go_exts",
-    "hdr_exts",
 )
 load(
     "@io_bazel_rules_go//go/private:context.bzl",
@@ -60,7 +58,7 @@ go_library = go_rule(
     _go_library_impl,
     attrs = {
         "data": attr.label_list(allow_files = True),
-        "srcs": attr.label_list(allow_files = go_exts + asm_exts + hdr_exts + c_exts + cxx_exts),
+        "srcs": attr.label_list(allow_files = go_exts + asm_exts + cgo_exts),
         "deps": attr.label_list(providers = [GoLibrary]),
         "importpath": attr.string(),
         "importmap": attr.string(),

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -23,10 +23,8 @@ load(
 load(
     "@io_bazel_rules_go//go/private:common.bzl",
     "asm_exts",
-    "c_exts",
-    "cxx_exts",
+    "cgo_exts",
     "go_exts",
-    "hdr_exts",
     "pkg_dir",
     "split_srcs",
 )
@@ -185,7 +183,7 @@ go_test = go_rule(
     _go_test_impl,
     attrs = {
         "data": attr.label_list(allow_files = True),
-        "srcs": attr.label_list(allow_files = go_exts + asm_exts + hdr_exts + c_exts + cxx_exts),
+        "srcs": attr.label_list(allow_files = go_exts + asm_exts + cgo_exts),
         "deps": attr.label_list(
             providers = [GoLibrary],
             aspects = [go_archive_aspect],

--- a/go/tools/builders/filter.go
+++ b/go/tools/builders/filter.go
@@ -41,13 +41,14 @@ const (
 	goExt ext = iota
 	cExt
 	cxxExt
-	mExt
+	objcExt
+	objcxxExt
 	sExt
 	hExt
 )
 
 type archiveSrcs struct {
-	goSrcs, cSrcs, cxxSrcs, mSrcs, sSrcs, hSrcs []fileInfo
+	goSrcs, cSrcs, cxxSrcs, objcSrcs, objcxxSrcs, sSrcs, hSrcs []fileInfo
 }
 
 // filterAndSplitFiles filters files using build constraints and collates
@@ -70,8 +71,10 @@ func filterAndSplitFiles(fileNames []string) (archiveSrcs, error) {
 			srcs = &res.cSrcs
 		case cxxExt:
 			srcs = &res.cxxSrcs
-		case mExt:
-			srcs = &res.mSrcs
+		case objcExt:
+			srcs = &res.objcSrcs
+		case objcxxExt:
+			srcs = &res.objcxxSrcs
 		case sExt:
 			srcs = &res.sSrcs
 		case hExt:
@@ -96,8 +99,10 @@ func readFileInfo(bctx build.Context, input string, needPackage bool) (fileInfo,
 			fi.ext = cExt
 		case ".cc", ".cxx", ".cpp":
 			fi.ext = cxxExt
-		case ".m", ".mm":
-			fi.ext = mExt
+		case ".m":
+			fi.ext = objcExt
+		case ".mm":
+			fi.ext = objcxxExt
 		case ".s":
 			fi.ext = sExt
 		case ".h", ".hh", ".hpp", ".hxx":

--- a/tests/core/cgo/BUILD.bazel
+++ b/tests/core/cgo/BUILD.bazel
@@ -13,7 +13,13 @@ go_library(
         "add.cpp",
         "add.h",
         "adder.go",
-    ],
+    ] + select({
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "add.m",
+            "add.mm",
+        ],
+        "//conditions:default": [],
+    }),
     cgo = True,
     copts = ["-DRULES_GO_C"],
     cppopts = ["-DRULES_GO_CPP"],

--- a/tests/core/cgo/add.m
+++ b/tests/core/cgo/add.m
@@ -1,0 +1,5 @@
+#include "add.h"
+
+#if !defined(RULES_GO_C) || !defined(RULES_GO_CPP) || defined(RULES_GO_CXX)
+#error This is an Objective-C file, only RULES_GO_C and RULES_GO_CPP should be defined.
+#endif

--- a/tests/core/cgo/add.mm
+++ b/tests/core/cgo/add.mm
@@ -1,0 +1,5 @@
+#include "add.h"
+
+#if !defined(RULES_GO_CPP) || !defined(RULES_GO_CXX) || defined(RULES_GO_C)
+#error This is an Objective-C++ file, only RULES_GO_CXX and RULES_GO_CPP should be defined.
+#endif

--- a/tests/core/cgo/objc/BUILD.bazel
+++ b/tests/core/cgo/objc/BUILD.bazel
@@ -19,9 +19,8 @@ go_library(
     ],
     cdeps = [":sub"],
     cgo = True,
+    copts = ["-fmodules"],
     importpath = "github.com/bazelbuild/rules_go/tests/core/cgo/objc",
-    objc = True,
-    objc_enable_modules = True,
     tags = ["manual"],
 )
 


### PR DESCRIPTION
Objective C and C++ sources may now be compiled directly with
go_library, go_binary, and go_test without needing to use the cgo
legacy wrapper. The cpp toolchain must provide a compiler thats
supports these languages.

Appropriate flags will be passed to the compiler for each language,
but no additional objcopts, objcxxopts attributes are provided. These
are meant to accomodate CGO_CFLAGS, CGO_CXXFLAGS, and there is are no
CGO_MFLAGS, CGO_MMFLAGS directives. These attributes can be added if
necessary though.

Updates #1957