### PR TITLE
go_path: add include_transitive

### DIFF
--- a/go/core.rst
+++ b/go/core.rst
@@ -863,6 +863,11 @@ Attributes
 | included in the output directory. Files listed in the :param:`data` attribute                    |
 | for this rule will be included regardless of this attribute.                                     |
 +----------------------------+-----------------------------+---------------------------------------+
+| :param:`include_pkg`       | :type:`bool`                | :value:`False`                        |
++----------------------------+-----------------------------+---------------------------------------+
+| When true, a `pkg` subdirectory containing the compiled libraries will be created in the         |
+| generated `GOPATH` containing compiled libraries.                                                |
++----------------------------+-----------------------------+---------------------------------------+
 
 Defines and stamping
 --------------------

--- a/go/core.rst
+++ b/go/core.rst
@@ -868,6 +868,12 @@ Attributes
 | When true, a `pkg` subdirectory containing the compiled libraries will be created in the         |
 | generated `GOPATH` containing compiled libraries.                                                |
 +----------------------------+-----------------------------+---------------------------------------+
+| :param:`include_transitive`| :type:`bool`                | :value:`True`                         |
++----------------------------+-----------------------------+---------------------------------------+
+| When true, the transitive dependency graph will be included in the generated `GOPATH`. This is   |
+| the default behaviour. When false, only the direct dependencies will be included in the          |
+| generated `GOPATH`.                                                                              |
++----------------------------+-----------------------------+---------------------------------------+
 
 Defines and stamping
 --------------------

--- a/go/private/tools/path.bzl
+++ b/go/private/tools/path.bzl
@@ -38,7 +38,9 @@ def _go_path_impl(ctx):
     mode_to_archive = {}
     for mode, archives in mode_to_deps.items():
         direct = [a.data for a in archives]
-        transitive = [a.transitive for a in archives]
+        transitive = []
+        if ctx.attr.include_transitive:
+            transitive = [a.transitive for a in archives]
         mode_to_archive[mode] = depset(direct = direct, transitive = transitive)
 
     # Collect sources and data files from archives. Merge archives into packages.
@@ -163,6 +165,7 @@ go_path = rule(
         ),
         "include_data": attr.bool(default = True),
         "include_pkg": attr.bool(default = False),
+        "include_transitive": attr.bool(default = True),
         "_go_path": attr.label(
             default = "@io_bazel_rules_go//go/tools/builders:go_path",
             executable = True,

--- a/tests/core/go_path/BUILD.bazel
+++ b/tests/core/go_path/BUILD.bazel
@@ -27,6 +27,14 @@ go_path(
     deps = ["//tests/core/go_path/pkg/lib:go_default_library"],
 )
 
+go_path(
+    name = "notransitive_path",
+    testonly = True,
+    include_transitive = False,
+    mode = "copy",
+    deps = ["//tests/core/go_path/pkg/lib:go_default_library"],
+)
+
 go_test(
     name = "go_path_test",
     srcs = ["go_path_test.go"],
@@ -35,12 +43,14 @@ go_test(
         "-copy_path=$(location :copy_path)",
         "-link_path=tests/core/go_path/link_path",  # can't use location; not a single file
         "-nodata_path=$(location :nodata_path)",
+        "-notransitive_path=$(location :notransitive_path)",
     ],
     data = [
         ":archive_path",
         ":copy_path",
         ":link_path",
         ":nodata_path",
+        ":notransitive_path",
     ],
     deps = ["//go/tools/bazel:go_default_library"],
     rundir = ".",

--- a/tests/core/go_path/go_path_test.go
+++ b/tests/core/go_path/go_path_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/bazelbuild/rules_go/go/tools/bazel"
 )
 
-var copyPath, linkPath, archivePath, nodataPath string
+var copyPath, linkPath, archivePath, nodataPath, notransitivePath string
 
 var defaultMode = runtime.GOOS + "_" + runtime.GOARCH
 
@@ -58,6 +58,7 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&linkPath, "link_path", "", "path to symlinked go_path")
 	flag.StringVar(&archivePath, "archive_path", "", "path to archive go_path")
 	flag.StringVar(&nodataPath, "nodata_path", "", "path to go_path without data")
+	flag.StringVar(&notransitivePath, "notransitive_path", "", "path to go_path without transitive dependencies")
 	flag.Parse()
 	os.Exit(m.Run())
 }
@@ -131,6 +132,16 @@ func TestNoDataPath(t *testing.T) {
 		"-src/example.com/repo/pkg/lib/data.txt",
 	}
 	checkPath(t, nodataPath, files)
+}
+
+func TestNoTransitivePath(t *testing.T) {
+	if notransitivePath == "" {
+		t.Fatal("-notransitive_path not set")
+	}
+	files := []string{
+		"-src/example.com/repo/pkg/lib/transitive/transitive.go",
+	}
+	checkPath(t, notransitivePath, files)
 }
 
 // checkPath checks that dir contains a list of files. files is a list of

--- a/tests/core/go_path/pkg/lib/BUILD.bazel
+++ b/tests/core/go_path/pkg/lib/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "data.txt",
         "testdata/testdata.txt",
     ],
+    deps = [":transitive_lib"],
     importpath = "example.com/repo/pkg/lib",
     visibility = ["//visibility:public"],
 )
@@ -40,5 +41,12 @@ go_library(
     srcs = ["vendored.go"],
     importpath = "example.com/repo2",
     importmap = "example.com/repo/vendor/example.com/repo2",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "transitive_lib",
+    srcs = ["transitive.go"],
+    importpath = "example.com/repo/pkg/lib/transitive",
     visibility = ["//visibility:public"],
 )

--- a/tests/core/go_path/pkg/lib/transitive.go
+++ b/tests/core/go_path/pkg/lib/transitive.go
@@ -1,0 +1,5 @@
+package transitive
+
+var (
+	_ = ""
+)


### PR DESCRIPTION
This PR improves `go_path` in ~two~ one ways:
- ~add `go_archive_aspect` properties so that `include_pkg` are compiled with the right mode (since it consumes archives)~
- add `include_transitive` so that only the packages in `deps` are included in the GoPath. When used with `include_pkg`, this allows to only sandbox the needed packages, and thus invalidate potentially less.

When using gomobile's `gobind`, this reduces hot rebuild times by 2-3x, because less is invalidated.