### PR TITLE
Add a dynamic load test for c-shared link mode

### DIFF
--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -357,7 +357,6 @@ func compileArchive(
 			includes = append(includes, inc)
 		}
 		sort.Strings(includes)
-		asmFlags := make([]string, 0, len(includeSet)*2)
 		for _, inc := range includes {
 			asmFlags = append(asmFlags, "-I", inc)
 		}

--- a/tests/core/c_linkmodes/BUILD.bazel
+++ b/tests/core/c_linkmodes/BUILD.bazel
@@ -39,3 +39,32 @@ cc_test(
         "//conditions:default": [":adder_shared.cc"],
     }),
 )
+
+go_binary(
+    name = "crypto",
+    srcs = [":crypto.go"],
+    cgo = True,
+    linkmode = "c-shared",
+    tags = ["manual"],
+    deps = ["@org_golang_x_crypto//nacl/box:go_default_library"],
+)
+
+cc_test(
+    name = "c-shared_dl_test",
+    srcs = select({
+        "@io_bazel_rules_go//go/platform:windows": ["skip.c"],
+        "//conditions:default": ["crypto_test_dl.c"],
+    }),
+    copts = select({
+        "@io_bazel_rules_go//go/platform:windows": [],
+        "//conditions:default": ['-DSO=\\"$(rootpath :crypto)\\"'],
+    }),
+    data = select({
+        "@io_bazel_rules_go//go/platform:windows": [],
+        "//conditions:default": [":crypto"],
+    }),
+    linkopts = select({
+        "@io_bazel_rules_go//go/platform:windows": [],
+        "//conditions:default": ["-ldl"],
+    }),
+)

--- a/tests/core/c_linkmodes/README.rst
+++ b/tests/core/c_linkmodes/README.rst
@@ -20,3 +20,10 @@ add_test_shared.c
 Test that calls a CGo exported `GoAdd` method from C and check that the return
 value is correct. This is a `cc_test` that links dynamically against a
 `go_binary`.
+
+crypto_test_dl.c
+-----------------------
+
+Test that calls a CGo exported `GoFn` method that depends on a function from
+golang.org/x/crypto. This is a `cc_test` that loads the CGo shared library
+dynamically.

--- a/tests/core/c_linkmodes/crypto.go
+++ b/tests/core/c_linkmodes/crypto.go
@@ -1,0 +1,18 @@
+package main
+
+import "C"
+
+import (
+	"crypto/rand"
+
+	"golang.org/x/crypto/nacl/box"
+)
+
+//export GoFn
+func GoFn() {
+	box.GenerateKey(rand.Reader)
+	return
+}
+
+func main() {
+}

--- a/tests/core/c_linkmodes/crypto_test_dl.c
+++ b/tests/core/c_linkmodes/crypto_test_dl.c
@@ -1,0 +1,30 @@
+#include <dlfcn.h>
+#include <stdio.h>
+
+#ifndef SO
+#error No SO path defined
+#endif
+
+int main() {
+  void* handle = dlopen(SO, RTLD_NOW);
+  if (!handle) {
+    printf("dlopen: %s\n", dlerror());
+    return 1;
+  }
+
+  typedef void (*gofn_t)();
+  gofn_t gofn = (gofn_t)dlsym(handle, "GoFn");
+  const char* dlsym_error = dlerror();
+  if (dlsym_error) {
+    printf("dlsym: %s\n", dlerror());
+    dlclose(handle);
+    return 1;
+  }
+
+  gofn();
+
+  if (dlclose(handle)) {
+    printf("dlclose: %s\n", dlerror());
+  }
+  return 0;
+}


### PR DESCRIPTION
This test has a non-trivial dependency (golang.org/x/crypto) to check for more complex modes.

On master, this test currently fails. But it passes on 0.18.7.