### PR TITLE
Remove reference to platforms repository

### DIFF
--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -38,21 +38,6 @@ def go_rules_dependencies(is_rules_go = False):
     if getattr(native, "bazel_version", None):
         versions.check(MINIMUM_BAZEL_VERSION, bazel_version = native.bazel_version)
 
-    # Repository of standard constraint settings and values.
-    # Bazel declares this automatically after 0.28.0, but it's better to
-    # define an explicit version.
-    _maybe(
-        http_archive,
-        name = "platforms",
-        strip_prefix = "platforms-681f1ee032566aa2d443cf0335d012925d9c58d4",
-        # master, as of 2020-08-24
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/platforms/archive/681f1ee032566aa2d443cf0335d012925d9c58d4.zip",
-            "https://github.com/bazelbuild/platforms/archive/681f1ee032566aa2d443cf0335d012925d9c58d4.zip",
-        ],
-        sha256 = "ae95e4bfcd9f66e9dc73a92cee0107fede74163f788e3deefe00f3aaae75c431",
-    )
-
     # Needed by rules_go implementation and tests.
     # We can't call bazel_skylib_workspace from here. At the moment, it's only
     # used to register unittest toolchains, which rules_go does not need.


### PR DESCRIPTION
It is better to use version that comes with bazel, because no version
bumping is needed.

Referring to a fixed version resulted in two broken downstream project:
FlatBuffers and Cloud Robotics core, which depended on rules_go version
0.20.3, which depends on an old version of platforms, whcih is missing
definitions of macos os and arm64 cpus, whcih is needed by the latest
bazel release.

**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
It won't cause seemingly unrelated downstream project failures when platforms repository is updated within bazel.

**Other notes for review**
Example failures at: https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/1746
