### PR TITLE
tests/core/cgo: verify cdeps used when linking _cgo_.o

### DIFF
--- a/tests/README.rst
+++ b/tests/README.rst
@@ -6,10 +6,10 @@ Main test areas
 
 .. Child list start
 
-* `Integration tests <integration/README.rst>`_
 * `Core Go rules tests <core/README.rst>`_
-* `Go rules examples <examples/README.rst>`_
+* `Integration tests <integration/README.rst>`_
 * `Legacy tests <legacy/README.rst>`_
+* `Go rules examples <examples/README.rst>`_
 
 .. Child list end
 

--- a/tests/core/README.rst
+++ b/tests/core/README.rst
@@ -8,24 +8,24 @@ Contents
 
 .. Child list start
 
-* `output_groups functionality <output_groups/README.rst>`_
-* `Basic go_binary functionality <go_binary/README.rst>`_
-* `Import maps <importmap/README.rst>`_
-* `Basic cgo functionality <cgo/README.rst>`_
-* `c-archive / c-shared linkmodes <c_linkmodes/README.rst>`_
-* `stdlib functionality <stdlib/README.rst>`_
-* `go_proto_library importmap <go_proto_library_importmap/README.rst>`_
-* `Basic go_test functionality <go_test/README.rst>`_
-* `Basic go_path functionality <go_path/README.rst>`_
-* `Basic go_proto_library functionality <go_proto_library/README.rst>`_
 * `Basic go_library functionality <go_library/README.rst>`_
-* `Cross compilation <cross/README.rst>`_
+* `output_groups functionality <output_groups/README.rst>`_
 * `Basic -buildmode=plugin functionality <go_plugin/README.rst>`_
 * `Core Go rules tests <nogo/README.rst>`_
-* `Starlark unit tests <starlark/README.rst>`_
-* `race instrumentation <race/README.rst>`_
-* `coverage functionality <coverage/README.rst>`_
+* `go_proto_library importmap <go_proto_library_importmap/README.rst>`_
+* `Cross compilation <cross/README.rst>`_
+* `Basic go_proto_library functionality <go_proto_library/README.rst>`_
+* `c-archive / c-shared linkmodes <c_linkmodes/README.rst>`_
+* `Basic go_test functionality <go_test/README.rst>`_
+* `.. _#2067: https://github.com/bazelbuild/rules_go/issues/2067 <cgo/README.rst>`_
 * `Runfiles functionality <runfiles/README.rst>`_
+* `race instrumentation <race/README.rst>`_
+* `stdlib functionality <stdlib/README.rst>`_
+* `Basic go_binary functionality <go_binary/README.rst>`_
+* `Starlark unit tests <starlark/README.rst>`_
+* `coverage functionality <coverage/README.rst>`_
+* `Import maps <importmap/README.rst>`_
+* `Basic go_path functionality <go_path/README.rst>`_
 
 .. Child list end
 

--- a/tests/core/cgo/BUILD.bazel
+++ b/tests/core/cgo/BUILD.bazel
@@ -209,3 +209,18 @@ go_binary(
     cgo = True,
     pure = "off",
 )
+
+go_test(
+    name = "cgo_link_test",
+    srcs = [
+        "cgo_link_test.go",
+        "cgo_ref.go",
+    ],
+    cgo = True,
+    cdeps = [":cgo_link_dep"],
+)
+
+cc_library(
+    name = "cgo_link_dep",
+    srcs = ["cgo_link_dep.c"],
+)

--- a/tests/core/cgo/README.rst
+++ b/tests/core/cgo/README.rst
@@ -1,3 +1,5 @@
+.. _#2067: https://github.com/bazelbuild/rules_go/issues/2067
+
 Basic cgo functionality
 =======================
 
@@ -44,3 +46,9 @@ tag_test
 Checks that sources with ``// +build cgo`` are built when cgo is enabled
 (whether or not ``cgo = True`` is set), and sources with ``// +build !cgo``
 are only built in pure mode.
+
+cdeps_link_test
+---------------
+
+Checks that libraries in ``cdeps`` are linked into the generated ``_cgo_.o``
+executable used to produce ``_cgo_imports.go``. Verifies `#2067`_.

--- a/tests/core/cgo/cgo_link_dep.c
+++ b/tests/core/cgo/cgo_link_dep.c
@@ -1,0 +1,15 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+int f() { return 42; }

--- a/tests/core/cgo/cgo_link_test.go
+++ b/tests/core/cgo/cgo_link_test.go
@@ -1,0 +1,24 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cgo_link
+
+import "testing"
+
+func Test(t *testing.T) {
+	want := 42
+	if got := F(); got != want {
+		t.Errorf("got %d; want %d", got, want)
+	}
+}

--- a/tests/core/cgo/cgo_ref.go
+++ b/tests/core/cgo/cgo_ref.go
@@ -1,0 +1,20 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cgo_link
+
+// int f();
+import "C"
+
+func F() int { return int(C.f()) }

--- a/tests/core/nogo/README.rst
+++ b/tests/core/nogo/README.rst
@@ -8,10 +8,10 @@ Contents
 
 .. Child list start
 
-* `Custom nogo analyzers <custom/README.rst>`_
-* `nogo analyzers with dependencies <deps/README.rst>`_
 * `Vet check <vet/README.rst>`_
 * `Nogo configuration <config/README.rst>`_
+* `nogo analyzers with dependencies <deps/README.rst>`_
+* `Custom nogo analyzers <custom/README.rst>`_
 * `nogo test with coverage <coverage/README.rst>`_
 
 .. Child list end

--- a/tests/integration/README.rst
+++ b/tests/integration/README.rst
@@ -14,8 +14,8 @@ Contents
 
 .. Child list start
 
-* `Functionality related to @go_googleapis <googleapis/README.rst>`_
 * `Popular repository tests <popular_repos/README.rst>`_
+* `Functionality related to @go_googleapis <googleapis/README.rst>`_
 
 .. Child list end
 


### PR DESCRIPTION
This seems to have been fixed by another change after reporting, so
let's just add a test for it.

Fixes #2067