### PR TITLE
all: test with Go 1.16 in CI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -219,7 +219,7 @@ Go toolchain and register it for use.
 
     go_rules_dependencies()
 
-    go_register_toolchains(version = "1.15.7")
+    go_register_toolchains(version = "1.16")
 
 You can use rules_go at ``master`` by using `git_repository`_ instead of
 `http_archive`_ and pointing to a recent commit.
@@ -276,7 +276,7 @@ Add the ``bazel_gazelle`` repository and its dependencies to your
 
     go_rules_dependencies()
 
-    go_register_toolchains(version = "1.15.7")
+    go_register_toolchains(version = "1.16")
 
     gazelle_dependencies()
 
@@ -413,7 +413,7 @@ automatically from a go.mod or Gopkg.lock file.
     # Declare indirect dependencies and register toolchains.
     go_rules_dependencies()
 
-    go_register_toolchains(version = "1.15.7")
+    go_register_toolchains(version = "1.16")
 
     gazelle_dependencies()
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,7 +6,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 
 go_rules_dependencies(is_rules_go = True)
 
-go_register_toolchains(version = "1.16rc1")
+go_register_toolchains(version = "1.16")
 
 http_archive(
     name = "com_google_protobuf",


### PR DESCRIPTION
Also, update examples in README.rst to use 1.16.

For #2820
