### PR TITLE
go/tools/builders: don't format subcommand output as []byte

### DIFF
--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -137,7 +137,7 @@ func (e *env) runCommand(args []string) error {
 	cmd.Stdout = buf
 	cmd.Stderr = buf
 	err := runAndLogCommand(cmd, e.verbose)
-	fmt.Fprint(os.Stderr, relativizePaths(buf.Bytes()))
+	os.Stderr.Write(relativizePaths(buf.Bytes()))
 	return err
 }
 


### PR DESCRIPTION
Use os.Stderr.Write instead of fmt.Fprint. The latter formats the
value as a []byte, not a string.

(This was due to my own bad review comment on #2736. Sorry.)
