### PR TITLE
Add XML testreport generation using testwrapper

### DIFF
--- a/go/core.rst
+++ b/go/core.rst
@@ -643,6 +643,8 @@ To run a Go benchmark test, run
 You can run specific tests by passing the `--test_filter=pattern <test_filter_>`_ argument to Bazel.
 You can pass arguments to tests by passing `--test_arg=arg <test_arg_>`_ arguments to Bazel.
 
+To write structured testlog information to Bazel's ``XML_OUTPUT_FILE``, tests ran with ``bazel test`` execute using a wrapper that invokes the testbinary with ``-test.v``. This functionality can be disabled by setting ``GO_TEST_WRAP=0`` in the test environment.
+
 Attributes
 ^^^^^^^^^^
 

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -109,6 +109,7 @@ def _go_test_impl(ctx):
         "-import",
         "l_test=" + external_source.library.importpath,
     )
+    arguments.add("-pkgname", internal_source.library.importpath)
     arguments.add_all(go_srcs, before_each = "-src", format_each = "l=%s")
     ctx.actions.run(
         inputs = go_srcs,

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -136,7 +136,7 @@ def _go_test_impl(ctx):
     if ctx.configuration.coverage_enabled:
         test_deps.append(go.coverdata)
     test_source = go.library_to_source(go, struct(
-        srcs = [struct(files = [main_go])],
+        srcs = [struct(files = [main_go] + ctx.files._testmain_additional_srcs)],
         deps = test_deps,
     ), test_library, False)
     test_archive, executable, runfiles = go.binary(
@@ -237,6 +237,10 @@ go_test = go_rule(
         "copts": attr.string_list(),
         "cxxopts": attr.string_list(),
         "clinkopts": attr.string_list(),
+        "_testmain_additional_srcs": attr.label_list(
+            default = ["@io_bazel_rules_go//go/tools/testwrapper:srcs"],
+            allow_files = go_exts,
+        ),
         # Workaround for bazelbuild/bazel#6293. See comment in lcov_merger.sh.
         "_lcov_merger": attr.label(
             executable = True,

--- a/go/tools/BUILD.bazel
+++ b/go/tools/BUILD.bazel
@@ -5,6 +5,7 @@ filegroup(
         "//go/tools/bazel:all_files",
         "//go/tools/builders:all_files",
         "//go/tools/coverdata:all_files",
+        "//go/tools/testwrapper:all_files",
     ],
     visibility = ["//visibility:public"],
 )

--- a/go/tools/builders/generate_test_main.go
+++ b/go/tools/builders/generate_test_main.go
@@ -65,6 +65,7 @@ import (
 	"flag"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -117,6 +118,18 @@ func testsInShard() []testing.InternalTest {
 }
 
 func main() {
+	if shouldWrap() {
+		err := wrap()
+		if xerr, ok := err.(*exec.ExitError); ok {
+			os.Exit(xerr.ExitCode())
+		} else if err != nil {
+			log.Print(err)
+			os.Exit(testWrapperAbnormalExit)
+		} else {
+			os.Exit(0)
+		}
+	}
+
 	// Check if we're being run by Bazel and change directories if so.
 	// TEST_SRCDIR and TEST_WORKSPACE are set by the Bazel test runner, so that makes a decent proxy.
 	testSrcdir := os.Getenv("TEST_SRCDIR")

--- a/go/tools/builders/generate_test_main.go
+++ b/go/tools/builders/generate_test_main.go
@@ -57,6 +57,7 @@ type Cases struct {
 	Examples   []Example
 	TestMain   string
 	Coverage   bool
+	Pkgname    string
 }
 
 const testMainTpl = `
@@ -119,7 +120,7 @@ func testsInShard() []testing.InternalTest {
 
 func main() {
 	if shouldWrap() {
-		err := wrap()
+		err := wrap("{{.Pkgname}}")
 		if xerr, ok := err.(*exec.ExitError); ok {
 			os.Exit(xerr.ExitCode())
 		} else if err != nil {
@@ -185,6 +186,7 @@ func genTestMain(args []string) error {
 	runDir := flags.String("rundir", ".", "Path to directory where tests should run.")
 	out := flags.String("output", "", "output file to write. Defaults to stdout.")
 	coverage := flags.Bool("coverage", false, "whether coverage is supported")
+	pkgname := flags.String("pkgname", "", "package name of test")
 	flags.Var(&imports, "import", "Packages to import")
 	flags.Var(&sources, "src", "Sources to process for tests")
 	if err := flags.Parse(args); err != nil {
@@ -235,6 +237,7 @@ func genTestMain(args []string) error {
 	cases := Cases{
 		RunDir:   strings.Replace(filepath.FromSlash(*runDir), `\`, `\\`, -1),
 		Coverage: *coverage,
+		Pkgname:  *pkgname,
 	}
 
 	testFileSet := token.NewFileSet()

--- a/go/tools/testwrapper/BUILD.bazel
+++ b/go/tools/testwrapper/BUILD.bazel
@@ -1,6 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
 # srcs are compiled into the test package with the generated testmain.
 filegroup(
   name = "srcs",
-  srcs = glob(["*.go"]),
+  srcs = [
+    "test2json.go",
+    "wrap.go",
+    "xml.go",
+  ],
   visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"], exclude = ["testdata/*"]),
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [":srcs"] + glob(["*_test.go"]),
+    data = glob(["testdata/*"]),
 )

--- a/go/tools/testwrapper/BUILD.bazel
+++ b/go/tools/testwrapper/BUILD.bazel
@@ -1,0 +1,6 @@
+# srcs are compiled into the test package with the generated testmain.
+filegroup(
+  name = "srcs",
+  srcs = glob(["*.go"]),
+  visibility = ["//visibility:public"],
+)

--- a/go/tools/testwrapper/test2json.go
+++ b/go/tools/testwrapper/test2json.go
@@ -1,0 +1,450 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package test2json implements conversion of test binary output to JSON.
+// It is used by cmd/test2json and cmd/go.
+//
+// See the cmd/test2json documentation for details of the JSON encoding.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Mode controls details of the conversion.
+type Mode int
+
+const (
+	Timestamp Mode = 1 << iota // include Time in events
+)
+
+// event is the JSON struct we emit.
+type event struct {
+	Time    *time.Time `json:",omitempty"`
+	Action  string
+	Package string     `json:",omitempty"`
+	Test    string     `json:",omitempty"`
+	Elapsed *float64   `json:",omitempty"`
+	Output  *textBytes `json:",omitempty"`
+}
+
+// textBytes is a hack to get JSON to emit a []byte as a string
+// without actually copying it to a string.
+// It implements encoding.TextMarshaler, which returns its text form as a []byte,
+// and then json encodes that text form as a string (which was our goal).
+type textBytes []byte
+
+func (b textBytes) MarshalText() ([]byte, error) { return b, nil }
+
+// A converter holds the state of a test-to-JSON conversion.
+// It implements io.WriteCloser; the caller writes test output in,
+// and the converter writes JSON output to w.
+type converter struct {
+	w        io.Writer  // JSON output stream
+	pkg      string     // package to name in events
+	mode     Mode       // mode bits
+	start    time.Time  // time converter started
+	testName string     // name of current test, for output attribution
+	report   []*event   // pending test result reports (nested for subtests)
+	result   string     // overall test result if seen
+	input    lineBuffer // input buffer
+	output   lineBuffer // output buffer
+}
+
+// inBuffer and outBuffer are the input and output buffer sizes.
+// They're variables so that they can be reduced during testing.
+//
+// The input buffer needs to be able to hold any single test
+// directive line we want to recognize, like:
+//
+//     <many spaces> --- PASS: very/nested/s/u/b/t/e/s/t
+//
+// If anyone reports a test directive line > 4k not working, it will
+// be defensible to suggest they restructure their test or test names.
+//
+// The output buffer must be >= utf8.UTFMax, so that it can
+// accumulate any single UTF8 sequence. Lines that fit entirely
+// within the output buffer are emitted in single output events.
+// Otherwise they are split into multiple events.
+// The output buffer size therefore limits the size of the encoding
+// of a single JSON output event. 1k seems like a reasonable balance
+// between wanting to avoid splitting an output line and not wanting to
+// generate enormous output events.
+var (
+	inBuffer  = 4096
+	outBuffer = 1024
+)
+
+// NewConverter returns a "test to json" converter.
+// Writes on the returned writer are written as JSON to w,
+// with minimal delay.
+//
+// The writes to w are whole JSON events ending in \n,
+// so that it is safe to run multiple tests writing to multiple converters
+// writing to a single underlying output stream w.
+// As long as the underlying output w can handle concurrent writes
+// from multiple goroutines, the result will be a JSON stream
+// describing the relative ordering of execution in all the concurrent tests.
+//
+// The mode flag adjusts the behavior of the converter.
+// Passing ModeTime includes event timestamps and elapsed times.
+//
+// The pkg string, if present, specifies the import path to
+// report in the JSON stream.
+func NewConverter(w io.Writer, pkg string, mode Mode) io.WriteCloser {
+	c := new(converter)
+	*c = converter{
+		w:     w,
+		pkg:   pkg,
+		mode:  mode,
+		start: time.Now(),
+		input: lineBuffer{
+			b:    make([]byte, 0, inBuffer),
+			line: c.handleInputLine,
+			part: c.output.write,
+		},
+		output: lineBuffer{
+			b:    make([]byte, 0, outBuffer),
+			line: c.writeOutputEvent,
+			part: c.writeOutputEvent,
+		},
+	}
+	return c
+}
+
+// Write writes the test input to the converter.
+func (c *converter) Write(b []byte) (int, error) {
+	c.input.write(b)
+	return len(b), nil
+}
+
+var (
+	bigPass = []byte("PASS\n")
+	bigFail = []byte("FAIL\n")
+
+	updates = [][]byte{
+		[]byte("=== RUN   "),
+		[]byte("=== PAUSE "),
+		[]byte("=== CONT  "),
+	}
+
+	reports = [][]byte{
+		[]byte("--- PASS: "),
+		[]byte("--- FAIL: "),
+		[]byte("--- SKIP: "),
+		[]byte("--- BENCH: "),
+	}
+
+	fourSpace = []byte("    ")
+
+	skipLinePrefix = []byte("?   \t")
+	skipLineSuffix = []byte("\t[no test files]\n")
+)
+
+// handleInputLine handles a single whole test output line.
+// It must write the line to c.output but may choose to do so
+// before or after emitting other events.
+func (c *converter) handleInputLine(line []byte) {
+	// Final PASS or FAIL.
+	if bytes.Equal(line, bigPass) || bytes.Equal(line, bigFail) {
+		c.flushReport(0)
+		c.output.write(line)
+		if bytes.Equal(line, bigPass) {
+			c.result = "pass"
+		} else {
+			c.result = "fail"
+		}
+		return
+	}
+
+	// Special case for entirely skipped test binary: "?   \tpkgname\t[no test files]\n" is only line.
+	// Report it as plain output but remember to say skip in the final summary.
+	if bytes.HasPrefix(line, skipLinePrefix) && bytes.HasSuffix(line, skipLineSuffix) && len(c.report) == 0 {
+		c.result = "skip"
+	}
+
+	// "=== RUN   "
+	// "=== PAUSE "
+	// "=== CONT  "
+	actionColon := false
+	origLine := line
+	ok := false
+	indent := 0
+	for _, magic := range updates {
+		if bytes.HasPrefix(line, magic) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		// "--- PASS: "
+		// "--- FAIL: "
+		// "--- SKIP: "
+		// "--- BENCH: "
+		// but possibly indented.
+		for bytes.HasPrefix(line, fourSpace) {
+			line = line[4:]
+			indent++
+		}
+		for _, magic := range reports {
+			if bytes.HasPrefix(line, magic) {
+				actionColon = true
+				ok = true
+				break
+			}
+		}
+	}
+
+	if !ok {
+		// Not a special test output line.
+		c.output.write(origLine)
+		return
+	}
+
+	// Parse out action and test name.
+	i := 0
+	if actionColon {
+		i = bytes.IndexByte(line, ':') + 1
+	}
+	if i == 0 {
+		i = len(updates[0])
+	}
+	action := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(string(line[4:i])), ":"))
+	name := strings.TrimSpace(string(line[i:]))
+
+	e := &event{Action: action}
+	if line[0] == '-' { // PASS or FAIL report
+		// Parse out elapsed time.
+		if i := strings.Index(name, " ("); i >= 0 {
+			if strings.HasSuffix(name, "s)") {
+				t, err := strconv.ParseFloat(name[i+2:len(name)-2], 64)
+				if err == nil {
+					if c.mode&Timestamp != 0 {
+						e.Elapsed = &t
+					}
+				}
+			}
+			name = name[:i]
+		}
+		if len(c.report) < indent {
+			// Nested deeper than expected.
+			// Treat this line as plain output.
+			c.output.write(origLine)
+			return
+		}
+		// Flush reports at this indentation level or deeper.
+		c.flushReport(indent)
+		e.Test = name
+		c.testName = name
+		c.report = append(c.report, e)
+		c.output.write(origLine)
+		return
+	}
+	// === update.
+	// Finish any pending PASS/FAIL reports.
+	c.flushReport(0)
+	c.testName = name
+
+	if action == "pause" {
+		// For a pause, we want to write the pause notification before
+		// delivering the pause event, just so it doesn't look like the test
+		// is generating output immediately after being paused.
+		c.output.write(origLine)
+	}
+	c.writeEvent(e)
+	if action != "pause" {
+		c.output.write(origLine)
+	}
+
+	return
+}
+
+// flushReport flushes all pending PASS/FAIL reports at levels >= depth.
+func (c *converter) flushReport(depth int) {
+	c.testName = ""
+	for len(c.report) > depth {
+		e := c.report[len(c.report)-1]
+		c.report = c.report[:len(c.report)-1]
+		c.writeEvent(e)
+	}
+}
+
+// Close marks the end of the go test output.
+// It flushes any pending input and then output (only partial lines at this point)
+// and then emits the final overall package-level pass/fail event.
+func (c *converter) Close() error {
+	c.input.flush()
+	c.output.flush()
+	e := &event{Action: "pass"}
+	if c.result != "" {
+		e.Action = c.result
+	}
+	if c.mode&Timestamp != 0 {
+		dt := time.Since(c.start).Round(1 * time.Millisecond).Seconds()
+		e.Elapsed = &dt
+	}
+	c.writeEvent(e)
+	return nil
+}
+
+// writeOutputEvent writes a single output event with the given bytes.
+func (c *converter) writeOutputEvent(out []byte) {
+	c.writeEvent(&event{
+		Action: "output",
+		Output: (*textBytes)(&out),
+	})
+}
+
+// writeEvent writes a single event.
+// It adds the package, time (if requested), and test name (if needed).
+func (c *converter) writeEvent(e *event) {
+	e.Package = c.pkg
+	if c.mode&Timestamp != 0 {
+		t := time.Now()
+		e.Time = &t
+	}
+	if e.Test == "" {
+		e.Test = c.testName
+	}
+	js, err := json.Marshal(e)
+	if err != nil {
+		// Should not happen - event is valid for json.Marshal.
+		c.w.Write([]byte(fmt.Sprintf("testjson internal error: %v\n", err)))
+		return
+	}
+	js = append(js, '\n')
+	c.w.Write(js)
+}
+
+// A lineBuffer is an I/O buffer that reacts to writes by invoking
+// input-processing callbacks on whole lines or (for long lines that
+// have been split) line fragments.
+//
+// It should be initialized with b set to a buffer of length 0 but non-zero capacity,
+// and line and part set to the desired input processors.
+// The lineBuffer will call line(x) for any whole line x (including the final newline)
+// that fits entirely in cap(b). It will handle input lines longer than cap(b) by
+// calling part(x) for sections of the line. The line will be split at UTF8 boundaries,
+// and the final call to part for a long line includes the final newline.
+type lineBuffer struct {
+	b    []byte       // buffer
+	mid  bool         // whether we're in the middle of a long line
+	line func([]byte) // line callback
+	part func([]byte) // partial line callback
+}
+
+// write writes b to the buffer.
+func (l *lineBuffer) write(b []byte) {
+	for len(b) > 0 {
+		// Copy what we can into b.
+		m := copy(l.b[len(l.b):cap(l.b)], b)
+		l.b = l.b[:len(l.b)+m]
+		b = b[m:]
+
+		// Process lines in b.
+		i := 0
+		for i < len(l.b) {
+			j := bytes.IndexByte(l.b[i:], '\n')
+			if j < 0 {
+				if !l.mid {
+					if j := bytes.IndexByte(l.b[i:], '\t'); j >= 0 {
+						if isBenchmarkName(bytes.TrimRight(l.b[i:i+j], " ")) {
+							l.part(l.b[i : i+j+1])
+							l.mid = true
+							i += j + 1
+						}
+					}
+				}
+				break
+			}
+			e := i + j + 1
+			if l.mid {
+				// Found the end of a partial line.
+				l.part(l.b[i:e])
+				l.mid = false
+			} else {
+				// Found a whole line.
+				l.line(l.b[i:e])
+			}
+			i = e
+		}
+
+		// Whatever's left in l.b is a line fragment.
+		if i == 0 && len(l.b) == cap(l.b) {
+			// The whole buffer is a fragment.
+			// Emit it as the beginning (or continuation) of a partial line.
+			t := trimUTF8(l.b)
+			l.part(l.b[:t])
+			l.b = l.b[:copy(l.b, l.b[t:])]
+			l.mid = true
+		}
+
+		// There's room for more input.
+		// Slide it down in hope of completing the line.
+		if i > 0 {
+			l.b = l.b[:copy(l.b, l.b[i:])]
+		}
+	}
+}
+
+// flush flushes the line buffer.
+func (l *lineBuffer) flush() {
+	if len(l.b) > 0 {
+		// Must be a line without a \n, so a partial line.
+		l.part(l.b)
+		l.b = l.b[:0]
+	}
+}
+
+var benchmark = []byte("Benchmark")
+
+// isBenchmarkName reports whether b is a valid benchmark name
+// that might appear as the first field in a benchmark result line.
+func isBenchmarkName(b []byte) bool {
+	if !bytes.HasPrefix(b, benchmark) {
+		return false
+	}
+	if len(b) == len(benchmark) { // just "Benchmark"
+		return true
+	}
+	r, _ := utf8.DecodeRune(b[len(benchmark):])
+	return !unicode.IsLower(r)
+}
+
+// trimUTF8 returns a length t as close to len(b) as possible such that b[:t]
+// does not end in the middle of a possibly-valid UTF-8 sequence.
+//
+// If a large text buffer must be split before position i at the latest,
+// splitting at position trimUTF(b[:i]) avoids splitting a UTF-8 sequence.
+func trimUTF8(b []byte) int {
+	// Scan backward to find non-continuation byte.
+	for i := 1; i < utf8.UTFMax && i <= len(b); i++ {
+		if c := b[len(b)-i]; c&0xc0 != 0x80 {
+			switch {
+			case c&0xe0 == 0xc0:
+				if i < 2 {
+					return len(b) - i
+				}
+			case c&0xf0 == 0xe0:
+				if i < 3 {
+					return len(b) - i
+				}
+			case c&0xf8 == 0xf0:
+				if i < 4 {
+					return len(b) - i
+				}
+			}
+			break
+		}
+	}
+	return len(b)
+}

--- a/go/tools/testwrapper/test2json.go
+++ b/go/tools/testwrapper/test2json.go
@@ -6,6 +6,12 @@
 // It is used by cmd/test2json and cmd/go.
 //
 // See the cmd/test2json documentation for details of the JSON encoding.
+
+// The file test2json.go was copied from upstream go at
+// src/cmd/internal/test2json/test2json.go, revision
+// d47526ed777958aa4a2542382e931eb7b3c4c6a9. At the time of writing this was
+// deemed the best way of depending on this code that is otherwise not exposed
+// outside of the go toolchain. These files should be kept in sync.
 package main
 
 import (

--- a/go/tools/testwrapper/testdata/empty.json
+++ b/go/tools/testwrapper/testdata/empty.json
@@ -1,0 +1,1 @@
+{"Action":"fail"}

--- a/go/tools/testwrapper/testdata/empty.xml
+++ b/go/tools/testwrapper/testdata/empty.xml
@@ -1,0 +1,3 @@
+<testsuites>
+	<testsuite errors="0" failures="0" skipped="0" tests="0" time="" name="pkg/testing"></testsuite>
+</testsuites>

--- a/go/tools/testwrapper/testdata/report.json
+++ b/go/tools/testwrapper/testdata/report.json
@@ -20,10 +20,11 @@
 {"Action":"run","Test":"TestSubtests/another_subtest"}
 {"Action":"output","Test":"TestSubtests/another_subtest","Output":"=== RUN   TestSubtests/another_subtest\n"}
 {"Action":"output","Test":"TestSubtests","Output":"--- FAIL: TestSubtests (0.02s)\n"}
-{"Action":"output","Test":"TestSubtests/subtest_a","Output":"    --- FAIL: TestSubtests/subtest_a (0.00s)\n"}
+{"Action":"output","Test":"TestSubtests/subtest_a","Output":"    --- SKIP: TestSubtests/subtest_a (0.00s)\n"}
 {"Action":"output","Test":"TestSubtests/subtest_a","Output":"        test_test.go:29: from subtest subtest a\n"}
 {"Action":"output","Test":"TestSubtests/subtest_a","Output":"        test_test.go:31: from subtest subtest a\n"}
-{"Action":"fail","Test":"TestSubtests/subtest_a","Elapsed":0}
+{"Action":"output","Test":"TestSubtests/subtest_a","Output":"        test_test.go:33: skipping this test\n"}
+{"Action":"skip","Test":"TestSubtests/subtest_a","Elapsed":0}
 {"Action":"output","Test":"TestSubtests/testB","Output":"    --- PASS: TestSubtests/testB (0.01s)\n"}
 {"Action":"output","Test":"TestSubtests/testB","Output":"        test_test.go:29: from subtest testB\n"}
 {"Action":"output","Test":"TestSubtests/testB","Output":"        test_test.go:31: from subtest testB\n"}
@@ -35,13 +36,12 @@
 {"Action":"fail","Test":"TestSubtests","Elapsed":0.02}
 {"Action":"cont","Test":"TestPass"}
 {"Action":"output","Test":"TestPass","Output":"=== CONT  TestPass\n"}
-{"Action":"output","Test":"TestPass","Output":"--- PASS: TestPass (0.00s)\n"}
-{"Action":"pass","Test":"TestPass","Elapsed":0}
 {"Action":"cont","Test":"TestPassLog"}
 {"Action":"output","Test":"TestPassLog","Output":"=== CONT  TestPassLog\n"}
+{"Action":"output","Test":"TestPass","Output":"--- PASS: TestPass (0.00s)\n"}
+{"Action":"pass","Test":"TestPass","Elapsed":0}
 {"Action":"output","Test":"TestPassLog","Output":"--- PASS: TestPassLog (0.00s)\n"}
 {"Action":"output","Test":"TestPassLog","Output":"    test_test.go:19: pass\n"}
 {"Action":"pass","Test":"TestPassLog","Elapsed":0}
 {"Action":"output","Output":"FAIL\n"}
-{"Action":"output","Output":"FAIL\t_pkg\t1.081s\n"}
-{"Action":"fail","Elapsed":1.081}
+{"Action":"fail","Elapsed":0.03}

--- a/go/tools/testwrapper/testdata/report.json
+++ b/go/tools/testwrapper/testdata/report.json
@@ -1,0 +1,47 @@
+{"Action":"run","Test":"TestPass"}
+{"Action":"output","Test":"TestPass","Output":"=== RUN   TestPass\n"}
+{"Action":"output","Test":"TestPass","Output":"=== PAUSE TestPass\n"}
+{"Action":"pause","Test":"TestPass"}
+{"Action":"run","Test":"TestPassLog"}
+{"Action":"output","Test":"TestPassLog","Output":"=== RUN   TestPassLog\n"}
+{"Action":"output","Test":"TestPassLog","Output":"=== PAUSE TestPassLog\n"}
+{"Action":"pause","Test":"TestPassLog"}
+{"Action":"run","Test":"TestFail"}
+{"Action":"output","Test":"TestFail","Output":"=== RUN   TestFail\n"}
+{"Action":"output","Test":"TestFail","Output":"--- FAIL: TestFail (0.00s)\n"}
+{"Action":"output","Test":"TestFail","Output":"    test_test.go:23: Not working\n"}
+{"Action":"fail","Test":"TestFail","Elapsed":0}
+{"Action":"run","Test":"TestSubtests"}
+{"Action":"output","Test":"TestSubtests","Output":"=== RUN   TestSubtests\n"}
+{"Action":"run","Test":"TestSubtests/subtest_a"}
+{"Action":"output","Test":"TestSubtests/subtest_a","Output":"=== RUN   TestSubtests/subtest_a\n"}
+{"Action":"run","Test":"TestSubtests/testB"}
+{"Action":"output","Test":"TestSubtests/testB","Output":"=== RUN   TestSubtests/testB\n"}
+{"Action":"run","Test":"TestSubtests/another_subtest"}
+{"Action":"output","Test":"TestSubtests/another_subtest","Output":"=== RUN   TestSubtests/another_subtest\n"}
+{"Action":"output","Test":"TestSubtests","Output":"--- FAIL: TestSubtests (0.02s)\n"}
+{"Action":"output","Test":"TestSubtests/subtest_a","Output":"    --- FAIL: TestSubtests/subtest_a (0.00s)\n"}
+{"Action":"output","Test":"TestSubtests/subtest_a","Output":"        test_test.go:29: from subtest subtest a\n"}
+{"Action":"output","Test":"TestSubtests/subtest_a","Output":"        test_test.go:31: from subtest subtest a\n"}
+{"Action":"fail","Test":"TestSubtests/subtest_a","Elapsed":0}
+{"Action":"output","Test":"TestSubtests/testB","Output":"    --- PASS: TestSubtests/testB (0.01s)\n"}
+{"Action":"output","Test":"TestSubtests/testB","Output":"        test_test.go:29: from subtest testB\n"}
+{"Action":"output","Test":"TestSubtests/testB","Output":"        test_test.go:31: from subtest testB\n"}
+{"Action":"pass","Test":"TestSubtests/testB","Elapsed":0.01}
+{"Action":"output","Test":"TestSubtests/another_subtest","Output":"    --- FAIL: TestSubtests/another_subtest (0.01s)\n"}
+{"Action":"output","Test":"TestSubtests/another_subtest","Output":"        test_test.go:29: from subtest another subtest\n"}
+{"Action":"output","Test":"TestSubtests/another_subtest","Output":"        test_test.go:31: from subtest another subtest\n"}
+{"Action":"fail","Test":"TestSubtests/another_subtest","Elapsed":0.01}
+{"Action":"fail","Test":"TestSubtests","Elapsed":0.02}
+{"Action":"cont","Test":"TestPass"}
+{"Action":"output","Test":"TestPass","Output":"=== CONT  TestPass\n"}
+{"Action":"output","Test":"TestPass","Output":"--- PASS: TestPass (0.00s)\n"}
+{"Action":"pass","Test":"TestPass","Elapsed":0}
+{"Action":"cont","Test":"TestPassLog"}
+{"Action":"output","Test":"TestPassLog","Output":"=== CONT  TestPassLog\n"}
+{"Action":"output","Test":"TestPassLog","Output":"--- PASS: TestPassLog (0.00s)\n"}
+{"Action":"output","Test":"TestPassLog","Output":"    test_test.go:19: pass\n"}
+{"Action":"pass","Test":"TestPassLog","Elapsed":0}
+{"Action":"output","Output":"FAIL\n"}
+{"Action":"output","Output":"FAIL\t_pkg\t1.081s\n"}
+{"Action":"fail","Elapsed":1.081}

--- a/go/tools/testwrapper/testdata/report.xml
+++ b/go/tools/testwrapper/testdata/report.xml
@@ -1,5 +1,5 @@
 <testsuites>
-	<testsuite errors="0" failures="4" skipped="0" tests="7" time="1.081" name="pkg/testing">
+	<testsuite errors="0" failures="3" skipped="1" tests="7" time="0.030" name="pkg/testing">
 		<testcase classname="testing" name="TestFail" time="0.000">
 			<failure message="Failed" type="">=== RUN   TestFail&#xA;--- FAIL: TestFail (0.00s)&#xA;    test_test.go:23: Not working&#xA;</failure>
 		</testcase>
@@ -12,7 +12,7 @@
 			<failure message="Failed" type="">=== RUN   TestSubtests/another_subtest&#xA;    --- FAIL: TestSubtests/another_subtest (0.01s)&#xA;        test_test.go:29: from subtest another subtest&#xA;        test_test.go:31: from subtest another subtest&#xA;</failure>
 		</testcase>
 		<testcase classname="testing" name="TestSubtests/subtest_a" time="0.000">
-			<failure message="Failed" type="">=== RUN   TestSubtests/subtest_a&#xA;    --- FAIL: TestSubtests/subtest_a (0.00s)&#xA;        test_test.go:29: from subtest subtest a&#xA;        test_test.go:31: from subtest subtest a&#xA;</failure>
+			<skipped message="Skipped" type="">=== RUN   TestSubtests/subtest_a&#xA;    --- SKIP: TestSubtests/subtest_a (0.00s)&#xA;        test_test.go:29: from subtest subtest a&#xA;        test_test.go:31: from subtest subtest a&#xA;        test_test.go:33: skipping this test&#xA;</skipped>
 		</testcase>
 		<testcase classname="testing" name="TestSubtests/testB" time="0.010"></testcase>
 	</testsuite>

--- a/go/tools/testwrapper/testdata/report.xml
+++ b/go/tools/testwrapper/testdata/report.xml
@@ -1,0 +1,19 @@
+<testsuites>
+	<testsuite errors="0" failures="4" skipped="0" tests="7" time="1.081" name="pkg/testing">
+		<testcase classname="testing" name="TestFail" time="0.000">
+			<failure message="Failed" type="">=== RUN   TestFail&#xA;--- FAIL: TestFail (0.00s)&#xA;    test_test.go:23: Not working&#xA;</failure>
+		</testcase>
+		<testcase classname="testing" name="TestPass" time="0.000"></testcase>
+		<testcase classname="testing" name="TestPassLog" time="0.000"></testcase>
+		<testcase classname="testing" name="TestSubtests" time="0.020">
+			<failure message="Failed" type="">=== RUN   TestSubtests&#xA;--- FAIL: TestSubtests (0.02s)&#xA;</failure>
+		</testcase>
+		<testcase classname="testing" name="TestSubtests/another_subtest" time="0.010">
+			<failure message="Failed" type="">=== RUN   TestSubtests/another_subtest&#xA;    --- FAIL: TestSubtests/another_subtest (0.01s)&#xA;        test_test.go:29: from subtest another subtest&#xA;        test_test.go:31: from subtest another subtest&#xA;</failure>
+		</testcase>
+		<testcase classname="testing" name="TestSubtests/subtest_a" time="0.000">
+			<failure message="Failed" type="">=== RUN   TestSubtests/subtest_a&#xA;    --- FAIL: TestSubtests/subtest_a (0.00s)&#xA;        test_test.go:29: from subtest subtest a&#xA;        test_test.go:31: from subtest subtest a&#xA;</failure>
+		</testcase>
+		<testcase classname="testing" name="TestSubtests/testB" time="0.010"></testcase>
+	</testsuite>
+</testsuites>

--- a/go/tools/testwrapper/wrap.go
+++ b/go/tools/testwrapper/wrap.go
@@ -1,0 +1,55 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+// testWrapperAbnormalExit is used by the testwrapper to indicate the child
+// process exitted without an exit code (for example being killed by a signal).
+// We use 6, in line with Bazel's RUN_FAILURE.
+const testWrapperAbnormalExit = 6
+
+func shouldWrap() bool {
+	if wrapEnv, ok := os.LookupEnv("GO_TEST_WRAP"); ok {
+		wrap, err := strconv.ParseBool(wrapEnv)
+		if err != nil {
+			log.Fatalf("invalid value for GO_TEST_WRAP: %q", wrapEnv)
+		}
+		return wrap
+	}
+	if _, ok := os.LookupEnv("XML_OUTPUT_FILE"); ok {
+		return true
+	}
+	return false
+}
+
+func wrap() error {
+	var stdoutBuf bytes.Buffer
+	args := append([]string{"-test.v"}, os.Args[1:]...)
+	cmd := exec.Command(os.Args[0], args...)
+	cmd.Env = append(os.Environ(), "GO_TEST_WRAP=0")
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = io.MultiWriter(os.Stdout, &stdoutBuf)
+	err := cmd.Run()
+	// do something with stdoutBuf
+	return err
+}

--- a/go/tools/testwrapper/wrap_test.go
+++ b/go/tools/testwrapper/wrap_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestShouldWrap(t *testing.T) {
+	var tests = []struct {
+		envs       map[string]string
+		shouldWrap bool
+	}{
+		{
+			envs: map[string]string{
+				"GO_TEST_WRAP":    "0",
+				"XML_OUTPUT_FILE": "",
+			},
+			shouldWrap: false,
+		}, {
+			envs: map[string]string{
+				"GO_TEST_WRAP":    "1",
+				"XML_OUTPUT_FILE": "",
+			},
+			shouldWrap: true,
+		}, {
+			envs: map[string]string{
+				"GO_TEST_WRAP":    "",
+				"XML_OUTPUT_FILE": "path",
+			},
+			shouldWrap: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%v", tt.envs), func(t *testing.T) {
+			for k, v := range tt.envs {
+				if v == "" {
+					os.Unsetenv(k)
+				} else {
+					os.Setenv(k, v)
+				}
+			}
+			got := shouldWrap()
+			if tt.shouldWrap != got {
+				t.Errorf("shouldWrap returned %t, expected %t", got, tt.shouldWrap)
+			}
+		})
+	}
+}

--- a/go/tools/testwrapper/wrap_test.go
+++ b/go/tools/testwrapper/wrap_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/go/tools/testwrapper/xml.go
+++ b/go/tools/testwrapper/xml.go
@@ -157,7 +157,7 @@ func toXML(pkgName string, pkgDuration *float64, testcases map[string]*testCase)
 		case "skip":
 			suite.Skipped++
 			newCase.Skipped = &xmlMessage{
-				Message:  "Failed",
+				Message:  "Skipped",
 				Contents: c.output.String(),
 			}
 		case "fail":

--- a/go/tools/testwrapper/xml.go
+++ b/go/tools/testwrapper/xml.go
@@ -1,0 +1,181 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"path"
+	"sort"
+	"strings"
+	"time"
+)
+
+type xmlTestSuites struct {
+	XMLName xml.Name       `xml:"testsuites"`
+	Suites  []xmlTestSuite `xml:"testsuite"`
+}
+
+type xmlTestSuite struct {
+	XMLName   xml.Name      `xml:"testsuite"`
+	TestCases []xmlTestCase `xml:"testcase"`
+	Errors    int           `xml:"errors,attr"`
+	Failures  int           `xml:"failures,attr"`
+	Skipped   int           `xml:"skipped,attr"`
+	Tests     int           `xml:"tests,attr"`
+	Time      string        `xml:"time,attr"`
+	Name      string        `xml:"name,attr"`
+}
+
+type xmlTestCase struct {
+	XMLName   xml.Name    `xml:"testcase"`
+	Classname string      `xml:"classname,attr"`
+	Name      string      `xml:"name,attr"`
+	Time      string      `xml:"time,attr"`
+	Failure   *xmlMessage `xml:"failure,omitempty"`
+	Error     *xmlMessage `xml:"error,omitempty"`
+	Skipped   *xmlMessage `xml:"skipped,omitempty"`
+}
+
+type xmlMessage struct {
+	Message  string `xml:"message,attr"`
+	Type     string `xml:"type,attr"`
+	Contents string `xml:",chardata"`
+}
+
+// jsonEvent as encoded by the test2json package.
+type jsonEvent struct {
+	Time    *time.Time
+	Action  string
+	Package string
+	Test    string
+	Elapsed *float64
+	Output  string
+}
+
+type testCase struct {
+	state    string
+	output   strings.Builder
+	duration *float64
+}
+
+// json2xml converts test2json's output into an xml output readable by Bazel.
+// http://windyroad.com.au/dl/Open%20Source/JUnit.xsd
+func json2xml(r io.Reader, pkgName string) ([]byte, error) {
+	var pkgDuration *float64
+	testcases := make(map[string]*testCase)
+	testCaseByName := func(name string) *testCase {
+		if name == "" {
+			return nil
+		}
+		if _, ok := testcases[name]; !ok {
+			testcases[name] = &testCase{}
+		}
+		return testcases[name]
+	}
+
+	dec := json.NewDecoder(r)
+	for {
+		var e jsonEvent
+		if err := dec.Decode(&e); err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, fmt.Errorf("error decoding test2json output: %s", err)
+		}
+		switch s := e.Action; s {
+		case "run":
+			if c := testCaseByName(e.Test); c != nil {
+				c.state = s
+			}
+		case "output":
+			if c := testCaseByName(e.Test); c != nil {
+				c.output.WriteString(e.Output)
+			}
+		case "skip":
+			if c := testCaseByName(e.Test); c != nil {
+				c.output.WriteString(e.Output)
+				c.state = s
+				c.duration = e.Elapsed
+			}
+		case "fail":
+			if c := testCaseByName(e.Test); c != nil {
+				c.state = s
+				c.duration = e.Elapsed
+			} else {
+				pkgDuration = e.Elapsed
+			}
+		case "pass":
+			if c := testCaseByName(e.Test); c != nil {
+				c.duration = e.Elapsed
+				c.state = s
+			} else {
+				pkgDuration = e.Elapsed
+			}
+		}
+	}
+
+	return xml.MarshalIndent(toXML(pkgName, pkgDuration, testcases), "", "\t")
+}
+
+func toXML(pkgName string, pkgDuration *float64, testcases map[string]*testCase) *xmlTestSuites {
+	cases := make([]string, 0, len(testcases))
+	for k := range testcases {
+		cases = append(cases, k)
+	}
+	sort.Strings(cases)
+	suite := xmlTestSuite{
+		Name: pkgName,
+	}
+	if pkgDuration != nil {
+		suite.Time = fmt.Sprintf("%.3f", *pkgDuration)
+	}
+	for _, name := range cases {
+		c := testcases[name]
+		suite.Tests++
+		newCase := xmlTestCase{
+			Name:      name,
+			Classname: path.Base(pkgName),
+		}
+		if c.duration != nil {
+			newCase.Time = fmt.Sprintf("%.3f", *c.duration)
+		}
+		switch c.state {
+		case "skip":
+			suite.Skipped++
+			newCase.Skipped = &xmlMessage{
+				Message:  "Failed",
+				Contents: c.output.String(),
+			}
+		case "fail":
+			suite.Failures++
+			newCase.Failure = &xmlMessage{
+				Message:  "Failed",
+				Contents: c.output.String(),
+			}
+		case "pass":
+			break
+		default:
+			suite.Errors++
+			newCase.Error = &xmlMessage{
+				Message:  "No pass/skip/fail event found for test",
+				Contents: c.output.String(),
+			}
+		}
+		suite.TestCases = append(suite.TestCases, newCase)
+	}
+	return &xmlTestSuites{Suites: []xmlTestSuite{suite}}
+}

--- a/go/tools/testwrapper/xml_test.go
+++ b/go/tools/testwrapper/xml_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/go/tools/testwrapper/xml_test.go
+++ b/go/tools/testwrapper/xml_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestJSON2XML(t *testing.T) {
+	files, err := filepath.Glob("testdata/*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, file := range files {
+		name := strings.TrimSuffix(filepath.Base(file), ".json")
+		t.Run(name, func(t *testing.T) {
+			orig, err := os.Open(file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := json2xml(orig, "pkg/testing")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			target := strings.TrimSuffix(file, ".json") + ".xml"
+			want, err := ioutil.ReadFile(target)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(got, want) {
+				t.Errorf("json2xml for %s does not match, got:\n%s\nwant:\n%s\n", name, string(got), string(want))
+			}
+		})
+	}
+}

--- a/tests/core/go_test/BUILD.bazel
+++ b/tests/core/go_test/BUILD.bazel
@@ -144,6 +144,11 @@ go_bazel_test(
     srcs = ["test_filter_test.go"],
 )
 
+go_bazel_test(
+    name = "xmlreport_test",
+    srcs = ["xmlreport_test.go"],
+)
+
 go_test(
     name = "testmain_import_test",
     srcs = [

--- a/tests/core/go_test/xmlreport_test.go
+++ b/tests/core/go_test/xmlreport_test.go
@@ -17,6 +17,8 @@ package test_filter_test
 import (
 	"encoding/xml"
 	"io/ioutil"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
@@ -80,12 +82,16 @@ func Test(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected bazel test to have failed")
 	}
-	if xerr, ok := err.(*bazel_testing.StderrExitError); !ok {
+	if xerr, ok := err.(*bazel_testing.StderrExitError); !ok || xerr.Err.ExitCode() != 3 {
 		t.Fatalf("expected bazel tests to fail with exit code 3 (TESTS_FAILED), got: %s", err)
-	} else if xerr.Err.ExitCode() != 3 {
-		t.Fatalf("expected bazel tests to fail with exit code 3 (TESTS_FAILED), got: %s", xerr)
 	}
-	b, err := ioutil.ReadFile("bazel-out/darwin-fastbuild/testlogs/xml_test/test.xml")
+
+	p, err := bazel_testing.BazelOutput("info", "bazel-testlogs")
+	if err != nil {
+		t.Fatal("could not find testlog root: %s", err)
+	}
+	path := filepath.Join(strings.TrimSpace(string(p)), "xml_test/test.xml")
+	b, err := ioutil.ReadFile(path)
 	if err != nil {
 		t.Fatalf("could not read generated xml file: %s", err)
 	}

--- a/tests/core/go_test/xmlreport_test.go
+++ b/tests/core/go_test/xmlreport_test.go
@@ -1,0 +1,130 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test_filter_test
+
+import (
+	"encoding/xml"
+	"io/ioutil"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: `
+-- BUILD.bazel --
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "xml_test",
+    importpath = "github.com/bazelbuild/rules_go/tests/core/go_test/xml_test",
+    srcs = ["xml_test.go"],
+)
+
+-- xml_test.go --
+package test
+
+import (
+    "math/rand"
+    "testing"
+    "time"
+)
+
+func TestPass(t *testing.T) {
+    t.Parallel()
+}
+
+func TestPassLog(t *testing.T) {
+    t.Parallel()
+    t.Log("pass")
+}
+
+func TestFail(t *testing.T) {
+    t.Error("Not working")
+}
+
+func TestSubtests(t *testing.T) {
+    for i, subtest := range []string{"subtest a", "testB", "another subtest"} {
+        t.Run(subtest, func(t *testing.T) {
+            t.Logf("from subtest %s", subtest)
+            time.Sleep(time.Duration(rand.Intn(10)) * time.Millisecond)
+            t.Logf("from subtest %s", subtest)
+            if i%3 == 0 {
+                t.Skip("skipping this test")
+            }
+            if i%2 == 0 {
+                t.Fail()
+            }
+        })
+    }
+}
+`,
+	})
+}
+
+func Test(t *testing.T) {
+	err := bazel_testing.RunBazel("test", "//:xml_test")
+	if err == nil {
+		t.Fatal("expected bazel test to have failed")
+	}
+	if xerr, ok := err.(*bazel_testing.StderrExitError); !ok {
+		t.Fatalf("expected bazel tests to fail with exit code 3 (TESTS_FAILED), got: %s", err)
+	} else if xerr.Err.ExitCode() != 3 {
+		t.Fatalf("expected bazel tests to fail with exit code 3 (TESTS_FAILED), got: %s", xerr)
+	}
+	b, err := ioutil.ReadFile("bazel-out/darwin-fastbuild/testlogs/xml_test/test.xml")
+	if err != nil {
+		t.Fatalf("could not read generated xml file: %s", err)
+	}
+
+	// test execution time attributes will vary per testrun, so we must parse the
+	// xml to inspect a subset of testresults
+	type xmlTestSuite struct {
+		XMLName  xml.Name `xml:"testsuite"`
+		Errors   int      `xml:"errors,attr"`
+		Failures int      `xml:"failures,attr"`
+		Skipped  int      `xml:"skipped,attr"`
+		Tests    int      `xml:"tests,attr"`
+		Name     string   `xml:"name,attr"`
+	}
+	type xmlTestSuites struct {
+		XMLName xml.Name       `xml:"testsuites"`
+		Suites  []xmlTestSuite `xml:"testsuite"`
+	}
+	var suites xmlTestSuites
+	if err := xml.Unmarshal(b, &suites); err != nil {
+		t.Fatalf("could not unmarshall generated xml: %s", err)
+	}
+	if len(suites.Suites) != 1 {
+		t.Fatalf("expected 1 testsuite in the xml, got: %d", len(suites.Suites))
+	}
+	suite := suites.Suites[0]
+	if suite.Errors != 0 {
+		t.Errorf("expected suite.Errors to be 0, got %d", suite.Errors)
+	}
+	if suite.Failures != 3 {
+		t.Errorf("expected suite.Failures to be 3, got %d", suite.Failures)
+	}
+	if suite.Tests != 7 {
+		t.Errorf("expected suite.Tests to be 7, got %d", suite.Tests)
+	}
+	if suite.Skipped != 1 {
+		t.Errorf("expected suite.Skipped to be 1, got %d", suite.Skipped)
+	}
+	if suite.Name != "github.com/bazelbuild/rules_go/tests/core/go_test/xml_test" {
+		t.Errorf("expected suite.Name to be github.com/bazelbuild/rules_go/tests/core/go_test/xml_test, got %s", suite.Name)
+	}
+}


### PR DESCRIPTION
Based on the discussion in https://github.com/bazelbuild/rules_go/issues/236#issuecomment-577425507, add a testwrapper library that can be imported from the generated testmain.

The testlibrary has a Wrap function, that will check if the test was executed from Bazel. If it was, the wrapper function executes the binary itself, wraps some functionality like capturing stdout and exits with the exitcode from the child process. If the wrapper function decides to wrap, it does not return.