### PR TITLE
Migrate to rules_cc

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -7,6 +7,11 @@ platforms:
     test_targets:
     - "..."
   ubuntu1804:
+    # enable some unflipped incompatible flags on this platform to ensure we don't regress.
+    build_flags:
+    - "--incompatible_load_cc_rules_from_bzl"
+    test_flags:
+    - "--incompatible_load_cc_rules_from_bzl"
     build_targets:
     - "..."
     test_targets:

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -94,6 +94,17 @@ def go_rules_dependencies():
         patch_args = ["-p1"],
     )
 
+    # Needed for additional targets declared around binaries with c-archive
+    # and c-shared link modes.
+    _maybe(
+        git_repository,
+        name = "rules_cc",
+        remote = "https://github.com/bazelbuild/rules_cc",
+        # master, as of 2020-01-06
+        commit = "7e650b11fe6d49f70f2ca7a1c4cb8bcc4a1fe239",
+        shallow_since = "1578064657 -0800",
+    )
+
     # Proto dependencies
     # These are limited as much as possible. In most cases, users need to
     # declare these on their own (probably via go_repository rules generated

--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -25,6 +25,11 @@ load(
     "LINKMODE_NORMAL",
     "extldflags_from_cc_toolchain",
 )
+load(
+    "@rules_cc//cc:defs.bzl",
+    "cc_import",
+    "cc_library",
+)
 
 def cgo_configure(go, srcs, cdeps, cppopts, copts, cxxopts, clinkopts):
     """cgo_configure returns the inputs and compile / link options
@@ -229,13 +234,13 @@ def go_binary_c_archive_shared(name, kwargs):
     elif linkmode == LINKMODE_C_ARCHIVE:
         cc_import_kwargs["static_library"] = name
         cc_import_kwargs["alwayslink"] = 1
-    native.cc_import(
+    cc_import(
         name = cc_import_name,
         visibility = ["//visibility:private"],
         tags = tags,
         **cc_import_kwargs
     )
-    native.cc_library(
+    cc_library(
         name = cc_library_name,
         hdrs = [c_hdrs],
         deps = [cc_import_name],

--- a/tests/core/c_linkmodes/BUILD.bazel
+++ b/tests/core/c_linkmodes/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+load("@rules_cc//cc:defs.bzl", "cc_import", "cc_test")
 
 go_binary(
     name = "adder_archive",

--- a/tests/core/cgo/BUILD.bazel
+++ b/tests/core/cgo/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_import", "cc_library")
 
 go_test(
     name = "opts_test",
@@ -216,8 +217,8 @@ go_test(
         "cgo_link_test.go",
         "cgo_ref.go",
     ],
-    cgo = True,
     cdeps = [":cgo_link_dep"],
+    cgo = True,
 )
 
 cc_library(

--- a/tests/core/cgo/objc/BUILD.bazel
+++ b/tests/core/cgo/objc/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_cc//cc:defs.bzl", "objc_library")
 
 go_test(
     name = "objc_test",

--- a/tests/legacy/cgo_select/BUILD.bazel
+++ b/tests/legacy/cgo_select/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 
 go_library(
     name = "go_default_library",

--- a/tests/legacy/examples/cgo/cc_dependency/BUILD.bazel
+++ b/tests/legacy/examples/cgo/cc_dependency/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_import", "cc_library")
+
 config_setting(
     name = "darwin",
     values = {"cpu": "darwin"},

--- a/tests/legacy/transitive_data/BUILD.bazel
+++ b/tests/legacy/transitive_data/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 
 go_test(
     name = "go_default_test",


### PR DESCRIPTION
* All C/C++/ObjC test targets are now declared with rules_cc.
* Extra targets around "c-archive" and "c-shared" binaries are
  declared with rules_cc.
* Consequently, rules_cc is now declared in go_rules_dependencies.

Fixes #2318