### PR TITLE
Print out subcommand when it fails

### DIFF
--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -165,7 +165,7 @@ func runAndLogCommand(cmd *exec.Cmd, verbose bool) error {
 	cleanup := passLongArgsInResponseFiles(cmd)
 	defer cleanup()
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("error running subcommand %q: %v", buffer.String(), err)
+		return fmt.Errorf("error running the following subcommand: %v\n%s", err, buffer.String())
 	}
 	return nil
 }

--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -157,15 +157,14 @@ func absEnv(envNameList []string, argList []string) error {
 }
 
 func runAndLogCommand(cmd *exec.Cmd, verbose bool) error {
-	var buffer bytes.Buffer
-	formatCommand(&buffer, cmd)
+	formattedCmd := formatCommand(cmd)
 	if verbose {
-		io.Copy(os.Stderr, &buffer)
+		os.Stderr.WriteString(formattedCmd)
 	}
 	cleanup := passLongArgsInResponseFiles(cmd)
 	defer cleanup()
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("error running the following subcommand: %v\n%s", err, buffer.String())
+		return fmt.Errorf("error running the following subcommand: %v\n%s", err, formattedCmd)
 	}
 	return nil
 }
@@ -270,7 +269,7 @@ func absArgs(args []string, flags []string) {
 
 // formatCommand writes cmd to w in a format where it can be pasted into a
 // shell. Spaces in environment variables and arguments are escaped as needed.
-func formatCommand(w io.Writer, cmd *exec.Cmd) {
+func formatCommand(cmd *exec.Cmd) string {
 	quoteIfNeeded := func(s string) string {
 		if strings.IndexByte(s, ' ') < 0 {
 			return s
@@ -288,23 +287,23 @@ func formatCommand(w io.Writer, cmd *exec.Cmd) {
 		}
 		return fmt.Sprintf("%s=%s", key, strconv.Quote(value))
 	}
-
+	var w bytes.Buffer
 	environ := cmd.Env
 	if environ == nil {
 		environ = os.Environ()
 	}
 	for _, e := range environ {
-		fmt.Fprintf(w, "%s \\\n", quoteEnvIfNeeded(e))
+		fmt.Fprintf(&w, "%s \\\n", quoteEnvIfNeeded(e))
 	}
 
 	sep := ""
 	for _, arg := range cmd.Args {
-		fmt.Fprintf(w, "%s%s", sep, quoteIfNeeded(arg))
+		fmt.Fprintf(&w, "%s%s", sep, quoteIfNeeded(arg))
 		sep = " "
 	}
-	fmt.Fprint(w, "\n")
+	fmt.Fprint(&w, "\n")
+	return w.String()
 }
-
 
 // passLongArgsInResponseFiles modifies cmd such that, for
 // certain programs, long arguments are passed in "response files", a

--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -165,7 +165,7 @@ func runAndLogCommand(cmd *exec.Cmd, verbose bool) error {
 	cleanup := passLongArgsInResponseFiles(cmd)
 	defer cleanup()
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("error running subcommand '%s': %v", buffer.String(), err)
+		return fmt.Errorf("error running subcommand %q: %v", buffer.String(), err)
 	}
 	return nil
 }

--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -157,13 +157,15 @@ func absEnv(envNameList []string, argList []string) error {
 }
 
 func runAndLogCommand(cmd *exec.Cmd, verbose bool) error {
+	var buffer bytes.Buffer
+	formatCommand(&buffer, cmd)
 	if verbose {
-		formatCommand(os.Stderr, cmd)
+		io.Copy(os.Stderr, &buffer)
 	}
 	cleanup := passLongArgsInResponseFiles(cmd)
 	defer cleanup()
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("error running subcommand: %v", err)
+		return fmt.Errorf("error running subcommand '%s': %v", buffer.String(), err)
 	}
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

`--verbose_failures` only prints out the command that Bazel rules call directly. If a binary calls several subcommands (e.g., compilepkg), we don't know which subcommand fails until we run the parent command manually. For failures that cannot be reproduced locally (e.g., the Windows errors of #2461), printing out the subcommand gives us better idea what could have gone wrong.

