### PR TITLE
Handle long filenames on Windows in a few more places.

### DIFF
--- a/go/tools/builders/pack.go
+++ b/go/tools/builders/pack.go
@@ -347,6 +347,8 @@ func simpleName(name string, names map[string]struct{}) (string, error) {
 }
 
 func appendFiles(goenv *env, archive string, files []string) error {
+	archive = abs(archive) // required for long filenames on Windows.
+
 	// Create an empty archive if one doesn't already exist.
 	// In Go 1.16, 'go tool pack r' reports an error if the archive doesn't exist.
 	// 'go tool pack c' copies export data in addition to creating the archive,

--- a/go/tools/builders/protoc.go
+++ b/go/tools/builders/protoc.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -76,6 +77,11 @@ func run(args []string) error {
 		strings.TrimPrefix(filepath.Base(*plugin), "protoc-gen-"), ".exe")
 	for _, m := range imports {
 		options = append(options, fmt.Sprintf("M%v", m))
+	}
+	if runtime.GOOS == "windows" {
+		// Turn the plugin path into raw form, since we're handing it off to a non-go binary.
+		// This is required to work with long paths on Windows.
+		*plugin = "\\\\?\\" + abs(*plugin)
 	}
 	protoc_args := []string{
 		fmt.Sprintf("--%v_out=%v:%v", pluginName, strings.Join(options, ","), tmpDir),


### PR DESCRIPTION
C.f. #1382

**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
Makes rules_go work on Windows with long filenames.