### PR TITLE
go_toolchain: move cgo_context_data dep to go_context_data

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -63,14 +63,18 @@ nogo(
 # It may depend on cgo_context_data via go_toolchain.
 go_context_data(
     name = "go_context_data",
-    strip = select({
-        "@io_bazel_rules_go//go/private:strip-always": "always",
-        "@io_bazel_rules_go//go/private:strip-sometimes": "sometimes",
-        "@io_bazel_rules_go//go/private:strip-never": "never",
+    cgo_context_data = select({
+        "@io_bazel_rules_go//go/platform:internal_cgo_off": None,
+        "//conditions:default": ":cgo_context_data",
     }),
     stamp = select({
         "@io_bazel_rules_go//go/private:stamp": True,
         "//conditions:default": False,
+    }),
+    strip = select({
+        "@io_bazel_rules_go//go/private:strip-always": "always",
+        "@io_bazel_rules_go//go/private:strip-sometimes": "sometimes",
+        "@io_bazel_rules_go//go/private:strip-never": "never",
     }),
     visibility = ["//visibility:public"],
 )

--- a/go/platform/list.bzl
+++ b/go/platform/list.bzl
@@ -68,5 +68,14 @@ def declare_config_settings():
             constraint_values = [
                 "@bazel_tools//platforms:ios",
                 "@io_bazel_rules_go//go/toolchain:" + goarch,
-            ]
+            ],
         )
+
+    # Setting that determines whether cgo is enabled.
+    # This is experimental and may be changed or removed when we migrate
+    # to build settings.
+    native.config_setting(
+        name = "internal_cgo_off",
+        constraint_values = ["@io_bazel_rules_go//go/toolchain:cgo_off"],
+        visibility = ["@io_bazel_rules_go//:__pkg__"],
+    )

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -23,8 +23,8 @@ load(
     "CPP_LINK_EXECUTABLE_ACTION_NAME",
     "CPP_LINK_STATIC_LIBRARY_ACTION_NAME",
     "C_COMPILE_ACTION_NAME",
-    "OBJC_COMPILE_ACTION_NAME",
     "OBJCPP_COMPILE_ACTION_NAME",
+    "OBJC_COMPILE_ACTION_NAME",
 )
 load(
     "@io_bazel_rules_go_compat//:compat.bzl",
@@ -79,7 +79,6 @@ _COMPILER_OPTIONS_BLACKLIST = {
     # cgo also wants to see all the errors when it is testing the compiler.
     # fmax-errors limits that and causes build failures.
     "-fmax-errors=": None,
-
     "-Wall": None,
 
     # Symbols are needed by Go, so keep them
@@ -453,12 +452,12 @@ def go_context(ctx, attr = None):
     )
 
 def _go_context_data_impl(ctx):
-    go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:toolchain"]
-    if go_toolchain._cgo_context_data:
-        crosstool = go_toolchain._cgo_context_data.crosstool
-        env = dict(go_toolchain._cgo_context_data.env)
-        tags = go_toolchain._cgo_context_data.tags
-        cgo_tools = go_toolchain._cgo_context_data.cgo_tools
+    if ctx.attr.cgo_context_data:
+        cgo_context_data = ctx.attr.cgo_context_data[CgoContextData]
+        crosstool = cgo_context_data.crosstool
+        env = dict(cgo_context_data.env)
+        tags = cgo_context_data.tags
+        cgo_tools = cgo_context_data.cgo_tools
         tool_paths = [
             cgo_tools.c_compiler_path,
             cgo_tools.ld_executable_path,
@@ -508,8 +507,8 @@ go_context_data = rule(
     attrs = {
         "stamp": attr.bool(mandatory = True),
         "strip": attr.string(mandatory = True),
+        "cgo_context_data": attr.label(),
     },
-    toolchains = ["@io_bazel_rules_go//go:toolchain"],
     doc = """go_context_data gathers information about the build configuration.
 It is a common dependency of all Go targets.""",
 )

--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -54,7 +54,6 @@ def _go_toolchain_impl(ctx):
 
         # Internal fields -- may be read by emit functions.
         _builder = ctx.executable.builder,
-        _cgo_context_data = ctx.attr.cgo_context_data[CgoContextData] if ctx.attr.cgo_context_data else None,
     )]
 
 go_toolchain = rule(
@@ -81,10 +80,6 @@ go_toolchain = rule(
             doc = "The SDK this toolchain is based on",
         ),
         # Optional extras to a toolchain
-        "cgo_context_data": attr.label(
-            providers = [CgoContextData],
-            doc = "A target that collects information about the C/C++ toolchain.",
-        ),
         "link_flags": attr.string_list(
             doc = "Flags passed to the Go internal linker",
         ),
@@ -100,6 +95,12 @@ def declare_toolchains(host, sdk, builder):
     # keep in sync with generate_toolchain_names
     host_goos, _, host_goarch = host.partition("_")
     for p in PLATFORMS:
+        if p.cgo:
+            # Don't declare separate toolchains for cgo_on / cgo_off.
+            # This is controlled by the cgo_context_data dependency of
+            # go_context_data, which is configured using constraint_values.
+            continue
+
         link_flags = []
         cgo_link_flags = []
         if host_goos == "darwin":
@@ -110,18 +111,11 @@ def declare_toolchains(host, sdk, builder):
         toolchain_name = "go_" + p.name
         impl_name = toolchain_name + "-impl"
 
-        cgo_context_data = "@io_bazel_rules_go//:cgo_context_data" if p.cgo else None
-
-        constraints = p.constraints
-        if p.goos != host_goos or p.goarch != host_goarch:
-            # When cross-compiling, don't require cgo_off.
-            # It won't be set on a custom platform outside of //go/toolchain.
-            constraints = [c for c in constraints if c != "@io_bazel_rules_go//go/toolchain:cgo_off"]
-        else:
-            # When compiling for the host platform, don't require cgo_on.
-            # It won't be set on @bazel_tools//platforms:target_platform,
-            # which is probably the target.
-            constraints = [c for c in constraints if c != "@io_bazel_rules_go//go/toolchain:cgo_on"]
+        cgo_constraints = (
+            "@io_bazel_rules_go//go/toolchain:cgo_off",
+            "@io_bazel_rules_go//go/toolchain:cgo_on",
+        )
+        constraints = [c for c in p.constraints if c not in cgo_constraints]
 
         go_toolchain(
             name = impl_name,
@@ -131,7 +125,6 @@ def declare_toolchains(host, sdk, builder):
             builder = builder,
             link_flags = link_flags,
             cgo_link_flags = cgo_link_flags,
-            cgo_context_data = cgo_context_data,
             tags = ["manual"],
             visibility = ["//visibility:public"],
         )

--- a/go/private/platforms.bzl
+++ b/go/private/platforms.bzl
@@ -183,4 +183,4 @@ PLATFORMS = _generate_platforms()
 
 def generate_toolchain_names():
     # keep in sync with declare_toolchains
-    return ["go_" + p.name for p in PLATFORMS]
+    return ["go_" + p.name for p in PLATFORMS if not p.cgo]


### PR DESCRIPTION
Previously, we defined separate cgo and non-cgo variants of
go_toolchain. The cgo variant depended on cgo_context_data, which
requires a C/C++ toolchain. However, go_toolchain is built in host
mode, so we always got a toolchain for the execution platform, not the
target platform. This broke cross-compilation with cgo.

With this change, we only declare a go_toolchain per platform,
regardless of cgo. go_context_data depends on cgo_context_data
if the cgo_off constraint is not set.

This means a C/C++ toolchain (for the correct platform) will be
required for the default target platform and platforms that have not
specifically opted out of cgo. Platforms declared in //go/toolchain
are already fine. However, users defining their own platforms may be
broken by this change.

Fixes #2166