### PR TITLE
Use old_sets.bzl where sets are needed so that we do not have to pin

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load(
-    "@bazel_skylib//lib:sets.bzl",
+    "@bazel_skylib//lib:old_sets.bzl",
     "sets",
 )
 load(

--- a/go/private/actions/asm.bzl
+++ b/go/private/actions/asm.bzl
@@ -13,10 +13,6 @@
 # limitations under the License.
 
 load(
-    "@bazel_skylib//lib:sets.bzl",
-    "sets",
-)
-load(
     "@io_bazel_rules_go//go/private:mode.bzl",
     "link_mode_args",
 )

--- a/go/private/rules/aspect.bzl
+++ b/go/private/rules/aspect.bzl
@@ -13,10 +13,6 @@
 # limitations under the License.
 
 load(
-    "@bazel_skylib//lib:sets.bzl",
-    "sets",
-)
-load(
     "@io_bazel_rules_go//go/private:context.bzl",
     "go_context",
 )

--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load(
-    "@bazel_skylib//lib:sets.bzl",
+    "@bazel_skylib//lib:old_sets.bzl",
     "sets",
 )
 load(

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load(
-    "@bazel_skylib//lib:sets.bzl",
+    "@bazel_skylib//lib:old_sets.bzl",
     "sets",
 )
 load(

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -13,10 +13,6 @@
 # limitations under the License.
 
 load(
-    "@bazel_skylib//lib:sets.bzl",
-    "sets",
-)
-load(
     "@io_bazel_rules_go//go:def.bzl",
     "GoLibrary",
     "go_context",


### PR DESCRIPTION
skylib to 0.8.0 or below. This allows interoperability with the federation.
Federation users will end up bringing in bazel-skylib at 0.9.0, because
they (by default) pin the version before rules_go.  Another way of putting it
is that users may now force load bazel-skylib at 0.9.0 or greater without
breaking rules_go.

This was tested along with an update to bazel-skylib 0.9.0. This was to
prove that the old_sets change will continue to do the right thing with
the next skylib release. We could combine that into this release, but
it is not strictly necessary.

Also: do not load sets.bzl in modules that do not need it.