### PR TITLE
dont set TEST_TMPDIR to TMPDIR in the test runner

### DIFF
--- a/go/tools/bzltestutil/init.go
+++ b/go/tools/bzltestutil/init.go
@@ -57,9 +57,4 @@ func init() {
 			os.Setenv("PWD", abs)
 		}
 	}
-
-	// Setup the bazel tmpdir as the go tmpdir.
-	if tmpDir, ok := os.LookupEnv("TEST_TMPDIR"); ok {
-		os.Setenv("TMPDIR", tmpDir)
-	}
 }


### PR DESCRIPTION
This is a breaking change.

Partially-Reverts: 9c1568a7f510fe306a59f8d09e91579a71f5e08c
Fixes: #2776