### PR TITLE
go_compat_repo: alias constraint values and settings to bazel_tools or platforms

### DIFF
--- a/go/platform/list.bzl
+++ b/go/platform/list.bzl
@@ -59,14 +59,14 @@ def declare_config_settings():
     native.config_setting(
         name = "ios",
         constraint_values = [
-            "@bazel_tools//platforms:ios",
+            "@io_bazel_rules_go_compat//platforms:ios",
         ],
     )
     for goarch in ("arm", "arm64", "386", "amd64"):
         native.config_setting(
             name = "ios_" + goarch,
             constraint_values = [
-                "@bazel_tools//platforms:ios",
+                "@io_bazel_rules_go_compat//platforms:ios",
                 "@io_bazel_rules_go//go/toolchain:" + goarch,
             ],
         )

--- a/go/private/compat/BUILD.platforms.v23.bzl
+++ b/go/private/compat/BUILD.platforms.v23.bzl
@@ -1,0 +1,25 @@
+[alias(
+    name = name,
+    actual = "@bazel_tools//platforms:{}".format(name),
+    visibility = ["//visibility:public"],
+) for name in [
+    # OS constraint_values
+    "android",
+    "freebsd",
+    "ios",
+    "linux",
+    "osx",
+    "windows",
+
+    # Arch constraint_values
+    "aarch64",
+    "arm",
+    "ppc",
+    "s390x",
+    "x86_32",
+    "x86_64",
+
+    # constraint_settings
+    "os",
+    "cpu",
+]]

--- a/go/private/compat/BUILD.platforms.v28.bzl
+++ b/go/private/compat/BUILD.platforms.v28.bzl
@@ -1,0 +1,27 @@
+[alias(
+    name = name,
+    actual = "@platforms//os:{}".format(name),
+    visibility = ["//visibility:public"],
+) for name in (
+    "android",
+    "freebsd",
+    "ios",
+    "linux",
+    "os",
+    "osx",
+    "windows",
+)]
+
+[alias(
+    name = name,
+    actual = "@platforms//cpu:{}".format(name),
+    visibility = ["//visibility:public"],
+) for name in (
+    "aarch64",
+    "arm",
+    "cpu",
+    "ppc",
+    "s390x",
+    "x86_32",
+    "x86_64",
+)]

--- a/go/private/platforms.bzl
+++ b/go/private/platforms.bzl
@@ -17,20 +17,20 @@
 # constraint_values, platforms, and toolchains.
 
 BAZEL_GOOS_CONSTRAINTS = {
-    "android": "@bazel_tools//platforms:android",
-    "darwin": "@bazel_tools//platforms:osx",
-    "freebsd": "@bazel_tools//platforms:freebsd",
-    "linux": "@bazel_tools//platforms:linux",
-    "windows": "@bazel_tools//platforms:windows",
+    "android": "@io_bazel_rules_go_compat//platforms:android",
+    "darwin": "@io_bazel_rules_go_compat//platforms:osx",
+    "freebsd": "@io_bazel_rules_go_compat//platforms:freebsd",
+    "linux": "@io_bazel_rules_go_compat//platforms:linux",
+    "windows": "@io_bazel_rules_go_compat//platforms:windows",
 }
 
 BAZEL_GOARCH_CONSTRAINTS = {
-    "386": "@bazel_tools//platforms:x86_32",
-    "amd64": "@bazel_tools//platforms:x86_64",
-    "arm": "@bazel_tools//platforms:arm",
-    "arm64": "@bazel_tools//platforms:aarch64",
-    "ppc64le": "@bazel_tools//platforms:ppc",
-    "s390x": "@bazel_tools//platforms:s390x",
+    "386": "@io_bazel_rules_go_compat//platforms:x86_32",
+    "amd64": "@io_bazel_rules_go_compat//platforms:x86_64",
+    "arm": "@io_bazel_rules_go_compat//platforms:arm",
+    "arm64": "@io_bazel_rules_go_compat//platforms:aarch64",
+    "ppc64le": "@io_bazel_rules_go_compat//platforms:ppc",
+    "s390x": "@io_bazel_rules_go_compat//platforms:s390x",
 }
 
 GOOS_GOARCH = (
@@ -159,7 +159,7 @@ def _generate_platforms():
 
     for goarch in ("arm", "arm64", "386", "amd64"):
         constraints = [
-            "@bazel_tools//platforms:ios",
+            "@io_bazel_rules_go_compat//platforms:ios",
             GOARCH_CONSTRAINTS[goarch],
         ]
         platforms.append(struct(

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -47,6 +47,20 @@ def go_rules_dependencies():
         name = "io_bazel_rules_go_compat",
     )
 
+    # Repository of standard constraint settings and values.
+    # Bazel declares this automatically after 0.28.0, but it's better to
+    # define an explicit version.
+    _maybe(
+        http_archive,
+        name = "platforms",
+        strip_prefix = "platforms-441afe1bfdadd6236988e9cac159df6b5a9f5a98",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/platforms/archive/441afe1bfdadd6236988e9cac159df6b5a9f5a98.zip",
+            "https://github.com/bazelbuild/platforms/archive/441afe1bfdadd6236988e9cac159df6b5a9f5a98.zip",
+        ],
+        sha256 = "a07fe5e75964361885db725039c2ba673f0ee0313d971ae4f50c9b18cd28b0b5",
+    )
+
     # Needed by rules_go implementation and tests.
     # We can't call bazel_skylib_workspace from here. At the moment, it's only
     # used to register unittest toolchains, which rules_go does not need.

--- a/go/toolchain/toolchains.bzl
+++ b/go/toolchain/toolchains.bzl
@@ -40,8 +40,9 @@ def declare_constraints():
 
     Each constraint_value corresponds to a valid goos or goarch.
     The goos and goarch values belong to the constraint_settings
-    @bazel_tools//platforms:os and @bazel_tools//platforms:cpu, respectively.
-    To avoid redundancy, if there is an equivalent value in @bazel_tools,
+    @platforms//os:os and @platforms//cpu:cpu, respectively (which are
+    aliased through @io_bazel_rules_go_compat//platforms for compatibility).
+    To avoid redundancy, if there is an equivalent value in @platforms,
     we define an alias here instead of another constraint_value.
 
     Each platform defined here selects a goos and goarch constraint value.
@@ -53,7 +54,7 @@ def declare_constraints():
         if constraint.startswith("@io_bazel_rules_go//go/toolchain:"):
             native.constraint_value(
                 name = goos,
-                constraint_setting = "@bazel_tools//platforms:os",
+                constraint_setting = "@io_bazel_rules_go_compat//platforms:os",
             )
         else:
             native.alias(
@@ -65,7 +66,7 @@ def declare_constraints():
         if constraint.startswith("@io_bazel_rules_go//go/toolchain:"):
             native.constraint_value(
                 name = goarch,
-                constraint_setting = "@bazel_tools//platforms:cpu",
+                constraint_setting = "@io_bazel_rules_go_compat//platforms:cpu",
             )
         else:
             native.alias(

--- a/tests/core/cross/ios_select_test.go
+++ b/tests/core/cross/ios_select_test.go
@@ -37,7 +37,7 @@ go_library(
 
 config_setting(
     name = "is_osx",
-    constraint_values = ["@bazel_tools//platforms:osx"],
+    constraint_values = ["@io_bazel_rules_go_compat//platforms:osx"],
 )
 
 go_library(


### PR DESCRIPTION
os and cpu constraint settings and values are being removed from
@bazel_tools//platforms. They are currently available in the external
@platforms repo (now declared in go_rules_dependencies). So we should
reference those instead of @bazel_tools//platforms.

In order to support old Bazel versions (the current minimum is still
0.23.0), @io_bazel_rules_go_compat//platforms now declares aliases on
either @platforms or @bazel_tools//platforms.

Note that bazel-skylib 1.0.2 (the latest released version) is not
compatible with --incompatible_use_platforms_repo_for_constraints yet,
so not all rules_go tests pass with that flag yet.

Updates bazelbuild/bazel#8622