### PR TITLE
Windows: Use actions.run and explicitly format cmd.exe .bat invocation

### DIFF
--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -128,8 +128,9 @@ def _go_tool_binary_impl(ctx):
             content = cmd,
         )
         ctx.actions.run(
-            executable = bat,
-            inputs = sdk.libs + sdk.headers + sdk.tools + ctx.files.srcs + [sdk.go],
+            executable = "cmd.exe",
+            arguments = ["/S", "/C", bat.path.replace("/", "\\")],
+            inputs = sdk.libs + sdk.headers + sdk.tools + ctx.files.srcs + [sdk.go, bat],
             outputs = [cout],
             env = {"GOROOT": sdk.root_file.dirname},  # NOTE(#2005): avoid realpath in sandbox
             mnemonic = "GoToolchainBinaryCompile",


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

- Correctly formats the cmd.exe batch file invocation on Windows
- This was noted as a new failure with commit 280a1ed on particular GCP
RBE environments given some combination of PATHEXT and other system
factors which didn't correctly kick off the given batch file and treated
that invocation as using forward slash notation, confusing the cmd.exe
command invocation.
- See https://dev.azure.com/cncf/4684fb3d-0389-4e0b-8251-221942316e06/_apis/build/builds/42282/logs/32 namely the below

```
ERROR: C:/_eb/external/go_sdk/BUILD.bazel:43:1: GoToolchainBinaryCompile external/go_sdk/builder.exe.a failed (Exit 1): builder.exe.bat failed: error executing command 
  cd C:/_eb/execroot/envoy
  SET GOROOT=external/go_sdk
  bazel-out/host/bin/external/go_sdk/builder.exe.bat
Execution platform: @rbe_windows_msvc_cl//config:platform
'bazel-out' is not recognized as an internal or external command, operable program or batch file.
```

**Which issues(s) does this PR fix?**

N/A

**Other Notes**

If there is an alternate method of fixing this issue within Bazel, we would be open to it; there seems to be some discrepancy between how `ctx.actions.run` work on Windows when running locally (this change is not required for purely local builds) vs. via RBE (where this patch or reverting the relevant bits of https://github.com/bazelbuild/rules_go/pull/2488 is required).
