### PR TITLE
go_proto_library: add implicit dependencies on APIv2 packages

### DIFF
--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -7,6 +7,7 @@ load(
     "//proto/wkt:well_known_types.bzl",
     "GOGO_WELL_KNOWN_TYPE_REMAPS",
     "PROTO_RUNTIME_DEPS",
+    "WELL_KNOWN_TYPES_APIV2",
     "WELL_KNOWN_TYPE_RULES",
 )
 
@@ -19,14 +20,14 @@ go_proto_compiler(
 go_proto_compiler(
     name = "go_proto",
     visibility = ["//visibility:public"],
-    deps = PROTO_RUNTIME_DEPS + WELL_KNOWN_TYPE_RULES.values(),
+    deps = PROTO_RUNTIME_DEPS + WELL_KNOWN_TYPE_RULES.values() + WELL_KNOWN_TYPES_APIV2,
 )
 
 go_proto_compiler(
     name = "go_grpc",
     options = ["plugins=grpc"],
     visibility = ["//visibility:public"],
-    deps = PROTO_RUNTIME_DEPS + WELL_KNOWN_TYPE_RULES.values() + [
+    deps = PROTO_RUNTIME_DEPS + WELL_KNOWN_TYPE_RULES.values() + WELL_KNOWN_TYPES_APIV2 + [
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",

--- a/proto/wkt/well_known_types.bzl
+++ b/proto/wkt/well_known_types.bzl
@@ -6,6 +6,8 @@ _proto_library_suffix = "proto"
 _go_proto_library_suffix = "go_proto"
 
 # TODO: this should be private. Make sure nothing depends on it, then rename it.
+# TODO: remove after protoc 3.14 is the minimum supported version. The WKTs
+# changed their import paths in that version.
 WELL_KNOWN_TYPE_PACKAGES = {
     "any": ("github.com/golang/protobuf/ptypes/any", []),
     "api": ("google.golang.org/genproto/protobuf/api", ["source_context", "type"]),
@@ -41,6 +43,32 @@ PROTO_RUNTIME_DEPS = [
     "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
     "@org_golang_google_protobuf//runtime/protoiface:go_default_library",
     "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
+]
+
+# TODO(#2721): after com_google_protobuf 3.14 is the minimum supported version,
+# drop the implicit dependencies on WELL_KNOWN_TYPE_RULES.values() from
+# //proto/wkt:go_proto and //proto/wkt:go_grpc.
+#
+# In protobuf 3.14, the 'option go_package' declarations were changed in the
+# Well Known Types to point to the APIv2 packages. Consequently, generated
+# proto code will import APIv2 packages instead of the APIv1 packages, even
+# when the APIv1 compiler is used (which is still the default). We shouldn't
+# need the APIv1 dependencies with protobuf 3.14, but we don't know which
+# version is in use at load time. The extra packages will be compiled but not
+# linked.
+WELL_KNOWN_TYPES_APIV2 = [
+    "@org_golang_google_protobuf//types/descriptorpb",
+    "@org_golang_google_protobuf//types/known/anypb",
+    "@org_golang_google_protobuf//types/known/apipb",
+    "@org_golang_google_protobuf//types/known/durationpb",
+    "@org_golang_google_protobuf//types/known/emptypb",
+    "@org_golang_google_protobuf//types/known/fieldmaskpb",
+    "@org_golang_google_protobuf//types/known/sourcecontextpb",
+    "@org_golang_google_protobuf//types/known/structpb",
+    "@org_golang_google_protobuf//types/known/timestamppb",
+    "@org_golang_google_protobuf//types/known/typepb",
+    "@org_golang_google_protobuf//types/known/wrapperspb",
+    "@org_golang_google_protobuf//types/pluginpb",
 ]
 
 def gen_well_known_types():


### PR DESCRIPTION
Since protobuf 3.14, the Well Known Types declare APIv2 package paths,
which means generated code that imports them will import APIv2
packages.

This PR is intended to be cherry-picked to the 0.23 and 0.24 release
branches. It may slow down builds, since both APIv1 and APIv2 packages
will be compiled; we can't tell which is needed during analysis.

Fixes #2721
