### PR TITLE
Use paramfile for invoking nogo

### DIFF
--- a/go/tools/builders/nogo_main.go
+++ b/go/tools/builders/nogo_main.go
@@ -62,6 +62,11 @@ func main() {
 // run returns an error if there is a problem loading the package or if any
 // analysis fails.
 func run(args []string) error {
+	args, err := readParamsFiles(args)
+	if err != nil {
+		return fmt.Errorf("error reading paramfiles: %v", err)
+	}
+
 	factMap := factMultiFlag{}
 	flags := flag.NewFlagSet("nogo", flag.ExitOnError)
 	flags.Var(&factMap, "fact", "Import path and file containing facts for that library, separated by '=' (may be repeated)'")


### PR DESCRIPTION
When calling the builder binary from starlark, the `args.use_param_file`
option is used to support long argument lists. For nogo, the builder
calls the nogo binary with a list of arguments for which the size is
proportional to what the builder was called with. Currently nogo isn't
called with a parameter file but instead gets it's arguments from the
commandline.

This change writes the nogo arguments to file and calls nogo with an
argument to read the parameter file for arguments.

References #2002.