### PR TITLE
Manifest single entry

### DIFF
--- a/go/tools/bazel/runfiles.go
+++ b/go/tools/bazel/runfiles.go
@@ -330,12 +330,7 @@ func initRunfiles() {
 				continue
 			}
 			e := bytes.SplitN(line, []byte(" "), 2)
-			if len(e) < 2 {
-				entry := RunfileEntry{ShortPath: string(e[0]), Path: string(e[0])}
-			} else {
-				entry := RunfileEntry{ShortPath: string(e[0]), Path: string(e[1])}
-			}
-
+			entry := RunfileEntry{ShortPath: string(e[0]), Path: string(e[len(e)-1])}
 			if i := strings.IndexByte(entry.ShortPath, '/'); i >= 0 {
 				entry.Workspace = entry.ShortPath[:i]
 				entry.ShortPath = entry.ShortPath[i+1:]

--- a/go/tools/bazel/runfiles.go
+++ b/go/tools/bazel/runfiles.go
@@ -331,11 +331,11 @@ func initRunfiles() {
 			}
 			e := bytes.SplitN(line, []byte(" "), 2)
 			if len(e) < 2 {
-				runfiles.err = fmt.Errorf("error parsing runfiles manifest: %s:%d: no space", manifest, lineno)
-				return
+				entry := RunfileEntry{ShortPath: string(e[0]), Path: string(e[0])}
+			} else {
+				entry := RunfileEntry{ShortPath: string(e[0]), Path: string(e[1])}
 			}
 
-			entry := RunfileEntry{ShortPath: string(e[0]), Path: string(e[1])}
 			if i := strings.IndexByte(entry.ShortPath, '/'); i >= 0 {
 				entry.Workspace = entry.ShortPath[:i]
 				entry.ShortPath = entry.ShortPath[i+1:]


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

My Bazel seems to output lines in the runfiles manifest where the path and shortpath are the same as just one entry on the line. This causes issues with the runfile manifest parser.
