### PR TITLE
Fix CPU selector.

### DIFF
--- a/tests/legacy/asm_include/BUILD.bazel
+++ b/tests/legacy/asm_include/BUILD.bazel
@@ -2,12 +2,18 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 config_setting(
     name = "linux_amd64",
-    values = {"cpu": "k8"},
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
 )
 
 config_setting(
     name = "darwin_amd64",
-    values = {"cpu": "darwin"},
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:macos",
+    ],
 )
 
 LIB_AMD64_SRCS = [


### PR DESCRIPTION
Using the CPU “darwin” doesn’t work correctly on ARM-64.  Use the normal CPU
and operating system constraints from the \@platforms repository instead.

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Slightly improve ARM64 support on macOS.

**Which issues(s) does this PR fix?**

#2795 (not a complete fix, but a start)
