### PR TITLE
README.rst: use `protos` instead of `proto`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -474,7 +474,7 @@ files.
     go_proto_library(
         name = "foo_go_proto",
         importpath = "github.com/example/protos/foo_proto",
-        proto = ":foo_proto",
+        protos = [":foo_proto"],
         visibility = ["//visibility:public"],
     )
 


### PR DESCRIPTION
**What type of PR is this?**
Documentation

**What does this PR do? Why is it needed?**
The documentation for `go_proto_library` states that the `protos` attribute should be used instead of the old `proto` attribute. Updating the README might help with nudging people to use the new `protos` attribute.

**Which issues(s) does this PR fix?**
N/A

**Other notes for review**
N/A