### PR TITLE
Update cross compile instructions when using cgo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -455,6 +455,8 @@ For example:
 
   $ bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //cmd
 
+To cross-compile with cgo, add a _cgo suffix to the target platform. For
+example: ``--platforms=@io_bazel_rules_go//go/toolchain:linux_amd64_cgo``.  
 Platform-specific sources with build tags or filename suffixes are filtered
 automatically at compile time. You can selectively include platform-specific
 dependencies with ``select`` expressions (Gazelle does this automatically).

--- a/README.rst
+++ b/README.rst
@@ -455,8 +455,14 @@ For example:
 
   $ bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //cmd
 
-To cross-compile with cgo, add a _cgo suffix to the target platform. For
-example: ``--platforms=@io_bazel_rules_go//go/toolchain:linux_amd64_cgo``.  
+By default, cgo is disabled when cross-compiling. To cross-compile with cgo,
+add a ``_cgo`` suffix to the target platform. You must register a
+cross-compiling C/C++ toolchain with Bazel for this to work.
+
+.. code::
+
+  $ bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64_cgo //cmd
+
 Platform-specific sources with build tags or filename suffixes are filtered
 automatically at compile time. You can selectively include platform-specific
 dependencies with ``select`` expressions (Gazelle does this automatically).


### PR DESCRIPTION
This was noted in the release notes for 0.19.0: https://github.com/bazelbuild/rules_go/releases/tag/0.19.0, but hard to find anywhere else.