### PR TITLE
GoLink: force external link for static binaries

### DIFF
--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -79,11 +79,12 @@ def emit_link(
         tool_args.add("-race")
     if go.mode.msan:
         tool_args.add("-msan")
+    if go.mode.static or go.mode.link != LINKMODE_NORMAL:
+        tool_args.add("-linkmode", "external")
     if go.mode.static:
         extldflags.append("-static")
     if go.mode.link != LINKMODE_NORMAL:
         builder_args.add("-buildmode", go.mode.link)
-        tool_args.add("-linkmode", "external")
     if go.mode.link == LINKMODE_PLUGIN:
         tool_args.add("-pluginpath", archive.data.importpath)
 

--- a/tests/core/go_binary/BUILD.bazel
+++ b/tests/core/go_binary/BUILD.bazel
@@ -103,3 +103,30 @@ go_test(
     rundir = ".",
     deps = ["@io_bazel_rules_go//go/tools/bazel:go_default_library"],
 )
+
+go_test(
+    name = "static_test",
+    srcs = ["static_test.go"],
+    data = select({
+        "@io_bazel_rules_go//go/platform:linux": [
+            ":static_cgo_bin",
+            ":static_pure_bin",
+        ],
+        "//conditions:default": [],
+    }),
+    rundir = ".",
+    deps = ["//go/tools/bazel:go_default_library"],
+)
+
+go_binary(
+    name = "static_cgo_bin",
+    srcs = ["static_cgo_bin.go"],
+    cgo = True,
+    static = "on",
+)
+
+go_binary(
+    name = "static_pure_bin",
+    srcs = ["static_pure_bin.go"],
+    static = "on",
+)

--- a/tests/core/go_binary/BUILD.bazel
+++ b/tests/core/go_binary/BUILD.bazel
@@ -123,10 +123,12 @@ go_binary(
     srcs = ["static_cgo_bin.go"],
     cgo = True,
     static = "on",
+    tags = ["manual"],
 )
 
 go_binary(
     name = "static_pure_bin",
     srcs = ["static_pure_bin.go"],
     static = "on",
+    tags = ["manual"],
 )

--- a/tests/core/go_binary/README.rst
+++ b/tests/core/go_binary/README.rst
@@ -2,6 +2,7 @@ Basic go_binary functionality
 =============================
 
 .. _go_binary: /go/core.rst#_go_binary
+.. _#2168: https://github.com/bazelbuild/rules_go/issues/2168
 
 Tests to ensure the basic features of go_binary are working as expected.
 
@@ -38,7 +39,15 @@ binary and in an embedded library. Tests regular stamps and stamps that
 depend on values from the workspace status script. Verifies #2000.
 
 pie_test
-----------
+--------
 Tests that specifying the ``linkmode`` attribute on a `go_binary`_ target to be
 pie produces a position-independent executable and that no specifying it produces
 a position-dependent binary.
+
+static_test
+-----------
+Test that `go_binary`_ rules with ``static = "on"`` with and without cgo
+produce static binaries. Verifies `#2168`_.
+
+This test only runs on Linux. The darwin external linker cannot produce
+static binaries since there is no static version of C runtime libraries.

--- a/tests/core/go_binary/static_cgo_bin.go
+++ b/tests/core/go_binary/static_cgo_bin.go
@@ -1,0 +1,14 @@
+package main
+
+/*
+#include <stdio.h>
+
+void say_hello() {
+	printf("hello\n");
+}
+*/
+import "C"
+
+func main() {
+	C.say_hello()
+}

--- a/tests/core/go_binary/static_pure_bin.go
+++ b/tests/core/go_binary/static_pure_bin.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+	_ "net"
+	_ "os"
+)
+
+func main() {}

--- a/tests/core/go_binary/static_test.go
+++ b/tests/core/go_binary/static_test.go
@@ -1,0 +1,45 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package static_cgo_test
+
+import (
+	"debug/elf"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+)
+
+func TestStatic(t *testing.T) {
+	for _, name := range []string{"static_cgo_bin", "static_pure_bin"} {
+		t.Run(name, func(t *testing.T) {
+			path, ok := bazel.FindBinary("tests/core/go_binary", name)
+			if !ok {
+				t.Fatal("could not find static_cgo_bin")
+			}
+			f, err := elf.Open(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer f.Close()
+			for _, prog := range f.Progs {
+				if prog.Type == elf.PT_INTERP {
+					t.Fatalf("binary %s has PT_INTERP segment, indicating dynamic linkage", path)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
By default on Linux, the Go linker may produce a static binary if no
packages require cgo. net and os both require cgo, so for non-trivial
programs, the external linker will NOT be used, and the internal
linker will produce a dynamically linked executable.

With this change, in static mode, we force external linking. We were
already passing -static to the external linker, but we weren't always
using the external linker.

Fixes #2168