### PR TITLE
stdlib: zip sdk file inputs when executing remotely

### DIFF
--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -84,18 +84,20 @@ def _build_stdlib(go):
     # that we are executing under remote execution.  In this case an additional
     # action is created to package the sdk files into a single zip file rather
     # than 6100+ individual files.  An additional flag naming the zip file is
-    # passed to the builder that will unpackage it. 
+    # passed to the builder that will unpackage it.
     if go.zipper:
         sdkzip = go.actions.declare_file("sdk.zip")
+
         # for zipper usage see
         # https://github.com/bazelbuild/bazel/blob/master/third_party/ijar/zip_main.cc#L354
         zipargs = go.actions.args()
         zipargs.add("cC", sdkzip.path)
+
         # builder expects zip entries relative to GOROOT
         prefixlen = len(go.sdk.root_file.dirname) + 1
         for f in sdk_inputs:
             rel = f.path[prefixlen:]
-            zipargs.add(rel+"="+f.path)
+            zipargs.add(rel + "=" + f.path)
 
         archive = go.actions.run(
             inputs = sdk_inputs,

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -459,6 +459,7 @@ def go_context(ctx, attr = None):
         importpath_aliases = importpath_aliases,
         pathtype = pathtype,
         cgo_tools = cgo_tools,
+        zipper = toolchain._zipper,
         nogo = nogo,
         coverdata = coverdata,
         coverage_enabled = ctx.configuration.coverage_enabled,

--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -94,7 +94,6 @@ _go_toolchain = rule(
             executable = True,
             doc = "The zipper helper utility",
         ),
-
     },
     doc = "Defines a Go toolchain based on an SDK",
     provides = [platform_common.ToolchainInfo],
@@ -107,7 +106,6 @@ def go_toolchain(**kwargs):
         "//conditions:default": None,
     }))
     _go_toolchain(**kwargs)
-
 
 def declare_toolchains(host, sdk, builder):
     """Declares go_toolchain and toolchain targets for each platform."""

--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -47,6 +47,10 @@ type env struct {
 	// platform. This may be different than GOROOT.
 	sdk string
 
+	// sdk is the path to the Go SDK package as a zip file.  This is only used
+	// when building the stdlib, as an optimization for remote execution.
+	sdkzip string
+
 	// installSuffix is the name of the directory below GOROOT/pkg that contains
 	// the .a files for the standard library we should build against.
 	// For example, linux_amd64_race.
@@ -66,6 +70,7 @@ type env struct {
 func envFlags(flags *flag.FlagSet) *env {
 	env := &env{}
 	flags.StringVar(&env.sdk, "sdk", "", "Path to the Go SDK.")
+	flags.StringVar(&env.sdkzip, "sdkzip", "", "Path to the Go SDK (as a zip archive)")
 	flags.Var(&tagFlag{}, "tags", "List of build tags considered true.")
 	flags.StringVar(&env.installSuffix, "installsuffix", "", "Standard library under GOROOT/pkg")
 	flags.BoolVar(&env.verbose, "v", false, "Whether subprocess command lines should be printed")

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -2,9 +2,9 @@ load(":buildifier_test.bzl", "buildifier_test")
 
 buildifier_test(
     name = "buildifier_test",
+    size = "small",
     data = [
         ":buildifier_test.bzl",
         "//:all_files",
     ],
-    size = "small",
 )

--- a/tests/core/c_linkmodes/BUILD.bazel
+++ b/tests/core/c_linkmodes/BUILD.bazel
@@ -78,7 +78,7 @@ cc_test(
     }),
     copts = select({
         "@io_bazel_rules_go//go/platform:windows": [],
-        "//conditions:default": ['-DSO=\\"$(rootpath :crypto)\\"'],
+        "//conditions:default": ["-DSO=\\\"$(rootpath :crypto)\\\""],
     }),
     data = select({
         "@io_bazel_rules_go//go/platform:windows": [],

--- a/tests/core/go_path/BUILD.bazel
+++ b/tests/core/go_path/BUILD.bazel
@@ -42,6 +42,6 @@ go_test(
         ":link_path",
         ":nodata_path",
     ],
-    deps = ["//go/tools/bazel:go_default_library"],
     rundir = ".",
+    deps = ["//go/tools/bazel:go_default_library"],
 )

--- a/tests/core/go_path/pkg/lib/BUILD.bazel
+++ b/tests/core/go_path/pkg/lib/BUILD.bazel
@@ -38,7 +38,7 @@ go_library(
 go_library(
     name = "vendored",
     srcs = ["vendored.go"],
-    importpath = "example.com/repo2",
     importmap = "example.com/repo/vendor/example.com/repo2",
+    importpath = "example.com/repo2",
     visibility = ["//visibility:public"],
 )

--- a/tests/core/stdlib/BUILD.bazel
+++ b/tests/core/stdlib/BUILD.bazel
@@ -4,8 +4,8 @@ load(":stdlib_files.bzl", "stdlib_files")
 go_test(
     name = "buildid_test",
     srcs = ["buildid_test.go"],
-    rundir = ".",
     data = [":stdlib_files"],
+    rundir = ".",
 )
 
 stdlib_files(name = "stdlib_files")

--- a/tests/examples/executable_name/BUILD.bazel
+++ b/tests/examples/executable_name/BUILD.bazel
@@ -16,5 +16,5 @@ sh_test(
     name = "executable_name",
     size = "small",
     srcs = ["name_test.sh"],
-    data = [ ":normalised_binary" ],
+    data = [":normalised_binary"],
 )


### PR DESCRIPTION
This PR adds the "zipper" tool to the go_toolchain when `--define=EXECUTOR=remote`.

When the zipper tool is present in the go toolchain, it acts as a signal to package the sdk as a single zip archive and simplify the inputs to the `GoStdlib` action from ~6140 files to a handful.  The stdlib builder utility has been given a new `-sdkzip` flag, and the replicator.go code has a new responsibility to replicate the requisite files from that zip file rather than the filesystem.

Fixes #2188 

In my (rather puny) remote execution setup, the GoStdlib action never was able to finish (given  > 30m) in a cross-compilation scenario.  With this PR, it was able to finish in about 3m.  

The compressed sdk.zip is ~83M.