### PR TITLE
nogo: transition to default mode settings

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -316,6 +316,7 @@ platforms:
     - "-//tests/core/go_proto_library:transitive_test"
     - "-//tests/core/go_test:data_test"
     - "-//tests/core/go_test:pwd_test"
+    - "-//tests/core/nogo/config:config_test"
     - "-//tests/core/nogo/coverage:coverage_test"
     - "-//tests/core/nogo/vet:vet_test"
     - "-//tests/core/stdlib:buildid_test"

--- a/go/private/rules/transition.bzl
+++ b/go/private/rules/transition.bzl
@@ -26,7 +26,7 @@ load(
     "IS_RULES_GO",
 )
 
-def _filter_transition_label(label):
+def filter_transition_label(label):
     """Transforms transition labels for the current workspace.
 
     This is a workaround for bazelbuild/bazel#10499. If a transition refers to
@@ -120,7 +120,7 @@ def _go_transition_impl(settings, attr):
         platform = "@io_bazel_rules_go//go/toolchain:{}_{}{}".format(goos, goarch, "_cgo" if cgo else "")
         settings["//command_line_option:platforms"] = platform
     if pure != "auto":
-        pure_label = _filter_transition_label("@io_bazel_rules_go//go/config:pure")
+        pure_label = filter_transition_label("@io_bazel_rules_go//go/config:pure")
         settings[pure_label] = pure == "on"
 
     _set_ternary(settings, attr, "static")
@@ -129,21 +129,21 @@ def _go_transition_impl(settings, attr):
 
     tags = getattr(attr, "gotags", [])
     if tags:
-        tags_label = _filter_transition_label("@io_bazel_rules_go//go/config:tags")
+        tags_label = filter_transition_label("@io_bazel_rules_go//go/config:tags")
         settings[tags_label] = tags
 
     linkmode = getattr(attr, "linkmode", "auto")
     if linkmode != "auto":
         if linkmode not in LINKMODES:
             fail("linkmode: invalid mode {}; want one of {}".format(linkmode, ", ".join(LINKMODES)))
-        linkmode_label = _filter_transition_label("@io_bazel_rules_go//go/config:linkmode")
+        linkmode_label = filter_transition_label("@io_bazel_rules_go//go/config:linkmode")
         settings[linkmode_label] = linkmode
 
     return settings
 
 go_transition = transition(
     implementation = _go_transition_impl,
-    inputs = [_filter_transition_label(label) for label in [
+    inputs = [filter_transition_label(label) for label in [
         "//command_line_option:platforms",
         "@io_bazel_rules_go//go/config:static",
         "@io_bazel_rules_go//go/config:msan",
@@ -152,7 +152,7 @@ go_transition = transition(
         "@io_bazel_rules_go//go/config:tags",
         "@io_bazel_rules_go//go/config:linkmode",
     ]],
-    outputs = [_filter_transition_label(label) for label in [
+    outputs = [filter_transition_label(label) for label in [
         "//command_line_option:platforms",
         "@io_bazel_rules_go//go/config:static",
         "@io_bazel_rules_go//go/config:msan",
@@ -171,5 +171,5 @@ def _set_ternary(settings, attr, name):
     value = getattr(attr, name, "auto")
     _check_ternary(name, value)
     if value != "auto":
-        label = _filter_transition_label("@io_bazel_rules_go//go/config:{}".format(name))
+        label = filter_transition_label("@io_bazel_rules_go//go/config:{}".format(name))
         settings[label] = value == "on"

--- a/tests/core/nogo/config/README.rst
+++ b/tests/core/nogo/config/README.rst
@@ -3,6 +3,8 @@ Nogo configuration
 
 .. _nogo: /go/nogo.rst
 .. _go_binary: /go/core.rst#_go_binary
+.. _#1850: https://github.com/bazelbuild/rules_go/issues/1850
+.. _#2470: https://github.com/bazelbuild/rules_go/issues/2470
 
 Tests that verify nogo_ works on targets compiled in non-default configurations.
 
@@ -12,4 +14,4 @@ config_test
 -----------
 
 Verifies that a `go_binary`_ can be built in non-default configurations with
-nogo. Verifies #1850.
+nogo. Verifies `#1850`_, `#2470`_.

--- a/tests/core/nogo/config/config_test.go
+++ b/tests/core/nogo/config/config_test.go
@@ -28,35 +28,35 @@ func TestMain(m *testing.M) {
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_binary(
-    name = "pure_bin",
-    srcs = ["pure_bin.go"],
-    pure = "on",
-    deps = [":pure_lib"],
+    name = "shared_bin",
+    srcs = ["shared_bin.go"],
+    linkmode = "c-shared",
+    deps = [":shared_lib"],
 )
 
 go_library(
-    name = "pure_lib",
-    srcs = ["pure_lib.go"],
-    importpath = "example.com/nogo/config/pure_lib",
+    name = "shared_lib",
+    srcs = ["shared_lib.go"],
+    importpath = "example.com/nogo/config/shared_lib",
 )    
 
--- pure_bin.go --
+-- shared_bin.go --
 package main
 
-import _ "example.com/nogo/config/pure_lib"
+import _ "example.com/nogo/config/shared_lib"
 
 func main() {
 }
 
--- pure_lib.go --
-package pure_lib
+-- shared_lib.go --
+package shared_lib
 
 `,
 	})
 }
 
-func TestPureAspect(t *testing.T) {
-	if err := bazel_testing.RunBazel("build", "//:pure_bin"); err != nil {
+func TestShared(t *testing.T) {
+	if err := bazel_testing.RunBazel("build", "//:shared_bin"); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
nogo now uses an incoming-edge transition to reset all Go build
settings to their default values. This prevents nogo from being built
with an unusual link mode, as well as other issues.

This change uses some code from #2473, but it doesn't change how nogo
fits into the dependency graph.

Fixes #2470
