### PR TITLE
proto: upgrade go_proto_library to support APIv2

### DIFF
--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -120,19 +120,39 @@ def go_rules_dependencies(is_rules_go = False):
     # * Most proto repos are updated more frequently than rules_go, and
     #   we can't keep up.
 
-    # Go protoc plugin and runtime library
+    # Go protobuf runtime library and utilities.
+    _maybe(
+        http_archive,
+        name = "org_golang_google_protobuf",
+        sha256 = "22c82408718787bfa0453563a83681fc3905126040d6901eb1ce399795292937",
+        # v1.21.0, latest as of 2020-04-22
+        urls = [
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf-go/archive/v1.21.0.zip",
+            "https://github.com/protocolbuffers/protobuf-go/archive/v1.21.0.zip",
+        ],
+        strip_prefix = "protobuf-go-1.21.0",
+        patches = [
+            # gazelle args: -repo_root . -go_prefix google.golang.org/protobuf -proto disable_global
+            "@io_bazel_rules_go//third_party:org_golang_google_protobuf-gazelle.patch",
+        ],
+        patch_args = ["-p1"],
+    )
+
+    # Legacy protobuf compiler, runtime, and utilities.
+    # We still use protoc-gen-go because the new one doesn't support gRPC, and
+    # the gRPC compiler doesn't exist yet.
     # We need to apply a patch to enable both go_proto_library and
     # go_library with pre-generated sources.
     _maybe(
         http_archive,
         name = "com_github_golang_protobuf",
-        # v1.3.3, latest as of 2020-02-21
+        # v1.4.0, latest as of 2020-02-21
         urls = [
-            "https://mirror.bazel.build/github.com/golang/protobuf/archive/v1.3.3.zip",
-            "https://github.com/golang/protobuf/archive/v1.3.3.zip",
+            "https://mirror.bazel.build/github.com/golang/protobuf/archive/v1.4.0.zip",
+            "https://github.com/golang/protobuf/archive/v1.4.0.zip",
         ],
-        sha256 = "3b1ab4c27a3a3ea02fcd5d701d4680cf724e0b7499c67f520f1f1dd03ef0bc45",
-        strip_prefix = "protobuf-1.3.3",
+        sha256 = "9f74fe5ee107c75523d0d5ab1100a18e3e1e7d24f870b460083ab0a20966b910",
+        strip_prefix = "protobuf-1.4.0",
         patches = [
             # gazelle args: -repo_root . -go_prefix github.com/golang/protobuf -proto disable_global
             "@io_bazel_rules_go//third_party:com_github_golang_protobuf-gazelle.patch",

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -1,33 +1,35 @@
 load("//proto:compiler.bzl", "go_proto_compiler")
 load("//proto/wkt:well_known_types.bzl", "GOGO_WELL_KNOWN_TYPE_REMAPS", "WELL_KNOWN_TYPE_RULES")
 
+PROTO_RUNTIME_DEPS = [
+    "@com_github_golang_protobuf//proto:go_default_library",
+    "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
+    "@org_golang_google_protobuf//runtime/protoiface:go_default_library",
+    "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
+]
+
 go_proto_compiler(
     name = "go_proto_bootstrap",
     visibility = ["//visibility:public"],
-    deps = [
-        "@com_github_golang_protobuf//proto:go_default_library",
-    ],
+    deps = PROTO_RUNTIME_DEPS,
 )
 
 go_proto_compiler(
     name = "go_proto",
     visibility = ["//visibility:public"],
-    deps = [
-        "@com_github_golang_protobuf//proto:go_default_library",
-    ] + WELL_KNOWN_TYPE_RULES.values(),
+    deps = PROTO_RUNTIME_DEPS + WELL_KNOWN_TYPE_RULES.values(),
 )
 
 go_proto_compiler(
     name = "go_grpc",
     options = ["plugins=grpc"],
     visibility = ["//visibility:public"],
-    deps = [
-        "@com_github_golang_protobuf//proto:go_default_library",
+    deps = PROTO_RUNTIME_DEPS + WELL_KNOWN_TYPE_RULES.values() + [
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
         "@org_golang_x_net//context:go_default_library",
-    ] + WELL_KNOWN_TYPE_RULES.values(),
+    ],
 )
 
 go_proto_compiler(

--- a/third_party/com_github_golang_protobuf-extras.patch
+++ b/third_party/com_github_golang_protobuf-extras.patch
@@ -1,7 +1,7 @@
 diff -urN b/descriptor/BUILD.bazel c/descriptor/BUILD.bazel
 --- b/descriptor/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 +++ c/descriptor/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -11,6 +11,18 @@
+@@ -14,6 +14,21 @@
      ],
  )
  
@@ -13,6 +13,9 @@ diff -urN b/descriptor/BUILD.bazel c/descriptor/BUILD.bazel
 +    deps = [
 +        "//proto:go_default_library",
 +        "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
++        "@org_golang_google_protobuf//reflect/protodesc:go_default_library",
++        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
++        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
 +    ],
 +)
 +
@@ -23,72 +26,19 @@ diff -urN b/descriptor/BUILD.bazel c/descriptor/BUILD.bazel
 diff -urN b/jsonpb/BUILD.bazel c/jsonpb/BUILD.bazel
 --- b/jsonpb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 +++ c/jsonpb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -11,6 +11,17 @@
+@@ -19,6 +19,12 @@
      ],
  )
  
-+go_library(
++alias(
 +    name = "go_default_library_gen",
-+    srcs = ["jsonpb.go"],
-+    importpath = "github.com/golang/protobuf/jsonpb",
++    actual = ":go_default_library",
 +    visibility = ["//visibility:public"],
-+    deps = [
-+        "//proto:go_default_library",
-+        "@io_bazel_rules_go//proto/wkt:struct_go_proto",
-+    ],
 +)
 +
  go_test(
      name = "go_default_test",
-     srcs = ["jsonpb_test.go"],
-diff -urN b/jsonpb/jsonpb_test_proto/BUILD.bazel c/jsonpb/jsonpb_test_proto/BUILD.bazel
---- b/jsonpb/jsonpb_test_proto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-+++ c/jsonpb/jsonpb_test_proto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -1,5 +1,14 @@
- load("@io_bazel_rules_go//go:def.bzl", "go_library")
- 
-+filegroup(
-+    name = "go_default_library_protos",
-+    srcs = [
-+        "more_test_objects.proto",
-+        "test_objects.proto",
-+    ],
-+    visibility = ["//visibility:public"],
-+)
-+
- go_library(
-     name = "go_default_library",
-     srcs = [
-diff -urN b/proto/proto3_proto/BUILD.bazel c/proto/proto3_proto/BUILD.bazel
---- b/proto/proto3_proto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-+++ c/proto/proto3_proto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -1,5 +1,11 @@
- load("@io_bazel_rules_go//go:def.bzl", "go_library")
- 
-+filegroup(
-+    name = "go_default_library_protos",
-+    srcs = ["proto3.proto"],
-+    visibility = ["//visibility:public"],
-+)
-+
- go_library(
-     name = "go_default_library",
-     srcs = ["proto3.pb.go"],
-diff -urN b/proto/test_proto/BUILD.bazel c/proto/test_proto/BUILD.bazel
---- b/proto/test_proto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-+++ c/proto/test_proto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -1,5 +1,11 @@
- load("@io_bazel_rules_go//go:def.bzl", "go_library")
- 
-+filegroup(
-+    name = "go_default_library_protos",
-+    srcs = ["test.proto"],
-+    visibility = ["//visibility:public"],
-+)
-+
- go_library(
-     name = "go_default_library",
-     srcs = ["test.pb.go"],
+     srcs = ["json_test.go"],
 diff -urN b/protoc-gen-go/descriptor/BUILD.bazel c/protoc-gen-go/descriptor/BUILD.bazel
 --- b/protoc-gen-go/descriptor/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 +++ c/protoc-gen-go/descriptor/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
@@ -107,10 +57,11 @@ diff -urN b/protoc-gen-go/descriptor/BUILD.bazel c/protoc-gen-go/descriptor/BUIL
 diff -urN b/protoc-gen-go/generator/BUILD.bazel c/protoc-gen-go/generator/BUILD.bazel
 --- b/protoc-gen-go/generator/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 +++ c/protoc-gen-go/generator/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -13,6 +13,19 @@
+@@ -12,3 +12,16 @@
+         "//protoc-gen-go/plugin:go_default_library",
      ],
  )
- 
++
 +go_library(
 +    name = "go_default_library_gen",
 +    srcs = ["generator.go"],
@@ -123,10 +74,6 @@ diff -urN b/protoc-gen-go/generator/BUILD.bazel c/protoc-gen-go/generator/BUILD.
 +        "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
 +    ],
 +)
-+
- go_test(
-     name = "go_default_test",
-     srcs = ["name_test.go"],
 diff -urN b/protoc-gen-go/plugin/BUILD.bazel c/protoc-gen-go/plugin/BUILD.bazel
 --- b/protoc-gen-go/plugin/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 +++ c/protoc-gen-go/plugin/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
@@ -145,7 +92,7 @@ diff -urN b/protoc-gen-go/plugin/BUILD.bazel c/protoc-gen-go/plugin/BUILD.bazel
 diff -urN b/ptypes/BUILD.bazel c/ptypes/BUILD.bazel
 --- b/ptypes/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 +++ c/ptypes/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -18,6 +18,24 @@
+@@ -20,6 +20,26 @@
      ],
  )
  
@@ -164,6 +111,8 @@ diff -urN b/ptypes/BUILD.bazel c/ptypes/BUILD.bazel
 +        "@io_bazel_rules_go//proto/wkt:any_go_proto",
 +        "@io_bazel_rules_go//proto/wkt:duration_go_proto",
 +        "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",
++        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
++        "@org_golang_google_protobuf//reflect/protoregistry:go_default_library",
 +    ],
 +)
 +

--- a/third_party/com_github_golang_protobuf-gazelle.patch
+++ b/third_party/com_github_golang_protobuf-gazelle.patch
@@ -1,7 +1,7 @@
 diff -urN a/descriptor/BUILD.bazel b/descriptor/BUILD.bazel
 --- a/descriptor/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ b/descriptor/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,22 @@
+@@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -12,6 +12,9 @@ diff -urN a/descriptor/BUILD.bazel b/descriptor/BUILD.bazel
 +    deps = [
 +        "//proto:go_default_library",
 +        "//protoc-gen-go/descriptor:go_default_library",
++        "@org_golang_google_protobuf//reflect/protodesc:go_default_library",
++        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
++        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
 +    ],
 +)
 +
@@ -20,59 +23,148 @@ diff -urN a/descriptor/BUILD.bazel b/descriptor/BUILD.bazel
 +    srcs = ["descriptor_test.go"],
 +    embed = [":go_default_library"],
 +    deps = [
-+        "//proto/test_proto:go_default_library",
 +        "//protoc-gen-go/descriptor:go_default_library",
++        "@com_github_google_go_cmp//cmp:go_default_library",
++        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
 +    ],
 +)
-diff -urN a/jsonpb/BUILD.bazel b/jsonpb/BUILD.bazel
---- a/jsonpb/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/jsonpb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+diff -urN a/internal/cmd/generate-alias/BUILD.bazel b/internal/cmd/generate-alias/BUILD.bazel
+--- a/internal/cmd/generate-alias/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/cmd/generate-alias/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,29 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 +
 +go_library(
 +    name = "go_default_library",
-+    srcs = ["jsonpb.go"],
-+    importpath = "github.com/golang/protobuf/jsonpb",
-+    visibility = ["//visibility:public"],
++    srcs = ["main.go"],
++    importpath = "github.com/golang/protobuf/internal/cmd/generate-alias",
++    visibility = ["//visibility:private"],
 +    deps = [
 +        "//proto:go_default_library",
-+        "//ptypes/struct:go_default_library",
++        "@org_golang_google_protobuf//cmd/protoc-gen-go/internal_gengo:go_default_library",
++        "@org_golang_google_protobuf//compiler/protogen:go_default_library",
++        "@org_golang_google_protobuf//reflect/protodesc:go_default_library",
++        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
++        "@org_golang_google_protobuf//types/descriptorpb:go_default_library",
++        "@org_golang_google_protobuf//types/known/anypb:go_default_library",
++        "@org_golang_google_protobuf//types/known/durationpb:go_default_library",
++        "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
++        "@org_golang_google_protobuf//types/known/structpb:go_default_library",
++        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
++        "@org_golang_google_protobuf//types/known/wrapperspb:go_default_library",
++        "@org_golang_google_protobuf//types/pluginpb:go_default_library",
 +    ],
 +)
 +
-+go_test(
-+    name = "go_default_test",
-+    srcs = ["jsonpb_test.go"],
++go_binary(
++    name = "generate-alias",
 +    embed = [":go_default_library"],
++    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/gengogrpc/BUILD.bazel b/internal/gengogrpc/BUILD.bazel
+--- a/internal/gengogrpc/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/gengogrpc/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["grpc.go"],
++    importpath = "github.com/golang/protobuf/internal/gengogrpc",
++    visibility = ["//:__subpackages__"],
 +    deps = [
-+        "//jsonpb/jsonpb_test_proto:go_default_library",
-+        "//proto:go_default_library",
-+        "//proto/proto3_proto:go_default_library",
-+        "//ptypes:go_default_library",
-+        "//ptypes/any:go_default_library",
-+        "//ptypes/duration:go_default_library",
-+        "//ptypes/struct:go_default_library",
-+        "//ptypes/timestamp:go_default_library",
-+        "//ptypes/wrappers:go_default_library",
++        "@org_golang_google_protobuf//compiler/protogen:go_default_library",
++        "@org_golang_google_protobuf//types/descriptorpb:go_default_library",
 +    ],
 +)
-diff -urN a/jsonpb/jsonpb_test_proto/BUILD.bazel b/jsonpb/jsonpb_test_proto/BUILD.bazel
---- a/jsonpb/jsonpb_test_proto/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/jsonpb/jsonpb_test_proto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+diff -urN a/internal/testprotos/jsonpb_proto/BUILD.bazel b/internal/testprotos/jsonpb_proto/BUILD.bazel
+--- a/internal/testprotos/jsonpb_proto/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/jsonpb_proto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
 +    name = "go_default_library",
 +    srcs = [
-+        "more_test_objects.pb.go",
-+        "test_objects.pb.go",
++        "test2.pb.go",
++        "test3.pb.go",
 +    ],
-+    importpath = "github.com/golang/protobuf/jsonpb/jsonpb_test_proto",
++    importpath = "github.com/golang/protobuf/internal/testprotos/jsonpb_proto",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//proto:go_default_library",
++        "@org_golang_google_protobuf//types/known/anypb:go_default_library",
++        "@org_golang_google_protobuf//types/known/durationpb:go_default_library",
++        "@org_golang_google_protobuf//types/known/structpb:go_default_library",
++        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
++        "@org_golang_google_protobuf//types/known/wrapperspb:go_default_library",
++    ],
++)
+diff -urN a/internal/testprotos/proto2_proto/BUILD.bazel b/internal/testprotos/proto2_proto/BUILD.bazel
+--- a/internal/testprotos/proto2_proto/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/proto2_proto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,9 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["test.pb.go"],
++    importpath = "github.com/golang/protobuf/internal/testprotos/proto2_proto",
++    visibility = ["//:__subpackages__"],
++    deps = ["//proto:go_default_library"],
++)
+diff -urN a/internal/testprotos/proto3_proto/BUILD.bazel b/internal/testprotos/proto3_proto/BUILD.bazel
+--- a/internal/testprotos/proto3_proto/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/proto3_proto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,13 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["test.pb.go"],
++    importpath = "github.com/golang/protobuf/internal/testprotos/proto3_proto",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//internal/testprotos/proto2_proto:go_default_library",
++        "//proto:go_default_library",
++        "@org_golang_google_protobuf//types/known/anypb:go_default_library",
++    ],
++)
+diff -urN a/jsonpb/BUILD.bazel b/jsonpb/BUILD.bazel
+--- a/jsonpb/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/jsonpb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,38 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "decode.go",
++        "encode.go",
++        "json.go",
++    ],
++    importpath = "github.com/golang/protobuf/jsonpb",
 +    visibility = ["//visibility:public"],
 +    deps = [
 +        "//proto:go_default_library",
++        "@org_golang_google_protobuf//encoding/protojson:go_default_library",
++        "@org_golang_google_protobuf//proto:go_default_library",
++        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
++        "@org_golang_google_protobuf//reflect/protoregistry:go_default_library",
++        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
++    ],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = ["json_test.go"],
++    embed = [":go_default_library"],
++    deps = [
++        "//internal/testprotos/jsonpb_proto:go_default_library",
++        "//internal/testprotos/proto3_proto:go_default_library",
++        "//proto:go_default_library",
++        "//protoc-gen-go/descriptor:go_default_library",
++        "//ptypes:go_default_library",
 +        "//ptypes/any:go_default_library",
 +        "//ptypes/duration:go_default_library",
 +        "//ptypes/struct:go_default_library",
@@ -83,110 +175,76 @@ diff -urN a/jsonpb/jsonpb_test_proto/BUILD.bazel b/jsonpb/jsonpb_test_proto/BUIL
 diff -urN a/proto/BUILD.bazel b/proto/BUILD.bazel
 --- a/proto/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ b/proto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,55 @@
+@@ -0,0 +1,54 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
 +    name = "go_default_library",
 +    srcs = [
-+        "clone.go",
-+        "decode.go",
++        "buffer.go",
++        "defaults.go",
 +        "deprecated.go",
 +        "discard.go",
-+        "encode.go",
-+        "equal.go",
 +        "extensions.go",
-+        "lib.go",
-+        "message_set.go",
-+        "pointer_unsafe.go",
 +        "properties.go",
-+        "table_marshal.go",
-+        "table_merge.go",
-+        "table_unmarshal.go",
-+        "text.go",
-+        "text_parser.go",
++        "proto.go",
++        "registry.go",
++        "text_decode.go",
++        "text_encode.go",
++        "wire.go",
++        "wrappers.go",
 +    ],
 +    importpath = "github.com/golang/protobuf/proto",
 +    visibility = ["//visibility:public"],
++    deps = [
++        "@org_golang_google_protobuf//encoding/prototext:go_default_library",
++        "@org_golang_google_protobuf//encoding/protowire:go_default_library",
++        "@org_golang_google_protobuf//proto:go_default_library",
++        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
++        "@org_golang_google_protobuf//reflect/protoregistry:go_default_library",
++        "@org_golang_google_protobuf//runtime/protoiface:go_default_library",
++        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
++    ],
 +)
 +
 +go_test(
 +    name = "go_default_test",
 +    srcs = [
-+        "all_test.go",
-+        "any_test.go",
-+        "clone_test.go",
-+        "decode_test.go",
 +        "discard_test.go",
-+        "encode_test.go",
-+        "equal_test.go",
 +        "extensions_test.go",
-+        "map_test.go",
-+        "message_set_test.go",
-+        "proto3_test.go",
-+        "size2_test.go",
-+        "size_test.go",
-+        "text_parser_test.go",
++        "proto_clone_test.go",
++        "proto_equal_test.go",
++        "proto_test.go",
++        "registry_test.go",
 +        "text_test.go",
 +    ],
 +    embed = [":go_default_library"],
 +    deps = [
-+        "//jsonpb:go_default_library",
-+        "//proto/proto3_proto:go_default_library",
-+        "//proto/test_proto:go_default_library",
++        "//internal/testprotos/proto2_proto:go_default_library",
++        "//internal/testprotos/proto3_proto:go_default_library",
 +        "//protoc-gen-go/descriptor:go_default_library",
-+        "//ptypes:go_default_library",
 +        "//ptypes/any:go_default_library",
++        "//ptypes/timestamp:go_default_library",
++        "@com_github_google_go_cmp//cmp:go_default_library",
++        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
++        "@org_golang_google_protobuf//testing/protopack:go_default_library",
 +    ],
-+)
-diff -urN a/proto/proto3_proto/BUILD.bazel b/proto/proto3_proto/BUILD.bazel
---- a/proto/proto3_proto/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/proto/proto3_proto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,13 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "go_default_library",
-+    srcs = ["proto3.pb.go"],
-+    importpath = "github.com/golang/protobuf/proto/proto3_proto",
-+    visibility = ["//visibility:public"],
-+    deps = [
-+        "//proto:go_default_library",
-+        "//proto/test_proto:go_default_library",
-+        "//ptypes/any:go_default_library",
-+    ],
-+)
-diff -urN a/proto/test_proto/BUILD.bazel b/proto/test_proto/BUILD.bazel
---- a/proto/test_proto/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/proto/test_proto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,9 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "go_default_library",
-+    srcs = ["test.pb.go"],
-+    importpath = "github.com/golang/protobuf/proto/test_proto",
-+    visibility = ["//visibility:public"],
-+    deps = ["//proto:go_default_library"],
 +)
 diff -urN a/protoc-gen-go/BUILD.bazel b/protoc-gen-go/BUILD.bazel
 --- a/protoc-gen-go/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ b/protoc-gen-go/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,28 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 +
 +go_library(
 +    name = "go_default_library",
-+    srcs = [
-+        "link_grpc.go",
-+        "main.go",
-+    ],
++    srcs = ["main.go"],
 +    importpath = "github.com/golang/protobuf/protoc-gen-go",
 +    visibility = ["//visibility:private"],
 +    deps = [
-+        "//proto:go_default_library",
-+        "//protoc-gen-go/generator:go_default_library",
-+        "//protoc-gen-go/grpc:go_default_library",
++        "//internal/gengogrpc:go_default_library",
++        "@org_golang_google_protobuf//cmd/protoc-gen-go/internal_gengo:go_default_library",
++        "@org_golang_google_protobuf//compiler/protogen:go_default_library",
 +    ],
 +)
 +
@@ -195,16 +253,10 @@ diff -urN a/protoc-gen-go/BUILD.bazel b/protoc-gen-go/BUILD.bazel
 +    embed = [":go_default_library"],
 +    visibility = ["//visibility:public"],
 +)
-+
-+go_test(
-+    name = "go_default_test",
-+    srcs = ["golden_test.go"],
-+    embed = [":go_default_library"],
-+)
 diff -urN a/protoc-gen-go/descriptor/BUILD.bazel b/protoc-gen-go/descriptor/BUILD.bazel
 --- a/protoc-gen-go/descriptor/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ b/protoc-gen-go/descriptor/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,9 @@
+@@ -0,0 +1,13 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -212,13 +264,17 @@ diff -urN a/protoc-gen-go/descriptor/BUILD.bazel b/protoc-gen-go/descriptor/BUIL
 +    srcs = ["descriptor.pb.go"],
 +    importpath = "github.com/golang/protobuf/protoc-gen-go/descriptor",
 +    visibility = ["//visibility:public"],
-+    deps = ["//proto:go_default_library"],
++    deps = [
++        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
++        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
++        "@org_golang_google_protobuf//types/descriptorpb:go_default_library",
++    ],
 +)
 diff -urN a/protoc-gen-go/generator/BUILD.bazel b/protoc-gen-go/generator/BUILD.bazel
 --- a/protoc-gen-go/generator/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ b/protoc-gen-go/generator/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,21 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+@@ -0,0 +1,14 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
 +    name = "go_default_library",
@@ -231,13 +287,6 @@ diff -urN a/protoc-gen-go/generator/BUILD.bazel b/protoc-gen-go/generator/BUILD.
 +        "//protoc-gen-go/generator/internal/remap:go_default_library",
 +        "//protoc-gen-go/plugin:go_default_library",
 +    ],
-+)
-+
-+go_test(
-+    name = "go_default_test",
-+    srcs = ["name_test.go"],
-+    embed = [":go_default_library"],
-+    deps = ["//protoc-gen-go/descriptor:go_default_library"],
 +)
 diff -urN a/protoc-gen-go/generator/internal/remap/BUILD.bazel b/protoc-gen-go/generator/internal/remap/BUILD.bazel
 --- a/protoc-gen-go/generator/internal/remap/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -276,7 +325,7 @@ diff -urN a/protoc-gen-go/grpc/BUILD.bazel b/protoc-gen-go/grpc/BUILD.bazel
 diff -urN a/protoc-gen-go/plugin/BUILD.bazel b/protoc-gen-go/plugin/BUILD.bazel
 --- a/protoc-gen-go/plugin/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ b/protoc-gen-go/plugin/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,13 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -285,315 +334,15 @@ diff -urN a/protoc-gen-go/plugin/BUILD.bazel b/protoc-gen-go/plugin/BUILD.bazel
 +    importpath = "github.com/golang/protobuf/protoc-gen-go/plugin",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "//proto:go_default_library",
-+        "//protoc-gen-go/descriptor:go_default_library",
++        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
++        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
++        "@org_golang_google_protobuf//types/pluginpb:go_default_library",
 +    ],
-+)
-diff -urN a/protoc-gen-go/testdata/BUILD.bazel b/protoc-gen-go/testdata/BUILD.bazel
---- a/protoc-gen-go/testdata/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/protoc-gen-go/testdata/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,20 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_test")
-+
-+go_test(
-+    name = "go_default_test",
-+    srcs = [
-+        "extension_test.go",
-+        "import_public_test.go",
-+        "main_test.go",
-+    ],
-+    deps = [
-+        "//proto:go_default_library",
-+        "//protoc-gen-go/testdata/extension_base:go_default_library",
-+        "//protoc-gen-go/testdata/extension_user:go_default_library",
-+        "//protoc-gen-go/testdata/import_public:go_default_library",
-+        "//protoc-gen-go/testdata/import_public/sub:go_default_library",
-+        "//protoc-gen-go/testdata/imports:go_default_library",
-+        "//protoc-gen-go/testdata/multi:go_default_library",
-+        "//protoc-gen-go/testdata/my_test:go_default_library",
-+    ],
-+)
-diff -urN a/protoc-gen-go/testdata/deprecated/BUILD.bazel b/protoc-gen-go/testdata/deprecated/BUILD.bazel
---- a/protoc-gen-go/testdata/deprecated/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/protoc-gen-go/testdata/deprecated/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,14 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "go_default_library",
-+    srcs = ["deprecated.pb.go"],
-+    importpath = "github.com/golang/protobuf/protoc-gen-go/testdata/deprecated",
-+    visibility = ["//visibility:public"],
-+    deps = [
-+        "//proto:go_default_library",
-+        "@org_golang_google_grpc//:go_default_library",
-+        "@org_golang_google_grpc//codes:go_default_library",
-+        "@org_golang_google_grpc//status:go_default_library",
-+    ],
-+)
-diff -urN a/protoc-gen-go/testdata/extension_base/BUILD.bazel b/protoc-gen-go/testdata/extension_base/BUILD.bazel
---- a/protoc-gen-go/testdata/extension_base/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/protoc-gen-go/testdata/extension_base/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,9 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "go_default_library",
-+    srcs = ["extension_base.pb.go"],
-+    importpath = "github.com/golang/protobuf/protoc-gen-go/testdata/extension_base",
-+    visibility = ["//visibility:public"],
-+    deps = ["//proto:go_default_library"],
-+)
-diff -urN a/protoc-gen-go/testdata/extension_extra/BUILD.bazel b/protoc-gen-go/testdata/extension_extra/BUILD.bazel
---- a/protoc-gen-go/testdata/extension_extra/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/protoc-gen-go/testdata/extension_extra/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,9 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "go_default_library",
-+    srcs = ["extension_extra.pb.go"],
-+    importpath = "github.com/golang/protobuf/protoc-gen-go/testdata/extension_extra",
-+    visibility = ["//visibility:public"],
-+    deps = ["//proto:go_default_library"],
-+)
-diff -urN a/protoc-gen-go/testdata/extension_user/BUILD.bazel b/protoc-gen-go/testdata/extension_user/BUILD.bazel
---- a/protoc-gen-go/testdata/extension_user/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/protoc-gen-go/testdata/extension_user/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,13 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "go_default_library",
-+    srcs = ["extension_user.pb.go"],
-+    importpath = "github.com/golang/protobuf/protoc-gen-go/testdata/extension_user",
-+    visibility = ["//visibility:public"],
-+    deps = [
-+        "//proto:go_default_library",
-+        "//protoc-gen-go/testdata/extension_base:go_default_library",
-+        "//protoc-gen-go/testdata/extension_extra:go_default_library",
-+    ],
-+)
-diff -urN a/protoc-gen-go/testdata/grpc/BUILD.bazel b/protoc-gen-go/testdata/grpc/BUILD.bazel
---- a/protoc-gen-go/testdata/grpc/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/protoc-gen-go/testdata/grpc/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,17 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "go_default_library",
-+    srcs = [
-+        "grpc.pb.go",
-+        "grpc_empty.pb.go",
-+    ],
-+    importpath = "github.com/golang/protobuf/protoc-gen-go/testdata/grpc",
-+    visibility = ["//visibility:public"],
-+    deps = [
-+        "//proto:go_default_library",
-+        "@org_golang_google_grpc//:go_default_library",
-+        "@org_golang_google_grpc//codes:go_default_library",
-+        "@org_golang_google_grpc//status:go_default_library",
-+    ],
-+)
-diff -urN a/protoc-gen-go/testdata/import_public/BUILD.bazel b/protoc-gen-go/testdata/import_public/BUILD.bazel
---- a/protoc-gen-go/testdata/import_public/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/protoc-gen-go/testdata/import_public/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,15 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "go_default_library",
-+    srcs = [
-+        "a.pb.go",
-+        "b.pb.go",
-+    ],
-+    importpath = "github.com/golang/protobuf/protoc-gen-go/testdata/import_public",
-+    visibility = ["//visibility:public"],
-+    deps = [
-+        "//proto:go_default_library",
-+        "//protoc-gen-go/testdata/import_public/sub:go_default_library",
-+    ],
-+)
-diff -urN a/protoc-gen-go/testdata/import_public/importing/BUILD.bazel b/protoc-gen-go/testdata/import_public/importing/BUILD.bazel
---- a/protoc-gen-go/testdata/import_public/importing/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/protoc-gen-go/testdata/import_public/importing/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,13 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "go_default_library",
-+    srcs = ["importing.pb.go"],
-+    importpath = "github.com/golang/protobuf/protoc-gen-go/testdata/import_public/importing",
-+    visibility = ["//visibility:public"],
-+    deps = [
-+        "//proto:go_default_library",
-+        "//protoc-gen-go/testdata/import_public:go_default_library",
-+        "//protoc-gen-go/testdata/import_public/sub:go_default_library",
-+    ],
-+)
-diff -urN a/protoc-gen-go/testdata/import_public/sub/BUILD.bazel b/protoc-gen-go/testdata/import_public/sub/BUILD.bazel
---- a/protoc-gen-go/testdata/import_public/sub/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/protoc-gen-go/testdata/import_public/sub/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,12 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "go_default_library",
-+    srcs = [
-+        "a.pb.go",
-+        "b.pb.go",
-+    ],
-+    importpath = "github.com/golang/protobuf/protoc-gen-go/testdata/import_public/sub",
-+    visibility = ["//visibility:public"],
-+    deps = ["//proto:go_default_library"],
-+)
-diff -urN a/protoc-gen-go/testdata/imports/BUILD.bazel b/protoc-gen-go/testdata/imports/BUILD.bazel
---- a/protoc-gen-go/testdata/imports/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/protoc-gen-go/testdata/imports/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,19 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "go_default_library",
-+    srcs = [
-+        "test_import_a1m1.pb.go",
-+        "test_import_a1m2.pb.go",
-+        "test_import_all.pb.go",
-+    ],
-+    importpath = "github.com/golang/protobuf/protoc-gen-go/testdata/imports",
-+    visibility = ["//visibility:public"],
-+    deps = [
-+        "//proto:go_default_library",
-+        "//protoc-gen-go/testdata/imports/fmt:go_default_library",
-+        "//protoc-gen-go/testdata/imports/test_a_1:go_default_library",
-+        "//protoc-gen-go/testdata/imports/test_a_2:go_default_library",
-+        "//protoc-gen-go/testdata/imports/test_b_1:go_default_library",
-+    ],
-+)
-diff -urN a/protoc-gen-go/testdata/imports/fmt/BUILD.bazel b/protoc-gen-go/testdata/imports/fmt/BUILD.bazel
---- a/protoc-gen-go/testdata/imports/fmt/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/protoc-gen-go/testdata/imports/fmt/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,9 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "go_default_library",
-+    srcs = ["m.pb.go"],
-+    importpath = "github.com/golang/protobuf/protoc-gen-go/testdata/imports/fmt",
-+    visibility = ["//visibility:public"],
-+    deps = ["//proto:go_default_library"],
-+)
-diff -urN a/protoc-gen-go/testdata/imports/test_a_1/BUILD.bazel b/protoc-gen-go/testdata/imports/test_a_1/BUILD.bazel
---- a/protoc-gen-go/testdata/imports/test_a_1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/protoc-gen-go/testdata/imports/test_a_1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,12 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "go_default_library",
-+    srcs = [
-+        "m1.pb.go",
-+        "m2.pb.go",
-+    ],
-+    importpath = "github.com/golang/protobuf/protoc-gen-go/testdata/imports/test_a_1",
-+    visibility = ["//visibility:public"],
-+    deps = ["//proto:go_default_library"],
-+)
-diff -urN a/protoc-gen-go/testdata/imports/test_a_2/BUILD.bazel b/protoc-gen-go/testdata/imports/test_a_2/BUILD.bazel
---- a/protoc-gen-go/testdata/imports/test_a_2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/protoc-gen-go/testdata/imports/test_a_2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,12 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "go_default_library",
-+    srcs = [
-+        "m3.pb.go",
-+        "m4.pb.go",
-+    ],
-+    importpath = "github.com/golang/protobuf/protoc-gen-go/testdata/imports/test_a_2",
-+    visibility = ["//visibility:public"],
-+    deps = ["//proto:go_default_library"],
-+)
-diff -urN a/protoc-gen-go/testdata/imports/test_b_1/BUILD.bazel b/protoc-gen-go/testdata/imports/test_b_1/BUILD.bazel
---- a/protoc-gen-go/testdata/imports/test_b_1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/protoc-gen-go/testdata/imports/test_b_1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,12 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "go_default_library",
-+    srcs = [
-+        "m1.pb.go",
-+        "m2.pb.go",
-+    ],
-+    importpath = "github.com/golang/protobuf/protoc-gen-go/testdata/imports/test_b_1",
-+    visibility = ["//visibility:public"],
-+    deps = ["//proto:go_default_library"],
-+)
-diff -urN a/protoc-gen-go/testdata/issue780_oneof_conflict/BUILD.bazel b/protoc-gen-go/testdata/issue780_oneof_conflict/BUILD.bazel
---- a/protoc-gen-go/testdata/issue780_oneof_conflict/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/protoc-gen-go/testdata/issue780_oneof_conflict/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,9 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "go_default_library",
-+    srcs = ["test.pb.go"],
-+    importpath = "github.com/golang/protobuf/protoc-gen-go/testdata/issue780_oneof_conflict",
-+    visibility = ["//visibility:public"],
-+    deps = ["//proto:go_default_library"],
-+)
-diff -urN a/protoc-gen-go/testdata/multi/BUILD.bazel b/protoc-gen-go/testdata/multi/BUILD.bazel
---- a/protoc-gen-go/testdata/multi/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/protoc-gen-go/testdata/multi/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,13 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "go_default_library",
-+    srcs = [
-+        "multi1.pb.go",
-+        "multi2.pb.go",
-+        "multi3.pb.go",
-+    ],
-+    importpath = "github.com/golang/protobuf/protoc-gen-go/testdata/multi",
-+    visibility = ["//visibility:public"],
-+    deps = ["//proto:go_default_library"],
-+)
-diff -urN a/protoc-gen-go/testdata/my_test/BUILD.bazel b/protoc-gen-go/testdata/my_test/BUILD.bazel
---- a/protoc-gen-go/testdata/my_test/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/protoc-gen-go/testdata/my_test/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,12 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "go_default_library",
-+    srcs = ["test.pb.go"],
-+    importpath = "github.com/golang/protobuf/protoc-gen-go/testdata/my_test",
-+    visibility = ["//visibility:public"],
-+    deps = [
-+        "//proto:go_default_library",
-+        "//protoc-gen-go/testdata/multi:go_default_library",
-+    ],
-+)
-diff -urN a/protoc-gen-go/testdata/proto3/BUILD.bazel b/protoc-gen-go/testdata/proto3/BUILD.bazel
---- a/protoc-gen-go/testdata/proto3/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ b/protoc-gen-go/testdata/proto3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,9 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "go_default_library",
-+    srcs = ["proto3.pb.go"],
-+    importpath = "github.com/golang/protobuf/protoc-gen-go/testdata/proto3",
-+    visibility = ["//visibility:public"],
-+    deps = ["//proto:go_default_library"],
 +)
 diff -urN a/ptypes/BUILD.bazel b/ptypes/BUILD.bazel
 --- a/ptypes/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ b/ptypes/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,36 @@
+@@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -611,6 +360,8 @@ diff -urN a/ptypes/BUILD.bazel b/ptypes/BUILD.bazel
 +        "//ptypes/any:go_default_library",
 +        "//ptypes/duration:go_default_library",
 +        "//ptypes/timestamp:go_default_library",
++        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
++        "@org_golang_google_protobuf//reflect/protoregistry:go_default_library",
 +    ],
 +)
 +
@@ -633,7 +384,7 @@ diff -urN a/ptypes/BUILD.bazel b/ptypes/BUILD.bazel
 diff -urN a/ptypes/any/BUILD.bazel b/ptypes/any/BUILD.bazel
 --- a/ptypes/any/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ b/ptypes/any/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,9 @@
+@@ -0,0 +1,13 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -641,12 +392,16 @@ diff -urN a/ptypes/any/BUILD.bazel b/ptypes/any/BUILD.bazel
 +    srcs = ["any.pb.go"],
 +    importpath = "github.com/golang/protobuf/ptypes/any",
 +    visibility = ["//visibility:public"],
-+    deps = ["//proto:go_default_library"],
++    deps = [
++        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
++        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
++        "@org_golang_google_protobuf//types/known/anypb:go_default_library",
++    ],
 +)
 diff -urN a/ptypes/duration/BUILD.bazel b/ptypes/duration/BUILD.bazel
 --- a/ptypes/duration/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ b/ptypes/duration/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,9 @@
+@@ -0,0 +1,13 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -654,12 +409,16 @@ diff -urN a/ptypes/duration/BUILD.bazel b/ptypes/duration/BUILD.bazel
 +    srcs = ["duration.pb.go"],
 +    importpath = "github.com/golang/protobuf/ptypes/duration",
 +    visibility = ["//visibility:public"],
-+    deps = ["//proto:go_default_library"],
++    deps = [
++        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
++        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
++        "@org_golang_google_protobuf//types/known/durationpb:go_default_library",
++    ],
 +)
 diff -urN a/ptypes/empty/BUILD.bazel b/ptypes/empty/BUILD.bazel
 --- a/ptypes/empty/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ b/ptypes/empty/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,9 @@
+@@ -0,0 +1,13 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -667,12 +426,16 @@ diff -urN a/ptypes/empty/BUILD.bazel b/ptypes/empty/BUILD.bazel
 +    srcs = ["empty.pb.go"],
 +    importpath = "github.com/golang/protobuf/ptypes/empty",
 +    visibility = ["//visibility:public"],
-+    deps = ["//proto:go_default_library"],
++    deps = [
++        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
++        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
++        "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
++    ],
 +)
 diff -urN a/ptypes/struct/BUILD.bazel b/ptypes/struct/BUILD.bazel
 --- a/ptypes/struct/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ b/ptypes/struct/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,9 @@
+@@ -0,0 +1,13 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -680,12 +443,16 @@ diff -urN a/ptypes/struct/BUILD.bazel b/ptypes/struct/BUILD.bazel
 +    srcs = ["struct.pb.go"],
 +    importpath = "github.com/golang/protobuf/ptypes/struct",
 +    visibility = ["//visibility:public"],
-+    deps = ["//proto:go_default_library"],
++    deps = [
++        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
++        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
++        "@org_golang_google_protobuf//types/known/structpb:go_default_library",
++    ],
 +)
 diff -urN a/ptypes/timestamp/BUILD.bazel b/ptypes/timestamp/BUILD.bazel
 --- a/ptypes/timestamp/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ b/ptypes/timestamp/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,9 @@
+@@ -0,0 +1,13 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -693,12 +460,16 @@ diff -urN a/ptypes/timestamp/BUILD.bazel b/ptypes/timestamp/BUILD.bazel
 +    srcs = ["timestamp.pb.go"],
 +    importpath = "github.com/golang/protobuf/ptypes/timestamp",
 +    visibility = ["//visibility:public"],
-+    deps = ["//proto:go_default_library"],
++    deps = [
++        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
++        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
++        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
++    ],
 +)
 diff -urN a/ptypes/wrappers/BUILD.bazel b/ptypes/wrappers/BUILD.bazel
 --- a/ptypes/wrappers/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ b/ptypes/wrappers/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,9 @@
+@@ -0,0 +1,13 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -706,5 +477,9 @@ diff -urN a/ptypes/wrappers/BUILD.bazel b/ptypes/wrappers/BUILD.bazel
 +    srcs = ["wrappers.pb.go"],
 +    importpath = "github.com/golang/protobuf/ptypes/wrappers",
 +    visibility = ["//visibility:public"],
-+    deps = ["//proto:go_default_library"],
++    deps = [
++        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
++        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
++        "@org_golang_google_protobuf//types/known/wrapperspb:go_default_library",
++    ],
 +)

--- a/third_party/org_golang_google_protobuf-gazelle.patch
+++ b/third_party/org_golang_google_protobuf-gazelle.patch
@@ -1,0 +1,2742 @@
+diff -urN a/cmd/protoc-gen-go/BUILD.bazel b/cmd/protoc-gen-go/BUILD.bazel
+--- a/cmd/protoc-gen-go/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/cmd/protoc-gen-go/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,31 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["main.go"],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go",
++    visibility = ["//visibility:private"],
++    deps = [
++        "//cmd/protoc-gen-go/internal_gengo:go_default_library",
++        "//compiler/protogen:go_default_library",
++        "//internal/version:go_default_library",
++    ],
++)
++
++go_binary(
++    name = "protoc-gen-go",
++    embed = [":go_default_library"],
++    visibility = ["//visibility:public"],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = ["annotation_test.go"],
++    embed = [":go_default_library"],
++    deps = [
++        "//encoding/prototext:go_default_library",
++        "//internal/fieldnum:go_default_library",
++        "//proto:go_default_library",
++        "//types/descriptorpb:go_default_library",
++    ],
++)
+diff -urN a/cmd/protoc-gen-go/internal_gengo/BUILD.bazel b/cmd/protoc-gen-go/internal_gengo/BUILD.bazel
+--- a/cmd/protoc-gen-go/internal_gengo/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/cmd/protoc-gen-go/internal_gengo/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,25 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "init.go",
++        "main.go",
++        "reflect.go",
++    ],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/internal_gengo",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//compiler/protogen:go_default_library",
++        "//encoding/protowire:go_default_library",
++        "//internal/encoding/messageset:go_default_library",
++        "//internal/encoding/tag:go_default_library",
++        "//internal/fieldnum:go_default_library",
++        "//internal/genname:go_default_library",
++        "//internal/version:go_default_library",
++        "//proto:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++        "//types/descriptorpb:go_default_library",
++    ],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/BUILD.bazel b/cmd/protoc-gen-go/testdata/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/cmd/protoc-gen-go/testdata/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,33 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_test")
++
++go_test(
++    name = "go_default_test",
++    srcs = [
++        "gen_test.go",
++        "registry_test.go",
++    ],
++    deps = [
++        "//cmd/protoc-gen-go/testdata/annotations:go_default_library",
++        "//cmd/protoc-gen-go/testdata/comments:go_default_library",
++        "//cmd/protoc-gen-go/testdata/extensions/base:go_default_library",
++        "//cmd/protoc-gen-go/testdata/extensions/ext:go_default_library",
++        "//cmd/protoc-gen-go/testdata/extensions/extra:go_default_library",
++        "//cmd/protoc-gen-go/testdata/extensions/proto3:go_default_library",
++        "//cmd/protoc-gen-go/testdata/fieldnames:go_default_library",
++        "//cmd/protoc-gen-go/testdata/import_public:go_default_library",
++        "//cmd/protoc-gen-go/testdata/import_public/sub:go_default_library",
++        "//cmd/protoc-gen-go/testdata/import_public/sub2:go_default_library",
++        "//cmd/protoc-gen-go/testdata/imports:go_default_library",
++        "//cmd/protoc-gen-go/testdata/imports/fmt:go_default_library",
++        "//cmd/protoc-gen-go/testdata/imports/test_a_1:go_default_library",
++        "//cmd/protoc-gen-go/testdata/imports/test_a_2:go_default_library",
++        "//cmd/protoc-gen-go/testdata/imports/test_b_1:go_default_library",
++        "//cmd/protoc-gen-go/testdata/issue780_oneof_conflict:go_default_library",
++        "//cmd/protoc-gen-go/testdata/nopackage:go_default_library",
++        "//cmd/protoc-gen-go/testdata/proto2:go_default_library",
++        "//cmd/protoc-gen-go/testdata/proto3:go_default_library",
++        "//internal/filedesc:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//reflect/protoregistry:go_default_library",
++    ],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/annotations/BUILD.bazel b/cmd/protoc-gen-go/testdata/annotations/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/annotations/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/cmd/protoc-gen-go/testdata/annotations/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["annotations.pb.go"],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/annotations",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/comments/BUILD.bazel b/cmd/protoc-gen-go/testdata/comments/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/comments/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/cmd/protoc-gen-go/testdata/comments/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,16 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "comments.pb.go",
++        "deprecated.pb.go",
++    ],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/comments",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoiface:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/extensions/base/BUILD.bazel b/cmd/protoc-gen-go/testdata/extensions/base/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/extensions/base/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/cmd/protoc-gen-go/testdata/extensions/base/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,13 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["base.pb.go"],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/extensions/base",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoiface:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/extensions/ext/BUILD.bazel b/cmd/protoc-gen-go/testdata/extensions/ext/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/extensions/ext/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/cmd/protoc-gen-go/testdata/extensions/ext/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,15 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["ext.pb.go"],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/extensions/ext",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//cmd/protoc-gen-go/testdata/extensions/base:go_default_library",
++        "//cmd/protoc-gen-go/testdata/extensions/extra:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoiface:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/extensions/extra/BUILD.bazel b/cmd/protoc-gen-go/testdata/extensions/extra/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/extensions/extra/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/cmd/protoc-gen-go/testdata/extensions/extra/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["extra.pb.go"],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/extensions/extra",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/extensions/proto3/BUILD.bazel b/cmd/protoc-gen-go/testdata/extensions/proto3/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/extensions/proto3/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/cmd/protoc-gen-go/testdata/extensions/proto3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,13 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["ext3.pb.go"],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/extensions/proto3",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++        "//types/descriptorpb:go_default_library",
++    ],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/fieldnames/BUILD.bazel b/cmd/protoc-gen-go/testdata/fieldnames/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/fieldnames/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/cmd/protoc-gen-go/testdata/fieldnames/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["fieldnames.pb.go"],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/fieldnames",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/import_public/BUILD.bazel b/cmd/protoc-gen-go/testdata/import_public/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/import_public/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/cmd/protoc-gen-go/testdata/import_public/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,18 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "a.pb.go",
++        "b.pb.go",
++        "c.pb.go",
++    ],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/import_public",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//cmd/protoc-gen-go/testdata/import_public/sub:go_default_library",
++        "//cmd/protoc-gen-go/testdata/import_public/sub2:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/import_public/sub/BUILD.bazel b/cmd/protoc-gen-go/testdata/import_public/sub/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/import_public/sub/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/cmd/protoc-gen-go/testdata/import_public/sub/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,17 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "a.pb.go",
++        "b.pb.go",
++    ],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/import_public/sub",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//cmd/protoc-gen-go/testdata/import_public/sub2:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoiface:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/import_public/sub2/BUILD.bazel b/cmd/protoc-gen-go/testdata/import_public/sub2/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/import_public/sub2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/cmd/protoc-gen-go/testdata/import_public/sub2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["a.pb.go"],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/import_public/sub2",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/imports/BUILD.bazel b/cmd/protoc-gen-go/testdata/imports/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/imports/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/cmd/protoc-gen-go/testdata/imports/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,20 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "test_import_a1m1.pb.go",
++        "test_import_a1m2.pb.go",
++        "test_import_all.pb.go",
++    ],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/imports",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//cmd/protoc-gen-go/testdata/imports/fmt:go_default_library",
++        "//cmd/protoc-gen-go/testdata/imports/test_a_1:go_default_library",
++        "//cmd/protoc-gen-go/testdata/imports/test_a_2:go_default_library",
++        "//cmd/protoc-gen-go/testdata/imports/test_b_1:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/imports/fmt/BUILD.bazel b/cmd/protoc-gen-go/testdata/imports/fmt/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/imports/fmt/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/cmd/protoc-gen-go/testdata/imports/fmt/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["m.pb.go"],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/imports/fmt",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/imports/test_a_1/BUILD.bazel b/cmd/protoc-gen-go/testdata/imports/test_a_1/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/imports/test_a_1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/cmd/protoc-gen-go/testdata/imports/test_a_1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,15 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "m1.pb.go",
++        "m2.pb.go",
++    ],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/imports/test_a_1",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/imports/test_a_2/BUILD.bazel b/cmd/protoc-gen-go/testdata/imports/test_a_2/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/imports/test_a_2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/cmd/protoc-gen-go/testdata/imports/test_a_2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,15 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "m3.pb.go",
++        "m4.pb.go",
++    ],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/imports/test_a_2",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/imports/test_b_1/BUILD.bazel b/cmd/protoc-gen-go/testdata/imports/test_b_1/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/imports/test_b_1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/cmd/protoc-gen-go/testdata/imports/test_b_1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,15 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "m1.pb.go",
++        "m2.pb.go",
++    ],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/imports/test_b_1",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/issue780_oneof_conflict/BUILD.bazel b/cmd/protoc-gen-go/testdata/issue780_oneof_conflict/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/issue780_oneof_conflict/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/cmd/protoc-gen-go/testdata/issue780_oneof_conflict/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["test.pb.go"],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/issue780_oneof_conflict",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/nopackage/BUILD.bazel b/cmd/protoc-gen-go/testdata/nopackage/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/nopackage/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/cmd/protoc-gen-go/testdata/nopackage/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["nopackage.pb.go"],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/nopackage",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/proto2/BUILD.bazel b/cmd/protoc-gen-go/testdata/proto2/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/proto2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/cmd/protoc-gen-go/testdata/proto2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,17 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "enum.pb.go",
++        "fields.pb.go",
++        "nested_messages.pb.go",
++        "proto2.pb.go",
++    ],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/proto2",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/proto3/BUILD.bazel b/cmd/protoc-gen-go/testdata/proto3/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/proto3/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/cmd/protoc-gen-go/testdata/proto3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,15 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "enum.pb.go",
++        "fields.pb.go",
++    ],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/proto3",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/compiler/protogen/BUILD.bazel b/compiler/protogen/BUILD.bazel
+--- a/compiler/protogen/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/compiler/protogen/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,32 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["protogen.go"],
++    importpath = "google.golang.org/protobuf/compiler/protogen",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//encoding/prototext:go_default_library",
++        "//internal/fieldnum:go_default_library",
++        "//internal/strs:go_default_library",
++        "//proto:go_default_library",
++        "//reflect/protodesc:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//reflect/protoregistry:go_default_library",
++        "//types/descriptorpb:go_default_library",
++        "//types/pluginpb:go_default_library",
++    ],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = ["protogen_test.go"],
++    embed = [":go_default_library"],
++    deps = [
++        "//proto:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//types/descriptorpb:go_default_library",
++        "//types/pluginpb:go_default_library",
++        "@com_github_google_go_cmp//cmp:go_default_library",
++    ],
++)
+diff -urN a/encoding/BUILD.bazel b/encoding/BUILD.bazel
+--- a/encoding/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/encoding/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_test")
++
++go_test(
++    name = "go_default_test",
++    srcs = ["bench_test.go"],
++    deps = [
++        "//encoding/protojson:go_default_library",
++        "//encoding/prototext:go_default_library",
++        "//internal/testprotos/test:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++    ],
++)
+diff -urN a/encoding/protojson/BUILD.bazel b/encoding/protojson/BUILD.bazel
+--- a/encoding/protojson/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/encoding/protojson/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,57 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "decode.go",
++        "doc.go",
++        "encode.go",
++        "well_known_types.go",
++    ],
++    importpath = "google.golang.org/protobuf/encoding/protojson",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//internal/detectknown:go_default_library",
++        "//internal/encoding/json:go_default_library",
++        "//internal/encoding/messageset:go_default_library",
++        "//internal/errors:go_default_library",
++        "//internal/fieldnum:go_default_library",
++        "//internal/flags:go_default_library",
++        "//internal/pragma:go_default_library",
++        "//internal/set:go_default_library",
++        "//internal/strs:go_default_library",
++        "//proto:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//reflect/protoregistry:go_default_library",
++    ],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = [
++        "bench_test.go",
++        "decode_test.go",
++        "encode_test.go",
++    ],
++    embed = [":go_default_library"],
++    deps = [
++        "//internal/detrand:go_default_library",
++        "//internal/errors:go_default_library",
++        "//internal/flags:go_default_library",
++        "//internal/testprotos/fieldmaskpb:go_default_library",
++        "//internal/testprotos/test:go_default_library",
++        "//internal/testprotos/test/weak1:go_default_library",
++        "//internal/testprotos/textpb2:go_default_library",
++        "//internal/testprotos/textpb3:go_default_library",
++        "//proto:go_default_library",
++        "//reflect/protoregistry:go_default_library",
++        "//testing/protopack:go_default_library",
++        "//types/known/anypb:go_default_library",
++        "//types/known/durationpb:go_default_library",
++        "//types/known/emptypb:go_default_library",
++        "//types/known/structpb:go_default_library",
++        "//types/known/timestamppb:go_default_library",
++        "//types/known/wrapperspb:go_default_library",
++        "@com_github_google_go_cmp//cmp:go_default_library",
++    ],
++)
+diff -urN a/encoding/prototext/BUILD.bazel b/encoding/prototext/BUILD.bazel
+--- a/encoding/prototext/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/encoding/prototext/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,54 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "decode.go",
++        "doc.go",
++        "encode.go",
++    ],
++    importpath = "google.golang.org/protobuf/encoding/prototext",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//encoding/protowire:go_default_library",
++        "//internal/encoding/messageset:go_default_library",
++        "//internal/encoding/text:go_default_library",
++        "//internal/errors:go_default_library",
++        "//internal/fieldnum:go_default_library",
++        "//internal/flags:go_default_library",
++        "//internal/mapsort:go_default_library",
++        "//internal/pragma:go_default_library",
++        "//internal/set:go_default_library",
++        "//proto:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//reflect/protoregistry:go_default_library",
++    ],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = [
++        "decode_test.go",
++        "encode_test.go",
++        "other_test.go",
++    ],
++    embed = [":go_default_library"],
++    deps = [
++        "//internal/detrand:go_default_library",
++        "//internal/flags:go_default_library",
++        "//internal/testprotos/test:go_default_library",
++        "//internal/testprotos/test/weak1:go_default_library",
++        "//internal/testprotos/textpb2:go_default_library",
++        "//internal/testprotos/textpb3:go_default_library",
++        "//proto:go_default_library",
++        "//reflect/protoregistry:go_default_library",
++        "//testing/protopack:go_default_library",
++        "//types/known/anypb:go_default_library",
++        "//types/known/durationpb:go_default_library",
++        "//types/known/emptypb:go_default_library",
++        "//types/known/structpb:go_default_library",
++        "//types/known/timestamppb:go_default_library",
++        "//types/known/wrapperspb:go_default_library",
++        "@com_github_google_go_cmp//cmp:go_default_library",
++    ],
++)
+diff -urN a/encoding/protowire/BUILD.bazel b/encoding/protowire/BUILD.bazel
+--- a/encoding/protowire/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/encoding/protowire/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,15 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["wire.go"],
++    importpath = "google.golang.org/protobuf/encoding/protowire",
++    visibility = ["//visibility:public"],
++    deps = ["//internal/errors:go_default_library"],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = ["wire_test.go"],
++    embed = [":go_default_library"],
++)
+diff -urN a/internal/benchmarks/BUILD.bazel b/internal/benchmarks/BUILD.bazel
+--- a/internal/benchmarks/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/benchmarks/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_test")
++
++go_test(
++    name = "go_default_test",
++    srcs = ["bench_test.go"],
++    deps = [
++        "//encoding/protojson:go_default_library",
++        "//encoding/prototext:go_default_library",
++        "//internal/testprotos/benchmarks:go_default_library",
++        "//internal/testprotos/benchmarks/datasets/google_message1/proto2:go_default_library",
++        "//internal/testprotos/benchmarks/datasets/google_message1/proto3:go_default_library",
++        "//internal/testprotos/benchmarks/datasets/google_message2:go_default_library",
++        "//internal/testprotos/benchmarks/datasets/google_message3:go_default_library",
++        "//internal/testprotos/benchmarks/datasets/google_message4:go_default_library",
++        "//proto:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//reflect/protoregistry:go_default_library",
++    ],
++)
+diff -urN a/internal/benchmarks/micro/BUILD.bazel b/internal/benchmarks/micro/BUILD.bazel
+--- a/internal/benchmarks/micro/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/benchmarks/micro/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,14 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_test")
++
++go_test(
++    name = "go_default_test",
++    srcs = ["micro_test.go"],
++    deps = [
++        "//internal/impl:go_default_library",
++        "//internal/testprotos/benchmarks/micro:go_default_library",
++        "//internal/testprotos/test:go_default_library",
++        "//proto:go_default_library",
++        "//runtime/protoiface:go_default_library",
++        "//types/known/emptypb:go_default_library",
++    ],
++)
+diff -urN a/internal/cmd/generate-corpus/BUILD.bazel b/internal/cmd/generate-corpus/BUILD.bazel
+--- a/internal/cmd/generate-corpus/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/cmd/generate-corpus/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,21 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["main.go"],
++    importpath = "google.golang.org/protobuf/internal/cmd/generate-corpus",
++    visibility = ["//visibility:private"],
++    deps = [
++        "//encoding/protojson:go_default_library",
++        "//encoding/prototext:go_default_library",
++        "//internal/testprotos/fuzz:go_default_library",
++        "//internal/testprotos/test:go_default_library",
++        "//proto:go_default_library",
++    ],
++)
++
++go_binary(
++    name = "generate-corpus",
++    embed = [":go_default_library"],
++    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/cmd/generate-protos/BUILD.bazel b/internal/cmd/generate-protos/BUILD.bazel
+--- a/internal/cmd/generate-protos/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/cmd/generate-protos/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,20 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["main.go"],
++    importpath = "google.golang.org/protobuf/internal/cmd/generate-protos",
++    visibility = ["//visibility:private"],
++    deps = [
++        "//cmd/protoc-gen-go/internal_gengo:go_default_library",
++        "//compiler/protogen:go_default_library",
++        "//internal/detrand:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++    ],
++)
++
++go_binary(
++    name = "generate-protos",
++    embed = [":go_default_library"],
++    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/cmd/generate-types/BUILD.bazel b/internal/cmd/generate-types/BUILD.bazel
+--- a/internal/cmd/generate-types/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/cmd/generate-types/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,18 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "impl.go",
++        "main.go",
++        "proto.go",
++    ],
++    importpath = "google.golang.org/protobuf/internal/cmd/generate-types",
++    visibility = ["//visibility:private"],
++)
++
++go_binary(
++    name = "generate-types",
++    embed = [":go_default_library"],
++    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/cmd/pbdump/BUILD.bazel b/internal/cmd/pbdump/BUILD.bazel
+--- a/internal/cmd/pbdump/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/cmd/pbdump/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,35 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["pbdump.go"],
++    importpath = "google.golang.org/protobuf/internal/cmd/pbdump",
++    visibility = ["//visibility:private"],
++    deps = [
++        "//encoding/protowire:go_default_library",
++        "//internal/errors:go_default_library",
++        "//proto:go_default_library",
++        "//reflect/protodesc:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//testing/protopack:go_default_library",
++        "//types/descriptorpb:go_default_library",
++    ],
++)
++
++go_binary(
++    name = "pbdump",
++    embed = [":go_default_library"],
++    visibility = ["//:__subpackages__"],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = ["pbdump_test.go"],
++    embed = [":go_default_library"],
++    deps = [
++        "//encoding/prototext:go_default_library",
++        "//proto:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//types/descriptorpb:go_default_library",
++    ],
++)
+diff -urN a/internal/conformance/BUILD.bazel b/internal/conformance/BUILD.bazel
+--- a/internal/conformance/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/conformance/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_test")
++
++go_test(
++    name = "go_default_test",
++    srcs = ["conformance_test.go"],
++    deps = [
++        "//encoding/protojson:go_default_library",
++        "//encoding/prototext:go_default_library",
++        "//internal/testprotos/conformance:go_default_library",
++        "//proto:go_default_library",
++    ],
++)
+diff -urN a/internal/descfmt/BUILD.bazel b/internal/descfmt/BUILD.bazel
+--- a/internal/descfmt/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/descfmt/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["stringer.go"],
++    importpath = "google.golang.org/protobuf/internal/descfmt",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//internal/detrand:go_default_library",
++        "//internal/pragma:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++    ],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = ["desc_test.go"],
++    embed = [":go_default_library"],
++)
+diff -urN a/internal/descopts/BUILD.bazel b/internal/descopts/BUILD.bazel
+--- a/internal/descopts/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/descopts/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,9 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["options.go"],
++    importpath = "google.golang.org/protobuf/internal/descopts",
++    visibility = ["//:__subpackages__"],
++    deps = ["//reflect/protoreflect:go_default_library"],
++)
+diff -urN a/internal/detectknown/BUILD.bazel b/internal/detectknown/BUILD.bazel
+--- a/internal/detectknown/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/detectknown/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,27 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["detect.go"],
++    importpath = "google.golang.org/protobuf/internal/detectknown",
++    visibility = ["//:__subpackages__"],
++    deps = ["//reflect/protoreflect:go_default_library"],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = ["detect_test.go"],
++    embed = [":go_default_library"],
++    deps = [
++        "//internal/testprotos/fieldmaskpb:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//types/descriptorpb:go_default_library",
++        "//types/known/anypb:go_default_library",
++        "//types/known/durationpb:go_default_library",
++        "//types/known/emptypb:go_default_library",
++        "//types/known/structpb:go_default_library",
++        "//types/known/timestamppb:go_default_library",
++        "//types/known/wrapperspb:go_default_library",
++        "//types/pluginpb:go_default_library",
++    ],
++)
+diff -urN a/internal/detrand/BUILD.bazel b/internal/detrand/BUILD.bazel
+--- a/internal/detrand/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/detrand/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,14 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["rand.go"],
++    importpath = "google.golang.org/protobuf/internal/detrand",
++    visibility = ["//:__subpackages__"],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = ["rand_test.go"],
++    embed = [":go_default_library"],
++)
+diff -urN a/internal/encoding/defval/BUILD.bazel b/internal/encoding/defval/BUILD.bazel
+--- a/internal/encoding/defval/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/encoding/defval/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,23 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["default.go"],
++    importpath = "google.golang.org/protobuf/internal/encoding/defval",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//internal/encoding/text:go_default_library",
++        "//internal/errors:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++    ],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = ["default_test.go"],
++    embed = [":go_default_library"],
++    deps = [
++        "//internal/filedesc:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++    ],
++)
+diff -urN a/internal/encoding/json/BUILD.bazel b/internal/encoding/json/BUILD.bazel
+--- a/internal/encoding/json/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/encoding/json/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,34 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "decode.go",
++        "decode_number.go",
++        "decode_string.go",
++        "decode_token.go",
++        "encode.go",
++    ],
++    importpath = "google.golang.org/protobuf/internal/encoding/json",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//internal/detrand:go_default_library",
++        "//internal/errors:go_default_library",
++        "//internal/strs:go_default_library",
++    ],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = [
++        "bench_test.go",
++        "decode_test.go",
++        "encode_test.go",
++    ],
++    embed = [":go_default_library"],
++    deps = [
++        "//internal/detrand:go_default_library",
++        "@com_github_google_go_cmp//cmp:go_default_library",
++        "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
++    ],
++)
+diff -urN a/internal/encoding/messageset/BUILD.bazel b/internal/encoding/messageset/BUILD.bazel
+--- a/internal/encoding/messageset/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/encoding/messageset/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,14 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["messageset.go"],
++    importpath = "google.golang.org/protobuf/internal/encoding/messageset",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//encoding/protowire:go_default_library",
++        "//internal/errors:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//reflect/protoregistry:go_default_library",
++    ],
++)
+diff -urN a/internal/encoding/tag/BUILD.bazel b/internal/encoding/tag/BUILD.bazel
+--- a/internal/encoding/tag/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/encoding/tag/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,26 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["tag.go"],
++    importpath = "google.golang.org/protobuf/internal/encoding/tag",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//internal/encoding/defval:go_default_library",
++        "//internal/filedesc:go_default_library",
++        "//internal/strs:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++    ],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = ["tag_test.go"],
++    embed = [":go_default_library"],
++    deps = [
++        "//internal/filedesc:go_default_library",
++        "//proto:go_default_library",
++        "//reflect/protodesc:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++    ],
++)
+diff -urN a/internal/encoding/text/BUILD.bazel b/internal/encoding/text/BUILD.bazel
+--- a/internal/encoding/text/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/encoding/text/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,35 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "decode.go",
++        "decode_number.go",
++        "decode_string.go",
++        "decode_token.go",
++        "doc.go",
++        "encode.go",
++    ],
++    importpath = "google.golang.org/protobuf/internal/encoding/text",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//internal/detrand:go_default_library",
++        "//internal/errors:go_default_library",
++        "//internal/flags:go_default_library",
++        "//internal/strs:go_default_library",
++    ],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = [
++        "decode_test.go",
++        "encode_test.go",
++    ],
++    embed = [":go_default_library"],
++    deps = [
++        "//internal/detrand:go_default_library",
++        "//internal/flags:go_default_library",
++        "@com_github_google_go_cmp//cmp:go_default_library",
++    ],
++)
+diff -urN a/internal/errors/BUILD.bazel b/internal/errors/BUILD.bazel
+--- a/internal/errors/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/errors/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "errors.go",
++        "is_go112.go",
++        "is_go113.go",
++    ],
++    importpath = "google.golang.org/protobuf/internal/errors",
++    visibility = ["//:__subpackages__"],
++    deps = ["//internal/detrand:go_default_library"],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = ["errors_test.go"],
++    embed = [":go_default_library"],
++)
+diff -urN a/internal/fieldnum/BUILD.bazel b/internal/fieldnum/BUILD.bazel
+--- a/internal/fieldnum/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/fieldnum/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,21 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "any_gen.go",
++        "api_gen.go",
++        "descriptor_gen.go",
++        "doc.go",
++        "duration_gen.go",
++        "empty_gen.go",
++        "field_mask_gen.go",
++        "source_context_gen.go",
++        "struct_gen.go",
++        "timestamp_gen.go",
++        "type_gen.go",
++        "wrappers_gen.go",
++    ],
++    importpath = "google.golang.org/protobuf/internal/fieldnum",
++    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/fieldsort/BUILD.bazel b/internal/fieldsort/BUILD.bazel
+--- a/internal/fieldsort/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/fieldsort/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,9 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["fieldsort.go"],
++    importpath = "google.golang.org/protobuf/internal/fieldsort",
++    visibility = ["//:__subpackages__"],
++    deps = ["//reflect/protoreflect:go_default_library"],
++)
+diff -urN a/internal/filedesc/BUILD.bazel b/internal/filedesc/BUILD.bazel
+--- a/internal/filedesc/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/filedesc/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,48 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "build.go",
++        "desc.go",
++        "desc_init.go",
++        "desc_lazy.go",
++        "desc_list.go",
++        "desc_list_gen.go",
++        "placeholder.go",
++    ],
++    importpath = "google.golang.org/protobuf/internal/filedesc",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//encoding/protowire:go_default_library",
++        "//internal/descfmt:go_default_library",
++        "//internal/descopts:go_default_library",
++        "//internal/encoding/defval:go_default_library",
++        "//internal/errors:go_default_library",
++        "//internal/fieldnum:go_default_library",
++        "//internal/pragma:go_default_library",
++        "//internal/strs:go_default_library",
++        "//proto:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//reflect/protoregistry:go_default_library",
++    ],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = [
++        "build_test.go",
++        "desc_test.go",
++    ],
++    embed = [":go_default_library"],
++    deps = [
++        "//internal/detrand:go_default_library",
++        "//internal/testprotos/test:go_default_library",
++        "//internal/testprotos/test/weak1:go_default_library",
++        "//proto:go_default_library",
++        "//reflect/protodesc:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//types/descriptorpb:go_default_library",
++        "@com_github_google_go_cmp//cmp:go_default_library",
++    ],
++)
+diff -urN a/internal/filetype/BUILD.bazel b/internal/filetype/BUILD.bazel
+--- a/internal/filetype/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/filetype/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,15 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["build.go"],
++    importpath = "google.golang.org/protobuf/internal/filetype",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//internal/descopts:go_default_library",
++        "//internal/filedesc:go_default_library",
++        "//internal/impl:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//reflect/protoregistry:go_default_library",
++    ],
++)
+diff -urN a/internal/flags/BUILD.bazel b/internal/flags/BUILD.bazel
+--- a/internal/flags/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/flags/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,11 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "flags.go",
++        "proto_legacy_disable.go",
++    ],
++    importpath = "google.golang.org/protobuf/internal/flags",
++    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/fuzz/jsonfuzz/BUILD.bazel b/internal/fuzz/jsonfuzz/BUILD.bazel
+--- a/internal/fuzz/jsonfuzz/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/fuzz/jsonfuzz/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,20 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["fuzz.go"],
++    importpath = "google.golang.org/protobuf/internal/fuzz/jsonfuzz",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//encoding/protojson:go_default_library",
++        "//internal/testprotos/fuzz:go_default_library",
++        "//proto:go_default_library",
++    ],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = ["fuzz_test.go"],
++    embed = [":go_default_library"],
++    deps = ["//internal/fuzztest:go_default_library"],
++)
+diff -urN a/internal/fuzz/textfuzz/BUILD.bazel b/internal/fuzz/textfuzz/BUILD.bazel
+--- a/internal/fuzz/textfuzz/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/fuzz/textfuzz/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,20 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["fuzz.go"],
++    importpath = "google.golang.org/protobuf/internal/fuzz/textfuzz",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//encoding/prototext:go_default_library",
++        "//internal/testprotos/fuzz:go_default_library",
++        "//proto:go_default_library",
++    ],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = ["fuzz_test.go"],
++    embed = [":go_default_library"],
++    deps = ["//internal/fuzztest:go_default_library"],
++)
+diff -urN a/internal/fuzz/wirefuzz/BUILD.bazel b/internal/fuzz/wirefuzz/BUILD.bazel
+--- a/internal/fuzz/wirefuzz/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/fuzz/wirefuzz/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,21 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["fuzz.go"],
++    importpath = "google.golang.org/protobuf/internal/fuzz/wirefuzz",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//internal/impl:go_default_library",
++        "//internal/testprotos/fuzz:go_default_library",
++        "//proto:go_default_library",
++        "//runtime/protoiface:go_default_library",
++    ],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = ["fuzz_test.go"],
++    embed = [":go_default_library"],
++    deps = ["//internal/fuzztest:go_default_library"],
++)
+diff -urN a/internal/fuzztest/BUILD.bazel b/internal/fuzztest/BUILD.bazel
+--- a/internal/fuzztest/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/fuzztest/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["fuzztest.go"],
++    importpath = "google.golang.org/protobuf/internal/fuzztest",
++    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/genname/BUILD.bazel b/internal/genname/BUILD.bazel
+--- a/internal/genname/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/genname/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["name.go"],
++    importpath = "google.golang.org/protobuf/internal/genname",
++    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/impl/BUILD.bazel b/internal/impl/BUILD.bazel
+--- a/internal/impl/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/impl/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,103 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "api_export.go",
++        "checkinit.go",
++        "codec_extension.go",
++        "codec_field.go",
++        "codec_gen.go",
++        "codec_map.go",
++        "codec_map_go111.go",
++        "codec_map_go112.go",
++        "codec_message.go",
++        "codec_messageset.go",
++        "codec_tables.go",
++        "codec_unsafe.go",
++        "convert.go",
++        "convert_list.go",
++        "convert_map.go",
++        "decode.go",
++        "encode.go",
++        "enum.go",
++        "extension.go",
++        "legacy_enum.go",
++        "legacy_export.go",
++        "legacy_extension.go",
++        "legacy_file.go",
++        "legacy_message.go",
++        "merge.go",
++        "merge_gen.go",
++        "message.go",
++        "message_reflect.go",
++        "message_reflect_field.go",
++        "message_reflect_gen.go",
++        "pointer_unsafe.go",
++        "validate.go",
++        "weak.go",
++    ],
++    importpath = "google.golang.org/protobuf/internal/impl",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//encoding/prototext:go_default_library",
++        "//encoding/protowire:go_default_library",
++        "//internal/descopts:go_default_library",
++        "//internal/encoding/messageset:go_default_library",
++        "//internal/encoding/tag:go_default_library",
++        "//internal/errors:go_default_library",
++        "//internal/fieldsort:go_default_library",
++        "//internal/filedesc:go_default_library",
++        "//internal/flags:go_default_library",
++        "//internal/genname:go_default_library",
++        "//internal/pragma:go_default_library",
++        "//internal/strs:go_default_library",
++        "//proto:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//reflect/protoregistry:go_default_library",
++        "//runtime/protoiface:go_default_library",
++    ],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = [
++        "enum_test.go",
++        "extension_test.go",
++        "lazy_test.go",
++        "legacy_aberrant_test.go",
++        "legacy_export_test.go",
++        "legacy_file_test.go",
++        "legacy_test.go",
++        "message_reflect_test.go",
++    ],
++    embed = [":go_default_library"],
++    deps = [
++        "//encoding/prototext:go_default_library",
++        "//internal/flags:go_default_library",
++        "//internal/pragma:go_default_library",
++        "//internal/protobuild:go_default_library",
++        "//internal/testprotos/legacy/proto2_20160225_2fc053c5:go_default_library",
++        "//internal/testprotos/legacy/proto2_20160519_a4ab9ec5:go_default_library",
++        "//internal/testprotos/legacy/proto2_20180125_92554152:go_default_library",
++        "//internal/testprotos/legacy/proto2_20180430_b4deda09:go_default_library",
++        "//internal/testprotos/legacy/proto2_20180814_aa810b61:go_default_library",
++        "//internal/testprotos/legacy/proto2_20190205_c823c79e:go_default_library",
++        "//internal/testprotos/legacy/proto3_20160225_2fc053c5:go_default_library",
++        "//internal/testprotos/legacy/proto3_20160519_a4ab9ec5:go_default_library",
++        "//internal/testprotos/legacy/proto3_20180125_92554152:go_default_library",
++        "//internal/testprotos/legacy/proto3_20180430_b4deda09:go_default_library",
++        "//internal/testprotos/legacy/proto3_20180814_aa810b61:go_default_library",
++        "//internal/testprotos/legacy/proto3_20190205_c823c79e:go_default_library",
++        "//internal/testprotos/test:go_default_library",
++        "//proto:go_default_library",
++        "//reflect/protodesc:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//reflect/protoregistry:go_default_library",
++        "//runtime/protoiface:go_default_library",
++        "//testing/protocmp:go_default_library",
++        "//types/descriptorpb:go_default_library",
++        "@com_github_google_go_cmp//cmp:go_default_library",
++        "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
++    ],
++)
+diff -urN a/internal/mapsort/BUILD.bazel b/internal/mapsort/BUILD.bazel
+--- a/internal/mapsort/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/mapsort/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["mapsort.go"],
++    importpath = "google.golang.org/protobuf/internal/mapsort",
++    visibility = ["//:__subpackages__"],
++    deps = ["//reflect/protoreflect:go_default_library"],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = ["mapsort_test.go"],
++    embed = [":go_default_library"],
++    deps = [
++        "//internal/testprotos/test:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++    ],
++)
+diff -urN a/internal/msgfmt/BUILD.bazel b/internal/msgfmt/BUILD.bazel
+--- a/internal/msgfmt/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/msgfmt/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,37 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["format.go"],
++    importpath = "google.golang.org/protobuf/internal/msgfmt",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//encoding/protowire:go_default_library",
++        "//internal/detectknown:go_default_library",
++        "//internal/detrand:go_default_library",
++        "//internal/mapsort:go_default_library",
++        "//proto:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//reflect/protoregistry:go_default_library",
++    ],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = ["format_test.go"],
++    embed = [":go_default_library"],
++    deps = [
++        "//internal/detrand:go_default_library",
++        "//internal/testprotos/test:go_default_library",
++        "//internal/testprotos/textpb2:go_default_library",
++        "//proto:go_default_library",
++        "//testing/protocmp:go_default_library",
++        "//testing/protopack:go_default_library",
++        "//types/dynamicpb:go_default_library",
++        "//types/known/anypb:go_default_library",
++        "//types/known/durationpb:go_default_library",
++        "//types/known/timestamppb:go_default_library",
++        "//types/known/wrapperspb:go_default_library",
++        "@com_github_google_go_cmp//cmp:go_default_library",
++    ],
++)
+diff -urN a/internal/pragma/BUILD.bazel b/internal/pragma/BUILD.bazel
+--- a/internal/pragma/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/pragma/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["pragma.go"],
++    importpath = "google.golang.org/protobuf/internal/pragma",
++    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/protobuild/BUILD.bazel b/internal/protobuild/BUILD.bazel
+--- a/internal/protobuild/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/protobuild/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["build.go"],
++    importpath = "google.golang.org/protobuf/internal/protobuild",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//reflect/protoregistry:go_default_library",
++    ],
++)
+diff -urN a/internal/protolegacy/BUILD.bazel b/internal/protolegacy/BUILD.bazel
+--- a/internal/protolegacy/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/protolegacy/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,14 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["proto.go"],
++    importpath = "google.golang.org/protobuf/internal/protolegacy",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//reflect/protoregistry:go_default_library",
++        "//runtime/protoiface:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/internal/set/BUILD.bazel b/internal/set/BUILD.bazel
+--- a/internal/set/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/set/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,14 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["ints.go"],
++    importpath = "google.golang.org/protobuf/internal/set",
++    visibility = ["//:__subpackages__"],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = ["ints_test.go"],
++    embed = [":go_default_library"],
++)
+diff -urN a/internal/strs/BUILD.bazel b/internal/strs/BUILD.bazel
+--- a/internal/strs/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/strs/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,21 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "strings.go",
++        "strings_unsafe.go",
++    ],
++    importpath = "google.golang.org/protobuf/internal/strs",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//internal/flags:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++    ],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = ["strings_test.go"],
++    embed = [":go_default_library"],
++)
+diff -urN a/internal/testprotos/annotation/BUILD.bazel b/internal/testprotos/annotation/BUILD.bazel
+--- a/internal/testprotos/annotation/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/annotation/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,13 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["annotation.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/annotation",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++        "//types/descriptorpb:go_default_library",
++    ],
++)
+diff -urN a/internal/testprotos/benchmarks/BUILD.bazel b/internal/testprotos/benchmarks/BUILD.bazel
+--- a/internal/testprotos/benchmarks/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/benchmarks/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["benchmarks.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/benchmarks",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/internal/testprotos/benchmarks/datasets/google_message1/proto2/BUILD.bazel b/internal/testprotos/benchmarks/datasets/google_message1/proto2/BUILD.bazel
+--- a/internal/testprotos/benchmarks/datasets/google_message1/proto2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/benchmarks/datasets/google_message1/proto2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["benchmark_message1_proto2.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/benchmarks/datasets/google_message1/proto2",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/internal/testprotos/benchmarks/datasets/google_message1/proto3/BUILD.bazel b/internal/testprotos/benchmarks/datasets/google_message1/proto3/BUILD.bazel
+--- a/internal/testprotos/benchmarks/datasets/google_message1/proto3/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/benchmarks/datasets/google_message1/proto3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["benchmark_message1_proto3.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/benchmarks/datasets/google_message1/proto3",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/internal/testprotos/benchmarks/datasets/google_message2/BUILD.bazel b/internal/testprotos/benchmarks/datasets/google_message2/BUILD.bazel
+--- a/internal/testprotos/benchmarks/datasets/google_message2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/benchmarks/datasets/google_message2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["benchmark_message2.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/benchmarks/datasets/google_message2",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/internal/testprotos/benchmarks/datasets/google_message3/BUILD.bazel b/internal/testprotos/benchmarks/datasets/google_message3/BUILD.bazel
+--- a/internal/testprotos/benchmarks/datasets/google_message3/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/benchmarks/datasets/google_message3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,23 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "benchmark_message3.pb.go",
++        "benchmark_message3_1.pb.go",
++        "benchmark_message3_2.pb.go",
++        "benchmark_message3_3.pb.go",
++        "benchmark_message3_4.pb.go",
++        "benchmark_message3_5.pb.go",
++        "benchmark_message3_6.pb.go",
++        "benchmark_message3_7.pb.go",
++        "benchmark_message3_8.pb.go",
++    ],
++    importpath = "google.golang.org/protobuf/internal/testprotos/benchmarks/datasets/google_message3",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoiface:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/internal/testprotos/benchmarks/datasets/google_message4/BUILD.bazel b/internal/testprotos/benchmarks/datasets/google_message4/BUILD.bazel
+--- a/internal/testprotos/benchmarks/datasets/google_message4/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/benchmarks/datasets/google_message4/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,18 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "benchmark_message4.pb.go",
++        "benchmark_message4_1.pb.go",
++        "benchmark_message4_2.pb.go",
++        "benchmark_message4_3.pb.go",
++    ],
++    importpath = "google.golang.org/protobuf/internal/testprotos/benchmarks/datasets/google_message4",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoiface:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/internal/testprotos/benchmarks/micro/BUILD.bazel b/internal/testprotos/benchmarks/micro/BUILD.bazel
+--- a/internal/testprotos/benchmarks/micro/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/benchmarks/micro/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["micro.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/benchmarks/micro",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/internal/testprotos/conformance/BUILD.bazel b/internal/testprotos/conformance/BUILD.bazel
+--- a/internal/testprotos/conformance/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/conformance/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,23 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "conformance.pb.go",
++        "test_messages_proto2.pb.go",
++        "test_messages_proto3.pb.go",
++    ],
++    importpath = "google.golang.org/protobuf/internal/testprotos/conformance",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//internal/testprotos/fieldmaskpb:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoiface:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++        "//types/known/anypb:go_default_library",
++        "//types/known/durationpb:go_default_library",
++        "//types/known/structpb:go_default_library",
++        "//types/known/timestamppb:go_default_library",
++        "//types/known/wrapperspb:go_default_library",
++    ],
++)
+diff -urN a/internal/testprotos/fieldmaskpb/BUILD.bazel b/internal/testprotos/fieldmaskpb/BUILD.bazel
+--- a/internal/testprotos/fieldmaskpb/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/fieldmaskpb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["field_mask.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/fieldmaskpb",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/internal/testprotos/fieldtrack/BUILD.bazel b/internal/testprotos/fieldtrack/BUILD.bazel
+--- a/internal/testprotos/fieldtrack/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/fieldtrack/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,15 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["fieldtrack.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/fieldtrack",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//internal/testprotos/annotation:go_default_library",
++        "//internal/testprotos/test:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoiface:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/internal/testprotos/fuzz/BUILD.bazel b/internal/testprotos/fuzz/BUILD.bazel
+--- a/internal/testprotos/fuzz/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/fuzz/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,14 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["fuzz.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/fuzz",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//internal/testprotos/test:go_default_library",
++        "//internal/testprotos/test3:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/internal/testprotos/irregular/BUILD.bazel b/internal/testprotos/irregular/BUILD.bazel
+--- a/internal/testprotos/irregular/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/irregular/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "irregular.go",
++        "test.pb.go",
++    ],
++    importpath = "google.golang.org/protobuf/internal/testprotos/irregular",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//encoding/prototext:go_default_library",
++        "//reflect/protodesc:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoiface:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++        "//types/descriptorpb:go_default_library",
++    ],
++)
+diff -urN a/internal/testprotos/legacy/BUILD.bazel b/internal/testprotos/legacy/BUILD.bazel
+--- a/internal/testprotos/legacy/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/legacy/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,24 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["legacy.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/legacy",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//internal/testprotos/legacy/proto2_20160225_2fc053c5:go_default_library",
++        "//internal/testprotos/legacy/proto2_20160519_a4ab9ec5:go_default_library",
++        "//internal/testprotos/legacy/proto2_20180125_92554152:go_default_library",
++        "//internal/testprotos/legacy/proto2_20180430_b4deda09:go_default_library",
++        "//internal/testprotos/legacy/proto2_20180814_aa810b61:go_default_library",
++        "//internal/testprotos/legacy/proto2_20190205_c823c79e:go_default_library",
++        "//internal/testprotos/legacy/proto3_20160225_2fc053c5:go_default_library",
++        "//internal/testprotos/legacy/proto3_20160519_a4ab9ec5:go_default_library",
++        "//internal/testprotos/legacy/proto3_20180125_92554152:go_default_library",
++        "//internal/testprotos/legacy/proto3_20180430_b4deda09:go_default_library",
++        "//internal/testprotos/legacy/proto3_20180814_aa810b61:go_default_library",
++        "//internal/testprotos/legacy/proto3_20190205_c823c79e:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/internal/testprotos/legacy/bug1052/BUILD.bazel b/internal/testprotos/legacy/bug1052/BUILD.bazel
+--- a/internal/testprotos/legacy/bug1052/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/legacy/bug1052/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,18 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["bug1052.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/legacy/bug1052",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//internal/protolegacy:go_default_library",
++        "//types/descriptorpb:go_default_library",
++    ],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = ["bug1052_test.go"],
++    embed = [":go_default_library"],
++)
+diff -urN a/internal/testprotos/legacy/proto2_20160225_2fc053c5/BUILD.bazel b/internal/testprotos/legacy/proto2_20160225_2fc053c5/BUILD.bazel
+--- a/internal/testprotos/legacy/proto2_20160225_2fc053c5/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/legacy/proto2_20160225_2fc053c5/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,9 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["test.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/legacy/proto2_20160225_2fc053c5",
++    visibility = ["//:__subpackages__"],
++    deps = ["//internal/protolegacy:go_default_library"],
++)
+diff -urN a/internal/testprotos/legacy/proto2_20160519_a4ab9ec5/BUILD.bazel b/internal/testprotos/legacy/proto2_20160519_a4ab9ec5/BUILD.bazel
+--- a/internal/testprotos/legacy/proto2_20160519_a4ab9ec5/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/legacy/proto2_20160519_a4ab9ec5/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,9 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["test.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/legacy/proto2_20160519_a4ab9ec5",
++    visibility = ["//:__subpackages__"],
++    deps = ["//internal/protolegacy:go_default_library"],
++)
+diff -urN a/internal/testprotos/legacy/proto2_20180125_92554152/BUILD.bazel b/internal/testprotos/legacy/proto2_20180125_92554152/BUILD.bazel
+--- a/internal/testprotos/legacy/proto2_20180125_92554152/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/legacy/proto2_20180125_92554152/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,9 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["test.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/legacy/proto2_20180125_92554152",
++    visibility = ["//:__subpackages__"],
++    deps = ["//internal/protolegacy:go_default_library"],
++)
+diff -urN a/internal/testprotos/legacy/proto2_20180430_b4deda09/BUILD.bazel b/internal/testprotos/legacy/proto2_20180430_b4deda09/BUILD.bazel
+--- a/internal/testprotos/legacy/proto2_20180430_b4deda09/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/legacy/proto2_20180430_b4deda09/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,9 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["test.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/legacy/proto2_20180430_b4deda09",
++    visibility = ["//:__subpackages__"],
++    deps = ["//internal/protolegacy:go_default_library"],
++)
+diff -urN a/internal/testprotos/legacy/proto2_20180814_aa810b61/BUILD.bazel b/internal/testprotos/legacy/proto2_20180814_aa810b61/BUILD.bazel
+--- a/internal/testprotos/legacy/proto2_20180814_aa810b61/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/legacy/proto2_20180814_aa810b61/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,9 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["test.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/legacy/proto2_20180814_aa810b61",
++    visibility = ["//:__subpackages__"],
++    deps = ["//internal/protolegacy:go_default_library"],
++)
+diff -urN a/internal/testprotos/legacy/proto2_20190205_c823c79e/BUILD.bazel b/internal/testprotos/legacy/proto2_20190205_c823c79e/BUILD.bazel
+--- a/internal/testprotos/legacy/proto2_20190205_c823c79e/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/legacy/proto2_20190205_c823c79e/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,9 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["test.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/legacy/proto2_20190205_c823c79e",
++    visibility = ["//:__subpackages__"],
++    deps = ["//internal/protolegacy:go_default_library"],
++)
+diff -urN a/internal/testprotos/legacy/proto3_20160225_2fc053c5/BUILD.bazel b/internal/testprotos/legacy/proto3_20160225_2fc053c5/BUILD.bazel
+--- a/internal/testprotos/legacy/proto3_20160225_2fc053c5/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/legacy/proto3_20160225_2fc053c5/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,9 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["test.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/legacy/proto3_20160225_2fc053c5",
++    visibility = ["//:__subpackages__"],
++    deps = ["//internal/protolegacy:go_default_library"],
++)
+diff -urN a/internal/testprotos/legacy/proto3_20160519_a4ab9ec5/BUILD.bazel b/internal/testprotos/legacy/proto3_20160519_a4ab9ec5/BUILD.bazel
+--- a/internal/testprotos/legacy/proto3_20160519_a4ab9ec5/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/legacy/proto3_20160519_a4ab9ec5/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,9 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["test.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/legacy/proto3_20160519_a4ab9ec5",
++    visibility = ["//:__subpackages__"],
++    deps = ["//internal/protolegacy:go_default_library"],
++)
+diff -urN a/internal/testprotos/legacy/proto3_20180125_92554152/BUILD.bazel b/internal/testprotos/legacy/proto3_20180125_92554152/BUILD.bazel
+--- a/internal/testprotos/legacy/proto3_20180125_92554152/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/legacy/proto3_20180125_92554152/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,9 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["test.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/legacy/proto3_20180125_92554152",
++    visibility = ["//:__subpackages__"],
++    deps = ["//internal/protolegacy:go_default_library"],
++)
+diff -urN a/internal/testprotos/legacy/proto3_20180430_b4deda09/BUILD.bazel b/internal/testprotos/legacy/proto3_20180430_b4deda09/BUILD.bazel
+--- a/internal/testprotos/legacy/proto3_20180430_b4deda09/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/legacy/proto3_20180430_b4deda09/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,9 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["test.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/legacy/proto3_20180430_b4deda09",
++    visibility = ["//:__subpackages__"],
++    deps = ["//internal/protolegacy:go_default_library"],
++)
+diff -urN a/internal/testprotos/legacy/proto3_20180814_aa810b61/BUILD.bazel b/internal/testprotos/legacy/proto3_20180814_aa810b61/BUILD.bazel
+--- a/internal/testprotos/legacy/proto3_20180814_aa810b61/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/legacy/proto3_20180814_aa810b61/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,9 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["test.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/legacy/proto3_20180814_aa810b61",
++    visibility = ["//:__subpackages__"],
++    deps = ["//internal/protolegacy:go_default_library"],
++)
+diff -urN a/internal/testprotos/legacy/proto3_20190205_c823c79e/BUILD.bazel b/internal/testprotos/legacy/proto3_20190205_c823c79e/BUILD.bazel
+--- a/internal/testprotos/legacy/proto3_20190205_c823c79e/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/legacy/proto3_20190205_c823c79e/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,9 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["test.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/legacy/proto3_20190205_c823c79e",
++    visibility = ["//:__subpackages__"],
++    deps = ["//internal/protolegacy:go_default_library"],
++)
+diff -urN a/internal/testprotos/messageset/messagesetpb/BUILD.bazel b/internal/testprotos/messageset/messagesetpb/BUILD.bazel
+--- a/internal/testprotos/messageset/messagesetpb/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/messageset/messagesetpb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,13 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["message_set.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/messageset/messagesetpb",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoiface:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/internal/testprotos/messageset/msetextpb/BUILD.bazel b/internal/testprotos/messageset/msetextpb/BUILD.bazel
+--- a/internal/testprotos/messageset/msetextpb/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/messageset/msetextpb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,13 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["msetextpb.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/messageset/msetextpb",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//internal/testprotos/messageset/messagesetpb:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/internal/testprotos/order/BUILD.bazel b/internal/testprotos/order/BUILD.bazel
+--- a/internal/testprotos/order/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/order/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,13 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["order.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/order",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoiface:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/internal/testprotos/registry/BUILD.bazel b/internal/testprotos/registry/BUILD.bazel
+--- a/internal/testprotos/registry/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/registry/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,13 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["test.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/registry",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoiface:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/internal/testprotos/required/BUILD.bazel b/internal/testprotos/required/BUILD.bazel
+--- a/internal/testprotos/required/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/required/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["required.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/required",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/internal/testprotos/test/BUILD.bazel b/internal/testprotos/test/BUILD.bazel
+--- a/internal/testprotos/test/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/test/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,18 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "ext.pb.go",
++        "test.pb.go",
++        "test_import.pb.go",
++        "test_public.pb.go",
++    ],
++    importpath = "google.golang.org/protobuf/internal/testprotos/test",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoiface:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/internal/testprotos/test/weak1/BUILD.bazel b/internal/testprotos/test/weak1/BUILD.bazel
+--- a/internal/testprotos/test/weak1/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/test/weak1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["test_weak.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/test/weak1",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/internal/testprotos/test/weak2/BUILD.bazel b/internal/testprotos/test/weak2/BUILD.bazel
+--- a/internal/testprotos/test/weak2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/test/weak2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["test_weak.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/test/weak2",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/internal/testprotos/test3/BUILD.bazel b/internal/testprotos/test3/BUILD.bazel
+--- a/internal/testprotos/test3/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/test3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,15 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "test.pb.go",
++        "test_import.pb.go",
++    ],
++    importpath = "google.golang.org/protobuf/internal/testprotos/test3",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/internal/testprotos/textpb2/BUILD.bazel b/internal/testprotos/textpb2/BUILD.bazel
+--- a/internal/testprotos/textpb2/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/textpb2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,20 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["test.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/textpb2",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//internal/testprotos/fieldmaskpb:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoiface:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++        "//types/known/anypb:go_default_library",
++        "//types/known/durationpb:go_default_library",
++        "//types/known/emptypb:go_default_library",
++        "//types/known/structpb:go_default_library",
++        "//types/known/timestamppb:go_default_library",
++        "//types/known/wrapperspb:go_default_library",
++    ],
++)
+diff -urN a/internal/testprotos/textpb3/BUILD.bazel b/internal/testprotos/textpb3/BUILD.bazel
+--- a/internal/testprotos/textpb3/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/testprotos/textpb3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["test.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/textpb3",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/internal/version/BUILD.bazel b/internal/version/BUILD.bazel
+--- a/internal/version/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/version/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["version.go"],
++    importpath = "google.golang.org/protobuf/internal/version",
++    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/weakdeps/BUILD.bazel b/internal/weakdeps/BUILD.bazel
+--- a/internal/weakdeps/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/weakdeps/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["doc.go"],
++    importpath = "google.golang.org/protobuf/internal/weakdeps",
++    visibility = ["//:__subpackages__"],
++)
+diff -urN a/proto/BUILD.bazel b/proto/BUILD.bazel
+--- a/proto/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/proto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,87 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "checkinit.go",
++        "decode.go",
++        "decode_gen.go",
++        "doc.go",
++        "encode.go",
++        "encode_gen.go",
++        "equal.go",
++        "extension.go",
++        "merge.go",
++        "messageset.go",
++        "proto.go",
++        "proto_methods.go",
++        "reset.go",
++        "size.go",
++        "size_gen.go",
++        "wrappers.go",
++    ],
++    importpath = "google.golang.org/protobuf/proto",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//encoding/protowire:go_default_library",
++        "//internal/encoding/messageset:go_default_library",
++        "//internal/errors:go_default_library",
++        "//internal/fieldsort:go_default_library",
++        "//internal/flags:go_default_library",
++        "//internal/mapsort:go_default_library",
++        "//internal/pragma:go_default_library",
++        "//internal/strs:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//reflect/protoregistry:go_default_library",
++        "//runtime/protoiface:go_default_library",
++    ],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = [
++        "bench_test.go",
++        "checkinit_test.go",
++        "decode_test.go",
++        "encode_test.go",
++        "equal_test.go",
++        "extension_test.go",
++        "merge_test.go",
++        "messageset_test.go",
++        "methods_test.go",
++        "nil_test.go",
++        "noenforceutf8_test.go",
++        "reset_test.go",
++        "testmessages_test.go",
++        "validate_test.go",
++        "weak_test.go",
++    ],
++    embed = [":go_default_library"],
++    deps = [
++        "//encoding/prototext:go_default_library",
++        "//encoding/protowire:go_default_library",
++        "//internal/filedesc:go_default_library",
++        "//internal/flags:go_default_library",
++        "//internal/impl:go_default_library",
++        "//internal/protobuild:go_default_library",
++        "//internal/testprotos/legacy:go_default_library",
++        "//internal/testprotos/legacy/proto2_20160225_2fc053c5:go_default_library",
++        "//internal/testprotos/messageset/messagesetpb:go_default_library",
++        "//internal/testprotos/messageset/msetextpb:go_default_library",
++        "//internal/testprotos/order:go_default_library",
++        "//internal/testprotos/required:go_default_library",
++        "//internal/testprotos/test:go_default_library",
++        "//internal/testprotos/test/weak1:go_default_library",
++        "//internal/testprotos/test3:go_default_library",
++        "//reflect/protodesc:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//reflect/protoregistry:go_default_library",
++        "//runtime/protoiface:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++        "//testing/protocmp:go_default_library",
++        "//testing/protopack:go_default_library",
++        "//types/descriptorpb:go_default_library",
++        "//types/dynamicpb:go_default_library",
++        "@com_github_google_go_cmp//cmp:go_default_library",
++    ],
++)
+diff -urN a/reflect/protodesc/BUILD.bazel b/reflect/protodesc/BUILD.bazel
+--- a/reflect/protodesc/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/reflect/protodesc/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,41 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "desc.go",
++        "desc_init.go",
++        "desc_resolve.go",
++        "desc_validate.go",
++        "proto.go",
++    ],
++    importpath = "google.golang.org/protobuf/reflect/protodesc",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//encoding/protowire:go_default_library",
++        "//internal/encoding/defval:go_default_library",
++        "//internal/errors:go_default_library",
++        "//internal/filedesc:go_default_library",
++        "//internal/flags:go_default_library",
++        "//internal/pragma:go_default_library",
++        "//internal/strs:go_default_library",
++        "//proto:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//reflect/protoregistry:go_default_library",
++        "//types/descriptorpb:go_default_library",
++    ],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = ["file_test.go"],
++    embed = [":go_default_library"],
++    deps = [
++        "//encoding/prototext:go_default_library",
++        "//internal/flags:go_default_library",
++        "//proto:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//reflect/protoregistry:go_default_library",
++        "//types/descriptorpb:go_default_library",
++    ],
++)
+diff -urN a/reflect/protoreflect/BUILD.bazel b/reflect/protoreflect/BUILD.bazel
+--- a/reflect/protoreflect/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/reflect/protoreflect/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,29 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "methods.go",
++        "proto.go",
++        "source.go",
++        "type.go",
++        "value.go",
++        "value_union.go",
++        "value_unsafe.go",
++    ],
++    importpath = "google.golang.org/protobuf/reflect/protoreflect",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//encoding/protowire:go_default_library",
++        "//internal/pragma:go_default_library",
++    ],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = [
++        "proto_test.go",
++        "value_test.go",
++    ],
++    embed = [":go_default_library"],
++)
+diff -urN a/reflect/protoregistry/BUILD.bazel b/reflect/protoregistry/BUILD.bazel
+--- a/reflect/protoregistry/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/reflect/protoregistry/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,28 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["registry.go"],
++    importpath = "google.golang.org/protobuf/reflect/protoregistry",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//internal/errors:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++    ],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = ["registry_test.go"],
++    embed = [":go_default_library"],
++    deps = [
++        "//encoding/prototext:go_default_library",
++        "//internal/impl:go_default_library",
++        "//internal/testprotos/registry:go_default_library",
++        "//reflect/protodesc:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//types/descriptorpb:go_default_library",
++        "@com_github_google_go_cmp//cmp:go_default_library",
++        "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
++    ],
++)
+diff -urN a/runtime/protoiface/BUILD.bazel b/runtime/protoiface/BUILD.bazel
+--- a/runtime/protoiface/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/runtime/protoiface/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,15 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "legacy.go",
++        "methods.go",
++    ],
++    importpath = "google.golang.org/protobuf/runtime/protoiface",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//internal/pragma:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++    ],
++)
+diff -urN a/runtime/protoimpl/BUILD.bazel b/runtime/protoimpl/BUILD.bazel
+--- a/runtime/protoimpl/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/runtime/protoimpl/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,17 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "impl.go",
++        "version.go",
++    ],
++    importpath = "google.golang.org/protobuf/runtime/protoimpl",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//internal/filedesc:go_default_library",
++        "//internal/filetype:go_default_library",
++        "//internal/impl:go_default_library",
++        "//internal/version:go_default_library",
++    ],
++)
+diff -urN a/testing/protocmp/BUILD.bazel b/testing/protocmp/BUILD.bazel
+--- a/testing/protocmp/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/testing/protocmp/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,45 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "reflect.go",
++        "util.go",
++        "xform.go",
++    ],
++    importpath = "google.golang.org/protobuf/testing/protocmp",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//encoding/protowire:go_default_library",
++        "//internal/msgfmt:go_default_library",
++        "//proto:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//reflect/protoregistry:go_default_library",
++        "//runtime/protoiface:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++        "@com_github_google_go_cmp//cmp:go_default_library",
++        "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
++    ],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = [
++        "reflect_test.go",
++        "util_test.go",
++        "xform_test.go",
++    ],
++    embed = [":go_default_library"],
++    deps = [
++        "//internal/detrand:go_default_library",
++        "//internal/testprotos/test:go_default_library",
++        "//internal/testprotos/textpb2:go_default_library",
++        "//proto:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//testing/protopack:go_default_library",
++        "//types/dynamicpb:go_default_library",
++        "//types/known/anypb:go_default_library",
++        "//types/known/wrapperspb:go_default_library",
++        "@com_github_google_go_cmp//cmp:go_default_library",
++    ],
++)
+diff -urN a/testing/protopack/BUILD.bazel b/testing/protopack/BUILD.bazel
+--- a/testing/protopack/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/testing/protopack/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,25 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["pack.go"],
++    importpath = "google.golang.org/protobuf/testing/protopack",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//encoding/protowire:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++    ],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = ["pack_test.go"],
++    embed = [":go_default_library"],
++    deps = [
++        "//encoding/prototext:go_default_library",
++        "//reflect/protodesc:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//types/descriptorpb:go_default_library",
++        "@com_github_google_go_cmp//cmp:go_default_library",
++    ],
++)
+diff -urN a/testing/prototest/BUILD.bazel b/testing/prototest/BUILD.bazel
+--- a/testing/prototest/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/testing/prototest/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,33 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["prototest.go"],
++    importpath = "google.golang.org/protobuf/testing/prototest",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//encoding/prototext:go_default_library",
++        "//encoding/protowire:go_default_library",
++        "//proto:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//reflect/protoregistry:go_default_library",
++    ],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = ["prototest_test.go"],
++    embed = [":go_default_library"],
++    deps = [
++        "//internal/flags:go_default_library",
++        "//internal/testprotos/irregular:go_default_library",
++        "//internal/testprotos/legacy:go_default_library",
++        "//internal/testprotos/legacy/proto2_20160225_2fc053c5:go_default_library",
++        "//internal/testprotos/test:go_default_library",
++        "//internal/testprotos/test/weak1:go_default_library",
++        "//internal/testprotos/test/weak2:go_default_library",
++        "//internal/testprotos/test3:go_default_library",
++        "//proto:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/types/descriptorpb/BUILD.bazel b/types/descriptorpb/BUILD.bazel
+--- a/types/descriptorpb/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/types/descriptorpb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,13 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["descriptor.pb.go"],
++    importpath = "google.golang.org/protobuf/types/descriptorpb",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoiface:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/types/dynamicpb/BUILD.bazel b/types/dynamicpb/BUILD.bazel
+--- a/types/dynamicpb/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/types/dynamicpb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,28 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["dynamic.go"],
++    importpath = "google.golang.org/protobuf/types/dynamicpb",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//internal/errors:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoiface:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
++
++go_test(
++    name = "go_default_test",
++    srcs = ["dynamic_test.go"],
++    embed = [":go_default_library"],
++    deps = [
++        "//internal/testprotos/test:go_default_library",
++        "//internal/testprotos/test3:go_default_library",
++        "//proto:go_default_library",
++        "//reflect/protoreflect:go_default_library",
++        "//reflect/protoregistry:go_default_library",
++        "//testing/prototest:go_default_library",
++    ],
++)
+diff -urN a/types/known/anypb/BUILD.bazel b/types/known/anypb/BUILD.bazel
+--- a/types/known/anypb/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/types/known/anypb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["any.pb.go"],
++    importpath = "google.golang.org/protobuf/types/known/anypb",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/types/known/durationpb/BUILD.bazel b/types/known/durationpb/BUILD.bazel
+--- a/types/known/durationpb/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/types/known/durationpb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["duration.pb.go"],
++    importpath = "google.golang.org/protobuf/types/known/durationpb",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/types/known/emptypb/BUILD.bazel b/types/known/emptypb/BUILD.bazel
+--- a/types/known/emptypb/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/types/known/emptypb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["empty.pb.go"],
++    importpath = "google.golang.org/protobuf/types/known/emptypb",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/types/known/structpb/BUILD.bazel b/types/known/structpb/BUILD.bazel
+--- a/types/known/structpb/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/types/known/structpb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["struct.pb.go"],
++    importpath = "google.golang.org/protobuf/types/known/structpb",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/types/known/timestamppb/BUILD.bazel b/types/known/timestamppb/BUILD.bazel
+--- a/types/known/timestamppb/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/types/known/timestamppb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["timestamp.pb.go"],
++    importpath = "google.golang.org/protobuf/types/known/timestamppb",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/types/known/wrapperspb/BUILD.bazel b/types/known/wrapperspb/BUILD.bazel
+--- a/types/known/wrapperspb/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/types/known/wrapperspb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["wrappers.pb.go"],
++    importpath = "google.golang.org/protobuf/types/known/wrapperspb",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++    ],
++)
+diff -urN a/types/pluginpb/BUILD.bazel b/types/pluginpb/BUILD.bazel
+--- a/types/pluginpb/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/types/pluginpb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,13 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = ["plugin.pb.go"],
++    importpath = "google.golang.org/protobuf/types/pluginpb",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect:go_default_library",
++        "//runtime/protoimpl:go_default_library",
++        "//types/descriptorpb:go_default_library",
++    ],
++)


### PR DESCRIPTION
* Added org_golang_google_protobuf at v1.21.0 to
  go_rules_dependencies. This contains the new protobuf runtime.
  It doesn't seem like any *_gen rules are needed, so just using the
  gazelle patch for now.
* Upgraded com_github_golang_protobuf to v1.4.0. The packages here are
  wrappers org_golang_google_protobuf. Newly generated code should
  work with the old interface. The *_gen targets are still in place,
  but they're simpler.
* Added new dependencies for packages generated with
  //proto:go_proto, //proto:go_grpc, and //proto:go_proto_bootstrap,
  since the proto compiler imports more runtime packages.
* We're still using the compiler from com_github_golang_protobuf. It's
  a wrapper for the new one. The new one doesn't support gRPC, and the
  gRPC proto compiler doesn't exist yet. See
  https://github.com/protocolbuffers/protobuf-go/releases#v1.20-grpc-support.

Updates #2395