### PR TITLE
README: add missing strip_prefix on protobuf release

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -426,6 +426,7 @@ To generate code from protocol buffers, you'll need to add a dependency on
     http_archive(
         name = "com_google_protobuf",
         sha256 = "9748c0d90e54ea09e5e75fb7fac16edce15d2028d4356f32211cfa3c0e956564",
+        strip_prefix = "protobuf-3.11.4",
         urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.11.4.zip"],
     )
 


### PR DESCRIPTION
**What type of PR is this?**
Documentation

**What does this PR do? Why is it needed?**
Fixes build error when copy/pasting protobuf dependency example

**Which issues(s) does this PR fix?**
Fixes #2441