### PR TITLE
go_context: allow go_config_info to be None

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -491,7 +491,7 @@ def go_context(ctx, attr = None):
         # TODO: All uses of this should be removed
         _ctx = ctx,
         # TODO(#1374): Remove in v0.25.
-        _package_conflict_is_error = go_config_info._package_conflict_is_error,
+        _package_conflict_is_error = go_config_info._package_conflict_is_error if go_config_info else True,
     )
 
 def _go_context_data_impl(ctx):

--- a/go/private/mode.bzl
+++ b/go/private/mode.bzl
@@ -67,25 +67,24 @@ def _ternary(*values):
 def get_mode(ctx, go_toolchain, cgo_context_info, go_config_info):
     static = _ternary(
         "on" if "static" in ctx.features else "auto",
-        go_config_info.static,
-        "off",
+        go_config_info.static if go_config_info else "off",
     )
     pure = _ternary(
         "on" if not cgo_context_info else "auto",
-        go_config_info.pure,
+        go_config_info.pure if go_config_info else "off",
     )
     race = _ternary(
         "on" if ("race" in ctx.features and not pure) else "auto",
-        go_config_info.race,
+        go_config_info.race if go_config_info else "off",
     )
     msan = _ternary(
         "on" if ("msan" in ctx.features and not pure) else "auto",
-        go_config_info.msan,
+        go_config_info.msan if go_config_info else "off",
     )
-    strip = go_config_info.strip
-    stamp = go_config_info.stamp
-    debug = go_config_info.debug
-    linkmode = go_config_info.linkmode
+    strip = go_config_info.strip if go_config_info else False
+    stamp = go_config_info.stamp if go_config_info else False
+    debug = go_config_info.debug if go_config_info else False
+    linkmode = go_config_info.linkmode if go_config_info else LINKMODE_NORMAL
     goos = go_toolchain.default_goos
     goarch = go_toolchain.default_goarch
 
@@ -95,7 +94,7 @@ def get_mode(ctx, go_toolchain, cgo_context_info, go_config_info):
     if pure and msan:
         fail("msan instrumentation can't be enabled when cgo is disabled. Check that pure is not set to \"off\" and a C/C++ toolchain is configured.")
 
-    tags = list(go_config_info.tags)
+    tags = list(go_config_info.tags) if go_config_info else []
     if "gotags" in ctx.var:
         tags.extend(ctx.var["gotags"].split(","))
     if cgo_context_info:

--- a/tests/core/cross/BUILD.bazel
+++ b/tests/core/cross/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_source", "go_test")
 load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
+load(":def.bzl", "no_context_info")
 
 test_suite(
     name = "cross",
@@ -71,4 +72,8 @@ go_bazel_test(
 go_bazel_test(
     name = "proto_test",
     srcs = ["proto_test.go"],
+)
+
+no_context_info(
+    name = "no_context_info",
 )

--- a/tests/core/cross/README.rst
+++ b/tests/core/cross/README.rst
@@ -3,6 +3,7 @@ Cross compilation
 
 .. _go_binary: /go/core.rst#go_binary
 .. _go_library: /go/core.rst#go_library
+.. _#2523: https://github.com/bazelbuild/rules_go/issues/2523
 
 Tests to ensure that cross compilation is working as expected.
 
@@ -41,3 +42,10 @@ proto_test
 ----------
 
 Tests that a ``go_proto_library`` can be cross-compiled with ``--platforms``.
+
+no_context_info
+---------------
+
+Tests that a rule that uses ``@io_bazel_rules_go//go:toolchain`` but does not
+depend on any other target can call ``go_context`` without error. Verifies
+`#2523`_.

--- a/tests/core/cross/def.bzl
+++ b/tests/core/cross/def.bzl
@@ -1,0 +1,24 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//go:def.bzl", "go_context")
+
+def _no_context_info_impl(ctx):
+    go_context(ctx)
+    # do nothing and pass if that succeeds
+
+no_context_info = rule(
+    implementation = _no_context_info_impl,
+    toolchains = ["@io_bazel_rules_go//go:toolchain"],
+)


### PR DESCRIPTION
Bootstrapping rules that don't depend on //:go_context_data or other
targets that provide GoConfigInfo should be allowed to call go_context
without error.

Fixes #2523
