### PR TITLE
cgo: always generate export headers

### DIFF
--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -276,6 +276,11 @@ func compileArchive(
 
 		gcFlags = append(gcFlags, "-trimpath="+srcDir)
 	} else {
+		if cgoExportHPath != "" {
+			if err := ioutil.WriteFile(cgoExportHPath, nil, 0666); err != nil {
+				return err
+			}
+		}
 		gcFlags = append(gcFlags, "-trimpath=.")
 	}
 

--- a/tests/core/c_linkmodes/BUILD.bazel
+++ b/tests/core/c_linkmodes/BUILD.bazel
@@ -21,6 +21,26 @@ cc_test(
 )
 
 go_binary(
+    name = "c-archive_empty_hdr",
+    srcs = ["empty.go"],
+    cgo = True,
+    linkmode = "c-archive",
+    tags = ["manual"],
+)
+
+cc_test(
+    name = "c-archive_empty_hdr_test",
+    srcs = select({
+        "@io_bazel_rules_go//go/platform:windows": ["skip.c"],
+        "//conditions:default": ["c-archive_empty_hdr_test.c"],
+    }),
+    deps = select({
+        "@io_bazel_rules_go//go/platform:windows": [],
+        "//conditions:default": [":c-archive_empty_hdr.cc"],
+    }),
+)
+
+go_binary(
     name = "adder_shared",
     srcs = ["add.go"],
     cgo = True,

--- a/tests/core/c_linkmodes/README.rst
+++ b/tests/core/c_linkmodes/README.rst
@@ -2,28 +2,34 @@ c-archive / c-shared linkmodes
 ==============================
 
 .. _go_binary: /go/core.rst#go_binary
+.. _#2132: https://github.com/bazelbuild/rules_go/issues/2132
+.. _#2138: https://github.com/bazelbuild/rules_go/issues/2138
 
 Tests to ensure that c-archive link mode is working as expected.
 
 .. contents::
 
-add_test_archive.c
-------------------
+c-archive_test
+--------------
 
-Test that calls a CGo exported `GoAdd` method from C and check that the return
-value is correct. This is a `cc_test` that links statically against a
-`go_binary`.
+Checks that a ``go_binary`` can be built in ``c-archive`` mode and linked into
+a C/C++ binary as a dependency.
 
-add_test_shared.c
------------------
+c-archive_empty_hdr_test
+------------------------
 
-Test that calls a CGo exported `GoAdd` method from C and check that the return
-value is correct. This is a `cc_test` that links dynamically against a
-`go_binary`.
+Checks that a ``go_binary`` built with in ``c-archive`` mode without cgo code
+still produces an empty header file. Verifies `#2132`_.
 
-crypto_test_dl.c
------------------------
+c-shared_test
+-------------
 
-Test that calls a CGo exported `GoFn` method that depends on a function from
-golang.org/x/crypto. This is a `cc_test` that loads the CGo shared library
-dynamically.
+Checks that a ``go_binary`` can be built in ``c-shared`` mode and linked into
+a C/C++ binary as a dependency.
+
+c-shared_dl_test
+----------------
+
+Checks that a ``go_binary`` can be built in ``c-shared`` mode and loaded
+dynamically from a C/C++ binary. The binary depends on a package in
+``org_golang_x_crypto`` with a fair amount of assembly code. Verifies `#2138`_.

--- a/tests/core/c_linkmodes/c-archive_empty_hdr_test.c
+++ b/tests/core/c_linkmodes/c-archive_empty_hdr_test.c
@@ -1,0 +1,17 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tests/core/c_linkmodes/c-archive_empty_hdr.h"
+
+int main() { return 0; }

--- a/tests/core/c_linkmodes/empty.go
+++ b/tests/core/c_linkmodes/empty.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}


### PR DESCRIPTION
Previously, we didn't generate an export header when there wasn't any
cgo code.

Fixes #2132