### PR TITLE
Fixes com_google_protobuf reference

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -427,6 +427,7 @@ To generate code from protocol buffers, you'll need to add a dependency on
         name = "com_google_protobuf",
         sha256 = "9748c0d90e54ea09e5e75fb7fac16edce15d2028d4356f32211cfa3c0e956564",
         urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.11.4.zip"],
+        strip_prefix = "protobuf-3.11.4",
     )
 
     load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")


### PR DESCRIPTION
This fix enables direct copy-paste on the WORKSPACE file for bazel versions that don't handle strip_prefix automatically.

**What type of PR is this?**

Documentation

**What does this PR do? Why is it needed?**

Fixes the README reference of `com_google_protobuf`. Adds the strip_prefix so users don't spend minutes of their lives searching for the issue when getting the following error:

    ERROR: error loading package '': Every .bzl file must have a corresponding package, but 
    '@com_google_protobuf//:protobuf_deps.bzl' does not have one. Please create a BUILD file in the same or any parent directory. Note that this BUILD file does not need to do anything except exist.
