### PR TITLE
Create bzl_library entries using gazelle-skylark

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,13 +1,13 @@
 load(
-    "@io_bazel_rules_go//go/private:tools/lines_sorted_test.bzl",
+    "@io_bazel_rules_go//go/private/tools:lines_sorted_test.bzl",
     "lines_sorted_test",
 )
 load(
-    "@io_bazel_rules_go//go/private:rules/nogo.bzl",
+    "@io_bazel_rules_go//go/private/rules:nogo.bzl",
     "nogo",
 )
 load(
-    "@io_bazel_rules_go//go/private:rules/info.bzl",
+    "@io_bazel_rules_go//go/private/rules:info.bzl",
     "go_info",
 )
 load(
@@ -22,7 +22,7 @@ load(
     "go_context_data",
 )
 load(
-    "@io_bazel_rules_go//go/private:rules/stdlib.bzl",
+    "@io_bazel_rules_go//go/private/rules:stdlib.bzl",
     "stdlib",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,17 +27,6 @@ load("@io_bazel_rules_go//extras:embed_data_deps.bzl", "go_embed_data_dependenci
 
 go_embed_data_dependencies()
 
-http_archive(
-    name = "rules_proto",
-    sha256 = "4d421d51f9ecfe9bf96ab23b55c6f2b809cbaf0eea24952683e397decfbd0dd0",
-    strip_prefix = "rules_proto-f6b8d89b90a7956f6782a4a3609b2f0eee3ce965",
-    # master, as of 2020-01-06
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/f6b8d89b90a7956f6782a4a3609b2f0eee3ce965.tar.gz",
-        "https://github.com/bazelbuild/rules_proto/archive/f6b8d89b90a7956f6782a4a3609b2f0eee3ce965.tar.gz",
-    ],
-)
-
 # Used by //tests:buildifier_test.
 # Latest release is not compatible with the incompatible bazel flags we use
 # in CI, in particular, --incompatible_load_proto_rules_from_bzl.

--- a/extras/BUILD.bazel
+++ b/extras/BUILD.bazel
@@ -31,5 +31,6 @@ bzl_library(
     name = "embed_data_deps",
     srcs = ["embed_data_deps.bzl"],
     visibility = ["//visibility:public"],
-    deps = ["@bazel_tools//tools/build_defs/repo:git.bzl"],
+    # Don't list dependency on @bazel_tools//tools/build_defs/repo.bzl
+    deps = [],  # keep
 )

--- a/extras/BUILD.bazel
+++ b/extras/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 filegroup(
     name = "all_rules",
     srcs = glob(["*.bzl"]) + ["//go/private:all_rules"],
@@ -9,4 +11,25 @@ filegroup(
     testonly = True,
     srcs = glob(["**"]),
     visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "bindata",
+    srcs = ["bindata.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@io_bazel_rules_go//go:def"],
+)
+
+bzl_library(
+    name = "embed_data",
+    srcs = ["embed_data.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@io_bazel_rules_go//go/private:context"],
+)
+
+bzl_library(
+    name = "embed_data_deps",
+    srcs = ["embed_data_deps.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_tools//tools/build_defs/repo:git.bzl"],
 )

--- a/go/BUILD.bazel
+++ b/go/BUILD.bazel
@@ -33,16 +33,16 @@ bzl_library(
     srcs = ["def.bzl"],
     visibility = ["//visibility:public"],
     deps = [
-        "@io_bazel_rules_go//extras:embed_data",
-        "@io_bazel_rules_go//go/private:context",
-        "@io_bazel_rules_go//go/private:go_toolchain",
-        "@io_bazel_rules_go//go/private:providers",
-        "@io_bazel_rules_go//go/private/rules:library",
-        "@io_bazel_rules_go//go/private/rules:nogo",
-        "@io_bazel_rules_go//go/private/rules:sdk",
-        "@io_bazel_rules_go//go/private/rules:source",
-        "@io_bazel_rules_go//go/private/rules:wrappers",
-        "@io_bazel_rules_go//go/private/tools:path",
+        "//extras:embed_data",
+        "//go/private:context",
+        "//go/private:go_toolchain",
+        "//go/private:providers",
+        "//go/private/rules:library",
+        "//go/private/rules:nogo",
+        "//go/private/rules:sdk",
+        "//go/private/rules:source",
+        "//go/private/rules:wrappers",
+        "//go/private/tools:path",
     ],
 )
 
@@ -51,7 +51,7 @@ bzl_library(
     srcs = ["deps.bzl"],
     visibility = ["//visibility:public"],
     deps = [
-        "@io_bazel_rules_go//go/private:repositories",
-        "@io_bazel_rules_go//go/private:sdk",
+        "//go/private:repositories",
+        "//go/private:sdk",
     ],
 )

--- a/go/BUILD.bazel
+++ b/go/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 filegroup(
     name = "all_files",
     testonly = True,
@@ -24,4 +26,32 @@ filegroup(
 toolchain_type(
     name = "toolchain",
     visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "def",
+    srcs = ["def.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@io_bazel_rules_go//extras:embed_data",
+        "@io_bazel_rules_go//go/private:context",
+        "@io_bazel_rules_go//go/private:go_toolchain",
+        "@io_bazel_rules_go//go/private:providers",
+        "@io_bazel_rules_go//go/private/rules:library",
+        "@io_bazel_rules_go//go/private/rules:nogo",
+        "@io_bazel_rules_go//go/private/rules:sdk",
+        "@io_bazel_rules_go//go/private/rules:source",
+        "@io_bazel_rules_go//go/private/rules:wrappers",
+        "@io_bazel_rules_go//go/private/tools:path",
+    ],
+)
+
+bzl_library(
+    name = "deps",
+    srcs = ["deps.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@io_bazel_rules_go//go/private:repositories",
+        "@io_bazel_rules_go//go/private:sdk",
+    ],
 )

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -23,11 +23,11 @@ may change without notice.
 """
 
 load(
-    "@io_bazel_rules_go//go/private:context.bzl",
+    "//go/private:context.bzl",
     _go_context = "go_context",
 )
 load(
-    "@io_bazel_rules_go//go/private:providers.bzl",
+    "//go/private:providers.bzl",
     _GoArchive = "GoArchive",
     _GoArchiveData = "GoArchiveData",
     _GoLibrary = "GoLibrary",
@@ -36,38 +36,38 @@ load(
     _GoSource = "GoSource",
 )
 load(
-    "@io_bazel_rules_go//go/private/rules:sdk.bzl",
+    "//go/private/rules:sdk.bzl",
     _go_sdk = "go_sdk",
 )
 load(
-    "@io_bazel_rules_go//go/private:go_toolchain.bzl",
+    "//go/private:go_toolchain.bzl",
     _declare_toolchains = "declare_toolchains",
     _go_toolchain = "go_toolchain",
 )
 load(
-    "@io_bazel_rules_go//go/private/rules:wrappers.bzl",
+    "//go/private/rules:wrappers.bzl",
     _go_binary_macro = "go_binary_macro",
     _go_library_macro = "go_library_macro",
     _go_test_macro = "go_test_macro",
 )
 load(
-    "@io_bazel_rules_go//go/private/rules:source.bzl",
+    "//go/private/rules:source.bzl",
     _go_source = "go_source",
 )
 load(
-    "@io_bazel_rules_go//extras:embed_data.bzl",
+    "//extras:embed_data.bzl",
     _go_embed_data = "go_embed_data",
 )
 load(
-    "@io_bazel_rules_go//go/private/tools:path.bzl",
+    "//go/private/tools:path.bzl",
     _go_path = "go_path",
 )
 load(
-    "@io_bazel_rules_go//go/private/rules:library.bzl",
+    "//go/private/rules:library.bzl",
     _go_tool_library = "go_tool_library",
 )
 load(
-    "@io_bazel_rules_go//go/private/rules:nogo.bzl",
+    "//go/private/rules:nogo.bzl",
     _nogo = "nogo_wrapper",
 )
 

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -36,7 +36,7 @@ load(
     _GoSource = "GoSource",
 )
 load(
-    "@io_bazel_rules_go//go/private:rules/sdk.bzl",
+    "@io_bazel_rules_go//go/private/rules:sdk.bzl",
     _go_sdk = "go_sdk",
 )
 load(
@@ -45,13 +45,13 @@ load(
     _go_toolchain = "go_toolchain",
 )
 load(
-    "@io_bazel_rules_go//go/private:rules/wrappers.bzl",
+    "@io_bazel_rules_go//go/private/rules:wrappers.bzl",
     _go_binary_macro = "go_binary_macro",
     _go_library_macro = "go_library_macro",
     _go_test_macro = "go_test_macro",
 )
 load(
-    "@io_bazel_rules_go//go/private:rules/source.bzl",
+    "@io_bazel_rules_go//go/private/rules:source.bzl",
     _go_source = "go_source",
 )
 load(
@@ -59,15 +59,15 @@ load(
     _go_embed_data = "go_embed_data",
 )
 load(
-    "@io_bazel_rules_go//go/private:tools/path.bzl",
+    "@io_bazel_rules_go//go/private/tools:path.bzl",
     _go_path = "go_path",
 )
 load(
-    "@io_bazel_rules_go//go/private:rules/library.bzl",
+    "@io_bazel_rules_go//go/private/rules:library.bzl",
     _go_tool_library = "go_tool_library",
 )
 load(
-    "@io_bazel_rules_go//go/private:rules/nogo.bzl",
+    "@io_bazel_rules_go//go/private/rules:nogo.bzl",
     _nogo = "nogo_wrapper",
 )
 

--- a/go/platform/BUILD.bazel
+++ b/go/platform/BUILD.bazel
@@ -27,12 +27,12 @@ filegroup(
 )
 
 bzl_library(
-    name = "apple",
-    srcs = ["apple.bzl"],
-)
-
-bzl_library(
     name = "list",
     srcs = ["list.bzl"],
     deps = ["@io_bazel_rules_go//go/private:platforms"],
+)
+
+bzl_library(
+    name = "apple",
+    srcs = ["apple.bzl"],
 )

--- a/go/platform/BUILD.bazel
+++ b/go/platform/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 # This file declares a config_setting for each platform supported by the
 # Go SDK. These rules follow a goos_goarch naming convention, for example,
 # //go/platform:linux_amd64
@@ -22,4 +24,15 @@ filegroup(
     testonly = True,
     srcs = glob(["**"]),
     visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "apple",
+    srcs = ["apple.bzl"],
+)
+
+bzl_library(
+    name = "list",
+    srcs = ["list.bzl"],
+    deps = ["@io_bazel_rules_go//go/private:platforms"],
 )

--- a/go/private/BUILD.bazel
+++ b/go/private/BUILD.bazel
@@ -34,13 +34,12 @@ config_setting(
 )
 
 bzl_library(
-    name = "common",
-    srcs = ["common.bzl"],
-)
-
-bzl_library(
     name = "context",
     srcs = ["context.bzl"],
+    visibility = [
+        "//extras:__pkg__",  # Manually added
+        "//go:__subpackages__",
+    ],
     deps = [
         ":common",
         ":mode",
@@ -56,6 +55,7 @@ bzl_library(
 bzl_library(
     name = "go_toolchain",
     srcs = ["go_toolchain.bzl"],
+    visibility = ["//go:__subpackages__"],
     deps = [
         "@io_bazel_rules_go//go/private:platforms",
         "@io_bazel_rules_go//go/private:providers",
@@ -71,40 +71,22 @@ bzl_library(
 )
 
 bzl_library(
-    name = "mode",
-    srcs = ["mode.bzl"],
-)
-
-bzl_library(
-    name = "nogo",
-    srcs = ["nogo.bzl"],
-)
-
-bzl_library(
-    name = "platforms",
-    srcs = ["platforms.bzl"],
-)
-
-bzl_library(
-    name = "providers",
-    srcs = ["providers.bzl"],
-)
-
-bzl_library(
     name = "repositories",
     srcs = ["repositories.bzl"],
+    visibility = ["//go:__subpackages__"],
+    # Don't list dependency on @bazel_tools//tools/build_defs/repo:http.bzl
     deps = [
         ":common",
         ":nogo",
         "//go/private/skylib/lib:versions",
         "//proto:gogo",
-        "@bazel_tools//tools/build_defs/repo:http.bzl",
-    ],
+    ],  # keep
 )
 
 bzl_library(
     name = "sdk",
     srcs = ["sdk.bzl"],
+    visibility = ["//go:__subpackages__"],
     deps = [
         "@io_bazel_rules_go//go/private:common",
         "@io_bazel_rules_go//go/private:nogo",
@@ -115,6 +97,40 @@ bzl_library(
 )
 
 bzl_library(
+    name = "common",
+    srcs = ["common.bzl"],
+    visibility = ["//go:__subpackages__"],
+)
+
+bzl_library(
+    name = "mode",
+    srcs = ["mode.bzl"],
+    visibility = ["//go:__subpackages__"],
+)
+
+bzl_library(
+    name = "nogo",
+    srcs = ["nogo.bzl"],
+    visibility = ["//go:__subpackages__"],
+)
+
+bzl_library(
+    name = "platforms",
+    srcs = ["platforms.bzl"],
+    visibility = ["//go:__subpackages__"],
+)
+
+bzl_library(
+    name = "providers",
+    srcs = ["providers.bzl"],
+    visibility = [
+        "//go:__subpackages__",
+        "//proto:__pkg__",  # keep
+    ],
+)
+
+bzl_library(
     name = "sdk_list",
     srcs = ["sdk_list.bzl"],
+    visibility = ["//go:__subpackages__"],
 )

--- a/go/private/BUILD.bazel
+++ b/go/private/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 filegroup(
     name = "all_rules",
     srcs = glob(["**/*.bzl"]),
@@ -29,4 +31,90 @@ config_setting(
 config_setting(
     name = "stamp",
     values = {"stamp": "true"},
+)
+
+bzl_library(
+    name = "common",
+    srcs = ["common.bzl"],
+)
+
+bzl_library(
+    name = "context",
+    srcs = ["context.bzl"],
+    deps = [
+        ":common",
+        ":mode",
+        ":providers",
+        "//go/platform:apple",
+        "@bazel_skylib//lib:paths",
+        "@bazel_skylib//rules:common_settings",
+        "@bazel_tools//tools/build_defs/cc:action_names.bzl",
+        "@bazel_tools//tools/cpp:toolchain_utils.bzl",
+    ],
+)
+
+bzl_library(
+    name = "go_toolchain",
+    srcs = ["go_toolchain.bzl"],
+    deps = [
+        "@io_bazel_rules_go//go/private:platforms",
+        "@io_bazel_rules_go//go/private:providers",
+        "@io_bazel_rules_go//go/private/actions:archive",
+        "@io_bazel_rules_go//go/private/actions:asm",
+        "@io_bazel_rules_go//go/private/actions:binary",
+        "@io_bazel_rules_go//go/private/actions:compile",
+        "@io_bazel_rules_go//go/private/actions:cover",
+        "@io_bazel_rules_go//go/private/actions:link",
+        "@io_bazel_rules_go//go/private/actions:pack",
+        "@io_bazel_rules_go//go/private/actions:stdlib",
+    ],
+)
+
+bzl_library(
+    name = "mode",
+    srcs = ["mode.bzl"],
+)
+
+bzl_library(
+    name = "nogo",
+    srcs = ["nogo.bzl"],
+)
+
+bzl_library(
+    name = "platforms",
+    srcs = ["platforms.bzl"],
+)
+
+bzl_library(
+    name = "providers",
+    srcs = ["providers.bzl"],
+)
+
+bzl_library(
+    name = "repositories",
+    srcs = ["repositories.bzl"],
+    deps = [
+        ":common",
+        ":nogo",
+        "//go/private/skylib/lib:versions",
+        "//proto:gogo",
+        "@bazel_tools//tools/build_defs/repo:http.bzl",
+    ],
+)
+
+bzl_library(
+    name = "sdk",
+    srcs = ["sdk.bzl"],
+    deps = [
+        "@io_bazel_rules_go//go/private:common",
+        "@io_bazel_rules_go//go/private:nogo",
+        "@io_bazel_rules_go//go/private:platforms",
+        "@io_bazel_rules_go//go/private:sdk_list",
+        "@io_bazel_rules_go//go/private/skylib/lib:versions",
+    ],
+)
+
+bzl_library(
+    name = "sdk_list",
+    srcs = ["sdk_list.bzl"],
 )

--- a/go/private/BUILD.bazel
+++ b/go/private/BUILD.bazel
@@ -2,14 +2,24 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 filegroup(
     name = "all_rules",
-    srcs = glob(["**/*.bzl"]),
+    srcs = [
+        "//go/private/actions:all_rules",
+        "//go/private/rules:all_rules",
+        "//go/private/skylib/lib:all_rules",
+        "//go/private/tools:all_rules",
+    ] + glob(["**/*.bzl"]),
     visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "all_files",
     testonly = True,
-    srcs = glob(["**"]),
+    srcs = [
+        "//go/private/actions:all_files",
+        "//go/private/rules:all_files",
+        "//go/private/skylib/lib:all_files",
+        "//go/private/tools:all_files",
+    ] + glob(["**"]),
     visibility = ["//visibility:public"],
 )
 

--- a/go/private/BUILD.sdk.bazel
+++ b/go/private/BUILD.sdk.bazel
@@ -1,5 +1,5 @@
-load("@io_bazel_rules_go//go/private:rules/binary.bzl", "go_tool_binary")
-load("@io_bazel_rules_go//go/private:rules/sdk.bzl", "package_list")
+load("@io_bazel_rules_go//go/private/rules:binary.bzl", "go_tool_binary")
+load("@io_bazel_rules_go//go/private/rules:sdk.bzl", "package_list")
 load("@io_bazel_rules_go//go:def.bzl", "declare_toolchains", "go_sdk")
 
 package(default_visibility = ["//visibility:public"])

--- a/go/private/actions/BUILD.bazel
+++ b/go/private/actions/BUILD.bazel
@@ -3,6 +3,7 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 bzl_library(
     name = "archive",
     srcs = ["archive.bzl"],
+    visibility = ["//go:__subpackages__"],
     deps = [
         "@io_bazel_rules_go//go/private:common",
         "@io_bazel_rules_go//go/private:mode",
@@ -15,12 +16,14 @@ bzl_library(
 bzl_library(
     name = "asm",
     srcs = ["asm.bzl"],
+    visibility = ["//go:__subpackages__"],
     deps = ["@io_bazel_rules_go//go/private:mode"],
 )
 
 bzl_library(
     name = "binary",
     srcs = ["binary.bzl"],
+    visibility = ["//go:__subpackages__"],
     deps = [
         "@io_bazel_rules_go//go/private:common",
         "@io_bazel_rules_go//go/private:mode",
@@ -30,12 +33,14 @@ bzl_library(
 bzl_library(
     name = "compile",
     srcs = ["compile.bzl"],
+    visibility = ["//go:__subpackages__"],
     deps = ["@io_bazel_rules_go//go/private:mode"],
 )
 
 bzl_library(
     name = "compilepkg",
     srcs = ["compilepkg.bzl"],
+    visibility = ["//go:__subpackages__"],
     deps = [
         "@bazel_skylib//lib:shell",
         "@io_bazel_rules_go//go/private:mode",
@@ -45,6 +50,7 @@ bzl_library(
 bzl_library(
     name = "cover",
     srcs = ["cover.bzl"],
+    visibility = ["//go:__subpackages__"],
     deps = [
         "@bazel_skylib//lib:structs",
         "@io_bazel_rules_go//go/private:providers",
@@ -54,6 +60,7 @@ bzl_library(
 bzl_library(
     name = "link",
     srcs = ["link.bzl"],
+    visibility = ["//go:__subpackages__"],
     deps = [
         "@io_bazel_rules_go//go/private:common",
         "@io_bazel_rules_go//go/private:mode",
@@ -63,11 +70,13 @@ bzl_library(
 bzl_library(
     name = "pack",
     srcs = ["pack.bzl"],
+    visibility = ["//go:__subpackages__"],
 )
 
 bzl_library(
     name = "stdlib",
     srcs = ["stdlib.bzl"],
+    visibility = ["//go:__subpackages__"],
     deps = [
         "@io_bazel_rules_go//go/private:mode",
         "@io_bazel_rules_go//go/private:providers",

--- a/go/private/actions/BUILD.bazel
+++ b/go/private/actions/BUILD.bazel
@@ -1,0 +1,75 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "archive",
+    srcs = ["archive.bzl"],
+    deps = [
+        "@io_bazel_rules_go//go/private:common",
+        "@io_bazel_rules_go//go/private:mode",
+        "@io_bazel_rules_go//go/private:providers",
+        "@io_bazel_rules_go//go/private/actions:compilepkg",
+        "@io_bazel_rules_go//go/private/rules:cgo",
+    ],
+)
+
+bzl_library(
+    name = "asm",
+    srcs = ["asm.bzl"],
+    deps = ["@io_bazel_rules_go//go/private:mode"],
+)
+
+bzl_library(
+    name = "binary",
+    srcs = ["binary.bzl"],
+    deps = [
+        "@io_bazel_rules_go//go/private:common",
+        "@io_bazel_rules_go//go/private:mode",
+    ],
+)
+
+bzl_library(
+    name = "compile",
+    srcs = ["compile.bzl"],
+    deps = ["@io_bazel_rules_go//go/private:mode"],
+)
+
+bzl_library(
+    name = "compilepkg",
+    srcs = ["compilepkg.bzl"],
+    deps = [
+        "@bazel_skylib//lib:shell",
+        "@io_bazel_rules_go//go/private:mode",
+    ],
+)
+
+bzl_library(
+    name = "cover",
+    srcs = ["cover.bzl"],
+    deps = [
+        "@bazel_skylib//lib:structs",
+        "@io_bazel_rules_go//go/private:providers",
+    ],
+)
+
+bzl_library(
+    name = "link",
+    srcs = ["link.bzl"],
+    deps = [
+        "@io_bazel_rules_go//go/private:common",
+        "@io_bazel_rules_go//go/private:mode",
+    ],
+)
+
+bzl_library(
+    name = "pack",
+    srcs = ["pack.bzl"],
+)
+
+bzl_library(
+    name = "stdlib",
+    srcs = ["stdlib.bzl"],
+    deps = [
+        "@io_bazel_rules_go//go/private:mode",
+        "@io_bazel_rules_go//go/private:providers",
+    ],
+)

--- a/go/private/actions/BUILD.bazel
+++ b/go/private/actions/BUILD.bazel
@@ -1,5 +1,18 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
+filegroup(
+    name = "all_rules",
+    srcs = glob(["**/*.bzl"]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)
+
 bzl_library(
     name = "archive",
     srcs = ["archive.bzl"],

--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -31,11 +31,11 @@ load(
     "get_archive",
 )
 load(
-    "@io_bazel_rules_go//go/private:rules/cgo.bzl",
+    "@io_bazel_rules_go//go/private/rules:cgo.bzl",
     "cgo_configure",
 )
 load(
-    "@io_bazel_rules_go//go/private:actions/compilepkg.bzl",
+    "@io_bazel_rules_go//go/private/actions:compilepkg.bzl",
     "emit_compilepkg",
 )
 

--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -13,29 +13,29 @@
 # limitations under the License.
 
 load(
-    "@io_bazel_rules_go//go/private:common.bzl",
+    "//go/private:common.bzl",
     "as_tuple",
     "split_srcs",
 )
 load(
-    "@io_bazel_rules_go//go/private:mode.bzl",
+    "//go/private:mode.bzl",
     "LINKMODE_C_ARCHIVE",
     "LINKMODE_C_SHARED",
     "mode_string",
 )
 load(
-    "@io_bazel_rules_go//go/private:providers.bzl",
+    "//go/private:providers.bzl",
     "GoArchive",
     "GoArchiveData",
     "effective_importpath_pkgpath",
     "get_archive",
 )
 load(
-    "@io_bazel_rules_go//go/private/rules:cgo.bzl",
+    "//go/private/rules:cgo.bzl",
     "cgo_configure",
 )
 load(
-    "@io_bazel_rules_go//go/private/actions:compilepkg.bzl",
+    "//go/private/actions:compilepkg.bzl",
     "emit_compilepkg",
 )
 

--- a/go/private/actions/asm.bzl
+++ b/go/private/actions/asm.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load(
-    "@io_bazel_rules_go//go/private:mode.bzl",
+    "//go/private:mode.bzl",
     "link_mode_args",
 )
 

--- a/go/private/actions/binary.bzl
+++ b/go/private/actions/binary.bzl
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 load(
-    "@io_bazel_rules_go//go/private:mode.bzl",
+    "//go/private:mode.bzl",
     "LINKMODE_C_ARCHIVE",
     "LINKMODE_C_SHARED",
     "LINKMODE_PLUGIN",
 )
 load(
-    "@io_bazel_rules_go//go/private:common.bzl",
+    "//go/private:common.bzl",
     "ARCHIVE_EXTENSION",
     "has_shared_lib_extension",
 )

--- a/go/private/actions/compile.bzl
+++ b/go/private/actions/compile.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load(
-    "@io_bazel_rules_go//go/private:mode.bzl",
+    "//go/private:mode.bzl",
     "link_mode_args",
 )
 

--- a/go/private/actions/compilepkg.bzl
+++ b/go/private/actions/compilepkg.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load(
-    "@io_bazel_rules_go//go/private:mode.bzl",
+    "//go/private:mode.bzl",
     "link_mode_args",
 )
 load(

--- a/go/private/actions/cover.bzl
+++ b/go/private/actions/cover.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load(
-    "@io_bazel_rules_go//go/private:providers.bzl",
+    "//go/private:providers.bzl",
     "GoSource",
     "effective_importpath_pkgpath",
 )

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 load(
-    "@io_bazel_rules_go//go/private:common.bzl",
+    "//go/private:common.bzl",
     "as_set",
     "has_shared_lib_extension",
 )
 load(
-    "@io_bazel_rules_go//go/private:mode.bzl",
+    "//go/private:mode.bzl",
     "LINKMODE_NORMAL",
     "LINKMODE_PLUGIN",
     "extld_from_cc_toolchain",

--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 load(
-    "@io_bazel_rules_go//go/private:providers.bzl",
+    "//go/private:providers.bzl",
     "GoStdLib",
 )
 load(
-    "@io_bazel_rules_go//go/private:mode.bzl",
+    "//go/private:mode.bzl",
     "LINKMODE_NORMAL",
     "extldflags_from_cc_toolchain",
     "link_mode_args",

--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -17,14 +17,14 @@ Toolchain rules used by go.
 
 load("@io_bazel_rules_go//go/private:platforms.bzl", "PLATFORMS")
 load("@io_bazel_rules_go//go/private:providers.bzl", "GoSDK")
-load("@io_bazel_rules_go//go/private:actions/archive.bzl", "emit_archive")
-load("@io_bazel_rules_go//go/private:actions/asm.bzl", "emit_asm")
-load("@io_bazel_rules_go//go/private:actions/binary.bzl", "emit_binary")
-load("@io_bazel_rules_go//go/private:actions/compile.bzl", "emit_compile")
-load("@io_bazel_rules_go//go/private:actions/cover.bzl", "emit_cover")
-load("@io_bazel_rules_go//go/private:actions/link.bzl", "emit_link")
-load("@io_bazel_rules_go//go/private:actions/pack.bzl", "emit_pack")
-load("@io_bazel_rules_go//go/private:actions/stdlib.bzl", "emit_stdlib")
+load("@io_bazel_rules_go//go/private/actions:archive.bzl", "emit_archive")
+load("@io_bazel_rules_go//go/private/actions:asm.bzl", "emit_asm")
+load("@io_bazel_rules_go//go/private/actions:binary.bzl", "emit_binary")
+load("@io_bazel_rules_go//go/private/actions:compile.bzl", "emit_compile")
+load("@io_bazel_rules_go//go/private/actions:cover.bzl", "emit_cover")
+load("@io_bazel_rules_go//go/private/actions:link.bzl", "emit_link")
+load("@io_bazel_rules_go//go/private/actions:pack.bzl", "emit_pack")
+load("@io_bazel_rules_go//go/private/actions:stdlib.bzl", "emit_stdlib")
 
 def _go_toolchain_impl(ctx):
     sdk = ctx.attr.sdk[GoSDK]

--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -15,16 +15,16 @@
 Toolchain rules used by go.
 """
 
-load("@io_bazel_rules_go//go/private:platforms.bzl", "PLATFORMS")
-load("@io_bazel_rules_go//go/private:providers.bzl", "GoSDK")
-load("@io_bazel_rules_go//go/private/actions:archive.bzl", "emit_archive")
-load("@io_bazel_rules_go//go/private/actions:asm.bzl", "emit_asm")
-load("@io_bazel_rules_go//go/private/actions:binary.bzl", "emit_binary")
-load("@io_bazel_rules_go//go/private/actions:compile.bzl", "emit_compile")
-load("@io_bazel_rules_go//go/private/actions:cover.bzl", "emit_cover")
-load("@io_bazel_rules_go//go/private/actions:link.bzl", "emit_link")
-load("@io_bazel_rules_go//go/private/actions:pack.bzl", "emit_pack")
-load("@io_bazel_rules_go//go/private/actions:stdlib.bzl", "emit_stdlib")
+load("//go/private:platforms.bzl", "PLATFORMS")
+load("//go/private:providers.bzl", "GoSDK")
+load("//go/private/actions:archive.bzl", "emit_archive")
+load("//go/private/actions:asm.bzl", "emit_asm")
+load("//go/private/actions:binary.bzl", "emit_binary")
+load("//go/private/actions:compile.bzl", "emit_compile")
+load("//go/private/actions:cover.bzl", "emit_cover")
+load("//go/private/actions:link.bzl", "emit_link")
+load("//go/private/actions:pack.bzl", "emit_pack")
+load("//go/private/actions:stdlib.bzl", "emit_stdlib")
 
 def _go_toolchain_impl(ctx):
     sdk = ctx.attr.sdk[GoSDK]

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -279,7 +279,15 @@ def _maybe(repo_rule, name, **kwargs):
         repo_rule(name = name, **kwargs)
 
 def _go_name_hack_impl(ctx):
-    ctx.file("BUILD.bazel")
+    build_content = """\
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "def",
+    srcs = ["def.bzl"],
+)
+"""
+    ctx.file("BUILD.bazel", build_content)
     content = "IS_RULES_GO = {}".format(ctx.attr.is_rules_go)
     ctx.file("def.bzl", content)
 

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -15,7 +15,7 @@
 # Once nested repositories work, this file should cease to exist.
 
 load("//go/private:common.bzl", "MINIMUM_BAZEL_VERSION")
-load("//go/private:skylib/lib/versions.bzl", "versions")
+load("//go/private/skylib/lib:versions.bzl", "versions")
 load("//go/private:nogo.bzl", "DEFAULT_NOGO", "go_register_nogo")
 load("//proto:gogo.bzl", "gogo_special_proto")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/go/private/rules/BUILD.bazel
+++ b/go/private/rules/BUILD.bazel
@@ -3,34 +3,38 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 bzl_library(
     name = "binary",
     srcs = ["binary.bzl"],
+    visibility = ["//go:__subpackages__"],
     deps = [
-        ":common",
-        ":context",
-        ":mode",
-        ":providers",
-        ":rules/transition",
+        "@io_bazel_rules_go//go/private:common",
+        "@io_bazel_rules_go//go/private:context",
+        "@io_bazel_rules_go//go/private:mode",
+        "@io_bazel_rules_go//go/private:providers",
+        "@io_bazel_rules_go//go/private/rules:transition",
     ],
 )
 
 bzl_library(
     name = "cgo",
     srcs = ["cgo.bzl"],
+    visibility = ["//go:__subpackages__"],
+    # Don't list dependency on @rules_cc//cc:defs
     deps = [
         "@io_bazel_rules_go//go/private:common",
         "@io_bazel_rules_go//go/private:mode",
-        "@rules_cc//cc:defs",
-    ],
+    ],  # keep
 )
 
 bzl_library(
     name = "info",
     srcs = ["info.bzl"],
-    deps = ["//go/private:context"],
+    visibility = ["//go:__subpackages__"],
+    deps = ["@io_bazel_rules_go//go/private:context"],
 )
 
 bzl_library(
     name = "library",
     srcs = ["library.bzl"],
+    visibility = ["//go:__subpackages__"],
     deps = [
         "@io_bazel_rules_go//go/private:common",
         "@io_bazel_rules_go//go/private:context",
@@ -41,6 +45,7 @@ bzl_library(
 bzl_library(
     name = "nogo",
     srcs = ["nogo.bzl"],
+    visibility = ["//go:__subpackages__"],
     deps = [
         "@io_bazel_rules_go//go/private:context",
         "@io_bazel_rules_go//go/private:providers",
@@ -51,12 +56,14 @@ bzl_library(
 bzl_library(
     name = "sdk",
     srcs = ["sdk.bzl"],
+    visibility = ["//go:__subpackages__"],
     deps = ["@io_bazel_rules_go//go/private:providers"],
 )
 
 bzl_library(
     name = "source",
     srcs = ["source.bzl"],
+    visibility = ["//go:__subpackages__"],
     deps = [
         "@io_bazel_rules_go//go/private:context",
         "@io_bazel_rules_go//go/private:providers",
@@ -66,45 +73,52 @@ bzl_library(
 bzl_library(
     name = "stdlib",
     srcs = ["stdlib.bzl"],
+    visibility = ["//go:__subpackages__"],
     deps = [
-        ":context",
-        ":providers",
+        "@io_bazel_rules_go//go/private:context",
+        "@io_bazel_rules_go//go/private:providers",
     ],
 )
 
 bzl_library(
     name = "test",
     srcs = ["test.bzl"],
+    visibility = ["//go:__subpackages__"],
     deps = [
-        ":binary",
-        ":common",
-        ":context",
-        ":mode",
-        ":providers",
-        ":transition",
         "@bazel_skylib//lib:structs",
+        "@io_bazel_rules_go//go/private:common",
+        "@io_bazel_rules_go//go/private:context",
+        "@io_bazel_rules_go//go/private:mode",
+        "@io_bazel_rules_go//go/private:providers",
+        "@io_bazel_rules_go//go/private/rules:binary",
+        "@io_bazel_rules_go//go/private/rules:transition",
     ],
 )
 
 bzl_library(
     name = "transition",
     srcs = ["transition.bzl"],
-    deps = [
-        ":mode",
-        ":platforms",
-        ":providers",
-        "@io_bazel_rules_go_name_hack//:def",
+    visibility = [
+        "//go:__subpackages__",
+        "//proto:__pkg__",
     ],
+    # Don't list dependency on @io_bazel_rules_go_name_hack//:def
+    deps = [
+        "@io_bazel_rules_go//go/private:mode",
+        "@io_bazel_rules_go//go/private:platforms",
+        "@io_bazel_rules_go//go/private:providers",
+    ],  # keep
 )
 
 bzl_library(
     name = "wrappers",
     srcs = ["wrappers.bzl"],
+    visibility = ["//go:__subpackages__"],
     deps = [
-        ":binary",
-        ":cgo",
-        ":library",
-        ":test",
-        ":transition",
+        "@io_bazel_rules_go//go/private/rules:binary",
+        "@io_bazel_rules_go//go/private/rules:cgo",
+        "@io_bazel_rules_go//go/private/rules:library",
+        "@io_bazel_rules_go//go/private/rules:test",
+        "@io_bazel_rules_go//go/private/rules:transition",
     ],
 )

--- a/go/private/rules/BUILD.bazel
+++ b/go/private/rules/BUILD.bazel
@@ -1,0 +1,110 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "binary",
+    srcs = ["binary.bzl"],
+    deps = [
+        ":common",
+        ":context",
+        ":mode",
+        ":providers",
+        ":rules/transition",
+    ],
+)
+
+bzl_library(
+    name = "cgo",
+    srcs = ["cgo.bzl"],
+    deps = [
+        "@io_bazel_rules_go//go/private:common",
+        "@io_bazel_rules_go//go/private:mode",
+        "@rules_cc//cc:defs",
+    ],
+)
+
+bzl_library(
+    name = "info",
+    srcs = ["info.bzl"],
+    deps = ["//go/private:context"],
+)
+
+bzl_library(
+    name = "library",
+    srcs = ["library.bzl"],
+    deps = [
+        "@io_bazel_rules_go//go/private:common",
+        "@io_bazel_rules_go//go/private:context",
+        "@io_bazel_rules_go//go/private:providers",
+    ],
+)
+
+bzl_library(
+    name = "nogo",
+    srcs = ["nogo.bzl"],
+    deps = [
+        "@io_bazel_rules_go//go/private:context",
+        "@io_bazel_rules_go//go/private:providers",
+        "@io_bazel_rules_go//go/private/rules:transition",
+    ],
+)
+
+bzl_library(
+    name = "sdk",
+    srcs = ["sdk.bzl"],
+    deps = ["@io_bazel_rules_go//go/private:providers"],
+)
+
+bzl_library(
+    name = "source",
+    srcs = ["source.bzl"],
+    deps = [
+        "@io_bazel_rules_go//go/private:context",
+        "@io_bazel_rules_go//go/private:providers",
+    ],
+)
+
+bzl_library(
+    name = "stdlib",
+    srcs = ["stdlib.bzl"],
+    deps = [
+        ":context",
+        ":providers",
+    ],
+)
+
+bzl_library(
+    name = "test",
+    srcs = ["test.bzl"],
+    deps = [
+        ":binary",
+        ":common",
+        ":context",
+        ":mode",
+        ":providers",
+        ":transition",
+        "@bazel_skylib//lib:structs",
+    ],
+)
+
+bzl_library(
+    name = "transition",
+    srcs = ["transition.bzl"],
+    deps = [
+        ":mode",
+        ":platforms",
+        ":providers",
+        "@io_bazel_rules_go_name_hack//:def",
+    ],
+)
+
+bzl_library(
+    name = "wrappers",
+    srcs = ["wrappers.bzl"],
+    deps = [
+        ":binary",
+        ":cgo",
+        ":library",
+        ":test",
+        ":transition",
+    ],
+)

--- a/go/private/rules/BUILD.bazel
+++ b/go/private/rules/BUILD.bazel
@@ -1,5 +1,18 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
+filegroup(
+    name = "all_rules",
+    srcs = glob(["**/*.bzl"]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)
+
 bzl_library(
     name = "binary",
     srcs = ["binary.bzl"],

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -13,26 +13,26 @@
 # limitations under the License.
 
 load(
-    ":context.bzl",
+    "@io_bazel_rules_go//go/private:context.bzl",
     "go_context",
 )
 load(
-    ":common.bzl",
+    "//go/private:common.bzl",
     "asm_exts",
     "cgo_exts",
     "go_exts",
 )
 load(
-    ":providers.bzl",
+    "//go/private:providers.bzl",
     "GoLibrary",
     "GoSDK",
 )
 load(
-    ":rules/transition.bzl",
+    "//go/private/rules:transition.bzl",
     "go_transition_rule",
 )
 load(
-    ":mode.bzl",
+    "@io_bazel_rules_go//go/private:mode.bzl",
     "LINKMODE_PLUGIN",
     "LINKMODE_SHARED",
 )

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load(
-    "@io_bazel_rules_go//go/private:context.bzl",
+    "//go/private:context.bzl",
     "go_context",
 )
 load(
@@ -32,7 +32,7 @@ load(
     "go_transition_rule",
 )
 load(
-    "@io_bazel_rules_go//go/private:mode.bzl",
+    "//go/private:mode.bzl",
     "LINKMODE_PLUGIN",
     "LINKMODE_SHARED",
 )

--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 load(
-    "@io_bazel_rules_go//go/private:common.bzl",
+    "//go/private:common.bzl",
     "as_iterable",
     "has_simple_shared_lib_extension",
     "has_versioned_shared_lib_extension",
 )
 load(
-    "@io_bazel_rules_go//go/private:mode.bzl",
+    "//go/private:mode.bzl",
     "LINKMODE_C_ARCHIVE",
     "LINKMODE_C_SHARED",
     "LINKMODE_NORMAL",

--- a/go/private/rules/library.bzl
+++ b/go/private/rules/library.bzl
@@ -13,17 +13,17 @@
 # limitations under the License.
 
 load(
-    "@io_bazel_rules_go//go/private:common.bzl",
+    "//go/private:common.bzl",
     "asm_exts",
     "cgo_exts",
     "go_exts",
 )
 load(
-    "@io_bazel_rules_go//go/private:context.bzl",
+    "//go/private:context.bzl",
     "go_context",
 )
 load(
-    "@io_bazel_rules_go//go/private:providers.bzl",
+    "//go/private:providers.bzl",
     "GoLibrary",
     "INFERRED_PATH",
 )

--- a/go/private/rules/nogo.bzl
+++ b/go/private/rules/nogo.bzl
@@ -13,18 +13,18 @@
 # limitations under the License.
 
 load(
-    "@io_bazel_rules_go//go/private:context.bzl",
+    "//go/private:context.bzl",
     "go_context",
 )
 load(
-    "@io_bazel_rules_go//go/private:providers.bzl",
+    "//go/private:providers.bzl",
     "EXPORT_PATH",
     "GoArchive",
     "GoLibrary",
     "get_archive",
 )
 load(
-    "@io_bazel_rules_go//go/private/rules:transition.bzl",
+    "//go/private/rules:transition.bzl",
     "go_reset_transition",
 )
 

--- a/go/private/rules/nogo.bzl
+++ b/go/private/rules/nogo.bzl
@@ -24,7 +24,7 @@ load(
     "get_archive",
 )
 load(
-    "@io_bazel_rules_go//go/private:rules/transition.bzl",
+    "@io_bazel_rules_go//go/private/rules:transition.bzl",
     "go_reset_transition",
 )
 

--- a/go/private/rules/sdk.bzl
+++ b/go/private/rules/sdk.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load(
-    "@io_bazel_rules_go//go/private:providers.bzl",
+    "//go/private:providers.bzl",
     "GoSDK",
 )
 

--- a/go/private/rules/source.bzl
+++ b/go/private/rules/source.bzl
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 load(
-    "@io_bazel_rules_go//go/private:context.bzl",
+    "//go/private:context.bzl",
     "go_context",
 )
 load(
-    "@io_bazel_rules_go//go/private:providers.bzl",
+    "//go/private:providers.bzl",
     "GoLibrary",
 )
 

--- a/go/private/rules/stdlib.bzl
+++ b/go/private/rules/stdlib.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load(
-    "@io_bazel_rules_go//go/private:context.bzl",
+    "//go/private:context.bzl",
     "go_context",
 )
 load(

--- a/go/private/rules/stdlib.bzl
+++ b/go/private/rules/stdlib.bzl
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 load(
-    ":context.bzl",
+    "@io_bazel_rules_go//go/private:context.bzl",
     "go_context",
 )
 load(
-    ":providers.bzl",
+    "//go/private:providers.bzl",
     "CgoContextInfo",
     "GoConfigInfo",
 )

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load(
-    "@io_bazel_rules_go//go/private:context.bzl",
+    "//go/private:context.bzl",
     "go_context",
 )
 load(
@@ -41,7 +41,7 @@ load(
     "go_transition_rule",
 )
 load(
-    "@io_bazel_rules_go//go/private:mode.bzl",
+    "//go/private:mode.bzl",
     "LINKMODE_NORMAL",
 )
 load(

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -25,7 +25,7 @@ load(
     "split_srcs",
 )
 load(
-    ":rules/binary.bzl",
+    "//go/private/rules:binary.bzl",
     "gc_linkopts",
 )
 load(
@@ -37,7 +37,7 @@ load(
     "get_archive",
 )
 load(
-    ":rules/transition.bzl",
+    "//go/private/rules:transition.bzl",
     "go_transition_rule",
 )
 load(

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 load(
-    ":context.bzl",
+    "@io_bazel_rules_go//go/private:context.bzl",
     "go_context",
 )
 load(
-    ":common.bzl",
+    "//go/private:common.bzl",
     "asm_exts",
     "cgo_exts",
     "go_exts",
@@ -29,7 +29,7 @@ load(
     "gc_linkopts",
 )
 load(
-    ":providers.bzl",
+    "//go/private:providers.bzl",
     "GoArchive",
     "GoLibrary",
     "GoSource",
@@ -41,7 +41,7 @@ load(
     "go_transition_rule",
 )
 load(
-    ":mode.bzl",
+    "@io_bazel_rules_go//go/private:mode.bzl",
     "LINKMODE_NORMAL",
 )
 load(

--- a/go/private/rules/transition.bzl
+++ b/go/private/rules/transition.bzl
@@ -13,17 +13,17 @@
 # limitations under the License.
 
 load(
-    ":mode.bzl",
+    "@io_bazel_rules_go//go/private:mode.bzl",
     "LINKMODES",
     "LINKMODE_NORMAL",
 )
 load(
-    ":platforms.bzl",
+    "@io_bazel_rules_go//go/private:platforms.bzl",
     "CGO_GOOS_GOARCH",
     "GOOS_GOARCH",
 )
 load(
-    ":providers.bzl",
+    "//go/private:providers.bzl",
     "GoArchive",
     "GoLibrary",
     "GoSource",

--- a/go/private/rules/transition.bzl
+++ b/go/private/rules/transition.bzl
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 load(
-    "@io_bazel_rules_go//go/private:mode.bzl",
+    "//go/private:mode.bzl",
     "LINKMODES",
     "LINKMODE_NORMAL",
 )
 load(
-    "@io_bazel_rules_go//go/private:platforms.bzl",
+    "//go/private:platforms.bzl",
     "CGO_GOOS_GOARCH",
     "GOOS_GOARCH",
 )

--- a/go/private/rules/wrappers.bzl
+++ b/go/private/rules/wrappers.bzl
@@ -13,25 +13,25 @@
 # limitations under the License.
 
 load(
-    ":rules/library.bzl",
+    "//go/private/rules:library.bzl",
     "go_library",
 )
 load(
-    ":rules/binary.bzl",
+    "//go/private/rules:binary.bzl",
     "go_binary",
     "go_transition_binary",
 )
 load(
-    ":rules/test.bzl",
+    "//go/private/rules:test.bzl",
     "go_test",
     "go_transition_test",
 )
 load(
-    ":rules/cgo.bzl",
+    "//go/private/rules:cgo.bzl",
     "go_binary_c_archive_shared",
 )
 load(
-    ":rules/transition.bzl",
+    "//go/private/rules:transition.bzl",
     "go_transition_wrapper",
 )
 

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -13,25 +13,25 @@
 # limitations under the License.
 
 load(
-    "@io_bazel_rules_go//go/private:common.bzl",
+    "//go/private:common.bzl",
     "executable_path",
 )
 load(
-    "@io_bazel_rules_go//go/private:nogo.bzl",
+    "//go/private:nogo.bzl",
     "go_register_nogo",
 )
 load(
-    "@io_bazel_rules_go//go/private:sdk_list.bzl",
+    "//go/private:sdk_list.bzl",
     "DEFAULT_VERSION",
     "MIN_SUPPORTED_VERSION",
     "SDK_REPOSITORIES",
 )
 load(
-    "@io_bazel_rules_go//go/private:platforms.bzl",
+    "//go/private:platforms.bzl",
     "generate_toolchain_names",
 )
 load(
-    "@io_bazel_rules_go//go/private/skylib/lib:versions.bzl",
+    "//go/private/skylib/lib:versions.bzl",
     "versions",
 )
 

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -31,7 +31,7 @@ load(
     "generate_toolchain_names",
 )
 load(
-    "@io_bazel_rules_go//go/private:skylib/lib/versions.bzl",
+    "@io_bazel_rules_go//go/private/skylib/lib:versions.bzl",
     "versions",
 )
 

--- a/go/private/skylib/lib/BUILD.bazel
+++ b/go/private/skylib/lib/BUILD.bazel
@@ -1,0 +1,6 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "versions",
+    srcs = ["versions.bzl"],
+)

--- a/go/private/skylib/lib/BUILD.bazel
+++ b/go/private/skylib/lib/BUILD.bazel
@@ -3,4 +3,5 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 bzl_library(
     name = "versions",
     srcs = ["versions.bzl"],
+    visibility = ["//go:__subpackages__"],
 )

--- a/go/private/skylib/lib/BUILD.bazel
+++ b/go/private/skylib/lib/BUILD.bazel
@@ -1,5 +1,18 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
+filegroup(
+    name = "all_rules",
+    srcs = glob(["**/*.bzl"]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)
+
 bzl_library(
     name = "versions",
     srcs = ["versions.bzl"],

--- a/go/private/tools/BUILD.bazel
+++ b/go/private/tools/BUILD.bazel
@@ -3,6 +3,7 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 bzl_library(
     name = "path",
     srcs = ["path.bzl"],
+    visibility = ["//go:__subpackages__"],
     deps = [
         "@io_bazel_rules_go//go/private:common",
         "@io_bazel_rules_go//go/private:providers",

--- a/go/private/tools/BUILD.bazel
+++ b/go/private/tools/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "path",
+    srcs = ["path.bzl"],
+    deps = [
+        "@io_bazel_rules_go//go/private:common",
+        "@io_bazel_rules_go//go/private:providers",
+    ],
+)

--- a/go/private/tools/BUILD.bazel
+++ b/go/private/tools/BUILD.bazel
@@ -1,5 +1,18 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
+filegroup(
+    name = "all_rules",
+    srcs = glob(["**/*.bzl"]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)
+
 bzl_library(
     name = "path",
     srcs = ["path.bzl"],

--- a/go/private/tools/lines_sorted_test.bzl
+++ b/go/private/tools/lines_sorted_test.bzl
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_go//go/private/tools:files_equal_test.bzl", "files_equal_test")
+load("//go/private/tools:files_equal_test.bzl", "files_equal_test")
 
 def lines_sorted_test(name, file, cmd = "cat $< >$@", visibility = None, **kwargs):
     """Tests that lines within a file are sorted."""

--- a/go/private/tools/lines_sorted_test.bzl
+++ b/go/private/tools/lines_sorted_test.bzl
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_go//go/private:tools/files_equal_test.bzl", "files_equal_test")
+load("@io_bazel_rules_go//go/private/tools:files_equal_test.bzl", "files_equal_test")
 
 def lines_sorted_test(name, file, cmd = "cat $< >$@", visibility = None, **kwargs):
     """Tests that lines within a file are sorted."""

--- a/go/private/tools/path.bzl
+++ b/go/private/tools/path.bzl
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 load(
-    "@io_bazel_rules_go//go/private:providers.bzl",
+    "//go/private:providers.bzl",
     "GoArchive",
     "GoPath",
     "effective_importpath_pkgpath",
     "get_archive",
 )
 load(
-    "@io_bazel_rules_go//go/private:common.bzl",
+    "//go/private:common.bzl",
     "as_iterable",
     "as_list",
 )

--- a/go/toolchain/BUILD.bazel
+++ b/go/toolchain/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(
     ":toolchains.bzl",
     "declare_constraints",
@@ -18,4 +19,14 @@ filegroup(
     testonly = True,
     srcs = glob(["**"]),
     visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "toolchains",
+    srcs = ["toolchains.bzl"],
+    deps = [
+        "@io_bazel_rules_go//go/private:platforms",
+        "@io_bazel_rules_go//go/private:sdk",
+        "@io_bazel_rules_go//go/private:sdk_list",
+    ],
 )

--- a/go/tools/bazel_testing/BUILD.bazel
+++ b/go/tools/bazel_testing/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
@@ -22,4 +23,11 @@ alias(
     name = "go_default_library",
     actual = ":bazel_testing",
     visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "def",
+    srcs = ["def.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@io_bazel_rules_go//go:def"],
 )

--- a/go/tools/bazel_testing/def.bzl
+++ b/go/tools/bazel_testing/def.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("//go:def.bzl", "go_test")
 
 def go_bazel_test(rule_files = None, **kwargs):
     """go_bazel_test is a wrapper for go_test that simplifies the use of

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//go:def.bzl", "go_binary", "go_source", "go_test")
-load("//go/private:rules/transition.bzl", "go_reset_target")
+load("//go/private/rules:transition.bzl", "go_reset_target")
 
 go_test(
     name = "filter_test",

--- a/go/tools/coverdata/BUILD.bazel
+++ b/go/tools/coverdata/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go/private:rules/library.bzl", "go_tool_library")
+load("@io_bazel_rules_go//go/private/rules:library.bzl", "go_tool_library")
 
 go_tool_library(
     name = "coverdata",

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -140,12 +140,12 @@ bzl_library(
     name = "def",
     srcs = ["def.bzl"],
     visibility = ["//visibility:public"],
+    # Don't list dependency on @rules_proto//proto:defs
     deps = [
         "//go:def",
         "@io_bazel_rules_go//go/private:providers",
         "@io_bazel_rules_go//proto:compiler",
-        "@rules_proto//proto:defs",
-    ],
+    ],  # keep
 )
 
 bzl_library(

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(
     "//proto:compiler.bzl",
     "go_proto_compiler",
@@ -122,4 +123,33 @@ filegroup(
     testonly = True,
     srcs = glob(["**"]) + ["//proto/wkt:all_files"],
     visibility = ["//:__subpackages__"],
+)
+
+bzl_library(
+    name = "compiler",
+    srcs = ["compiler.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//go:def",
+        "//go/private/rules:transition",
+        "@bazel_skylib//lib:paths",
+    ],
+)
+
+bzl_library(
+    name = "def",
+    srcs = ["def.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//go:def",
+        "@io_bazel_rules_go//go/private:providers",
+        "@io_bazel_rules_go//proto:compiler",
+        "@rules_proto//proto:defs",
+    ],
+)
+
+bzl_library(
+    name = "gogo",
+    srcs = ["gogo.bzl"],
+    visibility = ["//visibility:public"],
 )

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -22,7 +22,7 @@ load(
     "go_context",
 )
 load(
-    "//go/private:rules/transition.bzl",
+    "//go/private/rules:transition.bzl",
     "go_reset_target",
 )
 

--- a/proto/wkt/BUILD.bazel
+++ b/proto/wkt/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(":well_known_types.bzl", "go_proto_wrapper")
 load("//proto:def.bzl", "go_proto_library")
 
@@ -175,4 +176,15 @@ filegroup(
     testonly = True,
     srcs = glob(["**"]),
     visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "well_known_types",
+    srcs = ["well_known_types.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//go:def",
+        "//proto:compiler",
+        "//proto:def",
+    ],
 )

--- a/tests/core/starlark/common_tests.bzl
+++ b/tests/core/starlark/common_tests.bzl
@@ -1,5 +1,5 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load("@io_bazel_rules_go//go/private:common.bzl", "has_shared_lib_extension")
+load("//go/private:common.bzl", "has_shared_lib_extension")
 
 def _versioned_shared_libraries_test(ctx):
     env = unittest.begin(ctx)

--- a/tests/core/stdlib/stdlib_files.bzl
+++ b/tests/core/stdlib/stdlib_files.bzl
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_go//go:def.bzl", "go_context")
-load("@io_bazel_rules_go//go/private:providers.bzl", "GoStdLib")
+load("//go:def.bzl", "go_context")
+load("//go/private:providers.bzl", "GoStdLib")
 
 def _pure_transition_impl(settings, attr):
     return {"//go/config:pure": True}

--- a/tests/legacy/binary_test_outputs/BUILD.bazel
+++ b/tests/legacy/binary_test_outputs/BUILD.bazel
@@ -2,7 +2,7 @@
 # See documentation in single_output_test.bzl.
 
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_test")
-load("@io_bazel_rules_go//go/private:tools/single_output_test.bzl", "single_output_test")
+load("@io_bazel_rules_go//go/private/tools:single_output_test.bzl", "single_output_test")
 
 single_output_test(
     name = "binary_single_output_test",


### PR DESCRIPTION
There are a few minor manual modifications that needed to be performed.
For example, some `.bzl` files depend on `.bzl` files that are generated
outside of this repo and do not presently exist. `@bazel_tools` is a
great example of this.

Additionally this effort has revealed that bazel gazelle has an explicit
dependency on the private parts of rules_go in
internal/gazelle_binary.bzl on line 21 where it imports from
`go/private:rules/transitions.bzl` which is no longer the path to import
from once I created the BUILD file in `go/private/rules`.

As a temporary fix for this, I'm included a patch that changes that to
point to the new path. I will provide a follow up patch once rules_go
has been released to fix it properly in the gazelle repo and then remove
the patch from rules_go.

Fixed: https://github.com/bazelbuild/rules_go/issues/2619
Bug: https://github.com/bazelbuild/bazel-skylib/issues/250
Bug: https://github.com/bazelbuild/bazel-gazelle/issues/803


**What type of PR is this?**

> Uncomment one line below and remove others.

Feature

**What does this PR do? Why is it needed?**

Adds a tree of `bzl_library` targets (generated by Gazelle with only small hand modifications for a few places where their deps don't actually exist).

**Which issues(s) does this PR fix?**

Fixes #2619

**Other notes for review**

This was great feedback for a couple of features that need to be added to the gazelle generator for `bzl_library`