### PR TITLE
Skip directory matching in FindBinary

### DIFF
--- a/go/tools/bazel/runfiles.go
+++ b/go/tools/bazel/runfiles.go
@@ -121,6 +121,9 @@ func FindBinary(pkg, name string) (string, bool) {
 		if err != nil {
 			return err
 		}
+		if info.IsDir() {
+			return nil
+		}
 		base := filepath.Base(path)
 		stem := strings.TrimSuffix(base, ".exe")
 		if stem != name {


### PR DESCRIPTION
When using this helper, I was noticing FindBinary returning directories that matched the expected binary name. Find binary should never return a directory.