### PR TITLE
go_googleapis: fix dependencies

### DIFF
--- a/third_party/go_googleapis-gazelle.patch
+++ b/third_party/go_googleapis-gazelle.patch
@@ -9,14 +9,14 @@ diff -urN c/google/actions/type/BUILD.bazel d/google/actions/type/BUILD.bazel
 +    name = "date_range_proto",
 +    srcs = ["date_range.proto"],
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/type:date_proto"],
++    deps = ["//google/type:date_proto"],
 +)
 +
 +proto_library(
 +    name = "date_time_range_proto",
 +    srcs = ["datetime_range.proto"],
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/type:datetime_proto"],
++    deps = ["//google/type:datetime_proto"],
 +)
 +
 +go_proto_library(
@@ -24,7 +24,7 @@ diff -urN c/google/actions/type/BUILD.bazel d/google/actions/type/BUILD.bazel
 +    importpath = "google.golang.org/genproto/googleapis/type/date_range",
 +    proto = ":date_range_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/type:date_go_proto"],
++    deps = ["//google/type:date_go_proto"],
 +)
 +
 +go_proto_library(
@@ -32,12 +32,12 @@ diff -urN c/google/actions/type/BUILD.bazel d/google/actions/type/BUILD.bazel
 +    importpath = "google.golang.org/genproto/googleapis/type/date_time_range",
 +    proto = ":date_time_range_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/type:datetime_go_proto"],
++    deps = ["//google/type:datetime_go_proto"],
 +)
 diff -urN c/google/ads/admob/v1/BUILD.bazel d/google/ads/admob/v1/BUILD.bazel
 --- c/google/ads/admob/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/ads/admob/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,27 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -49,9 +49,8 @@ diff -urN c/google/ads/admob/v1/BUILD.bazel d/google/ads/admob/v1/BUILD.bazel
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/ads/admob/v1:admob_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/type:date_proto",
++        "//google/api:annotations_proto",
++        "//google/type:date_proto",
 +    ],
 +)
 +
@@ -62,15 +61,14 @@ diff -urN c/google/ads/admob/v1/BUILD.bazel d/google/ads/admob/v1/BUILD.bazel
 +    proto = ":admob_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/ads/admob/v1:admob_go_proto",
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/type:date_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/type:date_go_proto",
 +    ],
 +)
 diff -urN c/google/ads/googleads/v1/common/BUILD.bazel d/google/ads/googleads/v1/common/BUILD.bazel
 --- c/google/ads/googleads/v1/common/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/ads/googleads/v1/common/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,54 @@
+@@ -0,0 +1,52 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -107,10 +105,9 @@ diff -urN c/google/ads/googleads/v1/common/BUILD.bazel d/google/ads/googleads/v1
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/ads/googleads/v1/enums:enums_proto",
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/ads/googleads/v1/common:common_proto",
-+        "@go_googleapis//google/ads/googleads/v1/enums:enums_proto",
-+        "@go_googleapis//google/api:annotations_proto",
 +    ],
 +)
 +
@@ -120,9 +117,8 @@ diff -urN c/google/ads/googleads/v1/common/BUILD.bazel d/google/ads/googleads/v1
 +    proto = ":common_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/ads/googleads/v1/common:common_go_proto",
-+        "@go_googleapis//google/ads/googleads/v1/enums:enums_go_proto",
-+        "@go_googleapis//google/api:annotations_go_proto",
++        "//google/ads/googleads/v1/enums:enums_go_proto",
++        "//google/api:annotations_go_proto",
 +    ],
 +)
 diff -urN c/google/ads/googleads/v1/enums/BUILD.bazel d/google/ads/googleads/v1/enums/BUILD.bazel
@@ -339,7 +335,7 @@ diff -urN c/google/ads/googleads/v1/enums/BUILD.bazel d/google/ads/googleads/v1/
 +        "webpage_condition_operator.proto",
 +    ],
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_proto"],
++    deps = ["//google/api:annotations_proto"],
 +)
 +
 +go_proto_library(
@@ -347,12 +343,12 @@ diff -urN c/google/ads/googleads/v1/enums/BUILD.bazel d/google/ads/googleads/v1/
 +    importpath = "google.golang.org/genproto/googleapis/ads/googleads/v1/enums",
 +    proto = ":enums_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/ads/googleads/v1/errors/BUILD.bazel d/google/ads/googleads/v1/errors/BUILD.bazel
 --- c/google/ads/googleads/v1/errors/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/ads/googleads/v1/errors/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,130 @@
+@@ -0,0 +1,128 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -465,10 +461,9 @@ diff -urN c/google/ads/googleads/v1/errors/BUILD.bazel d/google/ads/googleads/v1
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/ads/googleads/v1/common:common_proto",
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/ads/googleads/v1/common:common_proto",
-+        "@go_googleapis//google/ads/googleads/v1/errors:errors_proto",
-+        "@go_googleapis//google/api:annotations_proto",
 +    ],
 +)
 +
@@ -478,15 +473,14 @@ diff -urN c/google/ads/googleads/v1/errors/BUILD.bazel d/google/ads/googleads/v1
 +    proto = ":errors_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/ads/googleads/v1/common:common_go_proto",
-+        "@go_googleapis//google/ads/googleads/v1/errors:errors_go_proto",
-+        "@go_googleapis//google/api:annotations_go_proto",
++        "//google/ads/googleads/v1/common:common_go_proto",
++        "//google/api:annotations_go_proto",
 +    ],
 +)
 diff -urN c/google/ads/googleads/v1/resources/BUILD.bazel d/google/ads/googleads/v1/resources/BUILD.bazel
 --- c/google/ads/googleads/v1/resources/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/ads/googleads/v1/resources/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,128 @@
+@@ -0,0 +1,126 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -593,12 +587,11 @@ diff -urN c/google/ads/googleads/v1/resources/BUILD.bazel d/google/ads/googleads
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/ads/googleads/v1/common:common_proto",
++        "//google/ads/googleads/v1/enums:enums_proto",
++        "//google/ads/googleads/v1/errors:errors_proto",
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/ads/googleads/v1/common:common_proto",
-+        "@go_googleapis//google/ads/googleads/v1/enums:enums_proto",
-+        "@go_googleapis//google/ads/googleads/v1/errors:errors_proto",
-+        "@go_googleapis//google/ads/googleads/v1/resources:resources_proto",
-+        "@go_googleapis//google/api:annotations_proto",
 +    ],
 +)
 +
@@ -608,17 +601,16 @@ diff -urN c/google/ads/googleads/v1/resources/BUILD.bazel d/google/ads/googleads
 +    proto = ":resources_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/ads/googleads/v1/common:common_go_proto",
-+        "@go_googleapis//google/ads/googleads/v1/enums:enums_go_proto",
-+        "@go_googleapis//google/ads/googleads/v1/errors:errors_go_proto",
-+        "@go_googleapis//google/ads/googleads/v1/resources:resources_go_proto",
-+        "@go_googleapis//google/api:annotations_go_proto",
++        "//google/ads/googleads/v1/common:common_go_proto",
++        "//google/ads/googleads/v1/enums:enums_go_proto",
++        "//google/ads/googleads/v1/errors:errors_go_proto",
++        "//google/api:annotations_go_proto",
 +    ],
 +)
 diff -urN c/google/ads/googleads/v1/services/BUILD.bazel d/google/ads/googleads/v1/services/BUILD.bazel
 --- c/google/ads/googleads/v1/services/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/ads/googleads/v1/services/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,138 @@
+@@ -0,0 +1,136 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -728,16 +720,15 @@ diff -urN c/google/ads/googleads/v1/services/BUILD.bazel d/google/ads/googleads/
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/ads/googleads/v1/common:common_proto",
++        "//google/ads/googleads/v1/enums:enums_proto",
++        "//google/ads/googleads/v1/resources:resources_proto",
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/ads/googleads/v1/common:common_proto",
-+        "@go_googleapis//google/ads/googleads/v1/enums:enums_proto",
-+        "@go_googleapis//google/ads/googleads/v1/resources:resources_proto",
-+        "@go_googleapis//google/ads/googleads/v1/services:services_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -748,19 +739,18 @@ diff -urN c/google/ads/googleads/v1/services/BUILD.bazel d/google/ads/googleads/
 +    proto = ":services_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/ads/googleads/v1/common:common_go_proto",
-+        "@go_googleapis//google/ads/googleads/v1/enums:enums_go_proto",
-+        "@go_googleapis//google/ads/googleads/v1/resources:resources_go_proto",
-+        "@go_googleapis//google/ads/googleads/v1/services:services_go_proto",
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/ads/googleads/v1/common:common_go_proto",
++        "//google/ads/googleads/v1/enums:enums_go_proto",
++        "//google/ads/googleads/v1/resources:resources_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/ads/googleads/v2/common/BUILD.bazel d/google/ads/googleads/v2/common/BUILD.bazel
 --- c/google/ads/googleads/v2/common/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/ads/googleads/v2/common/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,54 @@
+@@ -0,0 +1,52 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -797,10 +787,9 @@ diff -urN c/google/ads/googleads/v2/common/BUILD.bazel d/google/ads/googleads/v2
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/ads/googleads/v2/enums:enums_proto",
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/ads/googleads/v2/common:common_proto",
-+        "@go_googleapis//google/ads/googleads/v2/enums:enums_proto",
-+        "@go_googleapis//google/api:annotations_proto",
 +    ],
 +)
 +
@@ -810,9 +799,8 @@ diff -urN c/google/ads/googleads/v2/common/BUILD.bazel d/google/ads/googleads/v2
 +    proto = ":common_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/ads/googleads/v2/common:common_go_proto",
-+        "@go_googleapis//google/ads/googleads/v2/enums:enums_go_proto",
-+        "@go_googleapis//google/api:annotations_go_proto",
++        "//google/ads/googleads/v2/enums:enums_go_proto",
++        "//google/api:annotations_go_proto",
 +    ],
 +)
 diff -urN c/google/ads/googleads/v2/enums/BUILD.bazel d/google/ads/googleads/v2/enums/BUILD.bazel
@@ -1038,7 +1026,7 @@ diff -urN c/google/ads/googleads/v2/enums/BUILD.bazel d/google/ads/googleads/v2/
 +        "webpage_condition_operator.proto",
 +    ],
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_proto"],
++    deps = ["//google/api:annotations_proto"],
 +)
 +
 +go_proto_library(
@@ -1046,12 +1034,12 @@ diff -urN c/google/ads/googleads/v2/enums/BUILD.bazel d/google/ads/googleads/v2/
 +    importpath = "google.golang.org/genproto/googleapis/ads/googleads/v2/enums",
 +    proto = ":enums_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/ads/googleads/v2/errors/BUILD.bazel d/google/ads/googleads/v2/errors/BUILD.bazel
 --- c/google/ads/googleads/v2/errors/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/ads/googleads/v2/errors/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,134 @@
+@@ -0,0 +1,132 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1168,10 +1156,9 @@ diff -urN c/google/ads/googleads/v2/errors/BUILD.bazel d/google/ads/googleads/v2
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/ads/googleads/v2/common:common_proto",
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/ads/googleads/v2/common:common_proto",
-+        "@go_googleapis//google/ads/googleads/v2/errors:errors_proto",
-+        "@go_googleapis//google/api:annotations_proto",
 +    ],
 +)
 +
@@ -1181,15 +1168,14 @@ diff -urN c/google/ads/googleads/v2/errors/BUILD.bazel d/google/ads/googleads/v2
 +    proto = ":errors_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/ads/googleads/v2/common:common_go_proto",
-+        "@go_googleapis//google/ads/googleads/v2/errors:errors_go_proto",
-+        "@go_googleapis//google/api:annotations_go_proto",
++        "//google/ads/googleads/v2/common:common_go_proto",
++        "//google/api:annotations_go_proto",
 +    ],
 +)
 diff -urN c/google/ads/googleads/v2/resources/BUILD.bazel d/google/ads/googleads/v2/resources/BUILD.bazel
 --- c/google/ads/googleads/v2/resources/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/ads/googleads/v2/resources/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,132 @@
+@@ -0,0 +1,130 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1300,12 +1286,11 @@ diff -urN c/google/ads/googleads/v2/resources/BUILD.bazel d/google/ads/googleads
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/ads/googleads/v2/common:common_proto",
++        "//google/ads/googleads/v2/enums:enums_proto",
++        "//google/ads/googleads/v2/errors:errors_proto",
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/ads/googleads/v2/common:common_proto",
-+        "@go_googleapis//google/ads/googleads/v2/enums:enums_proto",
-+        "@go_googleapis//google/ads/googleads/v2/errors:errors_proto",
-+        "@go_googleapis//google/ads/googleads/v2/resources:resources_proto",
-+        "@go_googleapis//google/api:annotations_proto",
 +    ],
 +)
 +
@@ -1315,17 +1300,16 @@ diff -urN c/google/ads/googleads/v2/resources/BUILD.bazel d/google/ads/googleads
 +    proto = ":resources_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/ads/googleads/v2/common:common_go_proto",
-+        "@go_googleapis//google/ads/googleads/v2/enums:enums_go_proto",
-+        "@go_googleapis//google/ads/googleads/v2/errors:errors_go_proto",
-+        "@go_googleapis//google/ads/googleads/v2/resources:resources_go_proto",
-+        "@go_googleapis//google/api:annotations_go_proto",
++        "//google/ads/googleads/v2/common:common_go_proto",
++        "//google/ads/googleads/v2/enums:enums_go_proto",
++        "//google/ads/googleads/v2/errors:errors_go_proto",
++        "//google/api:annotations_go_proto",
 +    ],
 +)
 diff -urN c/google/ads/googleads/v2/services/BUILD.bazel d/google/ads/googleads/v2/services/BUILD.bazel
 --- c/google/ads/googleads/v2/services/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/ads/googleads/v2/services/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,144 @@
+@@ -0,0 +1,142 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1441,16 +1425,15 @@ diff -urN c/google/ads/googleads/v2/services/BUILD.bazel d/google/ads/googleads/
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/ads/googleads/v2/common:common_proto",
++        "//google/ads/googleads/v2/enums:enums_proto",
++        "//google/ads/googleads/v2/resources:resources_proto",
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/ads/googleads/v2/common:common_proto",
-+        "@go_googleapis//google/ads/googleads/v2/enums:enums_proto",
-+        "@go_googleapis//google/ads/googleads/v2/resources:resources_proto",
-+        "@go_googleapis//google/ads/googleads/v2/services:services_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -1461,19 +1444,18 @@ diff -urN c/google/ads/googleads/v2/services/BUILD.bazel d/google/ads/googleads/
 +    proto = ":services_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/ads/googleads/v2/common:common_go_proto",
-+        "@go_googleapis//google/ads/googleads/v2/enums:enums_go_proto",
-+        "@go_googleapis//google/ads/googleads/v2/resources:resources_go_proto",
-+        "@go_googleapis//google/ads/googleads/v2/services:services_go_proto",
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/ads/googleads/v2/common:common_go_proto",
++        "//google/ads/googleads/v2/enums:enums_go_proto",
++        "//google/ads/googleads/v2/resources:resources_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/api/BUILD.bazel d/google/api/BUILD.bazel
 --- c/google/api/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/api/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,188 @@
+@@ -0,0 +1,182 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1487,10 +1469,7 @@ diff -urN c/google/api/BUILD.bazel d/google/api/BUILD.bazel
 +        "resource.proto",
 +    ],
 +    visibility = ["//visibility:public"],
-+    deps = [
-+        "@com_google_protobuf//:descriptor_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+    ],
++    deps = ["@com_google_protobuf//:descriptor_proto"],
 +)
 +
 +proto_library(
@@ -1533,9 +1512,9 @@ diff -urN c/google/api/BUILD.bazel d/google/api/BUILD.bazel
 +    srcs = ["metric.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        ":api_proto",
++        ":label_proto",
 +        "@com_google_protobuf//:duration_proto",
-+        "@go_googleapis//google/api:api_proto",
-+        "@go_googleapis//google/api:label_proto",
 +    ],
 +)
 +
@@ -1544,9 +1523,9 @@ diff -urN c/google/api/BUILD.bazel d/google/api/BUILD.bazel
 +    srcs = ["monitored_resource.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        ":api_proto",
++        ":label_proto",
 +        "@com_google_protobuf//:struct_proto",
-+        "@go_googleapis//google/api:api_proto",
-+        "@go_googleapis//google/api:label_proto",
 +    ],
 +)
 +
@@ -1572,15 +1551,14 @@ diff -urN c/google/api/BUILD.bazel d/google/api/BUILD.bazel
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        ":annotations_proto",
++        ":label_proto",
++        ":metric_proto",
++        ":monitoredres_proto",
 +        "@com_google_protobuf//:any_proto",
 +        "@com_google_protobuf//:api_proto",
 +        "@com_google_protobuf//:type_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/api:label_proto",
-+        "@go_googleapis//google/api:metric_proto",
-+        "@go_googleapis//google/api:monitoredres_proto",
-+        "@go_googleapis//google/api:serviceconfig_proto",
 +    ],
 +)
 +
@@ -1589,7 +1567,6 @@ diff -urN c/google/api/BUILD.bazel d/google/api/BUILD.bazel
 +    importpath = "google.golang.org/genproto/googleapis/api/annotations",
 +    proto = ":annotations_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
 +)
 +
 +go_proto_library(
@@ -1633,8 +1610,8 @@ diff -urN c/google/api/BUILD.bazel d/google/api/BUILD.bazel
 +    proto = ":metric_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:api_go_proto",
-+        "@go_googleapis//google/api:label_go_proto",
++        ":api_go_proto",
++        ":label_go_proto",
 +    ],
 +)
 +
@@ -1644,8 +1621,8 @@ diff -urN c/google/api/BUILD.bazel d/google/api/BUILD.bazel
 +    proto = ":monitoredres_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:api_go_proto",
-+        "@go_googleapis//google/api:label_go_proto",
++        ":api_go_proto",
++        ":label_go_proto",
 +    ],
 +)
 +
@@ -1655,17 +1632,16 @@ diff -urN c/google/api/BUILD.bazel d/google/api/BUILD.bazel
 +    proto = ":serviceconfig_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/api:label_go_proto",
-+        "@go_googleapis//google/api:metric_go_proto",
-+        "@go_googleapis//google/api:monitoredres_go_proto",
-+        "@go_googleapis//google/api:serviceconfig_go_proto",
++        ":annotations_go_proto",
++        ":label_go_proto",
++        ":metric_go_proto",
++        ":monitoredres_go_proto",
 +    ],
 +)
 diff -urN c/google/api/expr/v1alpha1/BUILD.bazel d/google/api/expr/v1alpha1/BUILD.bazel
 --- c/google/api/expr/v1alpha1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/api/expr/v1alpha1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,37 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1682,14 +1658,13 @@ diff -urN c/google/api/expr/v1alpha1/BUILD.bazel d/google/api/expr/v1alpha1/BUIL
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:any_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:struct_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/api/expr/v1alpha1:expr_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -1700,15 +1675,14 @@ diff -urN c/google/api/expr/v1alpha1/BUILD.bazel d/google/api/expr/v1alpha1/BUIL
 +    proto = ":expr_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/api/expr/v1alpha1:expr_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/api/expr/v1beta1/BUILD.bazel d/google/api/expr/v1beta1/BUILD.bazel
 --- c/google/api/expr/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/api/expr/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,31 @@
+@@ -0,0 +1,27 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1723,10 +1697,9 @@ diff -urN c/google/api/expr/v1beta1/BUILD.bazel d/google/api/expr/v1beta1/BUILD.
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:any_proto",
 +        "@com_google_protobuf//:struct_proto",
-+        "@go_googleapis//google/api/expr/v1beta1:expr_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -1735,15 +1708,12 @@ diff -urN c/google/api/expr/v1beta1/BUILD.bazel d/google/api/expr/v1beta1/BUILD.
 +    importpath = "google.golang.org/genproto/googleapis/api/expr/v1beta1",
 +    proto = ":expr_proto",
 +    visibility = ["//visibility:public"],
-+    deps = [
-+        "@go_googleapis//google/api/expr/v1beta1:expr_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
-+    ],
++    deps = ["//google/rpc:status_go_proto"],
 +)
 diff -urN c/google/api/servicecontrol/v1/BUILD.bazel d/google/api/servicecontrol/v1/BUILD.bazel
 --- c/google/api/servicecontrol/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/api/servicecontrol/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,41 @@
+@@ -0,0 +1,39 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1760,14 +1730,13 @@ diff -urN c/google/api/servicecontrol/v1/BUILD.bazel d/google/api/servicecontrol
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/logging/type:ltype_proto",
++        "//google/rpc:status_proto",
++        "//google/type:money_proto",
 +        "@com_google_protobuf//:any_proto",
 +        "@com_google_protobuf//:struct_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/api/servicecontrol/v1:servicecontrol_proto",
-+        "@go_googleapis//google/logging/type:ltype_proto",
-+        "@go_googleapis//google/rpc:status_proto",
-+        "@go_googleapis//google/type:money_proto",
 +    ],
 +)
 +
@@ -1778,17 +1747,16 @@ diff -urN c/google/api/servicecontrol/v1/BUILD.bazel d/google/api/servicecontrol
 +    proto = ":servicecontrol_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/api/servicecontrol/v1:servicecontrol_go_proto",
-+        "@go_googleapis//google/logging/type:ltype_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
-+        "@go_googleapis//google/type:money_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/logging/type:ltype_go_proto",
++        "//google/rpc:status_go_proto",
++        "//google/type:money_go_proto",
 +    ],
 +)
 diff -urN c/google/api/servicemanagement/v1/BUILD.bazel d/google/api/servicemanagement/v1/BUILD.bazel
 --- c/google/api/servicemanagement/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/api/servicemanagement/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,40 @@
+@@ -0,0 +1,38 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1800,16 +1768,15 @@ diff -urN c/google/api/servicemanagement/v1/BUILD.bazel d/google/api/servicemana
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/api:configchange_proto",
++        "//google/api:metric_proto",
++        "//google/api:serviceconfig_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:any_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/api:configchange_proto",
-+        "@go_googleapis//google/api:metric_proto",
-+        "@go_googleapis//google/api:serviceconfig_proto",
-+        "@go_googleapis//google/api/servicemanagement/v1:servicemanagement_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -1820,13 +1787,12 @@ diff -urN c/google/api/servicemanagement/v1/BUILD.bazel d/google/api/servicemana
 +    proto = ":servicemanagement_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/api:configchange_go_proto",
-+        "@go_googleapis//google/api:metric_go_proto",
-+        "@go_googleapis//google/api:serviceconfig_go_proto",
-+        "@go_googleapis//google/api/servicemanagement/v1:servicemanagement_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/api:configchange_go_proto",
++        "//google/api:metric_go_proto",
++        "//google/api:serviceconfig_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/appengine/legacy/BUILD.bazel d/google/appengine/legacy/BUILD.bazel
@@ -1860,9 +1826,9 @@ diff -urN c/google/appengine/logging/v1/BUILD.bazel d/google/appengine/logging/v
 +    srcs = ["request_log.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/logging/type:ltype_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/logging/type:ltype_proto",
 +    ],
 +)
 +
@@ -1871,12 +1837,12 @@ diff -urN c/google/appengine/logging/v1/BUILD.bazel d/google/appengine/logging/v
 +    importpath = "google.golang.org/genproto/googleapis/appengine/logging/v1",
 +    proto = ":logging_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/logging/type:ltype_go_proto"],
++    deps = ["//google/logging/type:ltype_go_proto"],
 +)
 diff -urN c/google/appengine/v1/BUILD.bazel d/google/appengine/v1/BUILD.bazel
 --- c/google/appengine/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/appengine/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,45 @@
+@@ -0,0 +1,43 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1896,15 +1862,14 @@ diff -urN c/google/appengine/v1/BUILD.bazel d/google/appengine/v1/BUILD.bazel
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/type:latlng_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/appengine/v1:appengine_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/type:latlng_proto",
 +    ],
 +)
 +
@@ -1915,11 +1880,10 @@ diff -urN c/google/appengine/v1/BUILD.bazel d/google/appengine/v1/BUILD.bazel
 +    proto = ":appengine_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/appengine/v1:appengine_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/type:latlng_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/type:latlng_go_proto",
 +    ],
 +)
 diff -urN c/google/assistant/embedded/v1alpha1/BUILD.bazel d/google/assistant/embedded/v1alpha1/BUILD.bazel
@@ -1934,8 +1898,8 @@ diff -urN c/google/assistant/embedded/v1alpha1/BUILD.bazel d/google/assistant/em
 +    srcs = ["embedded_assistant.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/rpc:status_proto",
++        "//google/api:annotations_proto",
++        "//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -1946,8 +1910,8 @@ diff -urN c/google/assistant/embedded/v1alpha1/BUILD.bazel d/google/assistant/em
 +    proto = ":embedded_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/assistant/embedded/v1alpha2/BUILD.bazel d/google/assistant/embedded/v1alpha2/BUILD.bazel
@@ -1962,8 +1926,8 @@ diff -urN c/google/assistant/embedded/v1alpha2/BUILD.bazel d/google/assistant/em
 +    srcs = ["embedded_assistant.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/type:latlng_proto",
++        "//google/api:annotations_proto",
++        "//google/type:latlng_proto",
 +    ],
 +)
 +
@@ -1974,14 +1938,14 @@ diff -urN c/google/assistant/embedded/v1alpha2/BUILD.bazel d/google/assistant/em
 +    proto = ":embedded_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/type:latlng_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/type:latlng_go_proto",
 +    ],
 +)
 diff -urN c/google/bigtable/admin/cluster/v1/BUILD.bazel d/google/bigtable/admin/cluster/v1/BUILD.bazel
 --- c/google/bigtable/admin/cluster/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/bigtable/admin/cluster/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,30 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -1994,11 +1958,10 @@ diff -urN c/google/bigtable/admin/cluster/v1/BUILD.bazel d/google/bigtable/admin
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/bigtable/admin/cluster/v1:cluster_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
 +    ],
 +)
 +
@@ -2009,15 +1972,14 @@ diff -urN c/google/bigtable/admin/cluster/v1/BUILD.bazel d/google/bigtable/admin
 +    proto = ":cluster_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/bigtable/admin/cluster/v1:cluster_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
 +    ],
 +)
 diff -urN c/google/bigtable/admin/table/v1/BUILD.bazel d/google/bigtable/admin/table/v1/BUILD.bazel
 --- c/google/bigtable/admin/table/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/bigtable/admin/table/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,30 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2030,11 +1992,10 @@ diff -urN c/google/bigtable/admin/table/v1/BUILD.bazel d/google/bigtable/admin/t
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/bigtable/admin/table/v1:table_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
 +    ],
 +)
 +
@@ -2045,15 +2006,14 @@ diff -urN c/google/bigtable/admin/table/v1/BUILD.bazel d/google/bigtable/admin/t
 +    proto = ":table_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/bigtable/admin/table/v1:table_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
 +    ],
 +)
 diff -urN c/google/bigtable/admin/v2/BUILD.bazel d/google/bigtable/admin/v2/BUILD.bazel
 --- c/google/bigtable/admin/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/bigtable/admin/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,38 @@
+@@ -0,0 +1,36 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2068,14 +2028,13 @@ diff -urN c/google/bigtable/admin/v2/BUILD.bazel d/google/bigtable/admin/v2/BUIL
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
++        "//google/longrunning:longrunning_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/bigtable/admin/v2:admin_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
 +    ],
 +)
 +
@@ -2086,16 +2045,15 @@ diff -urN c/google/bigtable/admin/v2/BUILD.bazel d/google/bigtable/admin/v2/BUIL
 +    proto = ":admin_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/bigtable/admin/v2:admin_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
++        "//google/longrunning:longrunning_go_proto",
 +    ],
 +)
 diff -urN c/google/bigtable/v1/BUILD.bazel d/google/bigtable/v1/BUILD.bazel
 --- c/google/bigtable/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/bigtable/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,31 @@
+@@ -0,0 +1,29 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2108,10 +2066,9 @@ diff -urN c/google/bigtable/v1/BUILD.bazel d/google/bigtable/v1/BUILD.bazel
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:empty_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/bigtable/v1:bigtable_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -2122,15 +2079,14 @@ diff -urN c/google/bigtable/v1/BUILD.bazel d/google/bigtable/v1/BUILD.bazel
 +    proto = ":bigtable_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/bigtable/v1:bigtable_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/bigtable/v2/BUILD.bazel d/google/bigtable/v2/BUILD.bazel
 --- c/google/bigtable/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/bigtable/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,30 @@
+@@ -0,0 +1,28 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2142,10 +2098,9 @@ diff -urN c/google/bigtable/v2/BUILD.bazel d/google/bigtable/v2/BUILD.bazel
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/bigtable/v2:bigtable_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -2156,9 +2111,8 @@ diff -urN c/google/bigtable/v2/BUILD.bazel d/google/bigtable/v2/BUILD.bazel
 +    proto = ":bigtable_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/bigtable/v2:bigtable_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/bytestream/BUILD.bazel d/google/bytestream/BUILD.bazel
@@ -2173,8 +2127,8 @@ diff -urN c/google/bytestream/BUILD.bazel d/google/bytestream/BUILD.bazel
 +    srcs = ["bytestream.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/api:annotations_proto",
 +    ],
 +)
 +
@@ -2184,7 +2138,7 @@ diff -urN c/google/bytestream/BUILD.bazel d/google/bytestream/BUILD.bazel
 +    importpath = "google.golang.org/genproto/googleapis/bytestream",
 +    proto = ":bytestream_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/cloud/BUILD.bazel d/google/cloud/BUILD.bazel
 --- c/google/cloud/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -2197,7 +2151,7 @@ diff -urN c/google/cloud/BUILD.bazel d/google/cloud/BUILD.bazel
 +    name = "cloud_proto",
 +    srcs = ["common_resources.proto"],
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_proto"],
++    deps = ["//google/api:annotations_proto"],
 +)
 +
 +go_proto_library(
@@ -2205,7 +2159,7 @@ diff -urN c/google/cloud/BUILD.bazel d/google/cloud/BUILD.bazel
 +    importpath = "google.golang.org/genproto/googleapis/cloud",
 +    proto = ":cloud_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/cloud/accessapproval/v1/BUILD.bazel d/google/cloud/accessapproval/v1/BUILD.bazel
 --- c/google/cloud/accessapproval/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -2219,10 +2173,10 @@ diff -urN c/google/cloud/accessapproval/v1/BUILD.bazel d/google/cloud/accessappr
 +    srcs = ["accessapproval.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
 +    ],
 +)
 +
@@ -2232,51 +2186,11 @@ diff -urN c/google/cloud/accessapproval/v1/BUILD.bazel d/google/cloud/accessappr
 +    importpath = "google.golang.org/genproto/googleapis/cloud/accessapproval/v1",
 +    proto = ":accessapproval_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/cloud/asset/v1/BUILD.bazel d/google/cloud/asset/v1/BUILD.bazel
 --- c/google/cloud/asset/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/asset/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,36 @@
-+load("@rules_proto//proto:defs.bzl", "proto_library")
-+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-+
-+proto_library(
-+    name = "asset_proto",
-+    srcs = [
-+        "asset_service.proto",
-+        "assets.proto",
-+    ],
-+    visibility = ["//visibility:public"],
-+    deps = [
-+        "@com_google_protobuf//:any_proto",
-+        "@com_google_protobuf//:empty_proto",
-+        "@com_google_protobuf//:field_mask_proto",
-+        "@com_google_protobuf//:struct_proto",
-+        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/asset/v1:asset_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+    ],
-+)
-+
-+go_proto_library(
-+    name = "asset_go_proto",
-+    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
-+    importpath = "google.golang.org/genproto/googleapis/cloud/asset/v1",
-+    proto = ":asset_proto",
-+    visibility = ["//visibility:public"],
-+    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/asset/v1:asset_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+    ],
-+)
-diff -urN c/google/cloud/asset/v1beta1/BUILD.bazel d/google/cloud/asset/v1beta1/BUILD.bazel
---- c/google/cloud/asset/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ d/google/cloud/asset/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,34 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
@@ -2289,13 +2203,50 @@ diff -urN c/google/cloud/asset/v1beta1/BUILD.bazel d/google/cloud/asset/v1beta1/
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
++        "//google/longrunning:longrunning_proto",
++        "@com_google_protobuf//:any_proto",
++        "@com_google_protobuf//:empty_proto",
++        "@com_google_protobuf//:field_mask_proto",
++        "@com_google_protobuf//:struct_proto",
++        "@com_google_protobuf//:timestamp_proto",
++    ],
++)
++
++go_proto_library(
++    name = "asset_go_proto",
++    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
++    importpath = "google.golang.org/genproto/googleapis/cloud/asset/v1",
++    proto = ":asset_proto",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++    ],
++)
+diff -urN c/google/cloud/asset/v1beta1/BUILD.bazel d/google/cloud/asset/v1beta1/BUILD.bazel
+--- c/google/cloud/asset/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ d/google/cloud/asset/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,32 @@
++load("@rules_proto//proto:defs.bzl", "proto_library")
++load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
++
++proto_library(
++    name = "asset_proto",
++    srcs = [
++        "asset_service.proto",
++        "assets.proto",
++    ],
++    visibility = ["//visibility:public"],
++    deps = [
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
++        "//google/longrunning:longrunning_proto",
 +        "@com_google_protobuf//:any_proto",
 +        "@com_google_protobuf//:struct_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/asset/v1beta1:asset_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
 +    ],
 +)
 +
@@ -2306,10 +2257,9 @@ diff -urN c/google/cloud/asset/v1beta1/BUILD.bazel d/google/cloud/asset/v1beta1/
 +    proto = ":asset_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/asset/v1beta1:asset_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
++        "//google/longrunning:longrunning_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/asset/v1p1beta1/BUILD.bazel d/google/cloud/asset/v1p1beta1/BUILD.bazel
@@ -2327,8 +2277,8 @@ diff -urN c/google/cloud/asset/v1p1beta1/BUILD.bazel d/google/cloud/asset/v1p1be
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
 +    ],
 +)
 +
@@ -2339,14 +2289,14 @@ diff -urN c/google/cloud/asset/v1p1beta1/BUILD.bazel d/google/cloud/asset/v1p1be
 +    proto = ":asset_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/asset/v1p2beta1/BUILD.bazel d/google/cloud/asset/v1p2beta1/BUILD.bazel
 --- c/google/cloud/asset/v1p2beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/asset/v1p2beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,36 @@
+@@ -0,0 +1,34 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2358,15 +2308,14 @@ diff -urN c/google/cloud/asset/v1p2beta1/BUILD.bazel d/google/cloud/asset/v1p2be
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
++        "//google/longrunning:longrunning_proto",
 +        "@com_google_protobuf//:any_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:struct_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/asset/v1p2beta1:asset_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
 +    ],
 +)
 +
@@ -2377,10 +2326,9 @@ diff -urN c/google/cloud/asset/v1p2beta1/BUILD.bazel d/google/cloud/asset/v1p2be
 +    proto = ":asset_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/asset/v1p2beta1:asset_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
++        "//google/longrunning:longrunning_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/asset/v1p4beta1/BUILD.bazel d/google/cloud/asset/v1p4beta1/BUILD.bazel
@@ -2398,11 +2346,11 @@ diff -urN c/google/cloud/asset/v1p4beta1/BUILD.bazel d/google/cloud/asset/v1p4be
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/rpc:code_proto",
 +        "@com_google_protobuf//:duration_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/rpc:code_proto",
 +    ],
 +)
 +
@@ -2413,10 +2361,10 @@ diff -urN c/google/cloud/asset/v1p4beta1/BUILD.bazel d/google/cloud/asset/v1p4be
 +    proto = ":asset_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/rpc:code_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/rpc:code_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/audit/BUILD.bazel d/google/cloud/audit/BUILD.bazel
@@ -2431,10 +2379,10 @@ diff -urN c/google/cloud/audit/BUILD.bazel d/google/cloud/audit/BUILD.bazel
 +    srcs = ["audit_log.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:any_proto",
 +        "@com_google_protobuf//:struct_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -2444,14 +2392,14 @@ diff -urN c/google/cloud/audit/BUILD.bazel d/google/cloud/audit/BUILD.bazel
 +    proto = ":audit_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/automl/v1/BUILD.bazel d/google/cloud/automl/v1/BUILD.bazel
 --- c/google/cloud/automl/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/automl/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,53 @@
+@@ -0,0 +1,51 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2480,15 +2428,14 @@ diff -urN c/google/cloud/automl/v1/BUILD.bazel d/google/cloud/automl/v1/BUILD.ba
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:any_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:struct_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/automl/v1:automl_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -2499,16 +2446,15 @@ diff -urN c/google/cloud/automl/v1/BUILD.bazel d/google/cloud/automl/v1/BUILD.ba
 +    proto = ":automl_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/automl/v1:automl_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/automl/v1beta1/BUILD.bazel d/google/cloud/automl/v1beta1/BUILD.bazel
 --- c/google/cloud/automl/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/automl/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,62 @@
+@@ -0,0 +1,60 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2546,15 +2492,14 @@ diff -urN c/google/cloud/automl/v1beta1/BUILD.bazel d/google/cloud/automl/v1beta
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:any_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:struct_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/automl/v1beta1:automl_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -2565,10 +2510,9 @@ diff -urN c/google/cloud/automl/v1beta1/BUILD.bazel d/google/cloud/automl/v1beta
 +    proto = ":automl_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/automl/v1beta1:automl_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/bigquery/connection/v1beta1/BUILD.bazel d/google/cloud/bigquery/connection/v1beta1/BUILD.bazel
@@ -2583,11 +2527,11 @@ diff -urN c/google/cloud/bigquery/connection/v1beta1/BUILD.bazel d/google/cloud/
 +    srcs = ["connection.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
 +    ],
 +)
 +
@@ -2598,14 +2542,14 @@ diff -urN c/google/cloud/bigquery/connection/v1beta1/BUILD.bazel d/google/cloud/
 +    proto = ":connection_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/bigquery/datatransfer/v1/BUILD.bazel d/google/cloud/bigquery/datatransfer/v1/BUILD.bazel
 --- c/google/cloud/bigquery/datatransfer/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/bigquery/datatransfer/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,35 @@
+@@ -0,0 +1,33 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2617,15 +2561,14 @@ diff -urN c/google/cloud/bigquery/datatransfer/v1/BUILD.bazel d/google/cloud/big
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:struct_proto",
 +        "@com_google_protobuf//:timestamp_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/bigquery/datatransfer/v1:datatransfer_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -2636,9 +2579,8 @@ diff -urN c/google/cloud/bigquery/datatransfer/v1/BUILD.bazel d/google/cloud/big
 +    proto = ":datatransfer_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/bigquery/datatransfer/v1:datatransfer_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/bigquery/logging/v1/BUILD.bazel d/google/cloud/bigquery/logging/v1/BUILD.bazel
@@ -2653,10 +2595,10 @@ diff -urN c/google/cloud/bigquery/logging/v1/BUILD.bazel d/google/cloud/bigquery
 +    srcs = ["audit_data.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -2666,8 +2608,8 @@ diff -urN c/google/cloud/bigquery/logging/v1/BUILD.bazel d/google/cloud/bigquery
 +    proto = ":logging_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/bigquery/reservation/v1beta1/BUILD.bazel d/google/cloud/bigquery/reservation/v1beta1/BUILD.bazel
@@ -2682,11 +2624,11 @@ diff -urN c/google/cloud/bigquery/reservation/v1beta1/BUILD.bazel d/google/cloud
 +    srcs = ["reservation.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -2697,8 +2639,8 @@ diff -urN c/google/cloud/bigquery/reservation/v1beta1/BUILD.bazel d/google/cloud
 +    proto = ":reservation_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/bigquery/storage/v1/BUILD.bazel d/google/cloud/bigquery/storage/v1/BUILD.bazel
@@ -2718,8 +2660,8 @@ diff -urN c/google/cloud/bigquery/storage/v1/BUILD.bazel d/google/cloud/bigquery
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
 +    ],
 +)
 +
@@ -2729,12 +2671,12 @@ diff -urN c/google/cloud/bigquery/storage/v1/BUILD.bazel d/google/cloud/bigquery
 +    importpath = "google.golang.org/genproto/googleapis/cloud/bigquery/storage/v1",
 +    proto = ":storage_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/cloud/bigquery/storage/v1alpha2/BUILD.bazel d/google/cloud/bigquery/storage/v1alpha2/BUILD.bazel
 --- c/google/cloud/bigquery/storage/v1alpha2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/bigquery/storage/v1alpha2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,35 @@
+@@ -0,0 +1,33 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2748,13 +2690,12 @@ diff -urN c/google/cloud/bigquery/storage/v1alpha2/BUILD.bazel d/google/cloud/bi
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:descriptor_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:timestamp_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/bigquery/storage/v1alpha2:storage_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -2765,15 +2706,14 @@ diff -urN c/google/cloud/bigquery/storage/v1alpha2/BUILD.bazel d/google/cloud/bi
 +    proto = ":storage_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/bigquery/storage/v1alpha2:storage_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/bigquery/storage/v1beta1/BUILD.bazel d/google/cloud/bigquery/storage/v1beta1/BUILD.bazel
 --- c/google/cloud/bigquery/storage/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/bigquery/storage/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,28 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2788,10 +2728,9 @@ diff -urN c/google/cloud/bigquery/storage/v1beta1/BUILD.bazel d/google/cloud/big
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/bigquery/storage/v1beta1:storage_proto",
 +    ],
 +)
 +
@@ -2801,15 +2740,12 @@ diff -urN c/google/cloud/bigquery/storage/v1beta1/BUILD.bazel d/google/cloud/big
 +    importpath = "google.golang.org/genproto/googleapis/cloud/bigquery/storage/v1beta1",
 +    proto = ":storage_proto",
 +    visibility = ["//visibility:public"],
-+    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/bigquery/storage/v1beta1:storage_go_proto",
-+    ],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/cloud/bigquery/storage/v1beta2/BUILD.bazel d/google/cloud/bigquery/storage/v1beta2/BUILD.bazel
 --- c/google/cloud/bigquery/storage/v1beta2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/bigquery/storage/v1beta2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,30 @@
+@@ -0,0 +1,26 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2823,9 +2759,8 @@ diff -urN c/google/cloud/bigquery/storage/v1beta2/BUILD.bazel d/google/cloud/big
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/bigquery/storage/v1beta2:storage_proto",
 +    ],
 +)
 +
@@ -2835,15 +2770,12 @@ diff -urN c/google/cloud/bigquery/storage/v1beta2/BUILD.bazel d/google/cloud/big
 +    importpath = "google.golang.org/genproto/googleapis/cloud/bigquery/storage/v1beta2",
 +    proto = ":storage_proto",
 +    visibility = ["//visibility:public"],
-+    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/bigquery/storage/v1beta2:storage_go_proto",
-+    ],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/cloud/bigquery/v2/BUILD.bazel d/google/cloud/bigquery/v2/BUILD.bazel
 --- c/google/cloud/bigquery/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/bigquery/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,28 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2857,11 +2789,10 @@ diff -urN c/google/cloud/bigquery/v2/BUILD.bazel d/google/cloud/bigquery/v2/BUIL
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:timestamp_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/bigquery/v2:bigquery_proto",
 +    ],
 +)
 +
@@ -2871,15 +2802,12 @@ diff -urN c/google/cloud/bigquery/v2/BUILD.bazel d/google/cloud/bigquery/v2/BUIL
 +    importpath = "google.golang.org/genproto/googleapis/cloud/bigquery/v2",
 +    proto = ":bigquery_proto",
 +    visibility = ["//visibility:public"],
-+    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/bigquery/v2:bigquery_go_proto",
-+    ],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/cloud/billing/budgets/v1alpha1/BUILD.bazel d/google/cloud/billing/budgets/v1alpha1/BUILD.bazel
 --- c/google/cloud/billing/budgets/v1alpha1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/billing/budgets/v1alpha1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,31 @@
+@@ -0,0 +1,29 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2891,11 +2819,10 @@ diff -urN c/google/cloud/billing/budgets/v1alpha1/BUILD.bazel d/google/cloud/bil
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/type:money_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/billing/budgets/v1alpha1:budgets_proto",
-+        "@go_googleapis//google/type:money_proto",
 +    ],
 +)
 +
@@ -2906,15 +2833,14 @@ diff -urN c/google/cloud/billing/budgets/v1alpha1/BUILD.bazel d/google/cloud/bil
 +    proto = ":budgets_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/billing/budgets/v1alpha1:budgets_go_proto",
-+        "@go_googleapis//google/type:money_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/type:money_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/billing/budgets/v1beta1/BUILD.bazel d/google/cloud/billing/budgets/v1beta1/BUILD.bazel
 --- c/google/cloud/billing/budgets/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/billing/budgets/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,31 @@
+@@ -0,0 +1,29 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2926,11 +2852,10 @@ diff -urN c/google/cloud/billing/budgets/v1beta1/BUILD.bazel d/google/cloud/bill
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/type:money_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/billing/budgets/v1beta1:budgets_proto",
-+        "@go_googleapis//google/type:money_proto",
 +    ],
 +)
 +
@@ -2941,9 +2866,8 @@ diff -urN c/google/cloud/billing/budgets/v1beta1/BUILD.bazel d/google/cloud/bill
 +    proto = ":budgets_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/billing/budgets/v1beta1:budgets_go_proto",
-+        "@go_googleapis//google/type:money_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/type:money_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/billing/v1/BUILD.bazel d/google/cloud/billing/v1/BUILD.bazel
@@ -2961,11 +2885,11 @@ diff -urN c/google/cloud/billing/v1/BUILD.bazel d/google/cloud/billing/v1/BUILD.
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
++        "//google/type:money_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
-+        "@go_googleapis//google/type:money_proto",
 +    ],
 +)
 +
@@ -2976,15 +2900,15 @@ diff -urN c/google/cloud/billing/v1/BUILD.bazel d/google/cloud/billing/v1/BUILD.
 +    proto = ":billing_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
-+        "@go_googleapis//google/type:money_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
++        "//google/type:money_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/binaryauthorization/v1beta1/BUILD.bazel d/google/cloud/binaryauthorization/v1beta1/BUILD.bazel
 --- c/google/cloud/binaryauthorization/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/binaryauthorization/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,25 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -2996,10 +2920,9 @@ diff -urN c/google/cloud/binaryauthorization/v1beta1/BUILD.bazel d/google/cloud/
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/binaryauthorization/v1beta1:binaryauthorization_proto",
 +    ],
 +)
 +
@@ -3009,15 +2932,12 @@ diff -urN c/google/cloud/binaryauthorization/v1beta1/BUILD.bazel d/google/cloud/
 +    importpath = "google.golang.org/genproto/googleapis/cloud/binaryauthorization/v1beta1",
 +    proto = ":binaryauthorization_proto",
 +    visibility = ["//visibility:public"],
-+    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/binaryauthorization/v1beta1:binaryauthorization_go_proto",
-+    ],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/cloud/datacatalog/v1beta1/BUILD.bazel d/google/cloud/datacatalog/v1beta1/BUILD.bazel
 --- c/google/cloud/datacatalog/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/datacatalog/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,40 @@
+@@ -0,0 +1,38 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3037,12 +2957,11 @@ diff -urN c/google/cloud/datacatalog/v1beta1/BUILD.bazel d/google/cloud/datacata
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/datacatalog/v1beta1:datacatalog_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
 +    ],
 +)
 +
@@ -3053,15 +2972,14 @@ diff -urN c/google/cloud/datacatalog/v1beta1/BUILD.bazel d/google/cloud/datacata
 +    proto = ":datacatalog_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/datacatalog/v1beta1:datacatalog_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/datalabeling/v1beta1/BUILD.bazel d/google/cloud/datalabeling/v1beta1/BUILD.bazel
 --- c/google/cloud/datalabeling/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/datalabeling/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,43 @@
+@@ -0,0 +1,41 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3081,14 +2999,13 @@ diff -urN c/google/cloud/datalabeling/v1beta1/BUILD.bazel d/google/cloud/datalab
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/datalabeling/v1beta1:datalabeling_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -3099,16 +3016,15 @@ diff -urN c/google/cloud/datalabeling/v1beta1/BUILD.bazel d/google/cloud/datalab
 +    proto = ":datalabeling_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/datalabeling/v1beta1:datalabeling_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/dataproc/v1/BUILD.bazel d/google/cloud/dataproc/v1/BUILD.bazel
 --- c/google/cloud/dataproc/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/dataproc/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,37 @@
+@@ -0,0 +1,35 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3124,13 +3040,12 @@ diff -urN c/google/cloud/dataproc/v1/BUILD.bazel d/google/cloud/dataproc/v1/BUIL
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/dataproc/v1:dataproc_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
 +    ],
 +)
 +
@@ -3141,15 +3056,14 @@ diff -urN c/google/cloud/dataproc/v1/BUILD.bazel d/google/cloud/dataproc/v1/BUIL
 +    proto = ":dataproc_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/dataproc/v1:dataproc_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/dataproc/v1beta2/BUILD.bazel d/google/cloud/dataproc/v1beta2/BUILD.bazel
 --- c/google/cloud/dataproc/v1beta2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/dataproc/v1beta2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,37 @@
+@@ -0,0 +1,35 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3165,13 +3079,12 @@ diff -urN c/google/cloud/dataproc/v1beta2/BUILD.bazel d/google/cloud/dataproc/v1
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/dataproc/v1beta2:dataproc_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
 +    ],
 +)
 +
@@ -3182,15 +3095,14 @@ diff -urN c/google/cloud/dataproc/v1beta2/BUILD.bazel d/google/cloud/dataproc/v1
 +    proto = ":dataproc_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/dataproc/v1beta2:dataproc_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/dialogflow/v2/BUILD.bazel d/google/cloud/dialogflow/v2/BUILD.bazel
 --- c/google/cloud/dialogflow/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/dialogflow/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,43 @@
+@@ -0,0 +1,41 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3208,15 +3120,14 @@ diff -urN c/google/cloud/dialogflow/v2/BUILD.bazel d/google/cloud/dialogflow/v2/
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/rpc:status_proto",
++        "//google/type:latlng_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:struct_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/dialogflow/v2:dialogflow_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/rpc:status_proto",
-+        "@go_googleapis//google/type:latlng_proto",
 +    ],
 +)
 +
@@ -3227,17 +3138,16 @@ diff -urN c/google/cloud/dialogflow/v2/BUILD.bazel d/google/cloud/dialogflow/v2/
 +    proto = ":dialogflow_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/dialogflow/v2:dialogflow_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
-+        "@go_googleapis//google/type:latlng_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/rpc:status_go_proto",
++        "//google/type:latlng_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/dialogflow/v2beta1/BUILD.bazel d/google/cloud/dialogflow/v2beta1/BUILD.bazel
 --- c/google/cloud/dialogflow/v2beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/dialogflow/v2beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,48 @@
+@@ -0,0 +1,46 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3259,16 +3169,15 @@ diff -urN c/google/cloud/dialogflow/v2beta1/BUILD.bazel d/google/cloud/dialogflo
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/rpc:status_proto",
++        "//google/type:latlng_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:struct_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/dialogflow/v2beta1:dialogflow_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/rpc:status_proto",
-+        "@go_googleapis//google/type:latlng_proto",
 +    ],
 +)
 +
@@ -3279,17 +3188,16 @@ diff -urN c/google/cloud/dialogflow/v2beta1/BUILD.bazel d/google/cloud/dialogflo
 +    proto = ":dialogflow_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/dialogflow/v2beta1:dialogflow_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
-+        "@go_googleapis//google/type:latlng_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/rpc:status_go_proto",
++        "//google/type:latlng_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/documentai/v1beta1/BUILD.bazel d/google/cloud/documentai/v1beta1/BUILD.bazel
 --- c/google/cloud/documentai/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/documentai/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,35 @@
+@@ -0,0 +1,33 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3302,12 +3210,11 @@ diff -urN c/google/cloud/documentai/v1beta1/BUILD.bazel d/google/cloud/documenta
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/rpc:status_proto",
++        "//google/type:color_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/documentai/v1beta1:documentai_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/rpc:status_proto",
-+        "@go_googleapis//google/type:color_proto",
 +    ],
 +)
 +
@@ -3318,11 +3225,10 @@ diff -urN c/google/cloud/documentai/v1beta1/BUILD.bazel d/google/cloud/documenta
 +    proto = ":documentai_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/documentai/v1beta1:documentai_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
-+        "@go_googleapis//google/type:color_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/rpc:status_go_proto",
++        "//google/type:color_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/functions/v1beta2/BUILD.bazel d/google/cloud/functions/v1beta2/BUILD.bazel
@@ -3340,11 +3246,11 @@ diff -urN c/google/cloud/functions/v1beta2/BUILD.bazel d/google/cloud/functions/
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
 +        "@com_google_protobuf//:any_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
 +    ],
 +)
 +
@@ -3355,14 +3261,14 @@ diff -urN c/google/cloud/functions/v1beta2/BUILD.bazel d/google/cloud/functions/
 +    proto = ":functions_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/iot/v1/BUILD.bazel d/google/cloud/iot/v1/BUILD.bazel
 --- c/google/cloud/iot/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/iot/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,32 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3374,13 +3280,12 @@ diff -urN c/google/cloud/iot/v1/BUILD.bazel d/google/cloud/iot/v1/BUILD.bazel
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/iot/v1:iot_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -3391,16 +3296,15 @@ diff -urN c/google/cloud/iot/v1/BUILD.bazel d/google/cloud/iot/v1/BUILD.bazel
 +    proto = ":iot_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/iot/v1:iot_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/irm/v1alpha2/BUILD.bazel d/google/cloud/irm/v1alpha2/BUILD.bazel
 --- c/google/cloud/irm/v1alpha2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/irm/v1alpha2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,30 @@
+@@ -0,0 +1,26 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3412,11 +3316,10 @@ diff -urN c/google/cloud/irm/v1alpha2/BUILD.bazel d/google/cloud/irm/v1alpha2/BU
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/irm/v1alpha2:irm_proto",
 +    ],
 +)
 +
@@ -3426,15 +3329,12 @@ diff -urN c/google/cloud/irm/v1alpha2/BUILD.bazel d/google/cloud/irm/v1alpha2/BU
 +    importpath = "google.golang.org/genproto/googleapis/cloud/irm/v1alpha2",
 +    proto = ":irm_proto",
 +    visibility = ["//visibility:public"],
-+    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/irm/v1alpha2:irm_go_proto",
-+    ],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/cloud/kms/v1/BUILD.bazel d/google/cloud/kms/v1/BUILD.bazel
 --- c/google/cloud/kms/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/kms/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,30 @@
+@@ -0,0 +1,26 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3446,11 +3346,10 @@ diff -urN c/google/cloud/kms/v1/BUILD.bazel d/google/cloud/kms/v1/BUILD.bazel
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/kms/v1:kms_proto",
 +    ],
 +)
 +
@@ -3460,10 +3359,7 @@ diff -urN c/google/cloud/kms/v1/BUILD.bazel d/google/cloud/kms/v1/BUILD.bazel
 +    importpath = "google.golang.org/genproto/googleapis/cloud/kms/v1",
 +    proto = ":kms_proto",
 +    visibility = ["//visibility:public"],
-+    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/kms/v1:kms_go_proto",
-+    ],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/cloud/language/v1/BUILD.bazel d/google/cloud/language/v1/BUILD.bazel
 --- c/google/cloud/language/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -3476,7 +3372,7 @@ diff -urN c/google/cloud/language/v1/BUILD.bazel d/google/cloud/language/v1/BUIL
 +    name = "language_proto",
 +    srcs = ["language_service.proto"],
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_proto"],
++    deps = ["//google/api:annotations_proto"],
 +)
 +
 +go_proto_library(
@@ -3485,7 +3381,7 @@ diff -urN c/google/cloud/language/v1/BUILD.bazel d/google/cloud/language/v1/BUIL
 +    importpath = "google.golang.org/genproto/googleapis/cloud/language/v1",
 +    proto = ":language_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/cloud/language/v1beta1/BUILD.bazel d/google/cloud/language/v1beta1/BUILD.bazel
 --- c/google/cloud/language/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -3498,7 +3394,7 @@ diff -urN c/google/cloud/language/v1beta1/BUILD.bazel d/google/cloud/language/v1
 +    name = "language_proto",
 +    srcs = ["language_service.proto"],
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_proto"],
++    deps = ["//google/api:annotations_proto"],
 +)
 +
 +go_proto_library(
@@ -3507,7 +3403,7 @@ diff -urN c/google/cloud/language/v1beta1/BUILD.bazel d/google/cloud/language/v1
 +    importpath = "google.golang.org/genproto/googleapis/cloud/language/v1beta1",
 +    proto = ":language_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/cloud/language/v1beta2/BUILD.bazel d/google/cloud/language/v1beta2/BUILD.bazel
 --- c/google/cloud/language/v1beta2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -3521,8 +3417,8 @@ diff -urN c/google/cloud/language/v1beta2/BUILD.bazel d/google/cloud/language/v1
 +    srcs = ["language_service.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
 +    ],
 +)
 +
@@ -3532,7 +3428,7 @@ diff -urN c/google/cloud/language/v1beta2/BUILD.bazel d/google/cloud/language/v1
 +    importpath = "google.golang.org/genproto/googleapis/cloud/language/v1beta2",
 +    proto = ":language_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/cloud/location/BUILD.bazel d/google/cloud/location/BUILD.bazel
 --- c/google/cloud/location/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -3546,8 +3442,8 @@ diff -urN c/google/cloud/location/BUILD.bazel d/google/cloud/location/BUILD.baze
 +    srcs = ["locations.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:any_proto",
-+        "@go_googleapis//google/api:annotations_proto",
 +    ],
 +)
 +
@@ -3557,7 +3453,7 @@ diff -urN c/google/cloud/location/BUILD.bazel d/google/cloud/location/BUILD.baze
 +    importpath = "google.golang.org/genproto/googleapis/cloud/location",
 +    proto = ":location_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/cloud/managedidentities/v1/BUILD.bazel d/google/cloud/managedidentities/v1/BUILD.bazel
 --- c/google/cloud/managedidentities/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -3574,10 +3470,10 @@ diff -urN c/google/cloud/managedidentities/v1/BUILD.bazel d/google/cloud/managed
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
 +    ],
 +)
 +
@@ -3588,8 +3484,8 @@ diff -urN c/google/cloud/managedidentities/v1/BUILD.bazel d/google/cloud/managed
 +    proto = ":managedidentities_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/managedidentities/v1beta1/BUILD.bazel d/google/cloud/managedidentities/v1beta1/BUILD.bazel
@@ -3607,10 +3503,10 @@ diff -urN c/google/cloud/managedidentities/v1beta1/BUILD.bazel d/google/cloud/ma
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
 +    ],
 +)
 +
@@ -3621,8 +3517,8 @@ diff -urN c/google/cloud/managedidentities/v1beta1/BUILD.bazel d/google/cloud/ma
 +    proto = ":managedidentities_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/memcache/v1beta2/BUILD.bazel d/google/cloud/memcache/v1beta2/BUILD.bazel
@@ -3637,10 +3533,10 @@ diff -urN c/google/cloud/memcache/v1beta2/BUILD.bazel d/google/cloud/memcache/v1
 +    srcs = ["cloud_memcache.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
 +    ],
 +)
 +
@@ -3651,14 +3547,14 @@ diff -urN c/google/cloud/memcache/v1beta2/BUILD.bazel d/google/cloud/memcache/v1
 +    proto = ":memcache_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/ml/v1/BUILD.bazel d/google/cloud/ml/v1/BUILD.bazel
 --- c/google/cloud/ml/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/ml/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,38 @@
+@@ -0,0 +1,36 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3673,13 +3569,12 @@ diff -urN c/google/cloud/ml/v1/BUILD.bazel d/google/cloud/ml/v1/BUILD.bazel
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/api:httpbody_proto",
++        "//google/api:serviceconfig_proto",
++        "//google/longrunning:longrunning_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/api:httpbody_proto",
-+        "@go_googleapis//google/api:serviceconfig_proto",
-+        "@go_googleapis//google/cloud/ml/v1:ml_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
 +    ],
 +)
 +
@@ -3690,11 +3585,10 @@ diff -urN c/google/cloud/ml/v1/BUILD.bazel d/google/cloud/ml/v1/BUILD.bazel
 +    proto = ":ml_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/api:httpbody_go_proto",
-+        "@go_googleapis//google/api:serviceconfig_go_proto",
-+        "@go_googleapis//google/cloud/ml/v1:ml_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/api:httpbody_go_proto",
++        "//google/api:serviceconfig_go_proto",
++        "//google/longrunning:longrunning_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/orgpolicy/v1/BUILD.bazel d/google/cloud/orgpolicy/v1/BUILD.bazel
@@ -3709,9 +3603,9 @@ diff -urN c/google/cloud/orgpolicy/v1/BUILD.bazel d/google/cloud/orgpolicy/v1/BU
 +    srcs = ["orgpolicy.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
 +    ],
 +)
 +
@@ -3720,12 +3614,12 @@ diff -urN c/google/cloud/orgpolicy/v1/BUILD.bazel d/google/cloud/orgpolicy/v1/BU
 +    importpath = "google.golang.org/genproto/googleapis/cloud/orgpolicy/v1",
 +    proto = ":orgpolicy_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/cloud/osconfig/agentendpoint/v1beta/BUILD.bazel d/google/cloud/osconfig/agentendpoint/v1beta/BUILD.bazel
 --- c/google/cloud/osconfig/agentendpoint/v1beta/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/osconfig/agentendpoint/v1beta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,23 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3738,10 +3632,7 @@ diff -urN c/google/cloud/osconfig/agentendpoint/v1beta/BUILD.bazel d/google/clou
 +        "tasks.proto",
 +    ],
 +    visibility = ["//visibility:public"],
-+    deps = [
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/osconfig/agentendpoint/v1beta:agentendpoint_proto",
-+    ],
++    deps = ["//google/api:annotations_proto"],
 +)
 +
 +go_proto_library(
@@ -3750,15 +3641,12 @@ diff -urN c/google/cloud/osconfig/agentendpoint/v1beta/BUILD.bazel d/google/clou
 +    importpath = "google.golang.org/genproto/googleapis/cloud/osconfig/agentendpoint/v1beta",
 +    proto = ":agentendpoint_proto",
 +    visibility = ["//visibility:public"],
-+    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/osconfig/agentendpoint/v1beta:agentendpoint_go_proto",
-+    ],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/cloud/osconfig/v1beta/BUILD.bazel d/google/cloud/osconfig/v1beta/BUILD.bazel
 --- c/google/cloud/osconfig/v1beta/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/osconfig/v1beta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,37 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -3772,15 +3660,14 @@ diff -urN c/google/cloud/osconfig/v1beta/BUILD.bazel d/google/cloud/osconfig/v1b
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/type:datetime_proto",
++        "//google/type:dayofweek_proto",
++        "//google/type:timeofday_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/osconfig/v1beta:osconfig_proto",
-+        "@go_googleapis//google/type:datetime_proto",
-+        "@go_googleapis//google/type:dayofweek_proto",
-+        "@go_googleapis//google/type:timeofday_proto",
 +    ],
 +)
 +
@@ -3791,11 +3678,10 @@ diff -urN c/google/cloud/osconfig/v1beta/BUILD.bazel d/google/cloud/osconfig/v1b
 +    proto = ":osconfig_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/osconfig/v1beta:osconfig_go_proto",
-+        "@go_googleapis//google/type:datetime_go_proto",
-+        "@go_googleapis//google/type:dayofweek_go_proto",
-+        "@go_googleapis//google/type:timeofday_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/type:datetime_go_proto",
++        "//google/type:dayofweek_go_proto",
++        "//google/type:timeofday_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/oslogin/common/BUILD.bazel d/google/cloud/oslogin/common/BUILD.bazel
@@ -3809,7 +3695,7 @@ diff -urN c/google/cloud/oslogin/common/BUILD.bazel d/google/cloud/oslogin/commo
 +    name = "common_proto",
 +    srcs = ["common.proto"],
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_proto"],
++    deps = ["//google/api:annotations_proto"],
 +)
 +
 +go_proto_library(
@@ -3817,7 +3703,7 @@ diff -urN c/google/cloud/oslogin/common/BUILD.bazel d/google/cloud/oslogin/commo
 +    importpath = "google.golang.org/genproto/googleapis/cloud/oslogin/common",
 +    proto = ":common_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/cloud/oslogin/v1/BUILD.bazel d/google/cloud/oslogin/v1/BUILD.bazel
 --- c/google/cloud/oslogin/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -3831,10 +3717,10 @@ diff -urN c/google/cloud/oslogin/v1/BUILD.bazel d/google/cloud/oslogin/v1/BUILD.
 +    srcs = ["oslogin.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/cloud/oslogin/common:common_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/oslogin/common:common_proto",
 +    ],
 +)
 +
@@ -3845,8 +3731,8 @@ diff -urN c/google/cloud/oslogin/v1/BUILD.bazel d/google/cloud/oslogin/v1/BUILD.
 +    proto = ":oslogin_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/oslogin/common:common_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/cloud/oslogin/common:common_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/oslogin/v1alpha/BUILD.bazel d/google/cloud/oslogin/v1alpha/BUILD.bazel
@@ -3861,10 +3747,10 @@ diff -urN c/google/cloud/oslogin/v1alpha/BUILD.bazel d/google/cloud/oslogin/v1al
 +    srcs = ["oslogin.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/cloud/oslogin/common:common_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/oslogin/common:common_proto",
 +    ],
 +)
 +
@@ -3875,8 +3761,8 @@ diff -urN c/google/cloud/oslogin/v1alpha/BUILD.bazel d/google/cloud/oslogin/v1al
 +    proto = ":oslogin_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/oslogin/common:common_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/cloud/oslogin/common:common_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/oslogin/v1beta/BUILD.bazel d/google/cloud/oslogin/v1beta/BUILD.bazel
@@ -3891,10 +3777,10 @@ diff -urN c/google/cloud/oslogin/v1beta/BUILD.bazel d/google/cloud/oslogin/v1bet
 +    srcs = ["oslogin.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/cloud/oslogin/common:common_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/oslogin/common:common_proto",
 +    ],
 +)
 +
@@ -3905,8 +3791,8 @@ diff -urN c/google/cloud/oslogin/v1beta/BUILD.bazel d/google/cloud/oslogin/v1bet
 +    proto = ":oslogin_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/oslogin/common:common_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/cloud/oslogin/common:common_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/phishingprotection/v1beta1/BUILD.bazel d/google/cloud/phishingprotection/v1beta1/BUILD.bazel
@@ -3920,7 +3806,7 @@ diff -urN c/google/cloud/phishingprotection/v1beta1/BUILD.bazel d/google/cloud/p
 +    name = "phishingprotection_proto",
 +    srcs = ["phishingprotection.proto"],
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_proto"],
++    deps = ["//google/api:annotations_proto"],
 +)
 +
 +go_proto_library(
@@ -3929,7 +3815,7 @@ diff -urN c/google/cloud/phishingprotection/v1beta1/BUILD.bazel d/google/cloud/p
 +    importpath = "google.golang.org/genproto/googleapis/cloud/phishingprotection/v1beta1",
 +    proto = ":phishingprotection_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/cloud/policytroubleshooter/v1/BUILD.bazel d/google/cloud/policytroubleshooter/v1/BUILD.bazel
 --- c/google/cloud/policytroubleshooter/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -3946,9 +3832,9 @@ diff -urN c/google/cloud/policytroubleshooter/v1/BUILD.bazel d/google/cloud/poli
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
-+        "@go_googleapis//google/type:expr_proto",
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
++        "//google/type:expr_proto",
 +    ],
 +)
 +
@@ -3959,9 +3845,9 @@ diff -urN c/google/cloud/policytroubleshooter/v1/BUILD.bazel d/google/cloud/poli
 +    proto = ":policytroubleshooter_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
-+        "@go_googleapis//google/type:expr_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
++        "//google/type:expr_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/recaptchaenterprise/v1beta1/BUILD.bazel d/google/cloud/recaptchaenterprise/v1beta1/BUILD.bazel
@@ -3976,10 +3862,10 @@ diff -urN c/google/cloud/recaptchaenterprise/v1beta1/BUILD.bazel d/google/cloud/
 +    srcs = ["recaptchaenterprise.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
 +    ],
 +)
 +
@@ -3989,7 +3875,7 @@ diff -urN c/google/cloud/recaptchaenterprise/v1beta1/BUILD.bazel d/google/cloud/
 +    importpath = "google.golang.org/genproto/googleapis/cloud/recaptchaenterprise/v1beta1",
 +    proto = ":recaptchaenterprise_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/cloud/recommendationengine/v1beta1/BUILD.bazel d/google/cloud/recommendationengine/v1beta1/BUILD.bazel
 --- c/google/cloud/recommendationengine/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -4012,15 +3898,15 @@ diff -urN c/google/cloud/recommendationengine/v1beta1/BUILD.bazel d/google/cloud
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/api:httpbody_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/rpc:status_proto",
++        "//google/type:date_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:struct_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/api:httpbody_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/rpc:status_proto",
-+        "@go_googleapis//google/type:date_proto",
 +    ],
 +)
 +
@@ -4031,11 +3917,11 @@ diff -urN c/google/cloud/recommendationengine/v1beta1/BUILD.bazel d/google/cloud
 +    proto = ":recommendationengine_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/api:httpbody_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
-+        "@go_googleapis//google/type:date_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/api:httpbody_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/rpc:status_go_proto",
++        "//google/type:date_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/recommender/v1/BUILD.bazel d/google/cloud/recommender/v1/BUILD.bazel
@@ -4053,11 +3939,11 @@ diff -urN c/google/cloud/recommender/v1/BUILD.bazel d/google/cloud/recommender/v
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/type:money_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:struct_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/type:money_proto",
 +    ],
 +)
 +
@@ -4068,14 +3954,14 @@ diff -urN c/google/cloud/recommender/v1/BUILD.bazel d/google/cloud/recommender/v
 +    proto = ":recommender_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/type:money_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/type:money_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/recommender/v1beta1/BUILD.bazel d/google/cloud/recommender/v1beta1/BUILD.bazel
 --- c/google/cloud/recommender/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/recommender/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,30 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -4087,12 +3973,11 @@ diff -urN c/google/cloud/recommender/v1beta1/BUILD.bazel d/google/cloud/recommen
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/type:money_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:struct_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/recommender/v1beta1:recommender_proto",
-+        "@go_googleapis//google/type:money_proto",
 +    ],
 +)
 +
@@ -4103,9 +3988,8 @@ diff -urN c/google/cloud/recommender/v1beta1/BUILD.bazel d/google/cloud/recommen
 +    proto = ":recommender_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/recommender/v1beta1:recommender_go_proto",
-+        "@go_googleapis//google/type:money_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/type:money_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/redis/v1/BUILD.bazel d/google/cloud/redis/v1/BUILD.bazel
@@ -4120,10 +4004,10 @@ diff -urN c/google/cloud/redis/v1/BUILD.bazel d/google/cloud/redis/v1/BUILD.baze
 +    srcs = ["cloud_redis.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
 +    ],
 +)
 +
@@ -4134,8 +4018,8 @@ diff -urN c/google/cloud/redis/v1/BUILD.bazel d/google/cloud/redis/v1/BUILD.baze
 +    proto = ":redis_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/redis/v1beta1/BUILD.bazel d/google/cloud/redis/v1beta1/BUILD.bazel
@@ -4150,10 +4034,10 @@ diff -urN c/google/cloud/redis/v1beta1/BUILD.bazel d/google/cloud/redis/v1beta1/
 +    srcs = ["cloud_redis.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
 +    ],
 +)
 +
@@ -4164,8 +4048,8 @@ diff -urN c/google/cloud/redis/v1beta1/BUILD.bazel d/google/cloud/redis/v1beta1/
 +    proto = ":redis_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/resourcemanager/v2/BUILD.bazel d/google/cloud/resourcemanager/v2/BUILD.bazel
@@ -4180,11 +4064,11 @@ diff -urN c/google/cloud/resourcemanager/v2/BUILD.bazel d/google/cloud/resourcem
 +    srcs = ["folders.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
++        "//google/longrunning:longrunning_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
 +    ],
 +)
 +
@@ -4195,15 +4079,15 @@ diff -urN c/google/cloud/resourcemanager/v2/BUILD.bazel d/google/cloud/resourcem
 +    proto = ":resourcemanager_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
++        "//google/longrunning:longrunning_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/runtimeconfig/v1beta1/BUILD.bazel d/google/cloud/runtimeconfig/v1beta1/BUILD.bazel
 --- c/google/cloud/runtimeconfig/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/runtimeconfig/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,32 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -4215,13 +4099,12 @@ diff -urN c/google/cloud/runtimeconfig/v1beta1/BUILD.bazel d/google/cloud/runtim
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/runtimeconfig/v1beta1:runtimeconfig_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -4232,16 +4115,15 @@ diff -urN c/google/cloud/runtimeconfig/v1beta1/BUILD.bazel d/google/cloud/runtim
 +    proto = ":runtimeconfig_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/runtimeconfig/v1beta1:runtimeconfig_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/scheduler/v1/BUILD.bazel d/google/cloud/scheduler/v1/BUILD.bazel
 --- c/google/cloud/scheduler/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/scheduler/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,32 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -4254,13 +4136,12 @@ diff -urN c/google/cloud/scheduler/v1/BUILD.bazel d/google/cloud/scheduler/v1/BU
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/scheduler/v1:scheduler_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -4271,15 +4152,14 @@ diff -urN c/google/cloud/scheduler/v1/BUILD.bazel d/google/cloud/scheduler/v1/BU
 +    proto = ":scheduler_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/scheduler/v1:scheduler_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/scheduler/v1beta1/BUILD.bazel d/google/cloud/scheduler/v1beta1/BUILD.bazel
 --- c/google/cloud/scheduler/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/scheduler/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,32 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -4292,13 +4172,12 @@ diff -urN c/google/cloud/scheduler/v1beta1/BUILD.bazel d/google/cloud/scheduler/
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/scheduler/v1beta1:scheduler_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -4309,9 +4188,8 @@ diff -urN c/google/cloud/scheduler/v1beta1/BUILD.bazel d/google/cloud/scheduler/
 +    proto = ":scheduler_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/scheduler/v1beta1:scheduler_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/secretmanager/v1/BUILD.bazel d/google/cloud/secretmanager/v1/BUILD.bazel
@@ -4329,11 +4207,11 @@ diff -urN c/google/cloud/secretmanager/v1/BUILD.bazel d/google/cloud/secretmanag
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
 +    ],
 +)
 +
@@ -4344,14 +4222,14 @@ diff -urN c/google/cloud/secretmanager/v1/BUILD.bazel d/google/cloud/secretmanag
 +    proto = ":secretmanager_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/secrets/v1beta1/BUILD.bazel d/google/cloud/secrets/v1beta1/BUILD.bazel
 --- c/google/cloud/secrets/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/secrets/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,30 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -4363,12 +4241,11 @@ diff -urN c/google/cloud/secrets/v1beta1/BUILD.bazel d/google/cloud/secrets/v1be
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/secrets/v1beta1:secretmanager_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
 +    ],
 +)
 +
@@ -4379,15 +4256,14 @@ diff -urN c/google/cloud/secrets/v1beta1/BUILD.bazel d/google/cloud/secrets/v1be
 +    proto = ":secretmanager_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/secrets/v1beta1:secretmanager_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/securitycenter/v1/BUILD.bazel d/google/cloud/securitycenter/v1/BUILD.bazel
 --- c/google/cloud/securitycenter/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/securitycenter/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,41 @@
+@@ -0,0 +1,39 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -4404,15 +4280,14 @@ diff -urN c/google/cloud/securitycenter/v1/BUILD.bazel d/google/cloud/securityce
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
++        "//google/longrunning:longrunning_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:struct_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/securitycenter/v1:securitycenter_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
 +    ],
 +)
 +
@@ -4423,16 +4298,15 @@ diff -urN c/google/cloud/securitycenter/v1/BUILD.bazel d/google/cloud/securityce
 +    proto = ":securitycenter_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/securitycenter/v1:securitycenter_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
++        "//google/longrunning:longrunning_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/securitycenter/v1beta1/BUILD.bazel d/google/cloud/securitycenter/v1beta1/BUILD.bazel
 --- c/google/cloud/securitycenter/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/securitycenter/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,41 @@
+@@ -0,0 +1,39 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -4449,15 +4323,14 @@ diff -urN c/google/cloud/securitycenter/v1beta1/BUILD.bazel d/google/cloud/secur
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
++        "//google/longrunning:longrunning_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:struct_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/securitycenter/v1beta1:securitycenter_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
 +    ],
 +)
 +
@@ -4468,10 +4341,9 @@ diff -urN c/google/cloud/securitycenter/v1beta1/BUILD.bazel d/google/cloud/secur
 +    proto = ":securitycenter_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/securitycenter/v1beta1:securitycenter_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
++        "//google/longrunning:longrunning_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/securitycenter/v1p1beta1/BUILD.bazel d/google/cloud/securitycenter/v1p1beta1/BUILD.bazel
@@ -4496,14 +4368,14 @@ diff -urN c/google/cloud/securitycenter/v1p1beta1/BUILD.bazel d/google/cloud/sec
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
++        "//google/longrunning:longrunning_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:struct_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
 +    ],
 +)
 +
@@ -4514,9 +4386,9 @@ diff -urN c/google/cloud/securitycenter/v1p1beta1/BUILD.bazel d/google/cloud/sec
 +    proto = ":securitycenter_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
++        "//google/longrunning:longrunning_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/speech/v1/BUILD.bazel d/google/cloud/speech/v1/BUILD.bazel
@@ -4531,12 +4403,12 @@ diff -urN c/google/cloud/speech/v1/BUILD.bazel d/google/cloud/speech/v1/BUILD.ba
 +    srcs = ["cloud_speech.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:any_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -4547,9 +4419,9 @@ diff -urN c/google/cloud/speech/v1/BUILD.bazel d/google/cloud/speech/v1/BUILD.ba
 +    proto = ":speech_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/speech/v1p1beta1/BUILD.bazel d/google/cloud/speech/v1p1beta1/BUILD.bazel
@@ -4564,12 +4436,12 @@ diff -urN c/google/cloud/speech/v1p1beta1/BUILD.bazel d/google/cloud/speech/v1p1
 +    srcs = ["cloud_speech.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:any_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -4580,9 +4452,9 @@ diff -urN c/google/cloud/speech/v1p1beta1/BUILD.bazel d/google/cloud/speech/v1p1
 +    proto = ":speech_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/support/BUILD.bazel d/google/cloud/support/BUILD.bazel
@@ -4597,8 +4469,8 @@ diff -urN c/google/cloud/support/BUILD.bazel d/google/cloud/support/BUILD.bazel
 +    srcs = ["common.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
 +    ],
 +)
 +
@@ -4607,7 +4479,7 @@ diff -urN c/google/cloud/support/BUILD.bazel d/google/cloud/support/BUILD.bazel
 +    importpath = "google.golang.org/genproto/googleapis/cloud/support/common",
 +    proto = ":common_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/cloud/support/v1alpha1/BUILD.bazel d/google/cloud/support/v1alpha1/BUILD.bazel
 --- c/google/cloud/support/v1alpha1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -4621,10 +4493,10 @@ diff -urN c/google/cloud/support/v1alpha1/BUILD.bazel d/google/cloud/support/v1a
 +    srcs = ["cloud_support.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/cloud/support:common_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/support:common_proto",
 +    ],
 +)
 +
@@ -4635,14 +4507,14 @@ diff -urN c/google/cloud/support/v1alpha1/BUILD.bazel d/google/cloud/support/v1a
 +    proto = ":support_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/support:common_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/cloud/support:common_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/talent/v4beta1/BUILD.bazel d/google/cloud/talent/v4beta1/BUILD.bazel
 --- c/google/cloud/talent/v4beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/talent/v4beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,62 @@
+@@ -0,0 +1,60 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -4669,21 +4541,20 @@ diff -urN c/google/cloud/talent/v4beta1/BUILD.bazel d/google/cloud/talent/v4beta
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/rpc:status_proto",
++        "//google/type:date_proto",
++        "//google/type:latlng_proto",
++        "//google/type:money_proto",
++        "//google/type:postaladdress_proto",
++        "//google/type:timeofday_proto",
 +        "@com_google_protobuf//:any_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/talent/v4beta1:talent_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/rpc:status_proto",
-+        "@go_googleapis//google/type:date_proto",
-+        "@go_googleapis//google/type:latlng_proto",
-+        "@go_googleapis//google/type:money_proto",
-+        "@go_googleapis//google/type:postaladdress_proto",
-+        "@go_googleapis//google/type:timeofday_proto",
 +    ],
 +)
 +
@@ -4694,21 +4565,20 @@ diff -urN c/google/cloud/talent/v4beta1/BUILD.bazel d/google/cloud/talent/v4beta
 +    proto = ":talent_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/talent/v4beta1:talent_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
-+        "@go_googleapis//google/type:date_go_proto",
-+        "@go_googleapis//google/type:latlng_go_proto",
-+        "@go_googleapis//google/type:money_go_proto",
-+        "@go_googleapis//google/type:postaladdress_go_proto",
-+        "@go_googleapis//google/type:timeofday_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/rpc:status_go_proto",
++        "//google/type:date_go_proto",
++        "//google/type:latlng_go_proto",
++        "//google/type:money_go_proto",
++        "//google/type:postaladdress_go_proto",
++        "//google/type:timeofday_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/tasks/v2/BUILD.bazel d/google/cloud/tasks/v2/BUILD.bazel
 --- c/google/cloud/tasks/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/tasks/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,37 @@
+@@ -0,0 +1,35 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -4722,14 +4592,13 @@ diff -urN c/google/cloud/tasks/v2/BUILD.bazel d/google/cloud/tasks/v2/BUILD.baze
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/tasks/v2:tasks_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -4740,16 +4609,15 @@ diff -urN c/google/cloud/tasks/v2/BUILD.bazel d/google/cloud/tasks/v2/BUILD.baze
 +    proto = ":tasks_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/tasks/v2:tasks_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/tasks/v2beta2/BUILD.bazel d/google/cloud/tasks/v2beta2/BUILD.bazel
 --- c/google/cloud/tasks/v2beta2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/tasks/v2beta2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,37 @@
+@@ -0,0 +1,35 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -4763,14 +4631,13 @@ diff -urN c/google/cloud/tasks/v2beta2/BUILD.bazel d/google/cloud/tasks/v2beta2/
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/tasks/v2beta2:tasks_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -4781,16 +4648,15 @@ diff -urN c/google/cloud/tasks/v2beta2/BUILD.bazel d/google/cloud/tasks/v2beta2/
 +    proto = ":tasks_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/tasks/v2beta2:tasks_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/tasks/v2beta3/BUILD.bazel d/google/cloud/tasks/v2beta3/BUILD.bazel
 --- c/google/cloud/tasks/v2beta3/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/tasks/v2beta3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,37 @@
+@@ -0,0 +1,35 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -4804,14 +4670,13 @@ diff -urN c/google/cloud/tasks/v2beta3/BUILD.bazel d/google/cloud/tasks/v2beta3/
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/tasks/v2beta3:tasks_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -4822,10 +4687,9 @@ diff -urN c/google/cloud/tasks/v2beta3/BUILD.bazel d/google/cloud/tasks/v2beta3/
 +    proto = ":tasks_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/tasks/v2beta3:tasks_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/texttospeech/v1/BUILD.bazel d/google/cloud/texttospeech/v1/BUILD.bazel
@@ -4839,7 +4703,7 @@ diff -urN c/google/cloud/texttospeech/v1/BUILD.bazel d/google/cloud/texttospeech
 +    name = "texttospeech_proto",
 +    srcs = ["cloud_tts.proto"],
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_proto"],
++    deps = ["//google/api:annotations_proto"],
 +)
 +
 +go_proto_library(
@@ -4848,7 +4712,7 @@ diff -urN c/google/cloud/texttospeech/v1/BUILD.bazel d/google/cloud/texttospeech
 +    importpath = "google.golang.org/genproto/googleapis/cloud/texttospeech/v1",
 +    proto = ":texttospeech_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/cloud/texttospeech/v1beta1/BUILD.bazel d/google/cloud/texttospeech/v1beta1/BUILD.bazel
 --- c/google/cloud/texttospeech/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -4861,7 +4725,7 @@ diff -urN c/google/cloud/texttospeech/v1beta1/BUILD.bazel d/google/cloud/texttos
 +    name = "texttospeech_proto",
 +    srcs = ["cloud_tts.proto"],
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_proto"],
++    deps = ["//google/api:annotations_proto"],
 +)
 +
 +go_proto_library(
@@ -4870,7 +4734,7 @@ diff -urN c/google/cloud/texttospeech/v1beta1/BUILD.bazel d/google/cloud/texttos
 +    importpath = "google.golang.org/genproto/googleapis/cloud/texttospeech/v1beta1",
 +    proto = ":texttospeech_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/cloud/translate/v3/BUILD.bazel d/google/cloud/translate/v3/BUILD.bazel
 --- c/google/cloud/translate/v3/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -4884,9 +4748,9 @@ diff -urN c/google/cloud/translate/v3/BUILD.bazel d/google/cloud/translate/v3/BU
 +    srcs = ["translation_service.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
 +    ],
 +)
 +
@@ -4897,8 +4761,8 @@ diff -urN c/google/cloud/translate/v3/BUILD.bazel d/google/cloud/translate/v3/BU
 +    proto = ":translate_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/translate/v3beta1/BUILD.bazel d/google/cloud/translate/v3beta1/BUILD.bazel
@@ -4913,9 +4777,9 @@ diff -urN c/google/cloud/translate/v3beta1/BUILD.bazel d/google/cloud/translate/
 +    srcs = ["translation_service.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
 +    ],
 +)
 +
@@ -4926,8 +4790,8 @@ diff -urN c/google/cloud/translate/v3beta1/BUILD.bazel d/google/cloud/translate/
 +    proto = ":translate_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/videointelligence/v1/BUILD.bazel d/google/cloud/videointelligence/v1/BUILD.bazel
@@ -4942,11 +4806,11 @@ diff -urN c/google/cloud/videointelligence/v1/BUILD.bazel d/google/cloud/videoin
 +    srcs = ["video_intelligence.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -4957,9 +4821,9 @@ diff -urN c/google/cloud/videointelligence/v1/BUILD.bazel d/google/cloud/videoin
 +    proto = ":videointelligence_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/videointelligence/v1beta2/BUILD.bazel d/google/cloud/videointelligence/v1beta2/BUILD.bazel
@@ -4974,11 +4838,11 @@ diff -urN c/google/cloud/videointelligence/v1beta2/BUILD.bazel d/google/cloud/vi
 +    srcs = ["video_intelligence.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -4989,9 +4853,9 @@ diff -urN c/google/cloud/videointelligence/v1beta2/BUILD.bazel d/google/cloud/vi
 +    proto = ":videointelligence_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/videointelligence/v1p1beta1/BUILD.bazel d/google/cloud/videointelligence/v1p1beta1/BUILD.bazel
@@ -5006,11 +4870,11 @@ diff -urN c/google/cloud/videointelligence/v1p1beta1/BUILD.bazel d/google/cloud/
 +    srcs = ["video_intelligence.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -5021,9 +4885,9 @@ diff -urN c/google/cloud/videointelligence/v1p1beta1/BUILD.bazel d/google/cloud/
 +    proto = ":videointelligence_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/videointelligence/v1p2beta1/BUILD.bazel d/google/cloud/videointelligence/v1p2beta1/BUILD.bazel
@@ -5038,11 +4902,11 @@ diff -urN c/google/cloud/videointelligence/v1p2beta1/BUILD.bazel d/google/cloud/
 +    srcs = ["video_intelligence.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -5053,9 +4917,9 @@ diff -urN c/google/cloud/videointelligence/v1p2beta1/BUILD.bazel d/google/cloud/
 +    proto = ":videointelligence_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/videointelligence/v1p3beta1/BUILD.bazel d/google/cloud/videointelligence/v1p3beta1/BUILD.bazel
@@ -5070,11 +4934,11 @@ diff -urN c/google/cloud/videointelligence/v1p3beta1/BUILD.bazel d/google/cloud/
 +    srcs = ["video_intelligence.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -5085,15 +4949,15 @@ diff -urN c/google/cloud/videointelligence/v1p3beta1/BUILD.bazel d/google/cloud/
 +    proto = ":videointelligence_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/vision/v1/BUILD.bazel d/google/cloud/vision/v1/BUILD.bazel
 --- c/google/cloud/vision/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/vision/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,42 @@
+@@ -0,0 +1,40 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -5109,15 +4973,14 @@ diff -urN c/google/cloud/vision/v1/BUILD.bazel d/google/cloud/vision/v1/BUILD.ba
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/rpc:status_proto",
++        "//google/type:color_proto",
++        "//google/type:latlng_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/vision/v1:vision_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/rpc:status_proto",
-+        "@go_googleapis//google/type:color_proto",
-+        "@go_googleapis//google/type:latlng_proto",
 +    ],
 +)
 +
@@ -5128,18 +4991,17 @@ diff -urN c/google/cloud/vision/v1/BUILD.bazel d/google/cloud/vision/v1/BUILD.ba
 +    proto = ":vision_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/vision/v1:vision_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
-+        "@go_googleapis//google/type:color_go_proto",
-+        "@go_googleapis//google/type:latlng_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/rpc:status_go_proto",
++        "//google/type:color_go_proto",
++        "//google/type:latlng_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/vision/v1p1beta1/BUILD.bazel d/google/cloud/vision/v1p1beta1/BUILD.bazel
 --- c/google/cloud/vision/v1p1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/vision/v1p1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,35 @@
+@@ -0,0 +1,33 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -5153,11 +5015,10 @@ diff -urN c/google/cloud/vision/v1p1beta1/BUILD.bazel d/google/cloud/vision/v1p1
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/vision/v1p1beta1:vision_proto",
-+        "@go_googleapis//google/rpc:status_proto",
-+        "@go_googleapis//google/type:color_proto",
-+        "@go_googleapis//google/type:latlng_proto",
++        "//google/api:annotations_proto",
++        "//google/rpc:status_proto",
++        "//google/type:color_proto",
++        "//google/type:latlng_proto",
 +    ],
 +)
 +
@@ -5168,17 +5029,16 @@ diff -urN c/google/cloud/vision/v1p1beta1/BUILD.bazel d/google/cloud/vision/v1p1
 +    proto = ":vision_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/vision/v1p1beta1:vision_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
-+        "@go_googleapis//google/type:color_go_proto",
-+        "@go_googleapis//google/type:latlng_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/rpc:status_go_proto",
++        "//google/type:color_go_proto",
++        "//google/type:latlng_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/vision/v1p2beta1/BUILD.bazel d/google/cloud/vision/v1p2beta1/BUILD.bazel
 --- c/google/cloud/vision/v1p2beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/vision/v1p2beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,38 @@
+@@ -0,0 +1,36 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -5192,13 +5052,12 @@ diff -urN c/google/cloud/vision/v1p2beta1/BUILD.bazel d/google/cloud/vision/v1p2
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/rpc:status_proto",
++        "//google/type:color_proto",
++        "//google/type:latlng_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/vision/v1p2beta1:vision_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/rpc:status_proto",
-+        "@go_googleapis//google/type:color_proto",
-+        "@go_googleapis//google/type:latlng_proto",
 +    ],
 +)
 +
@@ -5209,18 +5068,17 @@ diff -urN c/google/cloud/vision/v1p2beta1/BUILD.bazel d/google/cloud/vision/v1p2
 +    proto = ":vision_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/vision/v1p2beta1:vision_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
-+        "@go_googleapis//google/type:color_go_proto",
-+        "@go_googleapis//google/type:latlng_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/rpc:status_go_proto",
++        "//google/type:color_go_proto",
++        "//google/type:latlng_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/vision/v1p3beta1/BUILD.bazel d/google/cloud/vision/v1p3beta1/BUILD.bazel
 --- c/google/cloud/vision/v1p3beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/vision/v1p3beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,42 @@
+@@ -0,0 +1,40 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -5236,15 +5094,14 @@ diff -urN c/google/cloud/vision/v1p3beta1/BUILD.bazel d/google/cloud/vision/v1p3
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/rpc:status_proto",
++        "//google/type:color_proto",
++        "//google/type:latlng_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/vision/v1p3beta1:vision_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/rpc:status_proto",
-+        "@go_googleapis//google/type:color_proto",
-+        "@go_googleapis//google/type:latlng_proto",
 +    ],
 +)
 +
@@ -5255,18 +5112,17 @@ diff -urN c/google/cloud/vision/v1p3beta1/BUILD.bazel d/google/cloud/vision/v1p3
 +    proto = ":vision_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/vision/v1p3beta1:vision_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
-+        "@go_googleapis//google/type:color_go_proto",
-+        "@go_googleapis//google/type:latlng_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/rpc:status_go_proto",
++        "//google/type:color_go_proto",
++        "//google/type:latlng_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/vision/v1p4beta1/BUILD.bazel d/google/cloud/vision/v1p4beta1/BUILD.bazel
 --- c/google/cloud/vision/v1p4beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/vision/v1p4beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,43 @@
+@@ -0,0 +1,41 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -5283,15 +5139,14 @@ diff -urN c/google/cloud/vision/v1p4beta1/BUILD.bazel d/google/cloud/vision/v1p4
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/rpc:status_proto",
++        "//google/type:color_proto",
++        "//google/type:latlng_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/vision/v1p4beta1:vision_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/rpc:status_proto",
-+        "@go_googleapis//google/type:color_proto",
-+        "@go_googleapis//google/type:latlng_proto",
 +    ],
 +)
 +
@@ -5302,12 +5157,11 @@ diff -urN c/google/cloud/vision/v1p4beta1/BUILD.bazel d/google/cloud/vision/v1p4
 +    proto = ":vision_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/vision/v1p4beta1:vision_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
-+        "@go_googleapis//google/type:color_go_proto",
-+        "@go_googleapis//google/type:latlng_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/rpc:status_go_proto",
++        "//google/type:color_go_proto",
++        "//google/type:latlng_go_proto",
 +    ],
 +)
 diff -urN c/google/cloud/webrisk/v1beta1/BUILD.bazel d/google/cloud/webrisk/v1beta1/BUILD.bazel
@@ -5322,8 +5176,8 @@ diff -urN c/google/cloud/webrisk/v1beta1/BUILD.bazel d/google/cloud/webrisk/v1be
 +    srcs = ["webrisk.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
 +    ],
 +)
 +
@@ -5333,12 +5187,12 @@ diff -urN c/google/cloud/webrisk/v1beta1/BUILD.bazel d/google/cloud/webrisk/v1be
 +    importpath = "google.golang.org/genproto/googleapis/cloud/webrisk/v1beta1",
 +    proto = ":webrisk_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/cloud/websecurityscanner/v1alpha/BUILD.bazel d/google/cloud/websecurityscanner/v1alpha/BUILD.bazel
 --- c/google/cloud/websecurityscanner/v1alpha/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/websecurityscanner/v1alpha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,35 @@
+@@ -0,0 +1,31 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -5355,11 +5209,10 @@ diff -urN c/google/cloud/websecurityscanner/v1alpha/BUILD.bazel d/google/cloud/w
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/websecurityscanner/v1alpha:websecurityscanner_proto",
 +    ],
 +)
 +
@@ -5369,15 +5222,12 @@ diff -urN c/google/cloud/websecurityscanner/v1alpha/BUILD.bazel d/google/cloud/w
 +    importpath = "google.golang.org/genproto/googleapis/cloud/websecurityscanner/v1alpha",
 +    proto = ":websecurityscanner_proto",
 +    visibility = ["//visibility:public"],
-+    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/websecurityscanner/v1alpha:websecurityscanner_go_proto",
-+    ],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/cloud/websecurityscanner/v1beta/BUILD.bazel d/google/cloud/websecurityscanner/v1beta/BUILD.bazel
 --- c/google/cloud/websecurityscanner/v1beta/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/cloud/websecurityscanner/v1beta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,38 @@
+@@ -0,0 +1,34 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -5397,11 +5247,10 @@ diff -urN c/google/cloud/websecurityscanner/v1beta/BUILD.bazel d/google/cloud/we
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/cloud/websecurityscanner/v1beta:websecurityscanner_proto",
 +    ],
 +)
 +
@@ -5411,10 +5260,7 @@ diff -urN c/google/cloud/websecurityscanner/v1beta/BUILD.bazel d/google/cloud/we
 +    importpath = "google.golang.org/genproto/googleapis/cloud/websecurityscanner/v1beta",
 +    proto = ":websecurityscanner_proto",
 +    visibility = ["//visibility:public"],
-+    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/cloud/websecurityscanner/v1beta:websecurityscanner_go_proto",
-+    ],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/container/v1/BUILD.bazel d/google/container/v1/BUILD.bazel
 --- c/google/container/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -5428,9 +5274,9 @@ diff -urN c/google/container/v1/BUILD.bazel d/google/container/v1/BUILD.bazel
 +    srcs = ["cluster_service.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
 +    ],
 +)
 +
@@ -5440,7 +5286,7 @@ diff -urN c/google/container/v1/BUILD.bazel d/google/container/v1/BUILD.bazel
 +    importpath = "google.golang.org/genproto/googleapis/container/v1",
 +    proto = ":container_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/container/v1alpha1/BUILD.bazel d/google/container/v1alpha1/BUILD.bazel
 --- c/google/container/v1alpha1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -5454,8 +5300,8 @@ diff -urN c/google/container/v1alpha1/BUILD.bazel d/google/container/v1alpha1/BU
 +    srcs = ["cluster_service.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:empty_proto",
-+        "@go_googleapis//google/api:annotations_proto",
 +    ],
 +)
 +
@@ -5465,7 +5311,7 @@ diff -urN c/google/container/v1alpha1/BUILD.bazel d/google/container/v1alpha1/BU
 +    importpath = "google.golang.org/genproto/googleapis/container/v1alpha1",
 +    proto = ":container_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/container/v1beta1/BUILD.bazel d/google/container/v1beta1/BUILD.bazel
 --- c/google/container/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -5479,9 +5325,9 @@ diff -urN c/google/container/v1beta1/BUILD.bazel d/google/container/v1beta1/BUIL
 +    srcs = ["cluster_service.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
 +    ],
 +)
 +
@@ -5491,12 +5337,12 @@ diff -urN c/google/container/v1beta1/BUILD.bazel d/google/container/v1beta1/BUIL
 +    importpath = "google.golang.org/genproto/googleapis/container/v1beta1",
 +    proto = ":container_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/datastore/admin/v1/BUILD.bazel d/google/datastore/admin/v1/BUILD.bazel
 --- c/google/datastore/admin/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/datastore/admin/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,30 @@
+@@ -0,0 +1,28 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -5508,10 +5354,9 @@ diff -urN c/google/datastore/admin/v1/BUILD.bazel d/google/datastore/admin/v1/BU
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/datastore/admin/v1:admin_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
 +    ],
 +)
 +
@@ -5522,9 +5367,8 @@ diff -urN c/google/datastore/admin/v1/BUILD.bazel d/google/datastore/admin/v1/BU
 +    proto = ":admin_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/datastore/admin/v1:admin_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
 +    ],
 +)
 diff -urN c/google/datastore/admin/v1beta1/BUILD.bazel d/google/datastore/admin/v1beta1/BUILD.bazel
@@ -5539,9 +5383,9 @@ diff -urN c/google/datastore/admin/v1beta1/BUILD.bazel d/google/datastore/admin/
 +    srcs = ["datastore_admin.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
 +    ],
 +)
 +
@@ -5552,14 +5396,14 @@ diff -urN c/google/datastore/admin/v1beta1/BUILD.bazel d/google/datastore/admin/
 +    proto = ":admin_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
 +    ],
 +)
 diff -urN c/google/datastore/v1/BUILD.bazel d/google/datastore/v1/BUILD.bazel
 --- c/google/datastore/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/datastore/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,33 @@
+@@ -0,0 +1,31 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -5572,12 +5416,11 @@ diff -urN c/google/datastore/v1/BUILD.bazel d/google/datastore/v1/BUILD.bazel
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/type:latlng_proto",
 +        "@com_google_protobuf//:struct_proto",
 +        "@com_google_protobuf//:timestamp_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/datastore/v1:datastore_proto",
-+        "@go_googleapis//google/type:latlng_proto",
 +    ],
 +)
 +
@@ -5588,15 +5431,14 @@ diff -urN c/google/datastore/v1/BUILD.bazel d/google/datastore/v1/BUILD.bazel
 +    proto = ":datastore_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/datastore/v1:datastore_go_proto",
-+        "@go_googleapis//google/type:latlng_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/type:latlng_go_proto",
 +    ],
 +)
 diff -urN c/google/datastore/v1beta3/BUILD.bazel d/google/datastore/v1beta3/BUILD.bazel
 --- c/google/datastore/v1beta3/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/datastore/v1beta3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,33 @@
+@@ -0,0 +1,31 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -5609,12 +5451,11 @@ diff -urN c/google/datastore/v1beta3/BUILD.bazel d/google/datastore/v1beta3/BUIL
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/type:latlng_proto",
 +        "@com_google_protobuf//:struct_proto",
 +        "@com_google_protobuf//:timestamp_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/datastore/v1beta3:datastore_proto",
-+        "@go_googleapis//google/type:latlng_proto",
 +    ],
 +)
 +
@@ -5625,15 +5466,14 @@ diff -urN c/google/datastore/v1beta3/BUILD.bazel d/google/datastore/v1beta3/BUIL
 +    proto = ":datastore_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/datastore/v1beta3:datastore_go_proto",
-+        "@go_googleapis//google/type:latlng_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/type:latlng_go_proto",
 +    ],
 +)
 diff -urN c/google/devtools/build/v1/BUILD.bazel d/google/devtools/build/v1/BUILD.bazel
 --- c/google/devtools/build/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/devtools/build/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,28 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -5646,12 +5486,11 @@ diff -urN c/google/devtools/build/v1/BUILD.bazel d/google/devtools/build/v1/BUIL
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:any_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/devtools/build/v1:build_proto",
 +    ],
 +)
 +
@@ -5661,10 +5500,7 @@ diff -urN c/google/devtools/build/v1/BUILD.bazel d/google/devtools/build/v1/BUIL
 +    importpath = "google.golang.org/genproto/googleapis/devtools/build/v1",
 +    proto = ":build_proto",
 +    visibility = ["//visibility:public"],
-+    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/devtools/build/v1:build_go_proto",
-+    ],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/devtools/cloudbuild/v1/BUILD.bazel d/google/devtools/cloudbuild/v1/BUILD.bazel
 --- c/google/devtools/cloudbuild/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -5678,11 +5514,11 @@ diff -urN c/google/devtools/cloudbuild/v1/BUILD.bazel d/google/devtools/cloudbui
 +    srcs = ["cloudbuild.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
 +    ],
 +)
 +
@@ -5693,14 +5529,14 @@ diff -urN c/google/devtools/cloudbuild/v1/BUILD.bazel d/google/devtools/cloudbui
 +    proto = ":cloudbuild_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
 +    ],
 +)
 diff -urN c/google/devtools/clouddebugger/v2/BUILD.bazel d/google/devtools/clouddebugger/v2/BUILD.bazel
 --- c/google/devtools/clouddebugger/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/devtools/clouddebugger/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,33 @@
+@@ -0,0 +1,31 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -5713,12 +5549,11 @@ diff -urN c/google/devtools/clouddebugger/v2/BUILD.bazel d/google/devtools/cloud
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/devtools/source/v1:source_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:timestamp_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/devtools/clouddebugger/v2:clouddebugger_proto",
-+        "@go_googleapis//google/devtools/source/v1:source_proto",
 +    ],
 +)
 +
@@ -5729,15 +5564,14 @@ diff -urN c/google/devtools/clouddebugger/v2/BUILD.bazel d/google/devtools/cloud
 +    proto = ":clouddebugger_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/devtools/clouddebugger/v2:clouddebugger_go_proto",
-+        "@go_googleapis//google/devtools/source/v1:source_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/devtools/source/v1:source_go_proto",
 +    ],
 +)
 diff -urN c/google/devtools/clouderrorreporting/v1beta1/BUILD.bazel d/google/devtools/clouderrorreporting/v1beta1/BUILD.bazel
 --- c/google/devtools/clouderrorreporting/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/devtools/clouderrorreporting/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,31 @@
+@@ -0,0 +1,27 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -5751,10 +5585,9 @@ diff -urN c/google/devtools/clouderrorreporting/v1beta1/BUILD.bazel d/google/dev
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/devtools/clouderrorreporting/v1beta1:clouderrorreporting_proto",
 +    ],
 +)
 +
@@ -5764,10 +5597,7 @@ diff -urN c/google/devtools/clouderrorreporting/v1beta1/BUILD.bazel d/google/dev
 +    importpath = "google.golang.org/genproto/googleapis/devtools/clouderrorreporting/v1beta1",
 +    proto = ":clouderrorreporting_proto",
 +    visibility = ["//visibility:public"],
-+    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/devtools/clouderrorreporting/v1beta1:clouderrorreporting_go_proto",
-+    ],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/devtools/cloudprofiler/v2/BUILD.bazel d/google/devtools/cloudprofiler/v2/BUILD.bazel
 --- c/google/devtools/cloudprofiler/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -5781,10 +5611,10 @@ diff -urN c/google/devtools/cloudprofiler/v2/BUILD.bazel d/google/devtools/cloud
 +    srcs = ["profiler.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
 +    ],
 +)
 +
@@ -5794,7 +5624,7 @@ diff -urN c/google/devtools/cloudprofiler/v2/BUILD.bazel d/google/devtools/cloud
 +    importpath = "google.golang.org/genproto/googleapis/devtools/cloudprofiler/v2",
 +    proto = ":cloudprofiler_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/devtools/cloudtrace/v1/BUILD.bazel d/google/devtools/cloudtrace/v1/BUILD.bazel
 --- c/google/devtools/cloudtrace/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -5808,9 +5638,9 @@ diff -urN c/google/devtools/cloudtrace/v1/BUILD.bazel d/google/devtools/cloudtra
 +    srcs = ["trace.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
 +    ],
 +)
 +
@@ -5820,12 +5650,12 @@ diff -urN c/google/devtools/cloudtrace/v1/BUILD.bazel d/google/devtools/cloudtra
 +    importpath = "google.golang.org/genproto/googleapis/devtools/cloudtrace/v1",
 +    proto = ":cloudtrace_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/devtools/cloudtrace/v2/BUILD.bazel d/google/devtools/cloudtrace/v2/BUILD.bazel
 --- c/google/devtools/cloudtrace/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/devtools/cloudtrace/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,30 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -5837,12 +5667,11 @@ diff -urN c/google/devtools/cloudtrace/v2/BUILD.bazel d/google/devtools/cloudtra
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:timestamp_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/devtools/cloudtrace/v2:cloudtrace_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -5853,9 +5682,8 @@ diff -urN c/google/devtools/cloudtrace/v2/BUILD.bazel d/google/devtools/cloudtra
 +    proto = ":cloudtrace_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/devtools/cloudtrace/v2:cloudtrace_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/devtools/containeranalysis/v1/BUILD.bazel d/google/devtools/containeranalysis/v1/BUILD.bazel
@@ -5870,9 +5698,9 @@ diff -urN c/google/devtools/containeranalysis/v1/BUILD.bazel d/google/devtools/c
 +    srcs = ["containeranalysis.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
 +    ],
 +)
 +
@@ -5883,8 +5711,8 @@ diff -urN c/google/devtools/containeranalysis/v1/BUILD.bazel d/google/devtools/c
 +    proto = ":containeranalysis_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
 +    ],
 +)
 diff -urN c/google/devtools/containeranalysis/v1beta1/BUILD.bazel d/google/devtools/containeranalysis/v1beta1/BUILD.bazel
@@ -5899,9 +5727,9 @@ diff -urN c/google/devtools/containeranalysis/v1beta1/BUILD.bazel d/google/devto
 +    srcs = ["containeranalysis.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
 +    ],
 +)
 +
@@ -5912,8 +5740,8 @@ diff -urN c/google/devtools/containeranalysis/v1beta1/BUILD.bazel d/google/devto
 +    proto = ":containeranalysis_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
 +    ],
 +)
 diff -urN c/google/devtools/containeranalysis/v1beta1/attestation/BUILD.bazel d/google/devtools/containeranalysis/v1beta1/attestation/BUILD.bazel
@@ -5927,7 +5755,7 @@ diff -urN c/google/devtools/containeranalysis/v1beta1/attestation/BUILD.bazel d/
 +    name = "attestation_proto",
 +    srcs = ["attestation.proto"],
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/devtools/containeranalysis/v1beta1/common:common_proto"],
++    deps = ["//google/devtools/containeranalysis/v1beta1/common:common_proto"],
 +)
 +
 +go_proto_library(
@@ -5935,7 +5763,7 @@ diff -urN c/google/devtools/containeranalysis/v1beta1/attestation/BUILD.bazel d/
 +    importpath = "google.golang.org/genproto/googleapis/devtools/containeranalysis/v1beta1/attestation",
 +    proto = ":attestation_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/devtools/containeranalysis/v1beta1/common:common_go_proto"],
++    deps = ["//google/devtools/containeranalysis/v1beta1/common:common_go_proto"],
 +)
 diff -urN c/google/devtools/containeranalysis/v1beta1/build/BUILD.bazel d/google/devtools/containeranalysis/v1beta1/build/BUILD.bazel
 --- c/google/devtools/containeranalysis/v1beta1/build/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -5948,7 +5776,7 @@ diff -urN c/google/devtools/containeranalysis/v1beta1/build/BUILD.bazel d/google
 +    name = "build_proto",
 +    srcs = ["build.proto"],
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/devtools/containeranalysis/v1beta1/provenance:provenance_proto"],
++    deps = ["//google/devtools/containeranalysis/v1beta1/provenance:provenance_proto"],
 +)
 +
 +go_proto_library(
@@ -5956,7 +5784,7 @@ diff -urN c/google/devtools/containeranalysis/v1beta1/build/BUILD.bazel d/google
 +    importpath = "google.golang.org/genproto/googleapis/devtools/containeranalysis/v1beta1/build",
 +    proto = ":build_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/devtools/containeranalysis/v1beta1/provenance:provenance_go_proto"],
++    deps = ["//google/devtools/containeranalysis/v1beta1/provenance:provenance_go_proto"],
 +)
 diff -urN c/google/devtools/containeranalysis/v1beta1/common/BUILD.bazel d/google/devtools/containeranalysis/v1beta1/common/BUILD.bazel
 --- c/google/devtools/containeranalysis/v1beta1/common/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -6028,9 +5856,9 @@ diff -urN c/google/devtools/containeranalysis/v1beta1/discovery/BUILD.bazel d/go
 +    srcs = ["discovery.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/devtools/containeranalysis/v1beta1/common:common_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/devtools/containeranalysis/v1beta1/common:common_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -6040,8 +5868,8 @@ diff -urN c/google/devtools/containeranalysis/v1beta1/discovery/BUILD.bazel d/go
 +    proto = ":discovery_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/devtools/containeranalysis/v1beta1/common:common_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/devtools/containeranalysis/v1beta1/common:common_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/devtools/containeranalysis/v1beta1/grafeas/BUILD.bazel d/google/devtools/containeranalysis/v1beta1/grafeas/BUILD.bazel
@@ -6056,19 +5884,19 @@ diff -urN c/google/devtools/containeranalysis/v1beta1/grafeas/BUILD.bazel d/goog
 +    srcs = ["grafeas.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/devtools/containeranalysis/v1beta1/attestation:attestation_proto",
++        "//google/devtools/containeranalysis/v1beta1/build:build_proto",
++        "//google/devtools/containeranalysis/v1beta1/common:common_proto",
++        "//google/devtools/containeranalysis/v1beta1/deployment:deployment_proto",
++        "//google/devtools/containeranalysis/v1beta1/discovery:discovery_proto",
++        "//google/devtools/containeranalysis/v1beta1/image:image_proto",
++        "//google/devtools/containeranalysis/v1beta1/package:package_proto",
++        "//google/devtools/containeranalysis/v1beta1/provenance:provenance_proto",
++        "//google/devtools/containeranalysis/v1beta1/vulnerability:vulnerability_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/devtools/containeranalysis/v1beta1/attestation:attestation_proto",
-+        "@go_googleapis//google/devtools/containeranalysis/v1beta1/build:build_proto",
-+        "@go_googleapis//google/devtools/containeranalysis/v1beta1/common:common_proto",
-+        "@go_googleapis//google/devtools/containeranalysis/v1beta1/deployment:deployment_proto",
-+        "@go_googleapis//google/devtools/containeranalysis/v1beta1/discovery:discovery_proto",
-+        "@go_googleapis//google/devtools/containeranalysis/v1beta1/image:image_proto",
-+        "@go_googleapis//google/devtools/containeranalysis/v1beta1/package:package_proto",
-+        "@go_googleapis//google/devtools/containeranalysis/v1beta1/provenance:provenance_proto",
-+        "@go_googleapis//google/devtools/containeranalysis/v1beta1/vulnerability:vulnerability_proto",
 +    ],
 +)
 +
@@ -6079,16 +5907,16 @@ diff -urN c/google/devtools/containeranalysis/v1beta1/grafeas/BUILD.bazel d/goog
 +    proto = ":grafeas_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/devtools/containeranalysis/v1beta1/attestation:attestation_go_proto",
-+        "@go_googleapis//google/devtools/containeranalysis/v1beta1/build:build_go_proto",
-+        "@go_googleapis//google/devtools/containeranalysis/v1beta1/common:common_go_proto",
-+        "@go_googleapis//google/devtools/containeranalysis/v1beta1/deployment:deployment_go_proto",
-+        "@go_googleapis//google/devtools/containeranalysis/v1beta1/discovery:discovery_go_proto",
-+        "@go_googleapis//google/devtools/containeranalysis/v1beta1/image:image_go_proto",
-+        "@go_googleapis//google/devtools/containeranalysis/v1beta1/package:package_go_proto",
-+        "@go_googleapis//google/devtools/containeranalysis/v1beta1/provenance:provenance_go_proto",
-+        "@go_googleapis//google/devtools/containeranalysis/v1beta1/vulnerability:vulnerability_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/devtools/containeranalysis/v1beta1/attestation:attestation_go_proto",
++        "//google/devtools/containeranalysis/v1beta1/build:build_go_proto",
++        "//google/devtools/containeranalysis/v1beta1/common:common_go_proto",
++        "//google/devtools/containeranalysis/v1beta1/deployment:deployment_go_proto",
++        "//google/devtools/containeranalysis/v1beta1/discovery:discovery_go_proto",
++        "//google/devtools/containeranalysis/v1beta1/image:image_go_proto",
++        "//google/devtools/containeranalysis/v1beta1/package:package_go_proto",
++        "//google/devtools/containeranalysis/v1beta1/provenance:provenance_go_proto",
++        "//google/devtools/containeranalysis/v1beta1/vulnerability:vulnerability_go_proto",
 +    ],
 +)
 diff -urN c/google/devtools/containeranalysis/v1beta1/image/BUILD.bazel d/google/devtools/containeranalysis/v1beta1/image/BUILD.bazel
@@ -6141,8 +5969,8 @@ diff -urN c/google/devtools/containeranalysis/v1beta1/provenance/BUILD.bazel d/g
 +    srcs = ["provenance.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/devtools/containeranalysis/v1beta1/source:source_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/devtools/containeranalysis/v1beta1/source:source_proto",
 +    ],
 +)
 +
@@ -6151,7 +5979,7 @@ diff -urN c/google/devtools/containeranalysis/v1beta1/provenance/BUILD.bazel d/g
 +    importpath = "google.golang.org/genproto/googleapis/devtools/containeranalysis/v1beta1/provenance",
 +    proto = ":provenance_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/devtools/containeranalysis/v1beta1/source:source_go_proto"],
++    deps = ["//google/devtools/containeranalysis/v1beta1/source:source_go_proto"],
 +)
 diff -urN c/google/devtools/containeranalysis/v1beta1/source/BUILD.bazel d/google/devtools/containeranalysis/v1beta1/source/BUILD.bazel
 --- c/google/devtools/containeranalysis/v1beta1/source/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -6184,10 +6012,10 @@ diff -urN c/google/devtools/containeranalysis/v1beta1/vulnerability/BUILD.bazel 
 +    srcs = ["vulnerability.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/devtools/containeranalysis/v1beta1/common:common_proto",
++        "//google/devtools/containeranalysis/v1beta1/cvss:cvss_proto",
++        "//google/devtools/containeranalysis/v1beta1/package:package_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/devtools/containeranalysis/v1beta1/common:common_proto",
-+        "@go_googleapis//google/devtools/containeranalysis/v1beta1/cvss:cvss_proto",
-+        "@go_googleapis//google/devtools/containeranalysis/v1beta1/package:package_proto",
 +    ],
 +)
 +
@@ -6197,15 +6025,15 @@ diff -urN c/google/devtools/containeranalysis/v1beta1/vulnerability/BUILD.bazel 
 +    proto = ":vulnerability_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/devtools/containeranalysis/v1beta1/common:common_go_proto",
-+        "@go_googleapis//google/devtools/containeranalysis/v1beta1/cvss:cvss_go_proto",
-+        "@go_googleapis//google/devtools/containeranalysis/v1beta1/package:package_go_proto",
++        "//google/devtools/containeranalysis/v1beta1/common:common_go_proto",
++        "//google/devtools/containeranalysis/v1beta1/cvss:cvss_go_proto",
++        "//google/devtools/containeranalysis/v1beta1/package:package_go_proto",
 +    ],
 +)
 diff -urN c/google/devtools/remoteworkers/v1test2/BUILD.bazel d/google/devtools/remoteworkers/v1test2/BUILD.bazel
 --- c/google/devtools/remoteworkers/v1test2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/devtools/remoteworkers/v1test2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,35 @@
+@@ -0,0 +1,33 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -6219,13 +6047,12 @@ diff -urN c/google/devtools/remoteworkers/v1test2/BUILD.bazel d/google/devtools/
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:any_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/devtools/remoteworkers/v1test2:remoteworkers_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -6236,15 +6063,14 @@ diff -urN c/google/devtools/remoteworkers/v1test2/BUILD.bazel d/google/devtools/
 +    proto = ":remoteworkers_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/devtools/remoteworkers/v1test2:remoteworkers_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/devtools/resultstore/v2/BUILD.bazel d/google/devtools/resultstore/v2/BUILD.bazel
 --- c/google/devtools/resultstore/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/devtools/resultstore/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,47 @@
+@@ -0,0 +1,43 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -6271,13 +6097,12 @@ diff -urN c/google/devtools/resultstore/v2/BUILD.bazel d/google/devtools/results
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/devtools/resultstore/v2:resultstore_proto",
 +    ],
 +)
 +
@@ -6287,10 +6112,7 @@ diff -urN c/google/devtools/resultstore/v2/BUILD.bazel d/google/devtools/results
 +    importpath = "google.golang.org/genproto/googleapis/devtools/resultstore/v2",
 +    proto = ":resultstore_proto",
 +    visibility = ["//visibility:public"],
-+    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/devtools/resultstore/v2:resultstore_go_proto",
-+    ],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/devtools/source/v1/BUILD.bazel d/google/devtools/source/v1/BUILD.bazel
 --- c/google/devtools/source/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -6303,7 +6125,7 @@ diff -urN c/google/devtools/source/v1/BUILD.bazel d/google/devtools/source/v1/BU
 +    name = "source_proto",
 +    srcs = ["source_context.proto"],
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_proto"],
++    deps = ["//google/api:annotations_proto"],
 +)
 +
 +go_proto_library(
@@ -6311,7 +6133,7 @@ diff -urN c/google/devtools/source/v1/BUILD.bazel d/google/devtools/source/v1/BU
 +    importpath = "google.golang.org/genproto/googleapis/devtools/source/v1",
 +    proto = ":source_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/devtools/sourcerepo/v1/BUILD.bazel d/google/devtools/sourcerepo/v1/BUILD.bazel
 --- c/google/devtools/sourcerepo/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -6325,9 +6147,9 @@ diff -urN c/google/devtools/sourcerepo/v1/BUILD.bazel d/google/devtools/sourcere
 +    srcs = ["sourcerepo.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
 +        "@com_google_protobuf//:empty_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
 +    ],
 +)
 +
@@ -6338,8 +6160,8 @@ diff -urN c/google/devtools/sourcerepo/v1/BUILD.bazel d/google/devtools/sourcere
 +    proto = ":sourcerepo_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
 +    ],
 +)
 diff -urN c/google/example/library/v1/BUILD.bazel d/google/example/library/v1/BUILD.bazel
@@ -6354,8 +6176,8 @@ diff -urN c/google/example/library/v1/BUILD.bazel d/google/example/library/v1/BU
 +    srcs = ["library.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:empty_proto",
-+        "@go_googleapis//google/api:annotations_proto",
 +    ],
 +)
 +
@@ -6365,7 +6187,7 @@ diff -urN c/google/example/library/v1/BUILD.bazel d/google/example/library/v1/BU
 +    importpath = "google.golang.org/genproto/googleapis/example/library/v1",
 +    proto = ":library_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/firebase/fcm/connection/v1alpha1/BUILD.bazel d/google/firebase/fcm/connection/v1alpha1/BUILD.bazel
 --- c/google/firebase/fcm/connection/v1alpha1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -6379,8 +6201,8 @@ diff -urN c/google/firebase/fcm/connection/v1alpha1/BUILD.bazel d/google/firebas
 +    srcs = ["connection_api.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
 +    ],
 +)
 +
@@ -6390,12 +6212,12 @@ diff -urN c/google/firebase/fcm/connection/v1alpha1/BUILD.bazel d/google/firebas
 +    importpath = "google.golang.org/genproto/googleapis/firebase/fcm/connection/v1alpha1",
 +    proto = ":connection_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/firestore/admin/v1/BUILD.bazel d/google/firestore/admin/v1/BUILD.bazel
 --- c/google/firestore/admin/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/firestore/admin/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,37 @@
+@@ -0,0 +1,35 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -6410,13 +6232,12 @@ diff -urN c/google/firestore/admin/v1/BUILD.bazel d/google/firestore/admin/v1/BU
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/type:latlng_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/firestore/admin/v1:admin_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/type:latlng_proto",
 +    ],
 +)
 +
@@ -6427,16 +6248,15 @@ diff -urN c/google/firestore/admin/v1/BUILD.bazel d/google/firestore/admin/v1/BU
 +    proto = ":admin_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/firestore/admin/v1:admin_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/type:latlng_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/type:latlng_go_proto",
 +    ],
 +)
 diff -urN c/google/firestore/admin/v1beta1/BUILD.bazel d/google/firestore/admin/v1beta1/BUILD.bazel
 --- c/google/firestore/admin/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/firestore/admin/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,32 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -6449,12 +6269,11 @@ diff -urN c/google/firestore/admin/v1beta1/BUILD.bazel d/google/firestore/admin/
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/type:latlng_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/firestore/admin/v1beta1:admin_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/type:latlng_proto",
 +    ],
 +)
 +
@@ -6465,16 +6284,15 @@ diff -urN c/google/firestore/admin/v1beta1/BUILD.bazel d/google/firestore/admin/
 +    proto = ":admin_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/firestore/admin/v1beta1:admin_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/type:latlng_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/type:latlng_go_proto",
 +    ],
 +)
 diff -urN c/google/firestore/admin/v1beta2/BUILD.bazel d/google/firestore/admin/v1beta2/BUILD.bazel
 --- c/google/firestore/admin/v1beta2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/firestore/admin/v1beta2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,32 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -6488,12 +6306,11 @@ diff -urN c/google/firestore/admin/v1beta2/BUILD.bazel d/google/firestore/admin/
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/firestore/admin/v1beta2:admin_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
 +    ],
 +)
 +
@@ -6504,15 +6321,14 @@ diff -urN c/google/firestore/admin/v1beta2/BUILD.bazel d/google/firestore/admin/
 +    proto = ":admin_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/firestore/admin/v1beta2:admin_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
 +    ],
 +)
 diff -urN c/google/firestore/v1/BUILD.bazel d/google/firestore/v1/BUILD.bazel
 --- c/google/firestore/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/firestore/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,38 @@
+@@ -0,0 +1,36 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -6527,14 +6343,13 @@ diff -urN c/google/firestore/v1/BUILD.bazel d/google/firestore/v1/BUILD.bazel
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/rpc:status_proto",
++        "//google/type:latlng_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:struct_proto",
 +        "@com_google_protobuf//:timestamp_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/firestore/v1:firestore_proto",
-+        "@go_googleapis//google/rpc:status_proto",
-+        "@go_googleapis//google/type:latlng_proto",
 +    ],
 +)
 +
@@ -6545,16 +6360,15 @@ diff -urN c/google/firestore/v1/BUILD.bazel d/google/firestore/v1/BUILD.bazel
 +    proto = ":firestore_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/firestore/v1:firestore_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
-+        "@go_googleapis//google/type:latlng_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/rpc:status_go_proto",
++        "//google/type:latlng_go_proto",
 +    ],
 +)
 diff -urN c/google/firestore/v1beta1/BUILD.bazel d/google/firestore/v1beta1/BUILD.bazel
 --- c/google/firestore/v1beta1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/firestore/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,38 @@
+@@ -0,0 +1,36 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -6569,14 +6383,13 @@ diff -urN c/google/firestore/v1beta1/BUILD.bazel d/google/firestore/v1beta1/BUIL
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/rpc:status_proto",
++        "//google/type:latlng_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:struct_proto",
 +        "@com_google_protobuf//:timestamp_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/firestore/v1beta1:firestore_proto",
-+        "@go_googleapis//google/rpc:status_proto",
-+        "@go_googleapis//google/type:latlng_proto",
 +    ],
 +)
 +
@@ -6587,16 +6400,15 @@ diff -urN c/google/firestore/v1beta1/BUILD.bazel d/google/firestore/v1beta1/BUIL
 +    proto = ":firestore_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/firestore/v1beta1:firestore_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
-+        "@go_googleapis//google/type:latlng_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/rpc:status_go_proto",
++        "//google/type:latlng_go_proto",
 +    ],
 +)
 diff -urN c/google/genomics/v1/BUILD.bazel d/google/genomics/v1/BUILD.bazel
 --- c/google/genomics/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/genomics/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,49 @@
+@@ -0,0 +1,47 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -6618,17 +6430,16 @@ diff -urN c/google/genomics/v1/BUILD.bazel d/google/genomics/v1/BUILD.bazel
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:any_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:struct_proto",
 +        "@com_google_protobuf//:timestamp_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/genomics/v1:genomics_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -6639,11 +6450,10 @@ diff -urN c/google/genomics/v1/BUILD.bazel d/google/genomics/v1/BUILD.bazel
 +    proto = ":genomics_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/genomics/v1:genomics_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/genomics/v1alpha2/BUILD.bazel d/google/genomics/v1alpha2/BUILD.bazel
@@ -6658,12 +6468,12 @@ diff -urN c/google/genomics/v1alpha2/BUILD.bazel d/google/genomics/v1alpha2/BUIL
 +    srcs = ["pipelines.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/longrunning:longrunning_proto",
++        "//google/rpc:code_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
-+        "@go_googleapis//google/rpc:code_proto",
 +    ],
 +)
 +
@@ -6674,9 +6484,9 @@ diff -urN c/google/genomics/v1alpha2/BUILD.bazel d/google/genomics/v1alpha2/BUIL
 +    proto = ":genomics_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
-+        "@go_googleapis//google/rpc:code_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/longrunning:longrunning_go_proto",
++        "//google/rpc:code_go_proto",
 +    ],
 +)
 diff -urN c/google/geo/type/BUILD.bazel d/google/geo/type/BUILD.bazel
@@ -6690,7 +6500,7 @@ diff -urN c/google/geo/type/BUILD.bazel d/google/geo/type/BUILD.bazel
 +    name = "viewport_proto",
 +    srcs = ["viewport.proto"],
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/type:latlng_proto"],
++    deps = ["//google/type:latlng_proto"],
 +)
 +
 +go_proto_library(
@@ -6698,12 +6508,12 @@ diff -urN c/google/geo/type/BUILD.bazel d/google/geo/type/BUILD.bazel
 +    importpath = "google.golang.org/genproto/googleapis/geo/type/viewport",
 +    proto = ":viewport_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/type:latlng_go_proto"],
++    deps = ["//google/type:latlng_go_proto"],
 +)
 diff -urN c/google/home/graph/v1/BUILD.bazel d/google/home/graph/v1/BUILD.bazel
 --- c/google/home/graph/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/home/graph/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,25 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -6715,10 +6525,9 @@ diff -urN c/google/home/graph/v1/BUILD.bazel d/google/home/graph/v1/BUILD.bazel
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:struct_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/home/graph/v1:graph_proto",
 +    ],
 +)
 +
@@ -6728,10 +6537,7 @@ diff -urN c/google/home/graph/v1/BUILD.bazel d/google/home/graph/v1/BUILD.bazel
 +    importpath = "google.golang.org/genproto/googleapis/home/graph/v1",
 +    proto = ":graph_proto",
 +    visibility = ["//visibility:public"],
-+    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/home/graph/v1:graph_go_proto",
-+    ],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/iam/admin/v1/BUILD.bazel d/google/iam/admin/v1/BUILD.bazel
 --- c/google/iam/admin/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -6745,11 +6551,11 @@ diff -urN c/google/iam/admin/v1/BUILD.bazel d/google/iam/admin/v1/BUILD.bazel
 +    srcs = ["iam.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
 +    ],
 +)
 +
@@ -6760,14 +6566,14 @@ diff -urN c/google/iam/admin/v1/BUILD.bazel d/google/iam/admin/v1/BUILD.bazel
 +    proto = ":admin_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
 +    ],
 +)
 diff -urN c/google/iam/credentials/v1/BUILD.bazel d/google/iam/credentials/v1/BUILD.bazel
 --- c/google/iam/credentials/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/iam/credentials/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,25 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -6779,10 +6585,9 @@ diff -urN c/google/iam/credentials/v1/BUILD.bazel d/google/iam/credentials/v1/BU
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/iam/credentials/v1:credentials_proto",
 +    ],
 +)
 +
@@ -6792,15 +6597,12 @@ diff -urN c/google/iam/credentials/v1/BUILD.bazel d/google/iam/credentials/v1/BU
 +    importpath = "google.golang.org/genproto/googleapis/iam/credentials/v1",
 +    proto = ":credentials_proto",
 +    visibility = ["//visibility:public"],
-+    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/iam/credentials/v1:credentials_go_proto",
-+    ],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/iam/v1/BUILD.bazel d/google/iam/v1/BUILD.bazel
 --- c/google/iam/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/iam/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,30 @@
+@@ -0,0 +1,28 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -6813,9 +6615,8 @@ diff -urN c/google/iam/v1/BUILD.bazel d/google/iam/v1/BUILD.bazel
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
-+        "@go_googleapis//google/type:expr_proto",
++        "//google/api:annotations_proto",
++        "//google/type:expr_proto",
 +    ],
 +)
 +
@@ -6826,9 +6627,8 @@ diff -urN c/google/iam/v1/BUILD.bazel d/google/iam/v1/BUILD.bazel
 +    proto = ":iam_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
-+        "@go_googleapis//google/type:expr_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/type:expr_go_proto",
 +    ],
 +)
 diff -urN c/google/iam/v1/logging/BUILD.bazel d/google/iam/v1/logging/BUILD.bazel
@@ -6843,8 +6643,8 @@ diff -urN c/google/iam/v1/logging/BUILD.bazel d/google/iam/v1/logging/BUILD.baze
 +    srcs = ["audit_data.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
 +    ],
 +)
 +
@@ -6854,8 +6654,8 @@ diff -urN c/google/iam/v1/logging/BUILD.bazel d/google/iam/v1/logging/BUILD.baze
 +    proto = ":logging_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
 +    ],
 +)
 diff -urN c/google/logging/type/BUILD.bazel d/google/logging/type/BUILD.bazel
@@ -6873,8 +6673,8 @@ diff -urN c/google/logging/type/BUILD.bazel d/google/logging/type/BUILD.bazel
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:duration_proto",
-+        "@go_googleapis//google/api:annotations_proto",
 +    ],
 +)
 +
@@ -6883,12 +6683,12 @@ diff -urN c/google/logging/type/BUILD.bazel d/google/logging/type/BUILD.bazel
 +    importpath = "google.golang.org/genproto/googleapis/logging/type",
 +    proto = ":ltype_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/logging/v2/BUILD.bazel d/google/logging/v2/BUILD.bazel
 --- c/google/logging/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/logging/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,45 @@
+@@ -0,0 +1,43 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -6902,19 +6702,18 @@ diff -urN c/google/logging/v2/BUILD.bazel d/google/logging/v2/BUILD.bazel
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/api:distribution_proto",
++        "//google/api:metric_proto",
++        "//google/api:monitoredres_proto",
++        "//google/logging/type:ltype_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:any_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:struct_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/api:distribution_proto",
-+        "@go_googleapis//google/api:metric_proto",
-+        "@go_googleapis//google/api:monitoredres_proto",
-+        "@go_googleapis//google/logging/type:ltype_proto",
-+        "@go_googleapis//google/logging/v2:logging_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -6925,13 +6724,12 @@ diff -urN c/google/logging/v2/BUILD.bazel d/google/logging/v2/BUILD.bazel
 +    proto = ":logging_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/api:distribution_go_proto",
-+        "@go_googleapis//google/api:metric_go_proto",
-+        "@go_googleapis//google/api:monitoredres_go_proto",
-+        "@go_googleapis//google/logging/type:ltype_go_proto",
-+        "@go_googleapis//google/logging/v2:logging_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/api:distribution_go_proto",
++        "//google/api:metric_go_proto",
++        "//google/api:monitoredres_go_proto",
++        "//google/logging/type:ltype_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/longrunning/BUILD.bazel d/google/longrunning/BUILD.bazel
@@ -6946,12 +6744,12 @@ diff -urN c/google/longrunning/BUILD.bazel d/google/longrunning/BUILD.bazel
 +    srcs = ["operations.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:any_proto",
 +        "@com_google_protobuf//:descriptor_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/rpc:status_proto",
 +    ],
 +)
 +
@@ -6962,8 +6760,8 @@ diff -urN c/google/longrunning/BUILD.bazel d/google/longrunning/BUILD.bazel
 +    proto = ":longrunning_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/maps/playablelocations/v3/BUILD.bazel d/google/maps/playablelocations/v3/BUILD.bazel
@@ -6978,9 +6776,9 @@ diff -urN c/google/maps/playablelocations/v3/BUILD.bazel d/google/maps/playablel
 +    srcs = ["playablelocations.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "//google/maps/playablelocations/v3/sample:sample_proto",
 +        "@com_google_protobuf//:duration_proto",
-+        "@go_googleapis//google/api:annotations_proto",
 +    ],
 +)
 +
@@ -6991,8 +6789,8 @@ diff -urN c/google/maps/playablelocations/v3/BUILD.bazel d/google/maps/playablel
 +    proto = ":playablelocations_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_go_proto",
 +        "//google/maps/playablelocations/v3/sample:sample_go_proto",
-+        "@go_googleapis//google/api:annotations_go_proto",
 +    ],
 +)
 diff -urN c/google/maps/playablelocations/v3/sample/BUILD.bazel d/google/maps/playablelocations/v3/sample/BUILD.bazel
@@ -7007,9 +6805,9 @@ diff -urN c/google/maps/playablelocations/v3/sample/BUILD.bazel d/google/maps/pl
 +    srcs = ["resources.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/type:latlng_proto",
 +        "@com_google_protobuf//:field_mask_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/type:latlng_proto",
 +    ],
 +)
 +
@@ -7019,8 +6817,8 @@ diff -urN c/google/maps/playablelocations/v3/sample/BUILD.bazel d/google/maps/pl
 +    proto = ":sample_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/type:latlng_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/type:latlng_go_proto",
 +    ],
 +)
 diff -urN c/google/maps/roads/v1op/BUILD.bazel d/google/maps/roads/v1op/BUILD.bazel
@@ -7035,9 +6833,9 @@ diff -urN c/google/maps/roads/v1op/BUILD.bazel d/google/maps/roads/v1op/BUILD.ba
 +    srcs = ["roads.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/type:latlng_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/type:latlng_proto",
 +    ],
 +)
 +
@@ -7048,8 +6846,8 @@ diff -urN c/google/maps/roads/v1op/BUILD.bazel d/google/maps/roads/v1op/BUILD.ba
 +    proto = ":roads_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/type:latlng_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/type:latlng_go_proto",
 +    ],
 +)
 diff -urN c/google/maps/routes/v1/BUILD.bazel d/google/maps/routes/v1/BUILD.bazel
@@ -7073,13 +6871,13 @@ diff -urN c/google/maps/routes/v1/BUILD.bazel d/google/maps/routes/v1/BUILD.baze
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/geo/type:viewport_proto",
++        "//google/type:latlng_proto",
++        "//google/type:money_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:timestamp_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/geo/type:viewport_proto",
-+        "@go_googleapis//google/type:latlng_proto",
-+        "@go_googleapis//google/type:money_proto",
 +    ],
 +)
 +
@@ -7090,16 +6888,16 @@ diff -urN c/google/maps/routes/v1/BUILD.bazel d/google/maps/routes/v1/BUILD.baze
 +    proto = ":routes_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/geo/type:viewport_go_proto",
-+        "@go_googleapis//google/type:latlng_go_proto",
-+        "@go_googleapis//google/type:money_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/geo/type:viewport_go_proto",
++        "//google/type:latlng_go_proto",
++        "//google/type:money_go_proto",
 +    ],
 +)
 diff -urN c/google/monitoring/dashboard/v1/BUILD.bazel d/google/monitoring/dashboard/v1/BUILD.bazel
 --- c/google/monitoring/dashboard/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/monitoring/dashboard/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,35 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -7120,11 +6918,10 @@ diff -urN c/google/monitoring/dashboard/v1/BUILD.bazel d/google/monitoring/dashb
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/monitoring/dashboard/v1:dashboard_proto",
 +    ],
 +)
 +
@@ -7134,15 +6931,12 @@ diff -urN c/google/monitoring/dashboard/v1/BUILD.bazel d/google/monitoring/dashb
 +    importpath = "google.golang.org/genproto/googleapis/monitoring/dashboard/v1",
 +    proto = ":dashboard_proto",
 +    visibility = ["//visibility:public"],
-+    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/monitoring/dashboard/v1:dashboard_go_proto",
-+    ],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/monitoring/v3/BUILD.bazel d/google/monitoring/v3/BUILD.bazel
 --- c/google/monitoring/v3/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/monitoring/v3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,61 @@
+@@ -0,0 +1,59 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -7168,21 +6962,20 @@ diff -urN c/google/monitoring/v3/BUILD.bazel d/google/monitoring/v3/BUILD.bazel
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/api:api_proto",
++        "//google/api:distribution_proto",
++        "//google/api:label_proto",
++        "//google/api:metric_proto",
++        "//google/api:monitoredres_proto",
++        "//google/rpc:status_proto",
++        "//google/type:calendarperiod_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:struct_proto",
 +        "@com_google_protobuf//:timestamp_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/api:api_proto",
-+        "@go_googleapis//google/api:distribution_proto",
-+        "@go_googleapis//google/api:label_proto",
-+        "@go_googleapis//google/api:metric_proto",
-+        "@go_googleapis//google/api:monitoredres_proto",
-+        "@go_googleapis//google/monitoring/v3:monitoring_proto",
-+        "@go_googleapis//google/rpc:status_proto",
-+        "@go_googleapis//google/type:calendarperiod_proto",
 +    ],
 +)
 +
@@ -7193,21 +6986,20 @@ diff -urN c/google/monitoring/v3/BUILD.bazel d/google/monitoring/v3/BUILD.bazel
 +    proto = ":monitoring_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/api:api_go_proto",
-+        "@go_googleapis//google/api:distribution_go_proto",
-+        "@go_googleapis//google/api:label_go_proto",
-+        "@go_googleapis//google/api:metric_go_proto",
-+        "@go_googleapis//google/api:monitoredres_go_proto",
-+        "@go_googleapis//google/monitoring/v3:monitoring_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
-+        "@go_googleapis//google/type:calendarperiod_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/api:api_go_proto",
++        "//google/api:distribution_go_proto",
++        "//google/api:label_go_proto",
++        "//google/api:metric_go_proto",
++        "//google/api:monitoredres_go_proto",
++        "//google/rpc:status_go_proto",
++        "//google/type:calendarperiod_go_proto",
 +    ],
 +)
 diff -urN c/google/privacy/dlp/v2/BUILD.bazel d/google/privacy/dlp/v2/BUILD.bazel
 --- c/google/privacy/dlp/v2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/privacy/dlp/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,37 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -7219,16 +7011,15 @@ diff -urN c/google/privacy/dlp/v2/BUILD.bazel d/google/privacy/dlp/v2/BUILD.baze
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/rpc:status_proto",
++        "//google/type:date_proto",
++        "//google/type:dayofweek_proto",
++        "//google/type:timeofday_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/privacy/dlp/v2:dlp_proto",
-+        "@go_googleapis//google/rpc:status_proto",
-+        "@go_googleapis//google/type:date_proto",
-+        "@go_googleapis//google/type:dayofweek_proto",
-+        "@go_googleapis//google/type:timeofday_proto",
 +    ],
 +)
 +
@@ -7239,12 +7030,11 @@ diff -urN c/google/privacy/dlp/v2/BUILD.bazel d/google/privacy/dlp/v2/BUILD.baze
 +    proto = ":dlp_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/privacy/dlp/v2:dlp_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
-+        "@go_googleapis//google/type:date_go_proto",
-+        "@go_googleapis//google/type:dayofweek_go_proto",
-+        "@go_googleapis//google/type:timeofday_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/rpc:status_go_proto",
++        "//google/type:date_go_proto",
++        "//google/type:dayofweek_go_proto",
++        "//google/type:timeofday_go_proto",
 +    ],
 +)
 diff -urN c/google/pubsub/v1/BUILD.bazel d/google/pubsub/v1/BUILD.bazel
@@ -7259,11 +7049,11 @@ diff -urN c/google/pubsub/v1/BUILD.bazel d/google/pubsub/v1/BUILD.bazel
 +    srcs = ["pubsub.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
 +    ],
 +)
 +
@@ -7273,7 +7063,7 @@ diff -urN c/google/pubsub/v1/BUILD.bazel d/google/pubsub/v1/BUILD.bazel
 +    importpath = "google.golang.org/genproto/googleapis/pubsub/v1",
 +    proto = ":pubsub_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/google/pubsub/v1beta2/BUILD.bazel d/google/pubsub/v1beta2/BUILD.bazel
 --- c/google/pubsub/v1beta2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -7378,11 +7168,11 @@ diff -urN c/google/spanner/admin/database/v1/BUILD.bazel d/google/spanner/admin/
 +    srcs = ["spanner_database_admin.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
++        "//google/longrunning:longrunning_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
 +    ],
 +)
 +
@@ -7393,9 +7183,9 @@ diff -urN c/google/spanner/admin/database/v1/BUILD.bazel d/google/spanner/admin/
 +    proto = ":database_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
++        "//google/longrunning:longrunning_go_proto",
 +    ],
 +)
 diff -urN c/google/spanner/admin/instance/v1/BUILD.bazel d/google/spanner/admin/instance/v1/BUILD.bazel
@@ -7410,12 +7200,12 @@ diff -urN c/google/spanner/admin/instance/v1/BUILD.bazel d/google/spanner/admin/
 +    srcs = ["spanner_instance_admin.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
++        "//google/longrunning:longrunning_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
-+        "@go_googleapis//google/longrunning:longrunning_proto",
 +    ],
 +)
 +
@@ -7426,15 +7216,15 @@ diff -urN c/google/spanner/admin/instance/v1/BUILD.bazel d/google/spanner/admin/
 +    proto = ":instance_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
-+        "@go_googleapis//google/longrunning:longrunning_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
++        "//google/longrunning:longrunning_go_proto",
 +    ],
 +)
 diff -urN c/google/spanner/v1/BUILD.bazel d/google/spanner/v1/BUILD.bazel
 --- c/google/spanner/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/spanner/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,38 @@
+@@ -0,0 +1,36 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -7451,13 +7241,12 @@ diff -urN c/google/spanner/v1/BUILD.bazel d/google/spanner/v1/BUILD.bazel
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:struct_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/rpc:status_proto",
-+        "@go_googleapis//google/spanner/v1:spanner_proto",
 +    ],
 +)
 +
@@ -7468,9 +7257,8 @@ diff -urN c/google/spanner/v1/BUILD.bazel d/google/spanner/v1/BUILD.bazel
 +    proto = ":spanner_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
-+        "@go_googleapis//google/spanner/v1:spanner_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)
 diff -urN c/google/storage/v1/BUILD.bazel d/google/storage/v1/BUILD.bazel
@@ -7488,12 +7276,12 @@ diff -urN c/google/storage/v1/BUILD.bazel d/google/storage/v1/BUILD.bazel
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/iam/v1:iam_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
 +        "@com_google_protobuf//:wrappers_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/iam/v1:iam_proto",
 +    ],
 +)
 +
@@ -7504,14 +7292,14 @@ diff -urN c/google/storage/v1/BUILD.bazel d/google/storage/v1/BUILD.bazel
 +    proto = ":storage_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/iam/v1:iam_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/iam/v1:iam_go_proto",
 +    ],
 +)
 diff -urN c/google/storagetransfer/v1/BUILD.bazel d/google/storagetransfer/v1/BUILD.bazel
 --- c/google/storagetransfer/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/storagetransfer/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,37 @@
+@@ -0,0 +1,35 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -7523,15 +7311,14 @@ diff -urN c/google/storagetransfer/v1/BUILD.bazel d/google/storagetransfer/v1/BU
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/rpc:code_proto",
++        "//google/type:date_proto",
++        "//google/type:timeofday_proto",
 +        "@com_google_protobuf//:duration_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/rpc:code_proto",
-+        "@go_googleapis//google/storagetransfer/v1:storagetransfer_proto",
-+        "@go_googleapis//google/type:date_proto",
-+        "@go_googleapis//google/type:timeofday_proto",
 +    ],
 +)
 +
@@ -7542,17 +7329,16 @@ diff -urN c/google/storagetransfer/v1/BUILD.bazel d/google/storagetransfer/v1/BU
 +    proto = ":storagetransfer_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/rpc:code_go_proto",
-+        "@go_googleapis//google/storagetransfer/v1:storagetransfer_go_proto",
-+        "@go_googleapis//google/type:date_go_proto",
-+        "@go_googleapis//google/type:timeofday_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/rpc:code_go_proto",
++        "//google/type:date_go_proto",
++        "//google/type:timeofday_go_proto",
 +    ],
 +)
 diff -urN c/google/streetview/publish/v1/BUILD.bazel d/google/streetview/publish/v1/BUILD.bazel
 --- c/google/streetview/publish/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/google/streetview/publish/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,35 @@
+@@ -0,0 +1,33 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -7565,13 +7351,12 @@ diff -urN c/google/streetview/publish/v1/BUILD.bazel d/google/streetview/publish
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/rpc:status_proto",
++        "//google/type:latlng_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/rpc:status_proto",
-+        "@go_googleapis//google/streetview/publish/v1:publish_proto",
-+        "@go_googleapis//google/type:latlng_proto",
 +    ],
 +)
 +
@@ -7582,10 +7367,9 @@ diff -urN c/google/streetview/publish/v1/BUILD.bazel d/google/streetview/publish
 +    proto = ":publish_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
-+        "@go_googleapis//google/streetview/publish/v1:publish_go_proto",
-+        "@go_googleapis//google/type:latlng_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/rpc:status_go_proto",
++        "//google/type:latlng_go_proto",
 +    ],
 +)
 diff -urN c/google/type/BUILD.bazel d/google/type/BUILD.bazel
@@ -7777,9 +7561,9 @@ diff -urN c/google/watcher/v1/BUILD.bazel d/google/watcher/v1/BUILD.bazel
 +    srcs = ["watch.proto"],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
 +        "@com_google_protobuf//:any_proto",
 +        "@com_google_protobuf//:empty_proto",
-+        "@go_googleapis//google/api:annotations_proto",
 +    ],
 +)
 +
@@ -7789,12 +7573,12 @@ diff -urN c/google/watcher/v1/BUILD.bazel d/google/watcher/v1/BUILD.bazel
 +    importpath = "google.golang.org/genproto/googleapis/watcher/v1",
 +    proto = ":watcher_proto",
 +    visibility = ["//visibility:public"],
-+    deps = ["@go_googleapis//google/api:annotations_go_proto"],
++    deps = ["//google/api:annotations_go_proto"],
 +)
 diff -urN c/grafeas/v1/BUILD.bazel d/grafeas/v1/BUILD.bazel
 --- c/grafeas/v1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ d/grafeas/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,42 @@
+@@ -0,0 +1,40 @@
 +load("@rules_proto//proto:defs.bzl", "proto_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 +
@@ -7816,12 +7600,11 @@ diff -urN c/grafeas/v1/BUILD.bazel d/grafeas/v1/BUILD.bazel
 +    ],
 +    visibility = ["//visibility:public"],
 +    deps = [
++        "//google/api:annotations_proto",
++        "//google/rpc:status_proto",
 +        "@com_google_protobuf//:empty_proto",
 +        "@com_google_protobuf//:field_mask_proto",
 +        "@com_google_protobuf//:timestamp_proto",
-+        "@go_googleapis//google/api:annotations_proto",
-+        "@go_googleapis//google/rpc:status_proto",
-+        "@go_googleapis//grafeas/v1:grafeas_proto",
 +    ],
 +)
 +
@@ -7832,8 +7615,7 @@ diff -urN c/grafeas/v1/BUILD.bazel d/grafeas/v1/BUILD.bazel
 +    proto = ":grafeas_proto",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "@go_googleapis//google/api:annotations_go_proto",
-+        "@go_googleapis//google/rpc:status_go_proto",
-+        "@go_googleapis//grafeas/v1:grafeas_go_proto",
++        "//google/api:annotations_go_proto",
++        "//google/rpc:status_go_proto",
 +    ],
 +)


### PR DESCRIPTION
Re-generate the Gazelle patch after bazelbuild/bazel-gazelle#717.

Fixes #2387