### PR TITLE
Copy PKGDEF and nogo facts to the same archive

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -57,12 +57,9 @@ def emit_archive(go, source = None, _recompile_suffix = ""):
     if _recompile_suffix:
         pre_ext += _recompile_suffix
     out_lib = go.declare_file(go, ext = pre_ext + ".a")
-    if go.nogo:
-        # TODO(#1847): write nogo data into a new section in the .a file instead
-        # of writing a separate file.
-        out_export = go.declare_file(go, ext = pre_ext + ".x")
-    else:
-        out_export = None
+
+    # store __.PKGDEF and nogo facts in .x
+    out_export = go.declare_file(go, ext = pre_ext + ".x")
     out_cgo_export_h = None  # set if cgo used in c-shared or c-archive mode
 
     direct = [get_archive(dep) for dep in source.deps]

--- a/go/private/actions/compile.bzl
+++ b/go/private/actions/compile.bzl
@@ -20,11 +20,10 @@ load(
 def _archive(v):
     importpaths = [v.data.importpath]
     importpaths.extend(v.data.importpath_aliases)
-    return "{}={}={}={}".format(
+    return "{}={}={}".format(
         ":".join(importpaths),
         v.data.importmap,
-        v.data.file.path,
-        v.data.export_file.path if v.data.export_file else "",
+        v.data.export_file.path if v.data.export_file else v.data.file.path,
     )
 
 def emit_compile(
@@ -45,23 +44,21 @@ def emit_compile(
         fail("out_lib is a required parameter")
 
     inputs = (sources + [go.package_list] +
-              [archive.data.file for archive in archives] +
+              [archive.data.export_file for archive in archives] +
               go.sdk.tools + go.sdk.headers + go.stdlib.libs)
-    outputs = [out_lib]
+    outputs = [out_lib, out_export]
 
     builder_args = go.builder_args(go, "compile")
     builder_args.add_all(sources, before_each = "-src")
     builder_args.add_all(archives, before_each = "-arc", map_each = _archive)
     builder_args.add("-o", out_lib)
+    builder_args.add("-x", out_export)
     builder_args.add("-package_list", go.package_list)
     if testfilter:
         builder_args.add("-testfilter", testfilter)
     if go.nogo:
         builder_args.add("-nogo", go.nogo)
-        builder_args.add("-x", out_export)
         inputs.append(go.nogo)
-        inputs.extend([archive.data.export_file for archive in archives if archive.data.export_file])
-        outputs.append(out_export)
 
     tool_args = go.tool_args(go)
     if asmhdr:

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -50,6 +50,7 @@ go_source(
         "env.go",
         "flags.go",
         "nogo_main.go",
+        "pack.go",
     ],
     # //go/tools/builders:nogo_srcs is considered a different target by
     # Bazel's visibility check than

--- a/go/tools/builders/compile.go
+++ b/go/tools/builders/compile.go
@@ -221,6 +221,9 @@ func compile(args []string) error {
 	} else if size == 0 {
 		return fmt.Errorf("%s is empty in %s", pkgDef, *output)
 	}
+	if err = pkgDefFile.Sync(); err != nil {
+		return fmt.Errorf("error flushing %s: %v", pkgDefPath, err)
+	}
 	if nogoStatus == nogoSucceeded {
 		return appendFiles(goenv, *outExport, []string{pkgDefPath, outFact})
 	}

--- a/go/tools/builders/compile.go
+++ b/go/tools/builders/compile.go
@@ -215,14 +215,16 @@ func compile(args []string) error {
 	if err != nil {
 		return fmt.Errorf("error creating %s: %v", pkgDefPath, err)
 	}
-	defer pkgDefFile.Close()
 	if size, err := io.Copy(pkgDefFile, pkgDefReader); err != nil {
+		pkgDefFile.Close()
 		return fmt.Errorf("error writing %s: %v", pkgDefPath, err)
 	} else if size == 0 {
+		pkgDefFile.Close()
 		return fmt.Errorf("%s is empty in %s", pkgDef, *output)
 	}
-	if err = pkgDefFile.Sync(); err != nil {
-		return fmt.Errorf("error flushing %s: %v", pkgDefPath, err)
+	// pkgDefFile needs to be closed before appending it to another archive
+	if err = pkgDefFile.Close(); err != nil {
+		return fmt.Errorf("error closing %s: %v", pkgDefPath, err)
 	}
 	if nogoStatus == nogoSucceeded {
 		return appendFiles(goenv, *outExport, []string{pkgDefPath, outFact})

--- a/go/tools/builders/compile.go
+++ b/go/tools/builders/compile.go
@@ -211,7 +211,11 @@ func compile(args []string) error {
 	}
 	defer pkgDefReader.Close()
 	pkgDefPath := filepath.Join(filepath.Dir(*output), pkgDef)
-	pkgDefFile, err := os.OpenFile(pkgDefPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+	pkgDefFile, err := os.Create(pkgDefPath)
+	if err != nil {
+		return fmt.Errorf("error creating %s: %v", pkgDefPath, err)
+	}
+	defer pkgDefFile.Close()
 	if size, err := io.Copy(pkgDefFile, pkgDefReader); err != nil {
 		return fmt.Errorf("error writing %s: %v", pkgDefPath, err)
 	} else if size == 0 {

--- a/go/tools/builders/compile.go
+++ b/go/tools/builders/compile.go
@@ -37,7 +37,7 @@ func compile(args []string) error {
 	builderArgs, toolArgs := splitArgs(args)
 	flags := flag.NewFlagSet("GoCompile", flag.ExitOnError)
 	unfiltered := multiFlag{}
-	archives := compileArchiveMultiFlag{}
+	archives := archiveMultiFlag{}
 	goenv := envFlags(flags)
 	packagePath := flags.String("p", "", "The package path (importmap) of the package being compiled")
 	flags.Var(&unfiltered, "src", "A source file to be filtered and compiled")
@@ -165,7 +165,7 @@ func compile(args []string) error {
 		nogoargs = append(nogoargs, "-p", *packagePath)
 		nogoargs = append(nogoargs, "-importcfg", importcfgName)
 		for _, arc := range archives {
-			nogoargs = append(nogoargs, "-fact", fmt.Sprintf("%s=%s", arc.importPath, arc.xFile))
+			nogoargs = append(nogoargs, "-fact", fmt.Sprintf("%s=%s", arc.importPath, arc.file))
 		}
 		nogoargs = append(nogoargs, "-x", outFact)
 		nogoargs = append(nogoargs, filenames...)

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -420,14 +420,16 @@ func compileArchive(
 	if err != nil {
 		return fmt.Errorf("error creating %s: %v", pkgDefPath, err)
 	}
-	defer pkgDefFile.Close()
 	if size, err := io.Copy(pkgDefFile, pkgDefReader); err != nil {
+		pkgDefFile.Close()
 		return fmt.Errorf("error writing %s: %v", pkgDefPath, err)
 	} else if size == 0 {
+		pkgDefFile.Close()
 		return fmt.Errorf("%s is empty in %s", pkgDef, outPath)
 	}
-	if err = pkgDefFile.Sync(); err != nil {
-		return fmt.Errorf("error flushing %s: %v", pkgDefPath, err)
+	// pkgDefFile needs to be closed before appending it to another archive
+	if err = pkgDefFile.Close(); err != nil {
+		return fmt.Errorf("error closing %s: %v", pkgDefPath, err)
 	}
 	if nogoStatus == nogoSucceeded {
 		return appendFiles(goenv, outXPath, []string{pkgDefPath, outFactsPath})

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -321,12 +321,12 @@ func compileArchive(
 
 	// Run nogo concurrently.
 	var nogoChan chan error
-	outFactPath := filepath.Join(filepath.Dir(outXPath), nogoFact)
+	outFactsPath := filepath.Join(filepath.Dir(outXPath), nogoFact)
 	if nogoPath != "" {
 		ctx, cancel := context.WithCancel(context.Background())
 		nogoChan = make(chan error)
 		go func() {
-			nogoChan <- runNogo(ctx, workDir, nogoPath, goSrcs, deps, packagePath, importcfgPath, outFactPath)
+			nogoChan <- runNogo(ctx, workDir, nogoPath, goSrcs, deps, packagePath, importcfgPath, outFactsPath)
 		}()
 		defer func() {
 			if nogoChan != nil {
@@ -388,7 +388,7 @@ func compileArchive(
 		}
 	}
 
-	// Check results from nogo and create .x file
+	// Check results from nogo.
 	nogoStatus := nogoNotRun
 	if nogoChan != nil {
 		err := <-nogoChan
@@ -423,7 +423,7 @@ func compileArchive(
 		return fmt.Errorf("%s is empty in %s", pkgDef, outPath)
 	}
 	if nogoStatus == nogoSucceeded {
-		return appendFiles(goenv, outXPath, []string{pkgDefPath, outFactPath})
+		return appendFiles(goenv, outXPath, []string{pkgDefPath, outFactsPath})
 	}
 	return appendFiles(goenv, outXPath, []string{pkgDefPath})
 }
@@ -454,6 +454,7 @@ func runNogo(ctx context.Context, workDir string, nogoPath string, srcs []string
 	}
 	args = append(args, "-x", outFactsPath)
 	args = append(args, srcs...)
+
 	paramFile := filepath.Join(workDir, "nogo.param")
 	params := strings.Join(args[1:], "\n")
 	if err := ioutil.WriteFile(paramFile, []byte(params), 0666); err != nil {

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -42,7 +42,7 @@ func compilePkg(args []string) error {
 	fs := flag.NewFlagSet("GoCompilePkg", flag.ExitOnError)
 	goenv := envFlags(fs)
 	var unfilteredSrcs, coverSrcs multiFlag
-	var deps compileArchiveMultiFlag
+	var deps archiveMultiFlag
 	var importPath, packagePath, nogoPath, packageListPath, coverMode string
 	var outPath, outFactsPath, cgoExportHPath string
 	var testFilter string
@@ -450,7 +450,7 @@ func runNogo(ctx context.Context, workDir string, nogoPath string, srcs []string
 	args = append(args, "-p", packagePath)
 	args = append(args, "-importcfg", importcfgPath)
 	for _, dep := range deps {
-		args = append(args, "-fact", fmt.Sprintf("%s=%s", dep.importPath, dep.xFile))
+		args = append(args, "-fact", fmt.Sprintf("%s=%s", dep.importPath, dep.file))
 	}
 	args = append(args, "-x", outFactsPath)
 	args = append(args, srcs...)

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -416,7 +416,10 @@ func compileArchive(
 	}
 	defer pkgDefReader.Close()
 	pkgDefPath := filepath.Join(filepath.Dir(outPath), pkgDef)
-	pkgDefFile, err := os.OpenFile(pkgDefPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+	pkgDefFile, err := os.Create(pkgDefPath)
+	if err != nil {
+		return fmt.Errorf("error creating %s: %v", pkgDefPath, err)
+	}
 	if size, err := io.Copy(pkgDefFile, pkgDefReader); err != nil {
 		return fmt.Errorf("error writing %s: %v", pkgDefPath, err)
 	} else if size == 0 {

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -426,6 +426,9 @@ func compileArchive(
 	} else if size == 0 {
 		return fmt.Errorf("%s is empty in %s", pkgDef, outPath)
 	}
+	if err = pkgDefFile.Sync(); err != nil {
+		return fmt.Errorf("error flushing %s: %v", pkgDefPath, err)
+	}
 	if nogoStatus == nogoSucceeded {
 		return appendFiles(goenv, outXPath, []string{pkgDefPath, outFactsPath})
 	}

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -420,6 +420,7 @@ func compileArchive(
 	if err != nil {
 		return fmt.Errorf("error creating %s: %v", pkgDefPath, err)
 	}
+	defer pkgDefFile.Close()
 	if size, err := io.Copy(pkgDefFile, pkgDefReader); err != nil {
 		return fmt.Errorf("error writing %s: %v", pkgDefPath, err)
 	} else if size == 0 {

--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -157,15 +157,13 @@ func absEnv(envNameList []string, argList []string) error {
 }
 
 func runAndLogCommand(cmd *exec.Cmd, verbose bool) error {
-	var buffer bytes.Buffer
-	formatCommand(&buffer, cmd)
 	if verbose {
-		io.Copy(os.Stderr, &buffer)
+		formatCommand(os.Stderr, cmd)
 	}
 	cleanup := passLongArgsInResponseFiles(cmd)
 	defer cleanup()
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("error running the following subcommand: %v\n%s", err, buffer.String())
+		return fmt.Errorf("error running subcommand: %v", err)
 	}
 	return nil
 }

--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -157,13 +157,15 @@ func absEnv(envNameList []string, argList []string) error {
 }
 
 func runAndLogCommand(cmd *exec.Cmd, verbose bool) error {
+	var buffer bytes.Buffer
+	formatCommand(&buffer, cmd)
 	if verbose {
-		formatCommand(os.Stderr, cmd)
+		io.Copy(os.Stderr, &buffer)
 	}
 	cleanup := passLongArgsInResponseFiles(cmd)
 	defer cleanup()
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("error running subcommand '%s': %v", strings.Join(cmd.Args, " "), err)
+		return fmt.Errorf("error running subcommand %q: %v", buffer.String(), err)
 	}
 	return nil
 }

--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -163,7 +163,7 @@ func runAndLogCommand(cmd *exec.Cmd, verbose bool) error {
 	cleanup := passLongArgsInResponseFiles(cmd)
 	defer cleanup()
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("error running subcommand: %v", err)
+		return fmt.Errorf("error running subcommand '%s': %v", strings.Join(cmd.Args, " "), err)
 	}
 	return nil
 }

--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -165,7 +165,7 @@ func runAndLogCommand(cmd *exec.Cmd, verbose bool) error {
 	cleanup := passLongArgsInResponseFiles(cmd)
 	defer cleanup()
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("error running subcommand %q: %v", buffer.String(), err)
+		return fmt.Errorf("error running the following subcommand: %v\n%s", err, buffer.String())
 	}
 	return nil
 }

--- a/go/tools/builders/importcfg.go
+++ b/go/tools/builders/importcfg.go
@@ -28,9 +28,8 @@ import (
 )
 
 type archive struct {
-	//TODO merge aFile and xFile because compile only needs xFile and link only needs aFile
-	label, importPath, packagePath, aFile, xFile string
-	importPathAliases                            []string
+	label, importPath, packagePath, file string
+	importPathAliases                    []string
 }
 
 // checkImports verifies that each import in files refers to a
@@ -126,7 +125,7 @@ func buildImportcfgFileForCompile(imports map[string]*archive, installSuffix, di
 			if imp != arc.packagePath {
 				fmt.Fprintf(buf, "importmap %s=%s\n", imp, arc.packagePath)
 			}
-			fmt.Fprintf(buf, "packagefile %s=%s\n", arc.packagePath, arc.xFile)
+			fmt.Fprintf(buf, "packagefile %s=%s\n", arc.packagePath, arc.file)
 		}
 	}
 
@@ -180,7 +179,7 @@ func buildImportcfgFileForLink(archives []archive, stdPackageListPath, installSu
 			continue
 		}
 		depsSeen[arc.packagePath] = arc.label
-		fmt.Fprintf(buf, "packagefile %s=%s\n", arc.packagePath, arc.aFile)
+		fmt.Fprintf(buf, "packagefile %s=%s\n", arc.packagePath, arc.file)
 	}
 	f, err := ioutil.TempFile(dir, "importcfg")
 	if err != nil {
@@ -232,18 +231,16 @@ func isRelative(path string) bool {
 	return strings.HasPrefix(path, "./") || strings.HasPrefix(path, "../")
 }
 
-// TODO(jayconrod): consolidate compile and link archive flags.
+type archiveMultiFlag []archive
 
-type compileArchiveMultiFlag []archive
-
-func (m *compileArchiveMultiFlag) String() string {
+func (m *archiveMultiFlag) String() string {
 	if m == nil || len(*m) == 0 {
 		return ""
 	}
 	return fmt.Sprint(*m)
 }
 
-func (m *compileArchiveMultiFlag) Set(v string) error {
+func (m *archiveMultiFlag) Set(v string) error {
 	parts := strings.Split(v, "=")
 	if len(parts) != 3 {
 		return fmt.Errorf("badly formed -arc flag: %s", v)
@@ -253,30 +250,8 @@ func (m *compileArchiveMultiFlag) Set(v string) error {
 		importPath:        importPaths[0],
 		importPathAliases: importPaths[1:],
 		packagePath:       parts[1],
-		xFile:             abs(parts[2]),
+		file:              abs(parts[2]),
 	}
 	*m = append(*m, a)
-	return nil
-}
-
-type linkArchiveMultiFlag []archive
-
-func (m *linkArchiveMultiFlag) String() string {
-	if m == nil || len(*m) == 0 {
-		return ""
-	}
-	return fmt.Sprint(m)
-}
-
-func (m *linkArchiveMultiFlag) Set(v string) error {
-	parts := strings.Split(v, "=")
-	if len(parts) != 3 {
-		return fmt.Errorf("badly formed -arc flag: %s", v)
-	}
-	*m = append(*m, archive{
-		label:       parts[0],
-		packagePath: parts[1],
-		aFile:       abs(parts[2]),
-	})
 	return nil
 }

--- a/go/tools/builders/importcfg.go
+++ b/go/tools/builders/importcfg.go
@@ -28,6 +28,7 @@ import (
 )
 
 type archive struct {
+	//TODO merge aFile and xFile because compile only needs xFile and link only needs aFile
 	label, importPath, packagePath, aFile, xFile string
 	importPathAliases                            []string
 }
@@ -125,7 +126,7 @@ func buildImportcfgFileForCompile(imports map[string]*archive, installSuffix, di
 			if imp != arc.packagePath {
 				fmt.Fprintf(buf, "importmap %s=%s\n", imp, arc.packagePath)
 			}
-			fmt.Fprintf(buf, "packagefile %s=%s\n", arc.packagePath, arc.aFile)
+			fmt.Fprintf(buf, "packagefile %s=%s\n", arc.packagePath, arc.xFile)
 		}
 	}
 
@@ -244,7 +245,7 @@ func (m *compileArchiveMultiFlag) String() string {
 
 func (m *compileArchiveMultiFlag) Set(v string) error {
 	parts := strings.Split(v, "=")
-	if len(parts) != 4 {
+	if len(parts) != 3 {
 		return fmt.Errorf("badly formed -arc flag: %s", v)
 	}
 	importPaths := strings.Split(parts[0], ":")
@@ -252,10 +253,7 @@ func (m *compileArchiveMultiFlag) Set(v string) error {
 		importPath:        importPaths[0],
 		importPathAliases: importPaths[1:],
 		packagePath:       parts[1],
-		aFile:             abs(parts[2]),
-	}
-	if parts[3] != "" {
-		a.xFile = abs(parts[3])
+		xFile:             abs(parts[2]),
 	}
 	*m = append(*m, a)
 	return nil

--- a/go/tools/builders/link.go
+++ b/go/tools/builders/link.go
@@ -39,7 +39,7 @@ func link(args []string) error {
 	xstamps := multiFlag{}
 	stamps := multiFlag{}
 	xdefs := multiFlag{}
-	archives := linkArchiveMultiFlag{}
+	archives := archiveMultiFlag{}
 	flags := flag.NewFlagSet("link", flag.ExitOnError)
 	goenv := envFlags(flags)
 	main := flags.String("main", "", "Path to the main archive.")

--- a/go/tools/builders/nogo_main.go
+++ b/go/tools/builders/nogo_main.go
@@ -524,17 +524,17 @@ func (i *importer) readFacts(path string) ([]byte, error) {
 		// fmt.Printf accepts a format string.
 		return nil, nil
 	}
-	data, err := readFileInArchive(func(name string) bool {
-		return strings.HasSuffix(name, ".fact")
-	}, archive)
-	if err == fileNotFound {
+	factReader, err := readFileInArchive(nogoFact, archive)
+	if os.IsNotExist(err) {
 		// Packages that were not built with the nogo toolchain will not be
 		// analyzed, so there's no opportunity to store facts. This includes
 		// packages in the standard library and packages built with go_tool_library,
 		// such as coverdata.
 		return nil, nil
+	} else if err != nil {
+		return nil, err
 	}
-	return data, err
+	return ioutil.ReadAll(factReader)
 }
 
 type factMultiFlag map[string]string

--- a/go/tools/builders/nogo_main.go
+++ b/go/tools/builders/nogo_main.go
@@ -534,6 +534,7 @@ func (i *importer) readFacts(path string) ([]byte, error) {
 	} else if err != nil {
 		return nil, err
 	}
+	defer factReader.Close()
 	return ioutil.ReadAll(factReader)
 }
 

--- a/go/tools/builders/pack.go
+++ b/go/tools/builders/pack.go
@@ -416,8 +416,5 @@ func extractFileFromArchive(archive, dir, name string) (err error) {
 	} else if size == 0 {
 		return fmt.Errorf("%s is empty in %s", name, archive)
 	}
-	if err = outFile.Sync(); err != nil {
-		return fmt.Errorf("error persisting %s: %v", outPath, err)
-	}
 	return err
 }

--- a/go/tools/builders/pack.go
+++ b/go/tools/builders/pack.go
@@ -128,7 +128,7 @@ const (
 
 var zeroBytes = []byte("0                    ")
 
-// TODO(zplin): explain why this is needed
+// TODO(zplin): explain why this is needed.
 type readerWithCloser struct {
 	io.Reader
 	c io.Closer

--- a/go/tools/builders/pack.go
+++ b/go/tools/builders/pack.go
@@ -373,7 +373,7 @@ func readFileInArchive(fileName, archive string) (io.ReadCloser, error) {
 		if name == fileName {
 			return &readerWithCloser{
 				Reader: io.LimitReader(rc, size),
-				c: rc,
+				c:      rc,
 			}, nil
 		}
 		err = skipFile(bufReader, size)

--- a/go/tools/builders/pack.go
+++ b/go/tools/builders/pack.go
@@ -411,13 +411,20 @@ func extractFileFromArchive(archive, dir, name string) (err error) {
 			err = fmt.Errorf("error closing %q: %v", outPath, e)
 		}
 	}()
-	if size, err := io.Copy(outFile, archiveReader); err != nil {
+	size, err := io.Copy(outFile, archiveReader)
+	if err != nil {
 		return fmt.Errorf("error writing %s: %v", outPath, err)
-	} else if size == 0 {
+	}
+	if size == 0 {
 		return fmt.Errorf("%s is empty in %s", name, archive)
 	}
-	if err = outFile.Sync(); err != nil {
-		return fmt.Errorf("error persisting %s: %v", outPath, err)
+	// debugging Windows
+	content, err := ioutil.ReadFile(outPath)
+	if err != nil {
+		return fmt.Errorf("error reading %s: %v", outPath, err)
+	}
+	if len(content) != int(size) {
+		return fmt.Errorf("wrote %d to %s, read %d", size, outPath, len(content))
 	}
 	return err
 }

--- a/go/tools/builders/pack.go
+++ b/go/tools/builders/pack.go
@@ -128,6 +128,7 @@ const (
 
 var zeroBytes = []byte("0                    ")
 
+// TODO(zplin): explain why this is needed
 type readerWithCloser struct {
 	io.Reader
 	c io.Closer

--- a/go/tools/builders/pack.go
+++ b/go/tools/builders/pack.go
@@ -411,20 +411,13 @@ func extractFileFromArchive(archive, dir, name string) (err error) {
 			err = fmt.Errorf("error closing %q: %v", outPath, e)
 		}
 	}()
-	size, err := io.Copy(outFile, archiveReader)
-	if err != nil {
+	if size, err := io.Copy(outFile, archiveReader); err != nil {
 		return fmt.Errorf("error writing %s: %v", outPath, err)
-	}
-	if size == 0 {
+	} else if size == 0 {
 		return fmt.Errorf("%s is empty in %s", name, archive)
 	}
-	// debugging Windows
-	content, err := ioutil.ReadFile(outPath)
-	if err != nil {
-		return fmt.Errorf("error reading %s: %v", outPath, err)
-	}
-	if len(content) != int(size) {
-		return fmt.Errorf("wrote %d to %s, read %d", size, outPath, len(content))
+	if err = outFile.Sync(); err != nil {
+		return fmt.Errorf("error persisting %s: %v", outPath, err)
 	}
 	return err
 }

--- a/go/tools/builders/pack.go
+++ b/go/tools/builders/pack.go
@@ -416,5 +416,8 @@ func extractFileFromArchive(archive, dir, name string) (err error) {
 	} else if size == 0 {
 		return fmt.Errorf("%s is empty in %s", name, archive)
 	}
+	if err = outFile.Sync(); err != nil {
+		return fmt.Errorf("error persisting %s: %v", outPath, err)
+	}
 	return err
 }


### PR DESCRIPTION
Fixes #1803 based on the review comments of #2199:

>  We could invoke the compiler without -linkobj. After it runs, the builder could copy the export data from the compiled .a file into the .x file. So the export data would appear in both archives.

So this PR:

* makes the .x file an archive
* makes nogo be able to read the archive to get the facts
* copies `__.PKGDEF` from .a file to .x file
* stops passing .a file and instead always and only passing .x file to compiler

Tested on Uber's Go monorepo. All builds and tests passed.