### PR TITLE
Set minimum supported Bazel version to 2.2.0

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,7 +1,7 @@
 ---
 platforms:
   ubuntu1604:
-    bazel: 1.2.0 # test minimum supported version of bazel on ubuntu1604 only
+    bazel: 2.2.0 # test minimum supported version of bazel on ubuntu1604 only
     build_targets:
     - "..."
     test_targets:

--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -208,7 +208,7 @@ def has_versioned_shared_lib_extension(path):
 
     return True
 
-MINIMUM_BAZEL_VERSION = "1.2.0"
+MINIMUM_BAZEL_VERSION = "2.2.0"
 
 def as_list(v):
     """Returns a list, tuple, or depset as a list."""


### PR DESCRIPTION
This only applies to the master branch, not to current release
branches.

This is needed for configuration transition support. 1.2.0 (the
current minimum) and 2.1.0 (the version before 2.2.0) both have build
failures triggered by transitions.

For #2219