### PR TITLE
Clear GOPATH environment variable in builder

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -383,6 +383,14 @@ def go_context(ctx, attr = None):
         "GOROOT": goroot,
         "GOROOT_FINAL": "GOROOT",
         "CGO_ENABLED": "0" if mode.pure else "1",
+
+        # If we use --action_env=GOPATH, or in other cases where environment
+        # variables are passed through to this builder, the SDK build will try
+        # to write to that GOPATH (e.g. for x/net/nettest). This will fail if
+        # the GOPATH is on a read-only mount, and is generally a bad idea.
+        # Explicitly clear this environment variable to ensure that doesn't
+        # happen. See #2291 for more information.
+        "GOPATH": "",
     })
 
     # TODO(jayconrod): remove this. It's way too broad. Everything should


### PR DESCRIPTION
I'm still not 100% clear on the exact interaction, but this was precipitated by trying to do a Bazel build of something with a `host` Go toolchain that was on a read-only mount. When doing so, builds would fail with an error trying to `go install vendor/golang.org/x/net/nettest`, since it couldn't open the `nettest.a` file in the host Go toolchain for writing. My strong suspicion here is that the `stdlib` builder isn't setting a `GOPATH`, so it's trying to write to the file in `GOROOT`, which it can't actually do since that's read-only.

Either way, this fixes things and feels pretty low-impact.