### PR TITLE
GoCompilePkg: don't pass bogus flags to assembler

### DIFF
--- a/go/private/actions/compilepkg.bzl
+++ b/go/private/actions/compilepkg.bzl
@@ -98,13 +98,10 @@ def emit_compilepkg(
     asm_flags = []
     if go.mode.race:
         gc_flags.append("-race")
-        asm_flags.append("-race")
     if go.mode.msan:
         gc_flags.append("-msan")
-        asm_flags.append("-msan")
     if go.mode.debug:
         gc_flags.extend(["-N", "-l"])
-        asm_flags.extend(["-N", "-l"])
     gc_flags.extend(go.toolchain.flags.compile)
     gc_flags.extend(link_mode_args(go.mode))
     asm_flags.extend(link_mode_args(go.mode))

--- a/tests/core/race/racy/BUILD.bazel
+++ b/tests/core/race/racy/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "race_off.go",
         "race_on.go",
         "racy.go",
+        "empty.s", # verify #2143
     ],
     importpath = "github.com/bazelbuild/rules_go/tests/core/race/racy",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Fixes #2143
Fixes #2144