### PR TITLE
Use short_path for collisions

### DIFF
--- a/go/private/tools/path.bzl
+++ b/go/private/tools/path.bzl
@@ -180,9 +180,9 @@ def _merge_pkg(x, y):
 
 def _add_manifest_entry(entries, entry_map, inputs, src, dst):
     if dst in entry_map:
-        if entry_map[dst] != src.path:
-            fail("{}: references multiple files ({} and {})".format(dst, entry_map[dst], src.path))
+        if entry_map[dst] != src.short_path:
+            fail("{}: references multiple files ({} and {})".format(dst, entry_map[dst], src.short_path))
         return
+    entry_map[dst] = src.short_path
     entries.append(struct(src = src.path, dst = dst))
-    entry_map[dst] = src.path
     inputs.append(src)


### PR DESCRIPTION
I'm hitting an issue with "conflicting paths" in the same repo when
generating a gopath target.

It's all within a single repo: it's all the go_template_instances in the
[gVisor](https://github.com/google/gvisor) BUILD files. I believe it is
because they are included by filename instead of by target, but this
is necessary for some Go tools to work on the BUILD files.

It is happening with bazel3 and the latest versions of gazelle and
rules_go with remote execution, but does not seem to occur with
bazel2 and older versions. If this is useful, I can produce the older
versions where it's not happening.

This solution removes the problem, but I'm not sure it's right. The
two "colliding" targets are the same file, and share the same short
path. I don't think this causes issues for us, but it's not clear if this
may cause issues in some other way. Feedback is appreciated!