### PR TITLE
Improving nogo errors

### DIFF
--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -434,16 +434,16 @@ func runNogo(ctx context.Context, workDir string, nogoPath string, srcs []string
 	out := &bytes.Buffer{}
 	cmd.Stdout, cmd.Stderr = out, out
 	if err := cmd.Run(); err != nil {
-		cmdLine := strings.Join(args, " ")
-		if out.Len() != 0 {
-			fmt.Fprintln(os.Stderr, out.String())
-		}
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			if len(exitErr.Stderr) > 0 {
 				fmt.Fprintln(os.Stderr, string(exitErr.Stderr))
 			}
+			cmdLine := strings.Join(args, " ")
 			return fmt.Errorf("nogo command '%s' exited unexpectedly: %s", cmdLine, exitErr.String())
 		} else {
+			if out.Len() != 0 {
+				fmt.Fprintln(os.Stderr, out.String())
+			}
 			return fmt.Errorf("error running nogo: %v", err)
 		}
 	}

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -435,11 +435,11 @@ func runNogo(ctx context.Context, workDir string, nogoPath string, srcs []string
 	cmd.Stdout, cmd.Stderr = out, out
 	if err := cmd.Run(); err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			if len(exitErr.Stderr) > 0 {
-				fmt.Fprintln(os.Stderr, string(exitErr.Stderr))
+			if !exitErr.Exited() {
+				cmdLine := strings.Join(args, " ")
+				return fmt.Errorf("nogo command '%s' exited unexpectedly: %s", cmdLine, exitErr.String())
 			}
-			cmdLine := strings.Join(args, " ")
-			return fmt.Errorf("nogo command '%s' exited unexpectedly: %s", cmdLine, exitErr.String())
+			return errors.New(out.String())
 		} else {
 			if out.Len() != 0 {
 				fmt.Fprintln(os.Stderr, out.String())

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -434,12 +434,16 @@ func runNogo(ctx context.Context, workDir string, nogoPath string, srcs []string
 	out := &bytes.Buffer{}
 	cmd.Stdout, cmd.Stderr = out, out
 	if err := cmd.Run(); err != nil {
-		if _, ok := err.(*exec.ExitError); ok {
-			return errors.New(out.String())
-		} else {
-			if out.Len() != 0 {
-				fmt.Fprintln(os.Stderr, out.String())
+		cmdLine := strings.Join(args, " ")
+		if out.Len() != 0 {
+			fmt.Fprintln(os.Stderr, out.String())
+		}
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			if len(exitErr.Stderr) > 0 {
+				fmt.Fprintln(os.Stderr, string(exitErr.Stderr))
 			}
+			return fmt.Errorf("nogo command '%s' exited unexpectedly: %s", cmdLine, exitErr.String())
+		} else {
 			return fmt.Errorf("error running nogo: %v", err)
 		}
 	}


### PR DESCRIPTION
When nogo exits unexpectedly, the error before was:

```
compilepkg: 
```

With this PR, it becomes:
```
compilepkg: nogo command 'bazel-out/k8-opt-exec-2B5CBBC6-ST-9c9985fc97d8f8bef19f5d79323610d073a386b599d7ca1532565183d6fe3142/bin/libdefault_nogo.so -p golang.org/x/crypto/blowfish -importcfg /mnt/jenkins/.cache/bazel/_bazel_jenkins/e1d11652acf0c5d23aa28905edcc7be3/sandbox/linux-sandbox/211391/execroot/__main__/bazel-out/k8-fastbuild-ST-9c9985fc97d8f8bef19f5d79323610d073a386b599d7ca1532565183d6fe3142/bin/external/org_golang_x_crypto/blowfish/importcfg273671022 -x bazel-out/k8-fastbuild-ST-9c9985fc97d8f8bef19f5d79323610d073a386b599d7ca1532565183d6fe3142/bin/external/org_golang_x_crypto/blowfish/go_default_library.x /mnt/jenkins/.cache/bazel/_bazel_jenkins/e1d11652acf0c5d23aa28905edcc7be3/sandbox/linux-sandbox/211391/execroot/__main__/external/org_golang_x_crypto/blowfish/block.go /mnt/jenkins/.cache/bazel/_bazel_jenkins/e1d11652acf0c5d23aa28905edcc7be3/sandbox/linux-sandbox/211391/execroot/__main__/external/org_golang_x_crypto/blowfish/cipher.go /mnt/jenkins/.cache/bazel/_bazel_jenkins/e1d11652acf0c5d23aa28905edcc7be3/sandbox/linux-sandbox/211391/execroot/__main__/external/org_golang_x_crypto/blowfish/const.go' exited unexpectedly: signal: segmentation fault (core dumped)
```