### PR TITLE
nogo: ensure nogo binary can be built with coverage enabled

### DIFF
--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -152,7 +152,7 @@ def emit_link(
     tool_args.add_joined("-extldflags", extldflags, join_with = " ")
 
     inputs_direct = stamp_inputs + [go.sdk.package_list]
-    if go.coverage_enabled:
+    if go.coverage_enabled and go.coverdata:
         inputs_direct.append(go.coverdata.data.file)
     inputs_transitive = [
         archive.libs,

--- a/go/tools/bazel_testing/bazel_testing.go
+++ b/go/tools/bazel_testing/bazel_testing.go
@@ -52,6 +52,10 @@ type Args struct {
 	// a default file will be synthesized.
 	Main string
 
+	// Nogo is the nogo target to pass to go_register_toolchains. By default,
+	// nogo is not used.
+	Nogo string
+
 	// WorkspaceSuffix is a string that should be appended to the end
 	// of the default generated WORKSPACE file.
 	WorkspaceSuffix string
@@ -250,7 +254,10 @@ func setupWorkspace(args Args) (dir string, cleanup func(), err error) {
 				err = cerr
 			}
 		}()
-		info := workspaceTemplateInfo{Suffix: args.WorkspaceSuffix}
+		info := workspaceTemplateInfo{
+			Suffix: args.WorkspaceSuffix,
+			Nogo:   args.Nogo,
+		}
 		for name := range workspaceNames {
 			info.WorkspaceNames = append(info.WorkspaceNames, name)
 		}
@@ -285,6 +292,7 @@ func extractTxtar(dir, txt string) error {
 type workspaceTemplateInfo struct {
 	WorkspaceNames []string
 	GoSDKPath      string
+	Nogo           string
 	Suffix         string
 }
 
@@ -317,7 +325,7 @@ go_wrap_sdk(
     root_file = "@local_go_sdk//:ROOT",
 )
 
-go_register_toolchains()
+go_register_toolchains({{if .Nogo}}nogo = "{{.Nogo}}"{{end}})
 {{end}}
 {{.Suffix}}
 `))

--- a/tests/core/README.rst
+++ b/tests/core/README.rst
@@ -23,7 +23,7 @@ Contents
 * `stdlib functionality <stdlib/README.rst>`_
 * `Basic go_binary functionality <go_binary/README.rst>`_
 * `Starlark unit tests <starlark/README.rst>`_
-* `coverage functionality <coverage/README.rst>`_
+* `.. _#2127: https://github.com/bazelbuild/rules_go/issues/2127 <coverage/README.rst>`_
 * `Import maps <importmap/README.rst>`_
 * `Basic go_path functionality <go_path/README.rst>`_
 

--- a/tests/core/nogo/coverage/BUILD.bazel
+++ b/tests/core/nogo/coverage/BUILD.bazel
@@ -1,34 +1,6 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test", "go_tool_library")
-load("@io_bazel_rules_go//tests:bazel_tests.bzl", "bazel_test")
+load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
 
-COVERAGE_BUILD_FILE = """
-load("@io_bazel_rules_go//go:def.bzl", "nogo")
-
-nogo(
-    name = "nogo",
-    deps = ["@org_golang_x_tools//go/analysis/passes/printf:go_tool_library"],
-    visibility = ["//visibility:public"],
-)
-"""
-
-bazel_test(
+go_bazel_test(
     name = "coverage_test",
-    build = COVERAGE_BUILD_FILE,
-    command = "coverage",
-    nogo = "@//:nogo",
-    targets = [":coverage_target"],
-)
-
-go_test(
-    name = "coverage_target",
-    srcs = ["coverage_target_test.go"],
-    tags = ["manual"],
-    visibility = ["//visibility:public"],
-    deps = [":coverage_target_dep"],
-)
-
-go_tool_library(
-    name = "coverage_target_dep",
-    importmap = "mapped/coverage_target/dep",
-    importpath = "coverage_target/dep",
+    srcs = ["coverage_test.go"],
 )

--- a/tests/core/nogo/coverage/README.rst
+++ b/tests/core/nogo/coverage/README.rst
@@ -3,12 +3,17 @@ nogo test with coverage
 
 .. _nogo: /go/nogo.rst
 .. _go_tool_library: /go/core.rst#_go_tool_library
+.. _#1940: https://github.com/bazelbuild/rules_go/issues/1940
+.. _#2146: https://github.com/bazelbuild/rules_go/issues/2146
 
 Tests to ensure that `nogo`_ works with coverage.
 
-coverage_target_test
---------------------
+coverage_test
+-------------
 Checks that `nogo`_ works when coverage is enabled. All covered libraries gain
 an implicit dependencies on ``//go/tools/coverdata``, which is a
 `go_tool_library`_, which isn't built with `nogo`_. We should be able to
-handle libraries like this that do not have serialized facts. Verifies #1940.
+handle libraries like this that do not have serialized facts. Verifies `#1940`_.
+
+Also checks that `nogo`_ itself can be built with coverage enabled.
+Verifies `#2146`_.

--- a/tests/core/nogo/coverage/coverage_target_test.go
+++ b/tests/core/nogo/coverage/coverage_target_test.go
@@ -1,1 +1,0 @@
-package coverage_target_test

--- a/tests/core/nogo/coverage/coverage_test.go
+++ b/tests/core/nogo/coverage/coverage_test.go
@@ -1,0 +1,63 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coverage_test
+
+import (
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: `
+-- BUILD.bazel --
+load("@io_bazel_rules_go//go:def.bzl", "go_test", "go_tool_library", "nogo")
+
+go_test(
+    name = "coverage_target",
+    srcs = ["coverage_target_test.go"],
+    deps = [":coverage_target_dep"],
+)
+
+go_tool_library(
+    name = "coverage_target_dep",
+    importmap = "mapped/coverage_target/dep",
+    importpath = "coverage_target/dep",
+)
+
+nogo(
+    name = "nogo",
+    vet = True,
+    visibility = ["//visibility:public"],
+)
+-- coverage_target_test.go --
+package coverage_target_test
+`,
+		Nogo: `@//:nogo`,
+	})
+}
+
+func TestCoverageWithNogo(t *testing.T) {
+	if err := bazel_testing.RunBazel("coverage", "//:coverage_target"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCoverageOfNogo(t *testing.T) {
+	if err := bazel_testing.RunBazel("build", "--instrumentation_filter=.*", "--collect_code_coverage", "//:nogo"); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
emit_link was referencing go.coverdata.data when go.coverage_enabled
was true but go.coverdata was None. This is the case for nogo, since
nogo binaries don't have an implicit reference on coverdata.

Fixes #2146