### PR TITLE
go/tools/bazel_testing: don't treat test arguments as flags

### DIFF
--- a/go/tools/bazel_testing/def.bzl
+++ b/go/tools/bazel_testing/def.bzl
@@ -35,7 +35,10 @@ def go_bazel_test(rule_files = None, **kwargs):
     # Add paths to rules_go files to arguments. bazel_testing will copy or link
     # these files.
     kwargs.setdefault("args", [])
-    kwargs["args"] += ["--"] + ["$(locations {})".format(t) for t in rule_files]
+    kwargs["args"] = (["-begin_files"] +
+                      ["$(locations {})".format(t) for t in rule_files] +
+                      ["-end_files"] +
+                      kwargs["args"])
 
     # Set rundir to the workspace root directory to ensure relative paths
     # are interpreted correctly.


### PR DESCRIPTION
Fixes #2223