### PR TITLE
Add ARM-64 version to go_download_sdk test.

### DIFF
--- a/tests/core/go_download_sdk/go_download_sdk_test.go
+++ b/tests/core/go_download_sdk/go_download_sdk_test.go
@@ -64,11 +64,11 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk")
 
 go_download_sdk(
     name = "go_sdk",
-    version = "1.13",
+    version = "1.16",
 )
 
 `,
-			wantVersion: "go1.13",
+			wantVersion: "go1.16",
 		}, {
 			desc: "custom_archives",
 			rule: `
@@ -77,13 +77,14 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk")
 go_download_sdk(
     name = "go_sdk",
     sdks = {
-        "darwin_amd64": ("go1.13.darwin-amd64.tar.gz", "234ebbba1fbed8474340f79059cfb3af2a0f8b531c4ff0785346e0710e4003dd"),
-        "linux_amd64": ("go1.13.linux-amd64.tar.gz", "68a2297eb099d1a76097905a2ce334e3155004ec08cdea85f24527be3c48e856"),
-        "windows_amd64": ("go1.13.windows-amd64.zip", "7d162b83157d3171961f8e05a55b7da8476244df3fac28a5da1c9e215acfea89"),
+        "darwin_amd64": ("go1.16.darwin-amd64.tar.gz", "6000a9522975d116bf76044967d7e69e04e982e9625330d9a539a8b45395f9a8"),
+        "darwin_arm64": ("go1.16.darwin-arm64.tar.gz", "4dac57c00168d30bbd02d95131d5de9ca88e04f2c5a29a404576f30ae9b54810"),
+        "linux_amd64": ("go1.16.linux-amd64.tar.gz", "013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2"),
+        "windows_amd64": ("go1.16.windows-amd64.zip", "5cc88fa506b3d5c453c54c3ea218fc8dd05d7362ae1de15bb67986b72089ce93"),
     },
 )
 `,
-			wantVersion: "go1.13",
+			wantVersion: "go1.16",
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {


### PR DESCRIPTION
Since only Go 1.16 supports ARM-64 on macOS, switch to that version.

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

A bit of support for ARM-64.

**Which issues(s) does this PR fix?**

#2795 (not a complete fix, but a start)