### PR TITLE
nogo: defer wg.Done()

### DIFF
--- a/go/tools/builders/nogo_main.go
+++ b/go/tools/builders/nogo_main.go
@@ -215,8 +215,8 @@ func execAll(actions []*action) {
 	wg.Add(len(actions))
 	for _, act := range actions {
 		go func(act *action) {
+			defer wg.Done()
 			act.exec()
-			wg.Done()
 		}(act)
 	}
 	wg.Wait()


### PR DESCRIPTION
Since `act.exec()` might panic it is better to `defer w.Done()`