### PR TITLE
Redirecting all stdout of subcommands to stderr

### DIFF
--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -433,7 +433,8 @@ func compileGo(goenv *env, srcs []string, packagePath, importcfgPath, asmHdrPath
 	args = append(args, "--")
 	args = append(args, srcs...)
 	absArgs(args, []string{"-I", "-o", "-trimpath", "-importcfg"})
-	return goenv.runCommand(args)
+	// "go tool compile" writes syntax errors to stdout. Redirecting them to stderr
+	return goenv.runCommandToFile(os.Stderr, args)
 }
 
 func runNogo(ctx context.Context, workDir string, nogoPath string, srcs []string, deps []archive, packagePath, importcfgPath, outFactsPath string) error {

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -433,8 +433,7 @@ func compileGo(goenv *env, srcs []string, packagePath, importcfgPath, asmHdrPath
 	args = append(args, "--")
 	args = append(args, srcs...)
 	absArgs(args, []string{"-I", "-o", "-trimpath", "-importcfg"})
-	// "go tool compile" writes syntax errors to stdout. Redirecting them to stderr
-	return goenv.runCommandToFile(os.Stderr, args)
+	return goenv.runCommand(args)
 }
 
 func runNogo(ctx context.Context, workDir string, nogoPath string, srcs []string, deps []archive, packagePath, importcfgPath, outFactsPath string) error {

--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -131,7 +131,9 @@ func (e *env) goCmd(cmd string, args ...string) []string {
 // environment from this process.
 func (e *env) runCommand(args []string) error {
 	cmd := exec.Command(args[0], args[1:]...)
-	cmd.Stdout = os.Stdout
+	// Redirecting stdout to stderr. This mirrors behavior in the go command:
+	// https://go.googlesource.com/go/+/refs/tags/go1.15.2/src/cmd/go/internal/work/exec.go#1958
+	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 	return runAndLogCommand(cmd, e.verbose)
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
`go tool compile` writes syntax errors to [stdout](https://github.com/golang/go/blob/a3868028ac8470d1ab7782614707bb90925e7fe3/src/cmd/compile/internal/syntax/parser.go#L361), including the one reported in #2592. Meanwhile, all regular output of subcommands should have been written to files. We should direct all stdout of subcommands to stderr, so we can find all errors in stderr. This mirrors behavior in the [go command](https://go.googlesource.com/go/+/refs/tags/go1.15.2/src/cmd/go/internal/work/exec.go#1958)

