### PR TITLE
go_binary: use file name less likely to be a prefix

### DIFF
--- a/go/private/actions/binary.bzl
+++ b/go/private/actions/binary.bzl
@@ -48,7 +48,7 @@ def emit_binary(
             extension = ARCHIVE_EXTENSION
         elif go.mode.link == LINKMODE_PLUGIN:
             extension = go.shared_extension
-        executable = go.declare_file(go, name = name, ext = extension)
+        executable = go.declare_file(go, path = name, ext = extension)
     go.link(
         go,
         archive = archive,

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -105,10 +105,12 @@ def _filter_options(options, blacklist):
 def _child_name(go, path, ext, name):
     if not name:
         name = go._ctx.label.name
+        if path or not ext:
+            # The '_' avoids collisions with another file matching the label name.
+            # For example, hello and hello/testmain.go.
+            name += "_"
     if path:
-        # The '_' avoids collisions with another file matching the label name.
-        # For example, hello and hello/testmain.go.
-        name += "_/" + path
+        name += "/" + path
     if ext:
         name += ext
     return name

--- a/go/tools/bazel/runfiles.go
+++ b/go/tools/bazel/runfiles.go
@@ -99,7 +99,7 @@ func FindBinary(pkg, name string) (string, bool) {
 			if path.Base(entry.ShortPath) != name {
 				continue
 			}
-			pkgDir := path.Dir(entry.ShortPath)
+			pkgDir := path.Dir(path.Dir(entry.ShortPath))
 			if pkgDir == "." {
 				pkgDir = ""
 			}

--- a/tests/core/go_binary/BUILD.bazel
+++ b/tests/core/go_binary/BUILD.bazel
@@ -164,3 +164,8 @@ go_library(
     importpath = "tags_lib",
     tags = ["manual"],
 )
+
+go_binary(
+    name = "prefix",
+    embed = ["//tests/core/go_binary/prefix"],
+)

--- a/tests/core/go_binary/README.rst
+++ b/tests/core/go_binary/README.rst
@@ -3,6 +3,7 @@ Basic go_binary functionality
 
 .. _go_binary: /go/core.rst#_go_binary
 .. _#2168: https://github.com/bazelbuild/rules_go/issues/2168
+.. _#2463: https://github.com/bazelbuild/rules_go/issues/2463
 
 Tests to ensure the basic features of go_binary are working as expected.
 
@@ -56,3 +57,8 @@ tags_bin
 --------
 Checks that setting ``gotags`` affects source filtering. This binary won't build
 without a specific tag being set.
+
+prefix
+------
+This binary has a name that conflicts with a subdirectory. Its output file
+name should not have this conflict. Verifies `#2463`_.

--- a/tests/core/go_binary/prefix/BUILD.bazel
+++ b/tests/core/go_binary/prefix/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "prefix",
+    srcs = ["prefix.go"],
+    importpath = "github.com/bazelbuild/rules_go/tests/core/go_binary/prefix",
+    visibility = ["//tests/core/go_binary:__pkg__"],
+)

--- a/tests/core/go_binary/prefix/prefix.go
+++ b/tests/core/go_binary/prefix/prefix.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}


### PR DESCRIPTION
A binary named "foo" will now create the executable "foo_/foo" to
avoid conflicting with subdirectories named "foo".

go.declare_file will no longer cause this problem when only path is
specified.

Fixes #2463
