### PR TITLE
use skylib's old_sets.bzl to build on skylib 0.9.0

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load(
-    "@bazel_skylib//lib:sets.bzl",
+    "@bazel_skylib//lib:old_sets.bzl",
     "sets",
 )
 load(

--- a/go/private/actions/asm.bzl
+++ b/go/private/actions/asm.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load(
-    "@bazel_skylib//lib:sets.bzl",
+    "@bazel_skylib//lib:old_sets.bzl",
     "sets",
 )
 load(

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -51,9 +51,9 @@ def go_rules_dependencies():
         git_repository,
         name = "bazel_skylib",
         remote = "https://github.com/bazelbuild/bazel-skylib",
-        # 0.8.0, latest as of 2019-07-08
-        commit = "3721d32c14d3639ff94320c780a60a6e658fb033",
-        shallow_since = "1553102012 +0100",
+        # 0.9.0, latest as of 2019-08-29
+        commit = "2b38b2f8bd4b8603d610cfc651fcbb299498147f",
+        shallow_since = "1562957722 -0400",
     )
 
     # Needed for nogo vet checks and go/packages.

--- a/go/private/rules/aspect.bzl
+++ b/go/private/rules/aspect.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load(
-    "@bazel_skylib//lib:sets.bzl",
+    "@bazel_skylib//lib:old_sets.bzl",
     "sets",
 )
 load(

--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load(
-    "@bazel_skylib//lib:sets.bzl",
+    "@bazel_skylib//lib:old_sets.bzl",
     "sets",
 )
 load(

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load(
-    "@bazel_skylib//lib:sets.bzl",
+    "@bazel_skylib//lib:old_sets.bzl",
     "sets",
 )
 load(

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load(
-    "@bazel_skylib//lib:sets.bzl",
+    "@bazel_skylib//lib:old_sets.bzl",
     "sets",
 )
 load(


### PR DESCRIPTION
Bumps skylib to 0.9.0 and uses its old_sets.bzl to maintain compatibility.

This addresses #2157, but old_sets.bzl will be removed in the next version of
skylib, and a longer term solution would be good.

Updates #2157