### PR TITLE
Split compiled code and export data for each archive

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -48,6 +48,11 @@ def emit_archive(go, source = None):
     split = split_srcs(source.srcs)
     lib_name = source.library.importmap + ".a"
     out_lib = go.declare_file(go, path = lib_name)
+    out_archives = [out_lib]
+    out_linklib = None
+    if go.mode.linkobj:
+        out_linklib = go.declare_file(go, path = source.library.importmap + ".link.a")
+        out_archives.append(out_linklib)
     if go.nogo:
         # TODO(#1847): write nogo data into a new section in the .a file instead
         # of writing a separate file.
@@ -96,6 +101,7 @@ def emit_archive(go, source = None):
             importmap = importmap,
             archives = direct,
             out_lib = out_lib,
+            out_linklib = out_linklib,
             out_export = out_export,
             out_cgo_export_h = out_cgo_export_h,
             gc_goopts = source.gc_goopts,
@@ -119,6 +125,7 @@ def emit_archive(go, source = None):
             importmap = importmap,
             archives = direct,
             out_lib = out_lib,
+            out_linklib = out_linklib,
             out_export = out_export,
             gc_goopts = source.gc_goopts,
             cgo = False,
@@ -133,6 +140,7 @@ def emit_archive(go, source = None):
         importpath_aliases = source.library.importpath_aliases,
         pathtype = source.library.pathtype,
         file = out_lib,
+        linkfile = out_linklib,
         export_file = out_export,
         srcs = as_tuple(source.srcs),
         orig_srcs = as_tuple(source.orig_srcs),
@@ -151,7 +159,7 @@ def emit_archive(go, source = None):
         data = data,
         direct = direct,
         searchpaths = depset(direct = [searchpath], transitive = [a.searchpaths for a in direct]),
-        libs = depset(direct = [out_lib], transitive = [a.libs for a in direct]),
+        libs = depset(direct = out_archives, transitive = [a.libs for a in direct]),
         transitive = depset([data], transitive = [a.transitive for a in direct]),
         x_defs = x_defs,
         cgo_deps = depset(transitive = [cgo_deps] + [a.cgo_deps for a in direct]),

--- a/go/private/actions/compilepkg.bzl
+++ b/go/private/actions/compilepkg.bzl
@@ -47,6 +47,7 @@ def emit_compilepkg(
         objcxxopts = [],
         clinkopts = [],
         out_lib = None,
+        out_linklib = None,
         out_export = None,
         out_cgo_export_h = None,
         gc_goopts = [],
@@ -77,6 +78,11 @@ def emit_compilepkg(
     args.add("-package_list", go.package_list)
 
     args.add("-o", out_lib)
+
+    if go.mode.linkobj:
+        outputs.append(out_linklib)
+        args.add("-linkobj", out_linklib)
+
     if go.nogo:
         args.add("-nogo", go.nogo)
         args.add("-x", out_export)

--- a/go/private/mode.bzl
+++ b/go/private/mode.bzl
@@ -28,7 +28,7 @@ LINKMODE_C_ARCHIVE = "c-archive"
 
 LINKMODES = [LINKMODE_NORMAL, LINKMODE_PLUGIN, LINKMODE_C_SHARED, LINKMODE_C_ARCHIVE, LINKMODE_PIE]
 
-def new_mode(goos, goarch, static = False, race = False, msan = False, pure = False, link = LINKMODE_NORMAL, debug = False, strip = False):
+def new_mode(goos, goarch, static = False, race = False, msan = False, pure = False, link = LINKMODE_NORMAL, debug = False, strip = False, linkobj = False):
     return struct(
         static = static,
         race = race,
@@ -39,6 +39,7 @@ def new_mode(goos, goarch, static = False, race = False, msan = False, pure = Fa
         strip = strip,
         goos = goos,
         goarch = goarch,
+        linkobj = linkobj,
     )
 
 def mode_string(mode):
@@ -55,6 +56,8 @@ def mode_string(mode):
         result.append("debug")
     if mode.strip:
         result.append("stripped")
+    if mode.linkobj:
+        result.append("linkobj")
     if not result or not mode.link == LINKMODE_NORMAL:
         result.append(mode.link)
     return "_".join(result)
@@ -125,6 +128,7 @@ def get_mode(ctx, host_only, go_toolchain, go_context_data):
         # You are not allowed to compile in race mode with pure enabled
         race = False
     debug = ctx.var["COMPILATION_MODE"] == "dbg"
+    linkobj = ctx.var.get("go.linkobj", "") == "1"
     strip_mode = "sometimes"
     if go_context_data:
         strip_mode = go_context_data.strip
@@ -144,6 +148,7 @@ def get_mode(ctx, host_only, go_toolchain, go_context_data):
         strip = strip,
         goos = goos,
         goarch = goarch,
+        linkobj = linkobj,
     )
 
 def installsuffix(mode):


### PR DESCRIPTION
This a PoC to showcase #1803. Tests are not passing, but builds are. I'll update the tests asap.

It's pretty nice.

The metadata archive and the linking archives are smaller than the full archive, this means:
- most actions are faster
- linking is faster since the linking archive is smaller than the full archive
- i would figure this leads to significant speedups in RBE

All in all, in my non trivial project, building an Android AAR, changing a deep package:

Don't look at the time too much, as least half is spent zipping the AAR.

Without this PR:
```
INFO: Elapsed time: 15.596s, Critical Path: 14.72s
INFO: 22 processes: 22 darwin-sandbox.
```

With this PR:
```
INFO: Elapsed time: 12.385s, Critical Path: 11.73s
INFO: 6 processes: 6 darwin-sandbox.
```