### PR TITLE
cgo: use -I instead of -iquote for source header directories

### DIFF
--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -17,6 +17,7 @@ load(
     "as_iterable",
     "has_simple_shared_lib_extension",
     "has_versioned_shared_lib_extension",
+    "hdr_exts",
 )
 load(
     "@io_bazel_rules_go//go/private:mode.bzl",
@@ -83,8 +84,15 @@ def cgo_configure(go, srcs, cdeps, cppopts, copts, cxxopts, clinkopts):
     seen_includes = {}
     seen_quote_includes = {}
     seen_system_includes = {}
-    for f in srcs:
-        if f.basename.endswith(".h"):
+    have_hdrs = any([f.basename.endswith(ext) for f in srcs for ext in hdr_exts])
+    if have_hdrs:
+        # Add include paths for all sources so we can use include paths relative
+        # to any source file or any header file. The go command requires all
+        # sources to be in the same directory, but that's not necessarily the
+        # case here.
+        #
+        # Use -I so either <> or "" includes may be used (same as go command).
+        for f in srcs:
             _include_unique(cppopts, "-I", f.dirname, seen_includes)
 
     inputs_direct = []

--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -61,9 +61,6 @@ def cgo_configure(go, srcs, cdeps, cppopts, copts, cxxopts, clinkopts):
         fail("Go toolchain does not support cgo")
 
     cppopts = list(cppopts)
-    base_dir, _, _ = go._ctx.build_file_path.rpartition("/")
-    if base_dir:
-        cppopts.extend(["-I", base_dir])
     copts = go.cgo_tools.c_compile_options + copts
     cxxopts = go.cgo_tools.cxx_compile_options + cxxopts
     objcopts = go.cgo_tools.objc_compile_options + copts
@@ -88,7 +85,7 @@ def cgo_configure(go, srcs, cdeps, cppopts, copts, cxxopts, clinkopts):
     seen_system_includes = {}
     for f in srcs:
         if f.basename.endswith(".h"):
-            _include_unique(cppopts, "-iquote", f.dirname, seen_quote_includes)
+            _include_unique(cppopts, "-I", f.dirname, seen_includes)
 
     inputs_direct = []
     inputs_transitive = []

--- a/tests/core/cgo/add.c
+++ b/tests/core/cgo/add.c
@@ -1,4 +1,4 @@
-#include "add.h"
+#include <add.h>
 
 #if !defined(RULES_GO_C) || !defined(RULES_GO_CPP) || defined(RULES_GO_CXX)
 #error This is a C file, only RULES_GO_C and RULES_GO_CPP should be defined.


### PR DESCRIPTION
The go command uses -I for package directories, which makes
directories available for "" and <> includes. We should do the same.

We no longer use ctx.build_file_path, since that directory might not
actually provide any build files, and its value changed in Bazel
3.7.0.

Fixes #2685
