### PR TITLE
Use absolute paths in GoPath builder (mainly for Windows compatibility)

### DIFF
--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -69,7 +69,11 @@ go_source(
 
 go_binary(
     name = "go_path",
-    srcs = ["go_path.go"],
+    srcs = [
+        "env.go",
+        "flags.go",
+        "go_path.go"
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -72,7 +72,7 @@ go_binary(
     srcs = [
         "env.go",
         "flags.go",
-        "go_path.go"
+        "go_path.go",
     ],
     visibility = ["//visibility:public"],
 )

--- a/go/tools/builders/go_path.go
+++ b/go/tools/builders/go_path.go
@@ -125,7 +125,7 @@ func archivePath(out string, manifest []manifestEntry) (err error) {
 	outZip := zip.NewWriter(outFile)
 
 	for _, entry := range manifest {
-		srcFile, err := os.Open(entry.Src)
+		srcFile, err := os.Open(abs(filepath.FromSlash(entry.Src)))
 		if err != nil {
 			return err
 		}
@@ -158,7 +158,7 @@ func copyPath(out string, manifest []manifestEntry) error {
 		if err := os.MkdirAll(filepath.Dir(dst), 0777); err != nil {
 			return err
 		}
-		srcFile, err := os.Open(entry.Src)
+		srcFile, err := os.Open(abs(filepath.FromSlash(entry.Src)))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Windows has a limit of 256 characters for relative characters when using the syscalls the Go standard library uses. In a Bazel project I encountered recently I couldn't run the GoPath builder because of an `google.golang.org/grpc` dependency that included the file `bazel-out\x64_windows-fastbuild\bin\external\org_golang_google_grpc\reflection\grpc_reflection_v1alpha\grpc_reflection_v1alpha_go_proto_\google.golang.org\grpc\reflection\grpc_reflection_v1alpha\reflection.pb.go`, which even with my very short bazel root of `C:\tmp\bzl` was too long to open, and resulted in the error message `GoPath: open bazel-out\x64_windows-fastbuild\bin\external\org_golang_google_grpc\reflection\grpc_reflection_v1alpha\grpc_reflection_v1alpha_go_proto_\google.golang.org\grpc\reflection\grpc_reflection_v1alpha\reflection.pb.go: The system cannot find the path specified.` (pasting verbatim so people googling it can find it)

Using abs() and FromSlash() like in other builders fixes this issue.
