### PR TITLE
archive: use library's name for archive name

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -56,10 +56,10 @@ def emit_archive(go, source = None, _recompile_suffix = ""):
         pre_ext = ".external"
     if _recompile_suffix:
         pre_ext += _recompile_suffix
-    out_lib = go.declare_file(go, ext = pre_ext + ".a")
+    out_lib = go.declare_file(go, name = source.library.name, ext = pre_ext + ".a")
 
     # store __.PKGDEF and nogo facts in .x
-    out_export = go.declare_file(go, ext = pre_ext + ".x")
+    out_export = go.declare_file(go, name = source.library.name, ext = pre_ext + ".x")
     out_cgo_export_h = None  # set if cgo used in c-shared or c-archive mode
 
     direct = [get_archive(dep) for dep in source.deps]


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

If a custom Go rule generates more than one library, or otherwise
changes the name of the GoLibrary, the emitted archive will still have
the _ctx.label.name. To deconflict, use the library's name as the
emitted archive's name.

In the normal case, this is already the default, so it shouldn't hurt.

In the [very work in progress PR here](https://github.com/u-root/gobusybox/pull/23/files) I create an aspect that applies to go_binary rules. It takes either its srcs, or every embed'ed library's sources and rewrites them such that the go_binary is importable as a go_library. (The transformation is documented [here](https://github.com/u-root/gobusybox#command-transformation).)

This means every go_binary this is applied to generates 2 of GoLibrary, GoSource, and GoArchive. The aspect, of course, groups them into a new aspect (GoBusyboxLibrary) since the rule itself cannot return more than one aspect.