### PR TITLE
Use use_default_shell_env whenever possible

### DIFF
--- a/go/private/actions/asm.bzl
+++ b/go/private/actions/asm.bzl
@@ -47,5 +47,10 @@ def emit_asm(
         executable = go.toolchain._builder,
         arguments = [builder_args, "--", tool_args],
         env = go.env,
+        # We may need the shell environment (potentially augmented with --action_env)
+        # to invoke protoc on Windows. If protoc was built with mingw, it probably needs
+        # .dll files in non-default locations that must be in PATH. The target configuration
+        # may not have a C compiler, so we have no idea what PATH should be.
+        use_default_shell_env = "PATH" not in go.env,
     )
     return out_obj

--- a/go/private/actions/compile.bzl
+++ b/go/private/actions/compile.bzl
@@ -87,4 +87,9 @@ def emit_compile(
         executable = go.toolchain._builder,
         arguments = [builder_args, "--", tool_args],
         env = go.env,
+        # We may need the shell environment (potentially augmented with --action_env)
+        # to invoke protoc on Windows. If protoc was built with mingw, it probably needs
+        # .dll files in non-default locations that must be in PATH. The target configuration
+        # may not have a C compiler, so we have no idea what PATH should be.
+        use_default_shell_env = "PATH" not in go.env,
     )

--- a/go/private/actions/compilepkg.bzl
+++ b/go/private/actions/compilepkg.bzl
@@ -132,6 +132,11 @@ def emit_compilepkg(
         executable = go.toolchain._builder,
         arguments = [args],
         env = go.env,
+        # We may need the shell environment (potentially augmented with --action_env)
+        # to invoke protoc on Windows. If protoc was built with mingw, it probably needs
+        # .dll files in non-default locations that must be in PATH. The target configuration
+        # may not have a C compiler, so we have no idea what PATH should be.
+        use_default_shell_env = "PATH" not in go.env,
     )
 
 def _quote_opts(opts):

--- a/go/private/actions/cover.bzl
+++ b/go/private/actions/cover.bzl
@@ -67,6 +67,11 @@ def emit_cover(go, source):
             executable = go.toolchain._builder,
             arguments = [args],
             env = go.env,
+            # We may need the shell environment (potentially augmented with --action_env)
+            # to invoke protoc on Windows. If protoc was built with mingw, it probably needs
+            # .dll files in non-default locations that must be in PATH. The target configuration
+            # may not have a C compiler, so we have no idea what PATH should be.
+            use_default_shell_env = "PATH" not in go.env,
         )
     members = structs.to_dict(source)
     members["srcs"] = covered

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -181,6 +181,11 @@ def emit_link(
         executable = go.toolchain._builder,
         arguments = [builder_args, "--", tool_args],
         env = go.env,
+        # We may need the shell environment (potentially augmented with --action_env)
+        # to invoke protoc on Windows. If protoc was built with mingw, it probably needs
+        # .dll files in non-default locations that must be in PATH. The target configuration
+        # may not have a C compiler, so we have no idea what PATH should be.
+        use_default_shell_env = "PATH" not in go.env,
     )
 
 def _extract_extldflags(gc_linkopts, extldflags):

--- a/go/private/actions/pack.bzl
+++ b/go/private/actions/pack.bzl
@@ -40,4 +40,9 @@ def emit_pack(
         executable = go.toolchain._builder,
         arguments = [args],
         env = go.env,
+        # We may need the shell environment (potentially augmented with --action_env)
+        # to invoke protoc on Windows. If protoc was built with mingw, it probably needs
+        # .dll files in non-default locations that must be in PATH. The target configuration
+        # may not have a C compiler, so we have no idea what PATH should be.
+        use_default_shell_env = "PATH" not in go.env,
     )

--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -97,6 +97,11 @@ def _build_stdlib(go):
         executable = go.toolchain._builder,
         arguments = [args],
         env = env,
+        # We may need the shell environment (potentially augmented with --action_env)
+        # to invoke protoc on Windows. If protoc was built with mingw, it probably needs
+        # .dll files in non-default locations that must be in PATH. The target configuration
+        # may not have a C compiler, so we have no idea what PATH should be.
+        use_default_shell_env = "PATH" not in env,
     )
     return GoStdLib(
         root_file = root_file,

--- a/go/private/rules/info.bzl
+++ b/go/private/rules/info.bzl
@@ -28,6 +28,7 @@ def _go_info_impl(ctx):
         mnemonic = "GoInfo",
         executable = ctx.executable._go_info,
         arguments = [args],
+        use_default_shell_env = True,
     )
     return [DefaultInfo(
         files = depset([report]),


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
Bug fix

**What does this PR do? Why is it needed?**
This PR makes all actions use use_default_shell_env when possible.
This change is needed to increase the likelyhood of cache hits from rule_go actions

Fixes https://github.com/bazelbuild/rules_go/issues/1531