### PR TITLE
go: use "shell" params file format instead of "multiline"

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -128,7 +128,7 @@ def _new_args(go):
 def _builder_args(go, command = None):
     args = go.actions.args()
     args.use_param_file("-param=%s")
-    args.set_param_file_format("multiline")
+    args.set_param_file_format("shell")
     if command:
         args.add(command)
     args.add("-sdk", go.sdk.root_file.dirname)

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -139,7 +139,7 @@ def _builder_args(go, command = None):
 def _tool_args(go):
     args = go.actions.args()
     args.use_param_file("-param=%s")
-    args.set_param_file_format("multiline")
+    args.set_param_file_format("shell")
     return args
 
 def _new_library(go, name = None, importpath = None, resolver = None, importable = True, testfilter = None, is_main = False, **kwargs):

--- a/go/tools/builders/asm.go
+++ b/go/tools/builders/asm.go
@@ -30,7 +30,7 @@ import (
 // Go rules as an action.
 func asm(args []string) error {
 	// Parse arguments.
-	args, err := readParamsFiles(args)
+	args, err := expandParamsFiles(args)
 	if err != nil {
 		return err
 	}

--- a/go/tools/builders/builder.go
+++ b/go/tools/builders/builder.go
@@ -28,7 +28,7 @@ func main() {
 	log.SetFlags(0)
 	log.SetPrefix("builder: ")
 
-	args, err := readParamsFiles(os.Args[1:])
+	args, err := expandParamsFiles(os.Args[1:])
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/go/tools/builders/compile.go
+++ b/go/tools/builders/compile.go
@@ -29,7 +29,7 @@ import (
 
 func compile(args []string) error {
 	// Parse arguments.
-	args, err := readParamsFiles(args)
+	args, err := expandParamsFiles(args)
 	if err != nil {
 		return err
 	}

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -33,7 +33,7 @@ import (
 
 func compilePkg(args []string) error {
 	// Parse arguments.
-	args, err := readParamsFiles(args)
+	args, err := expandParamsFiles(args)
 	if err != nil {
 		return err
 	}

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -446,13 +446,12 @@ func runNogo(ctx context.Context, workDir string, nogoPath string, srcs []string
 	args = append(args, "-x", outFactsPath)
 	args = append(args, srcs...)
 
-	paramFile := filepath.Join(workDir, "nogo.param")
-	params := strings.Join(args[1:], "\n")
-	if err := ioutil.WriteFile(paramFile, []byte(params), 0666); err != nil {
-		return fmt.Errorf("error writing nogo paramfile: %v", err)
+	paramsFile := filepath.Join(workDir, "nogo.param")
+	if err := writeParamsFile(paramsFile, args[1:]); err != nil {
+		return fmt.Errorf("error writing nogo params file: %v", err)
 	}
 
-	cmd := exec.CommandContext(ctx, args[0], "-param="+paramFile)
+	cmd := exec.CommandContext(ctx, args[0], "-param="+paramsFile)
 	out := &bytes.Buffer{}
 	cmd.Stdout, cmd.Stderr = out, out
 	if err := cmd.Run(); err != nil {

--- a/go/tools/builders/cover.go
+++ b/go/tools/builders/cover.go
@@ -28,7 +28,7 @@ import (
 // cover transforms a source file with "go tool cover". It is invoked by the
 // Go rules as an action.
 func cover(args []string) error {
-	args, err := readParamsFiles(args)
+	args, err := expandParamsFiles(args)
 	if err != nil {
 		return err
 	}

--- a/go/tools/builders/generate_test_main.go
+++ b/go/tools/builders/generate_test_main.go
@@ -175,7 +175,7 @@ func main() {
 
 func genTestMain(args []string) error {
 	// Prepare our flags
-	args, err := readParamsFiles(args)
+	args, err := expandParamsFiles(args)
 	if err != nil {
 		return err
 	}

--- a/go/tools/builders/info.go
+++ b/go/tools/builders/info.go
@@ -24,7 +24,7 @@ import (
 )
 
 func run(args []string) error {
-	args, err := readParamsFiles(args)
+	args, err := expandParamsFiles(args)
 	if err != nil {
 		return err
 	}

--- a/go/tools/builders/link.go
+++ b/go/tools/builders/link.go
@@ -31,7 +31,7 @@ import (
 
 func link(args []string) error {
 	// Parse arguments.
-	args, err := readParamsFiles(args)
+	args, err := expandParamsFiles(args)
 	if err != nil {
 		return err
 	}

--- a/go/tools/builders/nogo_main.go
+++ b/go/tools/builders/nogo_main.go
@@ -62,7 +62,7 @@ func main() {
 // run returns an error if there is a problem loading the package or if any
 // analysis fails.
 func run(args []string) error {
-	args, err := readParamsFiles(args)
+	args, err := expandParamsFiles(args)
 	if err != nil {
 		return fmt.Errorf("error reading paramfiles: %v", err)
 	}

--- a/go/tools/builders/pack.go
+++ b/go/tools/builders/pack.go
@@ -38,7 +38,7 @@ import (
 // handle them, and ar may not be available (cpp.ar_executable is libtool
 // on darwin).
 func pack(args []string) error {
-	args, err := readParamsFiles(args)
+	args, err := expandParamsFiles(args)
 	if err != nil {
 		return err
 	}

--- a/go/tools/builders/protoc.go
+++ b/go/tools/builders/protoc.go
@@ -40,7 +40,7 @@ type genFileInfo struct {
 
 func run(args []string) error {
 	// process the args
-	args, err := readParamsFiles(args)
+	args, err := expandParamsFiles(args)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This lets arguments contain newlines.

Fixes #2635
