### PR TITLE
Include ARM64 in “select” calls.

### DIFF
--- a/tests/legacy/cgo_select/BUILD.bazel
+++ b/tests/legacy/cgo_select/BUILD.bazel
@@ -7,6 +7,9 @@ go_library(
         "@io_bazel_rules_go//go/platform:darwin_amd64": [
             "cgo_darwin.go",
         ],
+        "@io_bazel_rules_go//go/platform:darwin_arm64": [
+            "cgo_darwin.go",
+        ],
         "@io_bazel_rules_go//go/platform:linux_amd64": [
             "cgo_linux.go",
         ],
@@ -16,6 +19,9 @@ go_library(
     }),
     cdeps = select({
         "@io_bazel_rules_go//go/platform:darwin_amd64": [
+            ":darwin_lib",
+        ],
+        "@io_bazel_rules_go//go/platform:darwin_arm64": [
             ":darwin_lib",
         ],
         "@io_bazel_rules_go//go/platform:linux_amd64": [


### PR DESCRIPTION
These files are architecture-independent, so this works on ARM-64 without
further changes.

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Slightly improve ARM64 support on macOS.

**Which issues(s) does this PR fix?**

#2795 (not a complete fix, but a start)
