### PR TITLE
Import all pkg which tests depend on

### DIFF
--- a/go/tools/builders/generate_test_main.go
+++ b/go/tools/builders/generate_test_main.go
@@ -313,9 +313,13 @@ func genTestMain(args []string) error {
 			}
 		}
 	}
-	// Add only the imports we found tests for
-	for pkg := range pkgs {
-		cases.Imports = append(cases.Imports, importMap[pkg])
+
+	for name := range importMap {
+		// Set the names for all unused imports to "_"
+		if !pkgs[name] {
+			importMap[name].Name = "_"
+		}
+		cases.Imports = append(cases.Imports, importMap[name])
 	}
 	sort.Slice(cases.Imports, func(i, j int) bool {
 		return cases.Imports[i].Name < cases.Imports[j].Name

--- a/tests/core/go_test/BUILD.bazel
+++ b/tests/core/go_test/BUILD.bazel
@@ -143,3 +143,12 @@ go_bazel_test(
     name = "test_filter_test",
     srcs = ["test_filter_test.go"],
 )
+
+go_test(
+    name = "testmain_import_test",
+    srcs = [
+        "testmain_import_indirect_test.go",
+        "testmain_import_main_test.go",
+    ],
+    importpath = "example.com/imports/test_main",
+)

--- a/tests/core/go_test/README.rst
+++ b/tests/core/go_test/README.rst
@@ -76,3 +76,10 @@ test_filter_test
 ----------------
 
 Checks that ``--test_filter`` actually filters out test cases.
+
+testmain_import_test
+----------------
+
+Check if all packages in all source files are imported to test main, to ensure
+a consistent test behaviour. This ensures a consistent behaviour when thinking
+about global indirect depencencies.

--- a/tests/core/go_test/testmain_import_indirect_test.go
+++ b/tests/core/go_test/testmain_import_indirect_test.go
@@ -1,0 +1,7 @@
+package test_main_test
+
+import "example.com/imports/test_main"
+
+func init() {
+	test_main.Updated = true
+}

--- a/tests/core/go_test/testmain_import_main_test.go
+++ b/tests/core/go_test/testmain_import_main_test.go
@@ -1,0 +1,11 @@
+package test_main
+
+import "testing"
+
+var Updated bool
+
+func TestShouldPass(t *testing.T) {
+	if !Updated {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
All imports which gazelle identified as test dependencies should be
imported in the test main package.

This way "hidden" global registrations are properly added to the binary.

One use-case is Ginkgo. It has its own wrappers for tests and rules_go
would miss them in some cases, which would lead to tests being not added to the binary.

Fixes #1999