### PR TITLE
Add a build setting to disable architecture-specific binary output paths.

### DIFF
--- a/go/build_settings/BUILD.bazel
+++ b/go/build_settings/BUILD.bazel
@@ -1,0 +1,27 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load(
+    "@bazel_skylib//rules:common_settings.bzl",
+    "bool_flag",
+)
+
+# If true (the default), go_binary output paths will include the build mode
+# and target architecture. If false, binary output paths will match the
+# rule name.
+bool_flag(
+    name = "per_mode_binaries",
+    build_setting_default = True,
+    visibility = ["//visibility:public"],
+)

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -67,6 +67,10 @@ load(
     "@bazel_skylib//lib:paths.bzl",
     "paths",
 )
+load(
+    "@bazel_skylib//rules:common_settings.bzl",
+    "BuildSettingInfo",
+)
 
 GoContext = provider()
 _GoContextData = provider()
@@ -425,6 +429,7 @@ def go_context(ctx, attr = None):
         env = env,
         tags = tags,
         stamp = context_data.stamp,
+        build_settings = context_data.build_settings,
         # Action generators
         archive = toolchain.actions.archive,
         asm = toolchain.actions.asm,
@@ -496,6 +501,9 @@ def _go_context_data_impl(ctx):
         tags = tags,
         env = env,
         cgo_tools = cgo_tools,
+        build_settings = struct(
+            per_mode_binaries = ctx.attr._per_mode_binaries[BuildSettingInfo].value,
+        ),
     )]
 
 go_context_data = rule(
@@ -504,6 +512,7 @@ go_context_data = rule(
         "stamp": attr.bool(mandatory = True),
         "strip": attr.string(mandatory = True),
         "cgo_context_data": attr.label(),
+        "_per_mode_binaries": attr.label(default = "@io_bazel_rules_go//go/build_settings:per_mode_binaries"),
     },
     doc = """go_context_data gathers information about the build configuration.
 It is a common dependency of all Go targets.""",

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -79,12 +79,22 @@ def _go_binary_impl(ctx):
     name = ctx.attr.basename
     if not name:
         name = ctx.label.name
-    executable = None
+
+    executable_path = None
     if ctx.attr.out:
+        executable_path = ctx.attr.out
+    elif not go.build_settings.per_mode_binaries:
+        executable_path = ctx.attr.name
+        if go.exe_extension:
+            executable_path += go.exe_extension
+
+    executable = None
+    if executable_path:
         # Use declare_file instead of attr.output(). When users set output files
         # directly, Bazel warns them not to use the same name as the rule, which is
         # the common case with go_binary.
-        executable = ctx.actions.declare_file(ctx.attr.out)
+        executable = ctx.actions.declare_file(executable_path)
+
     archive, executable, runfiles = go.binary(
         go,
         name = name,


### PR DESCRIPTION
This is another attempt to fix https://github.com/bazelbuild/rules_go/issues/1239 (`go_binary` output paths containing architecture-specific components). See https://github.com/bazelbuild/rules_go/pull/1257 for a previous approach that wasn't accepted.

This time I'm using the "Starlark build settings" feature of newer Bazels (https://docs.bazel.build/versions/1.0.0/skylark/config.html), which lets us cleanly plumb the setting from a command-line flag to `GoContext`. The end result:

```
$ bazel build //tests/core/go_binary:hello
[...]
Target //tests/core/go_binary:hello up-to-date:
  bazel-bin/tests/core/go_binary/darwin_amd64_stripped/hello

$ bazel build //tests/core/go_binary:hello --@io_bazel_rules_go//go/build_settings:per_mode_binaries=false
Target //tests/core/go_binary:hello up-to-date:
  bazel-bin/tests/core/go_binary/hello
```

In addition to being set by a flag, Bazel has an in-development mechanism ("configuration transitions") for overriding this on a per-target basis, and having it propagate through the dependency graph. So a target that built a deployable container image could use this to ensure its contained binaries have consistent paths regardless of whether they're written in C++ or Go.

Note: Bazel's option parser doesn't accept flags for build settings defined in external repositories (https://github.com/bazelbuild/bazel/issues/10039). The fix is https://github.com/bazelbuild/bazel/pull/10052 and it should hopefully land in v1.2.