### PR TITLE
Update macOS -install_name linker flag

### DIFF
--- a/tests/core/cgo/BUILD.bazel
+++ b/tests/core/cgo/BUILD.bazel
@@ -56,7 +56,7 @@ cc_import(
 cc_binary(
     name = "libimported.dylib",
     srcs = ["imported.c"],
-    linkopts = ["-install_name @rpath/libimported.dylib"],
+    linkopts = ["-Wl,-install_name,@rpath/libimported.dylib"],
     linkshared = True,
     tags = ["manual"],
 )


### PR DESCRIPTION
**What does this PR do? Why is it needed?**

The macOS toolchain is gaining support for params files for link
commands. As part of this we're removing support for arguments with
leading `@`s. This change should be a no-op.

**Which issues(s) does this PR fix?**

Compatibility with https://github.com/bazelbuild/bazel/pull/12265