### PR TITLE
Adds a --cgo_compiler flag to control the C/C++ compiler used.

### DIFF
--- a/go/config/BUILD.bazel
+++ b/go/config/BUILD.bazel
@@ -58,6 +58,12 @@ string_list_flag(
     visibility = ["//visibility:public"],
 )
 
+string_flag(
+    name = "cgo_compiler",
+    build_setting_default = "",
+    visibility = ["//visibility:public"],
+)
+
 filegroup(
     name = "all_files",
     testonly = True,

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -14,6 +14,7 @@
 
 load(
     "//go/private:context.bzl",
+    "cgo_compiler_transition",
     "go_context",
 )
 load(
@@ -95,12 +96,15 @@ _go_binary_kwargs = {
         "basename": attr.string(),
         "out": attr.string(),
         "cgo": attr.bool(),
-        "cdeps": attr.label_list(),
+        "cdeps": attr.label_list(cfg = cgo_compiler_transition),
         "cppopts": attr.string_list(),
         "copts": attr.string_list(),
         "cxxopts": attr.string_list(),
         "clinkopts": attr.string_list(),
         "_go_context_data": attr.label(default = "//:go_context_data"),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
     },
     "executable": True,
     "toolchains": ["@io_bazel_rules_go//go:toolchain"],

--- a/go/private/rules/library.bzl
+++ b/go/private/rules/library.bzl
@@ -20,6 +20,7 @@ load(
 )
 load(
     "//go/private:context.bzl",
+    "cgo_compiler_transition",
     "go_context",
 )
 load(
@@ -63,12 +64,15 @@ go_library = rule(
         "gc_goopts": attr.string_list(),
         "x_defs": attr.string_dict(),
         "cgo": attr.bool(),
-        "cdeps": attr.label_list(),
+        "cdeps": attr.label_list(cfg = cgo_compiler_transition),
         "cppopts": attr.string_list(),
         "copts": attr.string_list(),
         "cxxopts": attr.string_list(),
         "clinkopts": attr.string_list(),
         "_go_context_data": attr.label(default = "//:go_context_data"),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
     },
     toolchains = ["@io_bazel_rules_go//go:toolchain"],
 )

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -14,6 +14,7 @@
 
 load(
     "//go/private:context.bzl",
+    "cgo_compiler_transition",
     "go_context",
 )
 load(
@@ -189,7 +190,7 @@ _go_test_kwargs = {
         "x_defs": attr.string_dict(),
         "linkmode": attr.string(default = LINKMODE_NORMAL),
         "cgo": attr.bool(),
-        "cdeps": attr.label_list(),
+        "cdeps": attr.label_list(cfg = cgo_compiler_transition),
         "cppopts": attr.string_list(),
         "copts": attr.string_list(),
         "cxxopts": attr.string_list(),
@@ -204,6 +205,9 @@ _go_test_kwargs = {
             executable = True,
             default = "@io_bazel_rules_go//go/tools/builders:lcov_merger",
             cfg = "target",
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),
     },
     "executable": True,


### PR DESCRIPTION
Adds a config transition that will modify the `--compiler` bazel flag for go rules based upon the `--cgo_compiler` flag. This allows users of rules_go to build non-cgo C/C++ code with a different compiler than cgo code. For example, on Windows users could use MSVC for their non-cgo code and MinGW gcc for the cgo code.