### PR TITLE
Adding GoAspectProviders to go_test

### DIFF
--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -37,6 +37,7 @@ load(
     "GoLibrary",
     "INFERRED_PATH",
     "get_archive",
+    "GoAspectProviders",
 )
 load(
     "@io_bazel_rules_go//go/private:rules/aspect.bzl",
@@ -173,6 +174,9 @@ def _go_test_impl(ctx):
                 files = depset([executable]),
                 runfiles = runfiles,
                 executable = executable,
+            ),
+            GoAspectProviders(
+                archive = internal_archive,
             ),
             OutputGroupInfo(
                 compilation_outputs = [internal_archive.data.file],


### PR DESCRIPTION
This is an alternative implementation to #2260 to provide `srcs` and `importpath` to aspects of `go_test` targets.