### PR TITLE
Make go_reset_target forward DefaultInfo.executable and pass go_path into it

### DIFF
--- a/go/private/tools/path.bzl
+++ b/go/private/tools/path.bzl
@@ -24,7 +24,6 @@ load(
     "as_iterable",
     "as_list",
 )
-load("//go/private/rules:transition.bzl", "go_reset_transition")
 
 def _go_path_impl(ctx):
     # Gather all archives. Note that there may be multiple packages with the same

--- a/go/private/tools/path.bzl
+++ b/go/private/tools/path.bzl
@@ -24,6 +24,7 @@ load(
     "as_iterable",
     "as_list",
 )
+load("//go/private/rules:transition.bzl", "go_reset_transition")
 
 def _go_path_impl(ctx):
     # Gather all archives. Note that there may be multiple packages with the same

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -68,12 +68,18 @@ go_source(
 )
 
 go_binary(
-    name = "go_path",
+    name = "go_path-bin",
     srcs = [
         "env.go",
         "flags.go",
         "go_path.go",
     ],
+    visibility = ["//visibility:public"],
+)
+
+go_reset_target(
+    name = "go_path",
+    dep = ":go_path-bin",
     visibility = ["//visibility:public"],
 )
 

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -176,8 +176,6 @@ def _go_proto_compiler_impl(ctx):
     go = go_context(ctx)
     library = go.new_library(go)
     source = go.library_to_source(go, ctx.attr, library, ctx.coverage_instrumented())
-    plugin = ctx.file.plugin
-    go_protoc = ctx.file._go_protoc
     return [
         GoProtoCompiler(
             deps = ctx.attr.deps,
@@ -187,8 +185,8 @@ def _go_proto_compiler_impl(ctx):
                 options = ctx.attr.options,
                 suffix = ctx.attr.suffix,
                 protoc = ctx.executable._protoc,
-                go_protoc = ctx.file._go_protoc,
-                plugin = ctx.file.plugin,
+                go_protoc = ctx.executable._go_protoc,
+                plugin = ctx.executable.plugin,
                 import_path_option = ctx.attr.import_path_option,
             ),
         ),
@@ -205,12 +203,12 @@ _go_proto_compiler = rule(
         "valid_archive": attr.bool(default = True),
         "import_path_option": attr.bool(default = False),
         "plugin": attr.label(
-            allow_single_file = True,
+            executable = True,
             cfg = "exec",
             mandatory = True,
         ),
         "_go_protoc": attr.label(
-            allow_single_file = True,
+            executable = True,
             cfg = "exec",
             default = "//go/tools/builders:go-protoc",
         ),


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

- Patch `go_reset_target` to properly forward `DefaultInfo.executable` via a symbolic link.
- Patch `go_proto*` rules to now use `ctx.executable`
- Pass `go_path` builder binary through `go_reset_target`

**Which issues(s) does this PR fix?**

- Fix #2689