### PR TITLE
Add minimal support for ARM64 on macOS.

### DIFF
--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -230,6 +230,15 @@ def _detect_host_platform(ctx):
 
     elif ctx.os.name == "mac os x":
         goos, goarch = "darwin", "amd64"
+
+        res = ctx.execute(["uname", "-m"])
+        if res.return_code == 0:
+            uname = res.stdout.strip()
+            if uname == "arm64":
+                goarch = "arm64"
+
+        # Default to amd64 when uname doesn't return a known value.
+
     elif ctx.os.name.startswith("windows"):
         goos, goarch = "windows", "amd64"
     elif ctx.os.name == "freebsd":


### PR DESCRIPTION
This still fails several tests that assume x86-64, but it’s at least a starting
point.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This implements basic support for ARM64 macOS systems.

**Which issues(s) does this PR fix?**

#2795

(This doesn't entirely fix the issue since some of the tests still fail)

**Other notes for review**
