### PR TITLE
Check that file is not nil before accessing the name

### DIFF
--- a/go/tools/builders/nogo_main.go
+++ b/go/tools/builders/nogo_main.go
@@ -386,7 +386,11 @@ func checkAnalysisResults(actions []*action, pkg *goPackage) string {
 		}
 		// Discard diagnostics based on the analyzer configuration.
 		for _, d := range act.diagnostics {
-			filename := pkg.fset.File(d.Pos).Name()
+			file := pkg.fset.File(d.Pos)
+			if file == nil {
+				continue
+			}
+			filename := file.Name()
 			include := true
 			if len(config.onlyFiles) > 0 {
 				// This analyzer emits diagnostics for only a set of files.


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

 Bug fix

**What does this PR do? Why is it needed?**

In some rare cases, go/tools/builders/nogo_main.go:389 caused a nil pointer deference.

```
compilepkg: panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x6cd735]

goroutine 1 [running]:
go/token.(*File).Name(...)
        GOROOT/src/go/token/position.go:110
main.checkAnalysisResults(0xc00022e000, 0x1d, 0x1d, 0xc0002d8e60, 0x2, 0x2)
        external/io_bazel_rules_go/go/tools/builders/nogo_main.go:389 +0x475
main.checkPackage(0x9ff7c0, 0x1d, 0x1d, 0xc000221003, 0x2b, 0xc0002015f0, 0xc000201620, 0xc000201560, 0xc000113d20, 0x2, ...)
        external/io_bazel_rules_go/go/tools/builders/nogo_main.go:192 +0x3f0
main.run(0xc000113ba0, 0x1a, 0x1a, 0x0, 0x0)
        external/io_bazel_rules_go/go/tools/builders/nogo_main.go:84 +0x47c
main.main()
        external/io_bazel_rules_go/go/tools/builders/nogo_main.go:57 +0xa6
```

**Which issues(s) does this PR fix?**

Nothing filed, I think

**Other notes for review**
