### PR TITLE
Exclude external repositories in Nogo

### DIFF
--- a/go/private/rules/nogo.bzl
+++ b/go/private/rules/nogo.bzl
@@ -47,6 +47,8 @@ def _nogo_impl(ctx):
     if ctx.file.config:
         nogo_args.add("-config", ctx.file.config)
         nogo_inputs.append(ctx.file.config)
+    if ctx.attr.importpath:
+        nogo_args.add("-importpath-restriction", ctx.attr.importpath)
     ctx.actions.run(
         inputs = nogo_inputs,
         outputs = [nogo_main],
@@ -91,6 +93,10 @@ nogo = rule(
         ),
         "config": attr.label(
             allow_single_file = True,
+        ),
+        "importpath": attr.string(
+            mandatory = False,
+            doc = "Restrict nogo checks to the given importpath",
         ),
         "_nogo_srcs": attr.label(
             default = "@io_bazel_rules_go//go/tools/builders:nogo_srcs",

--- a/go/tools/builders/nogo_main.go
+++ b/go/tools/builders/nogo_main.go
@@ -146,6 +146,9 @@ func readImportCfg(file string) (packageFile map[string]string, importMap map[st
 //
 // This implementation was adapted from that of golang.org/x/tools/go/checker/internal/checker.
 func checkPackage(analyzers []*analysis.Analyzer, packagePath string, packageFile, importMap map[string]string, factMap map[string]string, filenames []string) (string, []byte, error) {
+	if importPathRestriction != "" && !strings.HasPrefix(packagePath, importPathRestriction) {
+		return "", nil, nil
+	}
 	// Register fact types and establish dependencies between analyzers.
 	actions := make(map[*analysis.Analyzer]*action)
 	var visit func(a *analysis.Analyzer) *action


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Adds an attribute "importpath" to the nogo rule in order to restrict nogo to only run on a specific Go module. This way, users have the ability to not check external repositories / go libraries that are not in their control.

**Which issues(s) does this PR fix?**

Fixes #2513 

**Other notes for review**

There's no tests yet. I'm not sure where & how these would be implemented, if at all. Let me know if there's anything i can do for that.