### PR TITLE
proto: add google.golang.org/protobuf/proto to standard deps

### DIFF
--- a/proto/wkt/well_known_types.bzl
+++ b/proto/wkt/well_known_types.bzl
@@ -37,6 +37,7 @@ WELL_KNOWN_TYPE_RULES = {
 
 PROTO_RUNTIME_DEPS = [
     "@com_github_golang_protobuf//proto:go_default_library",
+    "@org_golang_google_protobuf//proto:go_default_library",
     "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
     "@org_golang_google_protobuf//runtime/protoiface:go_default_library",
     "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",


### PR DESCRIPTION
Newer versions of protoc-gen-go may generate files that import this
package, so it must be included in the standard set of
go_proto_library deps.

Fixes #2609
