### PR TITLE
Add bzl_library targets for Stardoc compatibility

### DIFF
--- a/go/BUILD.bazel
+++ b/go/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 filegroup(
     name = "all_files",
     testonly = True,
@@ -19,6 +21,13 @@ filegroup(
         "//go/toolchain:all_rules",
     ],
     visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "go_lib",
+    srcs = [":all_rules"],
+    visibility = ["//visibility:public"],
+    deps = ["//proto:proto_lib"],
 )
 
 toolchain_type(

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(
     "//proto:compiler.bzl",
     "go_proto_compiler",
@@ -112,9 +113,15 @@ go_proto_compiler(
 
 filegroup(
     name = "all_rules",
-    testonly = True,
     srcs = glob(["*.bzl"]) + ["//proto/wkt:all_rules"],
     visibility = ["//:__subpackages__"],
+)
+
+bzl_library(
+    name = "proto_lib",
+    srcs = [":all_rules"],
+    visibility = ["//visibility:public"],
+    deps = [],
 )
 
 filegroup(

--- a/proto/wkt/BUILD.bazel
+++ b/proto/wkt/BUILD.bazel
@@ -165,7 +165,6 @@ go_proto_library(
 
 filegroup(
     name = "all_rules",
-    testonly = True,
     srcs = glob(["*.bzl"]),
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION


<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Adds `bzl_library` targets for `//go:go_lib` and `//proto:proto_lib`. The latter is a dependency of `//go:go_lib`.
These targets are required to generate Stardoc documentation for rule sets that themselves depend on `rules_go`.

**Which issues(s) does this PR fix?**

Fixes #2619

