### PR TITLE
go: remove searchpaths and searchpath from GoArchive and GoArchiveData

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -54,7 +54,6 @@ def emit_archive(go, source = None):
         out_export = go.declare_file(go, path = lib_name[:-len(".a")] + ".x")
     else:
         out_export = None
-    searchpath = out_lib.path[:-len(lib_name)]
     testfilter = getattr(source.library, "testfilter", None)
     out_cgo_export_h = None  # set if cgo used in c-shared or c-archive mode
 
@@ -137,7 +136,6 @@ def emit_archive(go, source = None):
         srcs = as_tuple(source.srcs),
         orig_srcs = as_tuple(source.orig_srcs),
         data_files = as_tuple(data_files),
-        searchpath = searchpath,
     )
     x_defs = dict(source.x_defs)
     for a in direct:
@@ -150,7 +148,6 @@ def emit_archive(go, source = None):
         source = source,
         data = data,
         direct = direct,
-        searchpaths = depset(direct = [searchpath], transitive = [a.searchpaths for a in direct]),
         libs = depset(direct = [out_lib], transitive = [a.libs for a in direct]),
         transitive = depset([data], transitive = [a.transitive for a in direct]),
         x_defs = x_defs,

--- a/go/providers.rst
+++ b/go/providers.rst
@@ -265,10 +265,6 @@ rule.  Instead, it's referenced in the ``data`` field of GoArchive_.
 | Data files that should be available at runtime to binaries and tests built                       |
 | from this archive.                                                                               |
 +--------------------------------+-----------------------------------------------------------------+
-| :param:`searchpath`            | :type:`string`                                                  |
-+--------------------------------+-----------------------------------------------------------------+
-| **Deprecated:** The search path entry under which the :param:`lib` would be found.               |
-+--------------------------------+-----------------------------------------------------------------+
 
 GoArchive
 ~~~~~~~~~
@@ -294,10 +290,6 @@ which is available through the :param:`data` field.
 | :param:`direct`                | :type:`list of GoArchive`                                       |
 +--------------------------------+-----------------------------------------------------------------+
 | The direct dependencies of this archive.                                                         |
-+--------------------------------+-----------------------------------------------------------------+
-| :param:`searchpaths`           | :type:`depset of string`                                        |
-+--------------------------------+-----------------------------------------------------------------+
-| **Deprecated:** The transitive set of search paths needed to link with this archive.             |
 +--------------------------------+-----------------------------------------------------------------+
 | :param:`libs`                  | :type:`depset of File`                                          |
 +--------------------------------+-----------------------------------------------------------------+


### PR DESCRIPTION
These are thoroughly obsolete and have been deprecated for a while.

For #2448