### PR TITLE
Drop support for Go 1.13

### DIFF
--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -29,7 +29,7 @@ load(
     "versions",
 )
 
-MIN_SUPPORTED_VERSION = "1.13"
+MIN_SUPPORTED_VERSION = "1.14"
 
 def _go_host_sdk_impl(ctx):
     goroot = _detect_host_sdk(ctx)


### PR DESCRIPTION
Go 1.13 is no longer supported by the Go team and is not receiving
security updates.

Fixes #2728
