### PR TITLE
Test with --incompatible_restrict_string_escapes

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -11,9 +11,11 @@ platforms:
     build_flags:
     - "--incompatible_load_cc_rules_from_bzl"
     - "--incompatible_load_proto_rules_from_bzl"
+    - "--incompatible_restrict_string_escapes"
     test_flags:
     - "--incompatible_load_cc_rules_from_bzl"
     - "--incompatible_load_proto_rules_from_bzl"
+    - "--incompatible_restrict_string_escapes"
     build_targets:
     - "..."
     test_targets:


### PR DESCRIPTION
This verifies rules_go works with this flag after updating
bazel_toolchains.

Fixes #2321