### PR TITLE
go_test: pass cdeps files to linker after split test recompilation

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -167,6 +167,7 @@ def emit_archive(go, source = None, _recompile_suffix = ""):
         file = out_lib,
         export_file = out_export,
         data_files = as_tuple(data_files),
+        _cgo_deps = as_tuple(cgo_deps),
     )
     x_defs = dict(source.x_defs)
     for a in direct:

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -422,7 +422,7 @@ def _recompile_external_deps(go, external_source, internal_archive, library_labe
                 libs = depset(direct = [arc_data.file], transitive = [a.libs for a in deps]),
                 transitive = depset(direct = [arc_data], transitive = [a.transitive for a in deps]),
                 x_defs = source.x_defs,
-                cgo_deps = depset(),  # deprecated, not used
+                cgo_deps = depset(direct = arc_data._cgo_deps, transitive = [a.cgo_deps for a in deps]),
                 cgo_exports = depset(direct = list(source.cgo_exports), transitive = [a.cgo_exports for a in deps]),
                 runfiles = source.runfiles,
                 mode = go.mode,

--- a/tests/core/cgo/BUILD.bazel
+++ b/tests/core/cgo/BUILD.bazel
@@ -225,3 +225,43 @@ cc_library(
     name = "cgo_link_dep",
     srcs = ["cgo_link_dep.c"],
 )
+
+go_test(
+    name = "split_import_test",
+    srcs = [
+        "split_import_i_test.go",
+        "split_import_x_test.go",
+    ],
+    embed = [":split_import_a"],
+    deps = [":split_import_b"],
+)
+
+go_library(
+    name = "split_import_a",
+    srcs = ["split_import_a.go"],
+    importpath = "github.com/bazelbuild/rules_go/tests/core/cgo/split_import/a",
+)
+
+go_library(
+    name = "split_import_b",
+    srcs = ["split_import_b.go"],
+    importpath = "github.com/bazelbuild/rules_go/tests/core/cgo/split_import/b",
+    deps = [
+        ":split_import_a",
+        ":split_import_cgo",
+    ],
+)
+
+go_library(
+    name = "split_import_cgo",
+    srcs = ["split_import_cgo.go"],
+    cdeps = [":split_import_c"],
+    cgo = True,
+    importpath = "github.com/bazelbuild/rules_go/tests/core/cgo/split_import/cgo",
+)
+
+cc_library(
+    name = "split_import_c",
+    srcs = ["split_import_c.c"],
+    hdrs = ["split_import_c.h"],
+)

--- a/tests/core/cgo/README.rst
+++ b/tests/core/cgo/README.rst
@@ -1,4 +1,5 @@
 .. _#2067: https://github.com/bazelbuild/rules_go/issues/2067
+.. _#2622: https://github.com/bazelbuild/rules_go/issues/2622
 
 Basic cgo functionality
 =======================
@@ -52,3 +53,10 @@ cdeps_link_test
 
 Checks that libraries in ``cdeps`` are linked into the generated ``_cgo_.o``
 executable used to produce ``_cgo_imports.go``. Verifies `#2067`_.
+
+split_import_test
+-----------------
+
+Checks that when a package with ``cdeps`` is recompiled due to a split test,
+the input files from ``cdeps`` are included in the recompilation and are passed
+to the linker. Verifies `#2622`_.

--- a/tests/core/cgo/split_import_a.go
+++ b/tests/core/cgo/split_import_a.go
@@ -1,0 +1,3 @@
+package a
+
+func Answer() int { return 42 }

--- a/tests/core/cgo/split_import_b.go
+++ b/tests/core/cgo/split_import_b.go
@@ -1,0 +1,10 @@
+package b
+
+import (
+	"github.com/bazelbuild/rules_go/tests/core/cgo/split_import/a"
+	"github.com/bazelbuild/rules_go/tests/core/cgo/split_import/cgo"
+)
+
+func HalfAnswer() int {
+	return cgo.Half(a.Answer())
+}

--- a/tests/core/cgo/split_import_c.c
+++ b/tests/core/cgo/split_import_c.c
@@ -1,0 +1,2 @@
+int half(int x) { return x/2; }
+

--- a/tests/core/cgo/split_import_c.h
+++ b/tests/core/cgo/split_import_c.h
@@ -1,0 +1,6 @@
+#ifndef split_import_c
+#define split_import_c
+
+int half(int);
+
+#endif

--- a/tests/core/cgo/split_import_cgo.go
+++ b/tests/core/cgo/split_import_cgo.go
@@ -1,0 +1,10 @@
+package cgo
+
+/*
+#include "tests/core/cgo/split_import_c.h"
+*/
+import "C"
+
+func Half(x int) int {
+	return int(C.half(C.int(x)))
+}

--- a/tests/core/cgo/split_import_i_test.go
+++ b/tests/core/cgo/split_import_i_test.go
@@ -1,0 +1,9 @@
+package a
+
+import "testing"
+
+func TestInternal(t *testing.T) {
+	if Answer() != 42 {
+		t.Error("wrong answer")
+	}
+}

--- a/tests/core/cgo/split_import_x_test.go
+++ b/tests/core/cgo/split_import_x_test.go
@@ -1,0 +1,13 @@
+package a_test
+
+import (
+	"testing"
+
+	"github.com/bazelbuild/rules_go/tests/core/cgo/split_import/b"
+)
+
+func TestExternal(t *testing.T) {
+	if b.HalfAnswer() != 21 {
+		t.Error("wrong answer")
+	}
+}


### PR DESCRIPTION
When a test contains both internal and external files, and the
external files indirectly import the library under test, some package
need to be recompiled so that the packages that import the library
under test are compiled with the internal test archive instead. This
was implemented in #2579.

That change caused a regression: the recompiled archives didn't
include input files from cdeps dependencies. This change adds a new
GoArchiveData field to track direct dependencies. That can be used to
rebuild a depset of all the needed files.

Fixes #2622
