### PR TITLE
adding gogo proto descriptor to deps of gogo proto compiler

### DIFF
--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -80,6 +80,7 @@ go_proto_compiler(
     deps = [
         "@com_github_gogo_protobuf//gogoproto:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_github_gogo_protobuf//protoc-gen-gogo/descriptor:go_default_library",
         "@com_github_gogo_protobuf//sortkeys:go_default_library",
         "@com_github_gogo_protobuf//types:go_default_library",
         "@org_golang_google_grpc//:go_default_library",


### PR DESCRIPTION
Some of the proto-generated code depends on "github.com/gogo/protobuf/protoc-gen-gogo/descriptor", leading to the follow error a build time. This PR fixes it.

```
import of "github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
Known dependencies are:
	github.com/gogo/protobuf/gogoproto
	github.com/gogo/protobuf/proto
	github.com/gogo/protobuf/sortkeys
	github.com/gogo/protobuf/types
	google.golang.org/grpc
	golang.org/x/net/context
	github.com/golang/protobuf/ptypes/any
	google.golang.org/genproto/protobuf/api
	github.com/golang/protobuf/protoc-gen-go/plugin
	github.com/golang/protobuf/protoc-gen-go/descriptor
	github.com/golang/protobuf/ptypes/duration
	github.com/golang/protobuf/ptypes/empty
	google.golang.org/genproto/protobuf/field_mask
	google.golang.org/genproto/protobuf/source_context
	github.com/golang/protobuf/ptypes/struct
	github.com/golang/protobuf/ptypes/timestamp
	google.golang.org/genproto/protobuf/ptype
	github.com/golang/protobuf/ptypes/wrappers
Check that imports in Go sources match importpath attributes in deps.
```