### PR TITLE
go_proto_compiler: reset go config when building go-protoc, plugins

### DIFF
--- a/go/private/rules/nogo.bzl
+++ b/go/private/rules/nogo.bzl
@@ -17,10 +17,6 @@ load(
     "go_context",
 )
 load(
-    "@io_bazel_rules_go//go/private:mode.bzl",
-    "LINKMODE_NORMAL",
-)
-load(
     "@io_bazel_rules_go//go/private:providers.bzl",
     "EXPORT_PATH",
     "GoArchive",
@@ -29,40 +25,7 @@ load(
 )
 load(
     "@io_bazel_rules_go//go/private:rules/transition.bzl",
-    "filter_transition_label",
-)
-
-_nogo_transition_dict = {
-    "@io_bazel_rules_go//go/config:static": False,
-    "@io_bazel_rules_go//go/config:msan": False,
-    "@io_bazel_rules_go//go/config:race": False,
-    "@io_bazel_rules_go//go/config:pure": False,
-    "@io_bazel_rules_go//go/config:strip": False,
-    "@io_bazel_rules_go//go/config:debug": False,
-    "@io_bazel_rules_go//go/config:linkmode": LINKMODE_NORMAL,
-    "@io_bazel_rules_go//go/config:tags": [],
-}
-
-_nogo_transition_keys = sorted([filter_transition_label(label) for label in _nogo_transition_dict.keys()])
-
-def _nogo_transition_impl(settings, attr):
-    """Ensures nogo is built in a safe configuration.
-
-    nogo_transition sets all of the //go/config settings to their default
-    values. The nogo binary shouldn't depend on the link mode or tags of the
-    binary being checked. This transition doesn't explicitly change the
-    platform (goos, goarch), but nogo dependencies should have `cfg = "exec"`,
-    so nogo binaries should be built for the execution platform.
-    """
-    settings = dict(settings)
-    for label, value in _nogo_transition_dict.items():
-        settings[filter_transition_label(label)] = value
-    return settings
-
-nogo_transition = transition(
-    implementation = _nogo_transition_impl,
-    inputs = _nogo_transition_keys,
-    outputs = _nogo_transition_keys,
+    "go_reset_transition",
 )
 
 def _nogo_impl(ctx):
@@ -140,7 +103,7 @@ nogo = rule(
         ),
     },
     toolchains = ["@io_bazel_rules_go//go:toolchain"],
-    cfg = nogo_transition,
+    cfg = go_reset_transition,
 )
 
 def nogo_wrapper(**kwargs):

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_source", "go_test")
+load("//go:def.bzl", "go_binary", "go_source", "go_test")
+load("//go/private:rules/transition.bzl", "go_reset_target")
 
 go_test(
     name = "filter_test",
@@ -89,12 +90,18 @@ go_binary(
 )
 
 go_binary(
-    name = "go-protoc",
+    name = "go-protoc-bin",
     srcs = [
         "env.go",
         "flags.go",
         "protoc.go",
     ],
+    visibility = ["//visibility:private"],
+)
+
+go_reset_target(
+    name = "go-protoc",
+    dep = ":go-protoc-bin",
     visibility = ["//visibility:public"],
 )
 

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -17,16 +17,39 @@ load(
     "paths",
 )
 load(
-    "@io_bazel_rules_go//go:def.bzl",
+    "//go:def.bzl",
     "GoLibrary",
     "go_context",
 )
 load(
-    "@io_bazel_rules_go//go/private:rules/rule.bzl",
-    "go_rule",
+    "//go/private:rules/transition.bzl",
+    "go_reset_target",
 )
 
-GoProtoCompiler = provider()
+GoProtoCompiler = provider(
+    doc = "Information and dependencies needed to generate Go code from protos",
+    fields = {
+        "compile": """A function with the signature:
+
+    def compile(go, compiler, protos, imports, importpath)
+
+where go is the go_context object, compiler is this GoProtoCompiler, protos
+is a list of ProtoInfo providers for protos to compile, imports is a depset
+of strings mapping proto import paths to Go import paths, and importpath is
+the import path of the Go library being generated.
+
+The function should declare output .go files and actions to generate them.
+It should return a list of .go Files to be compiled by the Go compiler.
+""",
+        "deps": """List of targets providing GoLibrary, GoSource, and GoArchive.
+These are added as implicit dependencies for any go_proto_library using this
+compiler. Typically, these are Well Known Types and proto runtime libraries.""",
+        "valid_archive": """A Boolean indicating whether the .go files produced
+by this compiler are buildable on their own. Compilers that just add methods
+to structs produced by other compilers will set this to False.""",
+        "internal": "Opaque value containing data used by compile.",
+    },
+)
 
 def go_proto_compile(go, compiler, protos, imports, importpath):
     """Invokes protoc to generate Go sources for a given set of protos
@@ -63,7 +86,7 @@ def go_proto_compile(go, compiler, protos, imports, importpath):
             out = go.declare_file(
                 go,
                 path = importpath + "/" + src.basename[:-len(".proto")],
-                ext = compiler.suffix,
+                ext = compiler.internal.suffix,
             )
             go_srcs.append(out)
             if outpath == None:
@@ -72,14 +95,14 @@ def go_proto_compile(go, compiler, protos, imports, importpath):
     transitive_descriptor_sets = depset(direct = [], transitive = desc_sets)
 
     args = go.actions.args()
-    args.add("-protoc", compiler.protoc)
+    args.add("-protoc", compiler.internal.protoc)
     args.add("-importpath", importpath)
     args.add("-out_path", outpath)
-    args.add("-plugin", compiler.plugin)
+    args.add("-plugin", compiler.internal.plugin)
 
     # TODO(jayconrod): can we just use go.env instead?
-    args.add_all(compiler.options, before_each = "-option")
-    if compiler.import_path_option:
+    args.add_all(compiler.internal.options, before_each = "-option")
+    if compiler.internal.import_path_option:
         args.add_all([importpath], before_each = "-option", format_each = "import_path=%s")
     args.add_all(transitive_descriptor_sets, before_each = "-descriptor_set")
     args.add_all(go_srcs, before_each = "-expected")
@@ -88,16 +111,16 @@ def go_proto_compile(go, compiler, protos, imports, importpath):
     go.actions.run(
         inputs = depset(
             direct = [
-                compiler.go_protoc,
-                compiler.protoc,
-                compiler.plugin,
+                compiler.internal.go_protoc,
+                compiler.internal.protoc,
+                compiler.internal.plugin,
             ],
             transitive = [transitive_descriptor_sets],
         ),
         outputs = go_srcs,
         progress_message = "Generating into %s" % go_srcs[0].dirname,
         mnemonic = "GoProtocGen",
-        executable = compiler.go_protoc,
+        executable = compiler.internal.go_protoc,
         arguments = [args],
         env = go.env,
         # We may need the shell environment (potentially augmented with --action_env)
@@ -153,24 +176,28 @@ def _go_proto_compiler_impl(ctx):
     go = go_context(ctx)
     library = go.new_library(go)
     source = go.library_to_source(go, ctx.attr, library, ctx.coverage_instrumented())
+    plugin = ctx.file.plugin
+    go_protoc = ctx.file._go_protoc
     return [
         GoProtoCompiler(
             deps = ctx.attr.deps,
             compile = go_proto_compile,
-            options = ctx.attr.options,
-            suffix = ctx.attr.suffix,
-            go_protoc = ctx.executable._go_protoc,
-            protoc = ctx.executable._protoc,
-            plugin = ctx.executable.plugin,
             valid_archive = ctx.attr.valid_archive,
-            import_path_option = ctx.attr.import_path_option,
+            internal = struct(
+                options = ctx.attr.options,
+                suffix = ctx.attr.suffix,
+                protoc = ctx.executable._protoc,
+                go_protoc = ctx.file._go_protoc,
+                plugin = ctx.file.plugin,
+                import_path_option = ctx.attr.import_path_option,
+            ),
         ),
         library,
         source,
     ]
 
-go_proto_compiler = go_rule(
-    _go_proto_compiler_impl,
+_go_proto_compiler = rule(
+    implementation = _go_proto_compiler_impl,
     attrs = {
         "deps": attr.label_list(providers = [GoLibrary]),
         "options": attr.string_list(),
@@ -179,19 +206,36 @@ go_proto_compiler = go_rule(
         "import_path_option": attr.bool(default = False),
         "plugin": attr.label(
             allow_single_file = True,
-            executable = True,
             cfg = "exec",
-            default = "@com_github_golang_protobuf//protoc-gen-go",
+            mandatory = True,
         ),
         "_go_protoc": attr.label(
-            executable = True,
+            allow_single_file = True,
             cfg = "exec",
-            default = "@io_bazel_rules_go//go/tools/builders:go-protoc",
+            default = "//go/tools/builders:go-protoc",
         ),
         "_protoc": attr.label(
             executable = True,
             cfg = "exec",
             default = "@com_google_protobuf//:protoc",
         ),
+        "_go_context_data": attr.label(
+            default = "//:go_context_data",
+        ),
     },
+    toolchains = ["@io_bazel_rules_go//go:toolchain"],
 )
+
+def go_proto_compiler(name, **kwargs):
+    plugin = kwargs.pop("plugin", "@com_github_golang_protobuf//protoc-gen-go")
+    reset_plugin_name = name + "_reset_plugin_"
+    go_reset_target(
+        name = reset_plugin_name,
+        dep = plugin,
+        visibility = ["//visibility:private"],
+    )
+    _go_proto_compiler(
+        name = name,
+        plugin = reset_plugin_name,
+        **kwargs
+    )

--- a/tests/core/cross/README.rst
+++ b/tests/core/cross/README.rst
@@ -41,7 +41,8 @@ when building for iOS (tested by ``ios_select_test``) and macOS
 proto_test
 ----------
 
-Tests that a ``go_proto_library`` can be cross-compiled with ``--platforms``.
+Tests that a ``go_proto_library`` can be cross-compiled, both with
+``--platforms`` and with mode attributes.
 
 no_context_info
 ---------------

--- a/tests/core/cross/proto_test.go
+++ b/tests/core/cross/proto_test.go
@@ -22,22 +22,39 @@ import (
 
 var testArgs = bazel_testing.Args{
 	WorkspaceSuffix: `
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-git_repository(
+http_archive(
     name = "com_google_protobuf",
-    commit = "09745575a923640154bcf307fba8aedff47f240a",
-    remote = "https://github.com/protocolbuffers/protobuf",
-    shallow_since = "1558721209 -0700",
+    sha256 = "a79d19dcdf9139fa4b81206e318e33d245c4c9da1ffed21c87288ed4380426f9",
+    strip_prefix = "protobuf-3.11.4",
+    # latest, as of 2020-02-21
+    urls = [
+        "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v3.11.4.tar.gz",
+        "https://github.com/protocolbuffers/protobuf/archive/v3.11.4.tar.gz",
+    ],
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
+
+http_archive(
+    name = "rules_proto",
+    sha256 = "4d421d51f9ecfe9bf96ab23b55c6f2b809cbaf0eea24952683e397decfbd0dd0",
+    strip_prefix = "rules_proto-f6b8d89b90a7956f6782a4a3609b2f0eee3ce965",
+    # master, as of 2020-01-06
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/f6b8d89b90a7956f6782a4a3609b2f0eee3ce965.tar.gz",
+        "https://github.com/bazelbuild/rules_proto/archive/f6b8d89b90a7956f6782a4a3609b2f0eee3ce965.tar.gz",
+    ],
+)
 `,
 	Main: `
 -- BUILD.bazel --
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 
 proto_library(
     name = "cross_proto",
@@ -50,6 +67,21 @@ go_proto_library(
     protos = [":cross_proto"],
 )
 
+go_binary(
+    name = "use_bin",
+    srcs = ["use.go"],
+    deps = [":cross_go_proto"],
+    goos = "linux",
+    goarch = "386",
+)
+
+go_binary(
+    name = "use_shared",
+    srcs = ["use.go"],
+    deps = [":cross_go_proto"],
+    linkmode = "c-shared",
+)
+
 -- cross.proto --
 syntax = "proto3";
 
@@ -60,6 +92,13 @@ option go_package = "github.com/bazelbuild/rules_go/tests/core/cross";
 message Foo {
   int64 x = 1;
 }
+
+-- use.go --
+package main
+
+import _ "github.com/bazelbuild/rules_go/tests/core/cross"
+
+func main() {}
 `,
 }
 
@@ -67,13 +106,21 @@ func TestMain(m *testing.M) {
 	bazel_testing.TestMain(m, testArgs)
 }
 
-func TestProto(t *testing.T) {
+func TestCmdLine(t *testing.T) {
 	args := []string{
 		"build",
-		"--platforms=@io_bazel_rules_go//go/toolchain:ios_amd64",
+		"--platforms=@io_bazel_rules_go//go/toolchain:linux_386",
 		":cross_go_proto",
 	}
 	if err := bazel_testing.RunBazel(args...); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestTargets(t *testing.T) {
+	for _, target := range []string{"//:use_bin", "//:use_shared"} {
+		if err := bazel_testing.RunBazel("build", target); err != nil {
+			t.Errorf("building target %s: %v", target, err)
+		}
 	}
 }


### PR DESCRIPTION
Go settings like linkmode, pure, and race shouldn't affect Go
tools. In particular, they shouldn't affect go-protoc (go_binary used
to invoke protoc), protoc-gen-go, or other user-specified binaries.
go_proto_compiler depends on these targets using 'cfg = "exec"', which
ensures they're built for the execution platform but doesn't change
other Go settings.

This PR renames nogo_transition to go_reset_transition, so it can be
used for tools other than nogo. It also introduces go_reset_target, a
rule that forwards Go providers from a target built with
go_reset_transition. go_proto_compiler is now a macro that stitches
one of these together with a _go_proto_compiler rule so both
transitions may be used.

Fixes #2538
