### PR TITLE
allow libstdc++ static link

### DIFF
--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -71,11 +71,18 @@ def _build_stdlib(go):
     if go.mode.pure:
         env.update({"CGO_ENABLED": "0"})
     else:
+        # NOTE(#2545): avoid unnecessary dynamic link
+        # go std library doesn't use C++, so should not have -lstdc++
+        ldflags = [
+            option
+            for option in extldflags_from_cc_toolchain(go)
+            if option not in ("-lstdc++", "-lc++")
+        ]
         env.update({
             "CGO_ENABLED": "1",
             "CC": go.cgo_tools.c_compiler_path,
             "CGO_CFLAGS": " ".join(go.cgo_tools.c_compile_options),
-            "CGO_LDFLAGS": " ".join(extldflags_from_cc_toolchain(go)),
+            "CGO_LDFLAGS": " ".join(ldflags),
         })
     inputs = (go.sdk.srcs +
               go.sdk.headers +

--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -69,6 +69,15 @@ def cgo_configure(go, srcs, cdeps, cppopts, copts, cxxopts, clinkopts):
     objcopts = go.cgo_tools.objc_compile_options + copts
     objcxxopts = go.cgo_tools.objcxx_compile_options + cxxopts
     clinkopts = extldflags_from_cc_toolchain(go) + clinkopts
+
+    # NOTE(#2545): avoid unnecessary dynamic link
+    if "-static-libstdc++" in clinkopts:
+        clinkopts = [
+            option
+            for option in clinkopts
+            if option not in ("-lstdc++", "-lc++")
+        ]
+
     if go.mode != LINKMODE_NORMAL:
         for opt_list in (copts, cxxopts, objcopts, objcxxopts):
             if "-fPIC" not in opt_list:


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

if cc toolchain has -lstdc++ in link_flags or link_libs,
go_library records these flags, along with clinkopts, in *.a(_go_.o),
and go_binary uses these ldflags to link.
if -lstdc++ exists, even if -Wl,-Bstatic,-lstdc++,-Bdynamic or
-static-libstdc++ is specified, libstdc++ is dynamically linked.
Thus, these is no way to make libstdc++ statically linked
for go binary.

This patch removes -lstdc++ or -lc++ if go_library cgo=True uses
-static-libstdc++ in clinkopts.
User would need to specify -lWl,-Bstatic,-lstdc++,-Bdynamic too,
since clang ignores -static-libstdc++ (clang++ only use the flag).

It also remove -lstdc++ or -lc++ when building std go libraries
(for --feature=race etc).

**Which issues(s) does this PR fix?**

Fixes #2545

**Other notes for review**
