### PR TITLE
Test: use flag.Args() instead of os.Args[1:]

### DIFF
--- a/tests/legacy/transitive_data/transitive_data_test.go
+++ b/tests/legacy/transitive_data/transitive_data_test.go
@@ -1,17 +1,18 @@
 package transitive_data
 
 import (
+	"flag"
 	"os"
 	"testing"
 )
 
 func TestFiles(t *testing.T) {
-	filenames := os.Args[1:]
+	filenames := flag.Args()
 	if len(filenames) == 0 {
 		t.Fatal("no filenames given")
 	}
 
-	for _, filename := range os.Args[1:] {
+	for _, filename := range flag.Args() {
 		if _, err := os.Stat(filename); err != nil {
 			t.Error(err)
 		}


### PR DESCRIPTION
To make the test runnable with `-test.v` set.