### PR TITLE
Fix tests

### DIFF
--- a/go/tools/bazel/BUILD.bazel
+++ b/go/tools/bazel/BUILD.bazel
@@ -14,7 +14,7 @@ go_test(
     name = "go_default_test",
     size = "small",
     srcs = ["bazel_test.go"],
-    data = ["README.md"],
+    data = ["empty.txt"],
     embed = [":go_default_library"],
 )
 

--- a/go/tools/bazel/bazel_test.go
+++ b/go/tools/bazel/bazel_test.go
@@ -71,7 +71,7 @@ func createPaths(paths []string) error {
 }
 
 func TestRunfile(t *testing.T) {
-	file := "go/tools/bazel/README.md"
+	file := "go/tools/bazel/empty.txt"
 	runfile, err := Runfile(file)
 	if err != nil {
 		t.Errorf("When reading file %s got error %s", file, err)

--- a/tests/legacy/build_constraints/cgo_unknown.go
+++ b/tests/legacy/build_constraints/cgo_unknown.go
@@ -4,8 +4,8 @@ package build_constraints
 
 /*
 const char* cgoGo = "unknown";
-const const char* cgoC;
-const const char* cgoCGroup;
+extern const char* cgoC;
+extern const char* cgoCGroup;
 */
 import "C"
 


### PR DESCRIPTION
* go/tools/bazel: use empty.txt as test data instead of README.md
  which was deleted.
* tests/legacy/build_constraints: 'extern const', not 'const const'.
