### PR TITLE
go_local_sdk: more strict SDK platform detection

### DIFF
--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -252,13 +252,21 @@ def _detect_host_sdk(ctx):
     return root
 
 def _detect_sdk_platform(ctx, goroot):
-    res = ctx.execute(["ls", goroot + "/pkg/tool"])
+    path = goroot + "/pkg/tool"
+    res = ctx.execute(["ls", path])
     if res.return_code != 0:
-        fail("Could not detect SDK platform")
+        fail("Could not detect SDK platform: unable to list %s: %s" % (path, res.stderr))
+
+    platforms = []
     for f in res.stdout.strip().split("\n"):
         if f.find("_") >= 0:
-            return f
-    fail("Could not detect SDK platform")
+            platforms.append(f)
+
+    if len(platforms) == 0:
+        fail("Could not detect SDK platform: found no platforms in %s" % path)
+    if len(platforms) > 1:
+        fail("Could not detect SDK platform: found multiple platforms %s in %s" % (platforms, path))
+    return platforms[0]
 
 def _parse_versions_json(data):
     """Parses version metadata returned by golang.org.


### PR DESCRIPTION
We determine the "SDK platform" by looking at the goos_goarch
subdirectory of pkg/tool. If the goroot has actually built the toolchain
for multiple platforms, then we just pick the first one and potentially
fail cryptically later.

Ideally, we would simply register toolchains for all of the host
platforms we find, but that is likely a much larger change. Until then,
provide a much clearer error message that we don't like finding multiple
platforms.

Fixes #2764

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

When pointing a `go_local_sdk` to a toolchain with multiple platforms this improves the error from a cryptic "no matching toolchains found for types @io_bazel_rules_go//go:toolchain" to "Error in fail: Could not detect SDK platform: found multiple platforms ["darwin_amd64", "linux_amd64"] in /usr/local/google/home/mpratt/src/go/pkg/tool".

This will make it more clear that the user should delete the extra platforms. Though ideally they could either specify the platform in `go_local_sdk` or we could register _all_ of the platforms.

**Which issues(s) does this PR fix?**

Fixes #2764

**Other notes for review**
