### PR TITLE
go_test: Disable symbol table and DWARF for test binaries

### DIFF
--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -112,6 +112,11 @@ def _go_test_impl(ctx):
         },
     )
 
+    test_gc_linkopts = gc_linkopts(ctx)
+    if not go.mode.debug:
+        # Disable symbol table and DWARF generation for test binaries.
+        test_gc_linkopts.extend(["-s", "-w"])
+
     # Now compile the test binary itself
     test_library = GoLibrary(
         name = go._ctx.label.name + "~testmain",
@@ -135,7 +140,7 @@ def _go_test_impl(ctx):
         name = ctx.label.name,
         source = test_source,
         test_archives = [internal_archive.data],
-        gc_linkopts = gc_linkopts(ctx),
+        gc_linkopts = test_gc_linkopts,
         version_file = ctx.version_file,
         info_file = ctx.info_file,
     )


### PR DESCRIPTION
**What type of PR is this?**
> Feature

**What does this PR do? Why is it needed?**
This PR adds the `-s -w` linker flags for Go test binaries, and will omit the symbol table and DWARF data from the binary. This behaviour is consistent with the Go toolchain when running `go test pkg` and noticeably improves linker performance.

**Which issues(s) does this PR fix?**

Fixes https://github.com/bazelbuild/rules_go/issues/2550
