### PR TITLE
Add missing Starlark files to “all_rules” targets.

### DIFF
--- a/go/BUILD.bazel
+++ b/go/BUILD.bazel
@@ -12,7 +12,11 @@ filegroup(
 
 filegroup(
     name = "all_rules",
-    srcs = glob(["*.bzl"]) + ["//go/private:all_rules"],
+    srcs = glob(["*.bzl"]) + [
+        "//go/platform:all_rules",
+        "//go/private:all_rules",
+        "//go/toolchain:all_rules",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/go/platform/BUILD.bazel
+++ b/go/platform/BUILD.bazel
@@ -12,6 +12,12 @@ package(default_visibility = ["//visibility:public"])
 declare_config_settings()
 
 filegroup(
+    name = "all_rules",
+    srcs = glob(["*.bzl"]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
     name = "all_files",
     testonly = True,
     srcs = glob(["**"]),

--- a/go/toolchain/BUILD.bazel
+++ b/go/toolchain/BUILD.bazel
@@ -8,6 +8,12 @@ package(default_visibility = ["//visibility:public"])
 declare_constraints()
 
 filegroup(
+    name = "all_rules",
+    srcs = glob(["*.bzl"]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
     name = "all_files",
     testonly = True,
     srcs = glob(["**"]),


### PR DESCRIPTION
This is important for Stardoc, which insists on knowing about all transitively
loaded Starlark files.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.

Bug fix


**What does this PR do? Why is it needed?**

When generating documentation for a rule that uses these rules using Stardoc,
compilation currently fails because not all transitively loaded files are present.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
