### PR TITLE
go: add missing platforms from 'go tools dist list'

### DIFF
--- a/go/private/platforms.bzl
+++ b/go/private/platforms.bzl
@@ -34,6 +34,7 @@ BAZEL_GOARCH_CONSTRAINTS = {
 }
 
 GOOS_GOARCH = (
+    ("aix", "ppc64"),
     ("android", "386"),
     ("android", "amd64"),
     ("android", "arm"),
@@ -46,6 +47,9 @@ GOOS_GOARCH = (
     ("freebsd", "386"),
     ("freebsd", "amd64"),
     ("freebsd", "arm"),
+    ("freebsd", "arm64"),
+    ("illumos", "amd64"),
+    ("js", "wasm"),
     ("linux", "386"),
     ("linux", "amd64"),
     ("linux", "arm"),
@@ -56,6 +60,7 @@ GOOS_GOARCH = (
     ("linux", "mipsle"),
     ("linux", "ppc64"),
     ("linux", "ppc64le"),
+    ("linux", "riscv64"),
     ("linux", "s390x"),
     ("nacl", "386"),
     ("nacl", "amd64p32"),
@@ -63,16 +68,18 @@ GOOS_GOARCH = (
     ("netbsd", "386"),
     ("netbsd", "amd64"),
     ("netbsd", "arm"),
+    ("netbsd", "arm64"),
     ("openbsd", "386"),
     ("openbsd", "amd64"),
     ("openbsd", "arm"),
+    ("openbsd", "arm64"),
     ("plan9", "386"),
     ("plan9", "amd64"),
     ("plan9", "arm"),
     ("solaris", "amd64"),
     ("windows", "386"),
     ("windows", "amd64"),
-    ("js", "wasm"),
+    ("windows", "arm"),
 )
 
 RACE_GOOS_GOARCH = {


### PR DESCRIPTION
This will add new targets in //go/platforms and //go/toolchains.