### PR TITLE
Split up PIE tests.

### DIFF
--- a/tests/core/go_binary/BUILD.bazel
+++ b/tests/core/go_binary/BUILD.bazel
@@ -95,6 +95,7 @@ go_test(
     name = "pie_test",
     srcs = [
         "pie_darwin_test.go",
+        "pie_darwin_amd64_test.go",
         "pie_linux_test.go",
     ],
     data = select({

--- a/tests/core/go_binary/pie_darwin_amd64_test.go
+++ b/tests/core/go_binary/pie_darwin_amd64_test.go
@@ -1,0 +1,31 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"debug/macho"
+	"testing"
+)
+
+func TestNoPIE(t *testing.T) {
+	m, err := openMachO("tests/core/go_binary", "hello_nopie_bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if m.Flags&macho.FlagPIE != 0 {
+		t.Error("ELF binary is not position-dependent.")
+	}
+}

--- a/tests/core/go_binary/pie_darwin_test.go
+++ b/tests/core/go_binary/pie_darwin_test.go
@@ -33,14 +33,3 @@ func TestPIE(t *testing.T) {
 		t.Error("ELF binary is not position-independent.")
 	}
 }
-
-func TestNoPIE(t *testing.T) {
-	m, err := openMachO("tests/core/go_binary", "hello_nopie_bin")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if m.Flags&macho.FlagPIE != 0 {
-		t.Error("ELF binary is not position-dependent.")
-	}
-}


### PR DESCRIPTION
It looks like on ARM-64, all binaries are position-independent, so this test
only succeeds on x86-64.

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

A bit of support for ARM-64.

**Which issues(s) does this PR fix?**

#2795 (not a complete fix, but a start)