### PR TITLE
Adding descriptor dependency to gogo proto compiler

### DIFF
--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -61,6 +61,7 @@ GOGO_VARIANTS = [
     deps = [
         "@com_github_gogo_protobuf//gogoproto:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_github_gogo_protobuf//protoc-gen-gogo/descriptor:go_default_library",
         "@com_github_gogo_protobuf//sortkeys:go_default_library",
         "@com_github_gogo_protobuf//types:go_default_library",
     ] + WELL_KNOWN_TYPE_RULES.values(),


### PR DESCRIPTION
Similar to #2160, adding descriptor to the gogo proto compiler without grpc

Fixes #1385