### PR TITLE
Conditionally include Bazel testing library only if needed

### DIFF
--- a/go/tools/bazel_testing/def.bzl
+++ b/go/tools/bazel_testing/def.bzl
@@ -25,7 +25,10 @@ def go_bazel_test(rule_files = None, **kwargs):
 
     # Add dependency on bazel_testing library.
     kwargs.setdefault("deps", [])
-    kwargs["deps"] += ["@io_bazel_rules_go//go/tools/bazel_testing:go_default_library"]
+    
+    bazel_testing_library = "@io_bazel_rules_go//go/tools/bazel_testing:go_default_library"
+    if bazel_testing_library not in kwargs["deps"]:
+        kwargs["deps"] += []
 
     # Add data dependency on rules_go files. bazel_testing will copy or link
     # these files in an external repo.

--- a/go/tools/bazel_testing/def.bzl
+++ b/go/tools/bazel_testing/def.bzl
@@ -28,7 +28,7 @@ def go_bazel_test(rule_files = None, **kwargs):
     
     bazel_testing_library = "@io_bazel_rules_go//go/tools/bazel_testing:go_default_library"
     if bazel_testing_library not in kwargs["deps"]:
-        kwargs["deps"] += []
+        kwargs["deps"] += [bazel_testing_library]
 
     # Add data dependency on rules_go files. bazel_testing will copy or link
     # these files in an external repo.


### PR DESCRIPTION
Conditionally include the Bazel testing library. 

When using something like

```
# gazelle:map_kind go_test go_bazel_test @io_bazel_rules_go//go/tools/bazel_testing:def.bzl
```

with a directory of Bazel tests, Gazelle will automatically add this target as a
dep and duplicate entries is a build error.