### PR TITLE
nogo: mention analyzer name in diagnostic output

### DIFF
--- a/tests/core/nogo/custom/custom_test.go
+++ b/tests/core/nogo/custom/custom_test.go
@@ -327,17 +327,17 @@ func Test(t *testing.T) {
 			target:      "//:has_errors",
 			wantSuccess: false,
 			includes: []string{
-				"has_errors.go:.*package fmt must not be imported",
-				"has_errors.go:.*function must not be named Foo",
-				"has_errors.go:.*function D is not visible in this package",
+				`has_errors.go:.*package fmt must not be imported \(importfmt\)`,
+				`has_errors.go:.*function must not be named Foo \(foofuncname\)`,
+				`has_errors.go:.*function D is not visible in this package \(visibility\)`,
 			},
 		}, {
 			desc:        "custom_config",
 			target:      "//:has_errors",
 			wantSuccess: false,
 			includes: []string{
-				"has_errors.go:.*package fmt must not be imported",
-				"has_errors.go:.*function must not be named Foo",
+				`has_errors.go:.*package fmt must not be imported \(importfmt\)`,
+				`has_errors.go:.*function must not be named Foo \(foofuncname\)`,
 			},
 			excludes: []string{
 				"custom/has_errors.go:.*function D is not visible in this package",


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Report the analyzer name in the nogo diagnostic messages.

The additional data point should help the developer to investigate, and
if need be, suppress the error. This is especially useful to find nogo
checks that fail for third party dependencies.

**Which issues(s) does this PR fix?**

Fixes #2674

**Other notes for review**

The analyzer is appended in parentheses, similar to [golangci-lint](https://golangci-lint.run/)

Some sample output from `tests/core/nogo/custom_test.go`:

```
has_errors.go:4:2: package fmt must not be imported (importfmt)
has_errors.go:9:1: function must not be named Foo (foofuncname)
has_errors.go:10:2: function D is not visible in this package (visibility)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bazelbuild/rules_go/2770)
<!-- Reviewable:end -->
