### PR TITLE
Update org_golang_x_tools and add org_golang_x_sys

### DIFF
--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -70,19 +70,36 @@ def go_rules_dependencies(is_rules_go = False):
     _maybe(
         http_archive,
         name = "org_golang_x_tools",
-        # master, as of 2020-08-24
+        # v0.1.0, as of 2021-03-17
         urls = [
-            "https://mirror.bazel.build/github.com/golang/tools/archive/a1b87a1c0de44760bd00894ef736a8c36548068f.zip",
-            "https://github.com/golang/tools/archive/a1b87a1c0de44760bd00894ef736a8c36548068f.zip",
+            "https://mirror.bazel.build/github.com/golang/tools/archive/v0.1.0.zip",
+            "https://github.com/golang/tools/archive/v0.1.0.zip",
         ],
-        sha256 = "fe3987ccdff6a0e7e5a8353d4d1d2ca3ada5a72ea69462ba7b9b7343b5a25e06",
-        strip_prefix = "tools-a1b87a1c0de44760bd00894ef736a8c36548068f",
+        sha256 = "60a5cee8304b4d9130344f156a10ba648e315b5fca4b84939b765b26ce217dee",
+        strip_prefix = "tools-0.1.0",
         patches = [
             # deletegopls removes the gopls subdirectory. It contains a nested
             # module with additional dependencies. It's not needed by rules_go.
             "@io_bazel_rules_go//third_party:org_golang_x_tools-deletegopls.patch",
             # gazelle args: -repo_root . -go_prefix golang.org/x/tools -go_naming_convention import_alias
             "@io_bazel_rules_go//third_party:org_golang_x_tools-gazelle.patch",
+        ],
+        patch_args = ["-p1"],
+    )
+
+    _maybe(
+        http_archive,
+        name = "org_golang_x_sys",
+        # master, as of 2021-03-17
+        urls = [
+            "https://github.com/golang/sys/archive/390168757d9c647283340d526204e3409d5903f3.zip",
+            "https://mirror.bazel.build/github.com/golang/sys/archive/390168757d9c647283340d526204e3409d5903f3.zip",
+        ],
+        sha256 = "1e7128237f37a9e28f3ea08267ea95f0cd32cbe20c5a25c99430697001de85b5",
+        strip_prefix = "sys-390168757d9c647283340d526204e3409d5903f3",
+        patches = [
+            # gazelle args: -repo_root . -go_prefix golang.org/x/sys -go_naming_convention import_alias
+            "@io_bazel_rules_go//third_party:org_golang_x_sys-gazelle.patch",
         ],
         patch_args = ["-p1"],
     )

--- a/tests/integration/popular_repos/BUILD.bazel
+++ b/tests/integration/popular_repos/BUILD.bazel
@@ -98,6 +98,8 @@ test_suite(
     name = "org_golang_x_sys",
     tests = [
         "@org_golang_x_sys//cpu:cpu_test",
+        "@org_golang_x_sys//execabs:execabs_test",
+        "@org_golang_x_sys//internal/unsafeheader:unsafeheader_test",
         "@org_golang_x_sys//plan9:plan9_test",
         "@org_golang_x_sys//unix:unix_test",
         "@org_golang_x_sys//windows:windows_test",
@@ -161,6 +163,7 @@ test_suite(
         "@org_golang_x_tools//cmd/getgo:getgo_test",
         "@org_golang_x_tools//cmd/go-contrib-init:go-contrib-init_test",
         "@org_golang_x_tools//cmd/splitdwarf/internal/macho:macho_test",
+        "@org_golang_x_tools//copyright:copyright_test",
         "@org_golang_x_tools//cover:cover_test",
         "@org_golang_x_tools//go/analysis:analysis_test",
         "@org_golang_x_tools//go/analysis/internal/analysisflags:analysisflags_test",

--- a/tests/integration/popular_repos/README.rst
+++ b/tests/integration/popular_repos/README.rst
@@ -95,6 +95,8 @@ ________________
 This runs tests from the repository `golang.org/x/sys <https://golang.org/x/sys>`_
 
 * @org_golang_x_sys//cpu:cpu_test
+* @org_golang_x_sys//execabs:execabs_test
+* @org_golang_x_sys//internal/unsafeheader:unsafeheader_test
 * @org_golang_x_sys//plan9:plan9_test
 * @org_golang_x_sys//unix:unix_test
 * @org_golang_x_sys//windows:windows_test
@@ -160,6 +162,7 @@ This runs tests from the repository `golang.org/x/tools <https://golang.org/x/to
 * @org_golang_x_tools//cmd/getgo:getgo_test
 * @org_golang_x_tools//cmd/go-contrib-init:go-contrib-init_test
 * @org_golang_x_tools//cmd/splitdwarf/internal/macho:macho_test
+* @org_golang_x_tools//copyright:copyright_test
 * @org_golang_x_tools//cover:cover_test
 * @org_golang_x_tools//go/analysis:analysis_test
 * @org_golang_x_tools//go/analysis/internal/analysisflags:analysisflags_test

--- a/tests/integration/popular_repos/popular_repos.bzl
+++ b/tests/integration/popular_repos/popular_repos.bzl
@@ -41,7 +41,7 @@ def popular_repos():
         go_repository,
         name = "org_golang_x_sys",
         importpath = "golang.org/x/sys",
-        commit = "68d13333faf24bbe12c06419ed07e851a9dbf8f9",
+        commit = "390168757d9c647283340d526204e3409d5903f3",
     )
     _maybe(
         go_repository,
@@ -53,7 +53,7 @@ def popular_repos():
         go_repository,
         name = "org_golang_x_tools",
         importpath = "golang.org/x/tools",
-        commit = "a1b87a1c0de44760bd00894ef736a8c36548068f",
+        commit = "fe37c9e135b934191089b245ac29325091462508",
     )
     _maybe(
         go_repository,

--- a/tests/integration/popular_repos/popular_repos.py
+++ b/tests/integration/popular_repos/popular_repos.py
@@ -52,7 +52,7 @@ POPULAR_REPOS = [
     dict(
         name = "org_golang_x_sys",
         importpath = "golang.org/x/sys",
-        commit = "68d13333faf24bbe12c06419ed07e851a9dbf8f9",
+        commit = "390168757d9c647283340d526204e3409d5903f3",
     ),
 
     dict(
@@ -77,7 +77,7 @@ POPULAR_REPOS = [
     dict(
         name = "org_golang_x_tools",
         importpath = "golang.org/x/tools",
-        commit = "a1b87a1c0de44760bd00894ef736a8c36548068f",
+        commit = "fe37c9e135b934191089b245ac29325091462508",
         excludes = [
             "blog:blog_test", # Needs goldmark
             "cmd/bundle:bundle_test", # Needs testdata directory
@@ -180,7 +180,6 @@ POPULAR_REPOS = [
             "internal/lsp/mod:mod_test", # has additional deps
             "internal/lsp/snippet:snippet_test", # has additional deps
             "internal/lsp/source:source_test", # Needs testdata directory
-            "internal/lsp/source/genapijson:genapijson_test", # Needs GOROOT
             "internal/lsp:lsp_test", # Needs testdata directory
             "internal/lsp/testdata/analyzer:analyzer_test", # is testdata
             "internal/lsp/testdata/codelens:codelens_test", # is testdata

--- a/third_party/org_golang_x_sys-gazelle.patch
+++ b/third_party/org_golang_x_sys-gazelle.patch
@@ -1,0 +1,810 @@
+diff -urN a/cpu/BUILD.bazel b/cpu/BUILD.bazel
+--- a/cpu/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/cpu/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,57 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "cpu",
++    srcs = [
++        "asm_aix_ppc64.s",
++        "byteorder.go",
++        "cpu.go",
++        "cpu_aix.go",
++        "cpu_arm.go",
++        "cpu_arm64.go",
++        "cpu_arm64.s",
++        "cpu_gc_arm64.go",
++        "cpu_gc_s390x.go",
++        "cpu_gc_x86.go",
++        "cpu_linux.go",
++        "cpu_linux_arm.go",
++        "cpu_linux_arm64.go",
++        "cpu_linux_mips64x.go",
++        "cpu_linux_noinit.go",
++        "cpu_linux_ppc64x.go",
++        "cpu_linux_s390x.go",
++        "cpu_mips64x.go",
++        "cpu_mipsx.go",
++        "cpu_netbsd_arm64.go",
++        "cpu_other_arm.go",
++        "cpu_other_arm64.go",
++        "cpu_ppc64x.go",
++        "cpu_riscv64.go",
++        "cpu_s390x.go",
++        "cpu_s390x.s",
++        "cpu_wasm.go",
++        "cpu_x86.go",
++        "cpu_x86.s",
++        "cpu_zos.go",
++        "cpu_zos_s390x.go",
++        "hwcap_linux.go",
++        "syscall_aix_ppc64_gc.go",
++    ],
++    importpath = "golang.org/x/sys/cpu",
++    visibility = ["//visibility:public"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":cpu",
++    visibility = ["//visibility:public"],
++)
++
++go_test(
++    name = "cpu_test",
++    srcs = [
++        "cpu_s390x_test.go",
++        "cpu_test.go",
++    ],
++    deps = [":cpu"],
++)
+diff -urN a/execabs/BUILD.bazel b/execabs/BUILD.bazel
+--- a/execabs/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/execabs/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,20 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "execabs",
++    srcs = ["execabs.go"],
++    importpath = "golang.org/x/sys/execabs",
++    visibility = ["//visibility:public"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":execabs",
++    visibility = ["//visibility:public"],
++)
++
++go_test(
++    name = "execabs_test",
++    srcs = ["execabs_test.go"],
++    embed = [":execabs"],
++)
+diff -urN a/internal/unsafeheader/BUILD.bazel b/internal/unsafeheader/BUILD.bazel
+--- a/internal/unsafeheader/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/internal/unsafeheader/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,20 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "unsafeheader",
++    srcs = ["unsafeheader.go"],
++    importpath = "golang.org/x/sys/internal/unsafeheader",
++    visibility = ["//:__subpackages__"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":unsafeheader",
++    visibility = ["//:__subpackages__"],
++)
++
++go_test(
++    name = "unsafeheader_test",
++    srcs = ["unsafeheader_test.go"],
++    deps = [":unsafeheader"],
++)
+diff -urN a/plan9/BUILD.bazel b/plan9/BUILD.bazel
+--- a/plan9/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/plan9/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,51 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "plan9",
++    srcs = [
++        "asm.s",
++        "asm_plan9_386.s",
++        "asm_plan9_amd64.s",
++        "asm_plan9_arm.s",
++        "const_plan9.go",
++        "dir_plan9.go",
++        "env_plan9.go",
++        "errors_plan9.go",
++        "pwd_go15_plan9.go",
++        "pwd_plan9.go",
++        "race.go",
++        "race0.go",
++        "str.go",
++        "syscall.go",
++        "syscall_plan9.go",
++        "zsyscall_plan9_386.go",
++        "zsyscall_plan9_amd64.go",
++        "zsyscall_plan9_arm.go",
++        "zsysnum_plan9.go",
++    ],
++    importpath = "golang.org/x/sys/plan9",
++    visibility = ["//visibility:public"],
++    deps = select({
++        "@io_bazel_rules_go//go/platform:plan9": [
++            "//internal/unsafeheader",
++        ],
++        "//conditions:default": [],
++    }),
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":plan9",
++    visibility = ["//visibility:public"],
++)
++
++go_test(
++    name = "plan9_test",
++    srcs = ["syscall_test.go"],
++    deps = select({
++        "@io_bazel_rules_go//go/platform:plan9": [
++            ":plan9",
++        ],
++        "//conditions:default": [],
++    }),
++)
+diff -urN a/unix/BUILD.bazel b/unix/BUILD.bazel
+--- a/unix/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/unix/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,338 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "unix",
++    srcs = [
++        "affinity_linux.go",
++        "aliases.go",
++        "asm_aix_ppc64.s",
++        "asm_bsd_386.s",
++        "asm_bsd_amd64.s",
++        "asm_bsd_arm.s",
++        "asm_bsd_arm64.s",
++        "asm_linux_386.s",
++        "asm_linux_amd64.s",
++        "asm_linux_arm.s",
++        "asm_linux_arm64.s",
++        "asm_linux_mips64x.s",
++        "asm_linux_mipsx.s",
++        "asm_linux_ppc64x.s",
++        "asm_linux_riscv64.s",
++        "asm_linux_s390x.s",
++        "asm_solaris_amd64.s",
++        "bluetooth_linux.go",
++        "cap_freebsd.go",
++        "constants.go",
++        "dev_aix_ppc64.go",
++        "dev_darwin.go",
++        "dev_dragonfly.go",
++        "dev_freebsd.go",
++        "dev_linux.go",
++        "dev_netbsd.go",
++        "dev_openbsd.go",
++        "dirent.go",
++        "endian_big.go",
++        "endian_little.go",
++        "env_unix.go",
++        "errors_freebsd_386.go",
++        "errors_freebsd_amd64.go",
++        "errors_freebsd_arm.go",
++        "errors_freebsd_arm64.go",
++        "fcntl.go",
++        "fcntl_darwin.go",
++        "fcntl_linux_32bit.go",
++        "fdset.go",
++        "ioctl.go",
++        "pagesize_unix.go",
++        "pledge_openbsd.go",
++        "ptrace_darwin.go",
++        "ptrace_ios.go",
++        "race.go",
++        "race0.go",
++        "readdirent_getdents.go",
++        "readdirent_getdirentries.go",
++        "sockcmsg_dragonfly.go",
++        "sockcmsg_linux.go",
++        "sockcmsg_unix.go",
++        "sockcmsg_unix_other.go",
++        "str.go",
++        "syscall.go",
++        "syscall_aix.go",
++        "syscall_aix_ppc64.go",
++        "syscall_bsd.go",
++        "syscall_darwin.1_12.go",
++        "syscall_darwin.1_13.go",
++        "syscall_darwin.go",
++        "syscall_darwin_386.go",
++        "syscall_darwin_amd64.go",
++        "syscall_darwin_arm.go",
++        "syscall_darwin_arm64.go",
++        "syscall_darwin_libSystem.go",
++        "syscall_dragonfly.go",
++        "syscall_dragonfly_amd64.go",
++        "syscall_freebsd.go",
++        "syscall_freebsd_386.go",
++        "syscall_freebsd_amd64.go",
++        "syscall_freebsd_arm.go",
++        "syscall_freebsd_arm64.go",
++        "syscall_illumos.go",
++        "syscall_linux.go",
++        "syscall_linux_386.go",
++        "syscall_linux_amd64.go",
++        "syscall_linux_amd64_gc.go",
++        "syscall_linux_arm.go",
++        "syscall_linux_arm64.go",
++        "syscall_linux_gc.go",
++        "syscall_linux_gc_386.go",
++        "syscall_linux_gc_arm.go",
++        "syscall_linux_mips64x.go",
++        "syscall_linux_mipsx.go",
++        "syscall_linux_ppc64x.go",
++        "syscall_linux_riscv64.go",
++        "syscall_linux_s390x.go",
++        "syscall_netbsd.go",
++        "syscall_netbsd_386.go",
++        "syscall_netbsd_amd64.go",
++        "syscall_netbsd_arm.go",
++        "syscall_netbsd_arm64.go",
++        "syscall_openbsd.go",
++        "syscall_openbsd_386.go",
++        "syscall_openbsd_amd64.go",
++        "syscall_openbsd_arm.go",
++        "syscall_openbsd_arm64.go",
++        "syscall_solaris.go",
++        "syscall_solaris_amd64.go",
++        "syscall_unix.go",
++        "syscall_unix_gc.go",
++        "syscall_unix_gc_ppc64x.go",
++        "timestruct.go",
++        "unveil_openbsd.go",
++        "xattr_bsd.go",
++        "zerrors_aix_ppc64.go",
++        "zerrors_darwin_386.go",
++        "zerrors_darwin_amd64.go",
++        "zerrors_darwin_arm.go",
++        "zerrors_darwin_arm64.go",
++        "zerrors_dragonfly_amd64.go",
++        "zerrors_freebsd_386.go",
++        "zerrors_freebsd_amd64.go",
++        "zerrors_freebsd_arm.go",
++        "zerrors_freebsd_arm64.go",
++        "zerrors_linux.go",
++        "zerrors_linux_386.go",
++        "zerrors_linux_amd64.go",
++        "zerrors_linux_arm.go",
++        "zerrors_linux_arm64.go",
++        "zerrors_linux_mips.go",
++        "zerrors_linux_mips64.go",
++        "zerrors_linux_mips64le.go",
++        "zerrors_linux_mipsle.go",
++        "zerrors_linux_ppc64.go",
++        "zerrors_linux_ppc64le.go",
++        "zerrors_linux_riscv64.go",
++        "zerrors_linux_s390x.go",
++        "zerrors_netbsd_386.go",
++        "zerrors_netbsd_amd64.go",
++        "zerrors_netbsd_arm.go",
++        "zerrors_netbsd_arm64.go",
++        "zerrors_openbsd_386.go",
++        "zerrors_openbsd_amd64.go",
++        "zerrors_openbsd_arm.go",
++        "zerrors_openbsd_arm64.go",
++        "zerrors_solaris_amd64.go",
++        "zptrace_armnn_linux.go",
++        "zptrace_linux_arm64.go",
++        "zptrace_mipsnn_linux.go",
++        "zptrace_mipsnnle_linux.go",
++        "zptrace_x86_linux.go",
++        "zsyscall_aix_ppc64.go",
++        "zsyscall_aix_ppc64_gc.go",
++        "zsyscall_darwin_386.1_13.go",
++        "zsyscall_darwin_386.1_13.s",
++        "zsyscall_darwin_386.go",
++        "zsyscall_darwin_386.s",
++        "zsyscall_darwin_amd64.1_13.go",
++        "zsyscall_darwin_amd64.1_13.s",
++        "zsyscall_darwin_amd64.go",
++        "zsyscall_darwin_amd64.s",
++        "zsyscall_darwin_arm.1_13.go",
++        "zsyscall_darwin_arm.1_13.s",
++        "zsyscall_darwin_arm.go",
++        "zsyscall_darwin_arm.s",
++        "zsyscall_darwin_arm64.1_13.go",
++        "zsyscall_darwin_arm64.1_13.s",
++        "zsyscall_darwin_arm64.go",
++        "zsyscall_darwin_arm64.s",
++        "zsyscall_dragonfly_amd64.go",
++        "zsyscall_freebsd_386.go",
++        "zsyscall_freebsd_amd64.go",
++        "zsyscall_freebsd_arm.go",
++        "zsyscall_freebsd_arm64.go",
++        "zsyscall_illumos_amd64.go",
++        "zsyscall_linux.go",
++        "zsyscall_linux_386.go",
++        "zsyscall_linux_amd64.go",
++        "zsyscall_linux_arm.go",
++        "zsyscall_linux_arm64.go",
++        "zsyscall_linux_mips.go",
++        "zsyscall_linux_mips64.go",
++        "zsyscall_linux_mips64le.go",
++        "zsyscall_linux_mipsle.go",
++        "zsyscall_linux_ppc64.go",
++        "zsyscall_linux_ppc64le.go",
++        "zsyscall_linux_riscv64.go",
++        "zsyscall_linux_s390x.go",
++        "zsyscall_netbsd_386.go",
++        "zsyscall_netbsd_amd64.go",
++        "zsyscall_netbsd_arm.go",
++        "zsyscall_netbsd_arm64.go",
++        "zsyscall_openbsd_386.go",
++        "zsyscall_openbsd_amd64.go",
++        "zsyscall_openbsd_arm.go",
++        "zsyscall_openbsd_arm64.go",
++        "zsyscall_solaris_amd64.go",
++        "zsysctl_openbsd_386.go",
++        "zsysctl_openbsd_amd64.go",
++        "zsysctl_openbsd_arm.go",
++        "zsysctl_openbsd_arm64.go",
++        "zsysnum_darwin_386.go",
++        "zsysnum_darwin_amd64.go",
++        "zsysnum_darwin_arm.go",
++        "zsysnum_darwin_arm64.go",
++        "zsysnum_dragonfly_amd64.go",
++        "zsysnum_freebsd_386.go",
++        "zsysnum_freebsd_amd64.go",
++        "zsysnum_freebsd_arm.go",
++        "zsysnum_freebsd_arm64.go",
++        "zsysnum_linux_386.go",
++        "zsysnum_linux_amd64.go",
++        "zsysnum_linux_arm.go",
++        "zsysnum_linux_arm64.go",
++        "zsysnum_linux_mips.go",
++        "zsysnum_linux_mips64.go",
++        "zsysnum_linux_mips64le.go",
++        "zsysnum_linux_mipsle.go",
++        "zsysnum_linux_ppc64.go",
++        "zsysnum_linux_ppc64le.go",
++        "zsysnum_linux_riscv64.go",
++        "zsysnum_linux_s390x.go",
++        "zsysnum_netbsd_386.go",
++        "zsysnum_netbsd_amd64.go",
++        "zsysnum_netbsd_arm.go",
++        "zsysnum_netbsd_arm64.go",
++        "zsysnum_openbsd_386.go",
++        "zsysnum_openbsd_amd64.go",
++        "zsysnum_openbsd_arm.go",
++        "zsysnum_openbsd_arm64.go",
++        "ztypes_aix_ppc64.go",
++        "ztypes_darwin_386.go",
++        "ztypes_darwin_amd64.go",
++        "ztypes_darwin_arm.go",
++        "ztypes_darwin_arm64.go",
++        "ztypes_dragonfly_amd64.go",
++        "ztypes_freebsd_386.go",
++        "ztypes_freebsd_amd64.go",
++        "ztypes_freebsd_arm.go",
++        "ztypes_freebsd_arm64.go",
++        "ztypes_illumos_amd64.go",
++        "ztypes_linux.go",
++        "ztypes_linux_386.go",
++        "ztypes_linux_amd64.go",
++        "ztypes_linux_arm.go",
++        "ztypes_linux_arm64.go",
++        "ztypes_linux_mips.go",
++        "ztypes_linux_mips64.go",
++        "ztypes_linux_mips64le.go",
++        "ztypes_linux_mipsle.go",
++        "ztypes_linux_ppc64.go",
++        "ztypes_linux_ppc64le.go",
++        "ztypes_linux_riscv64.go",
++        "ztypes_linux_s390x.go",
++        "ztypes_netbsd_386.go",
++        "ztypes_netbsd_amd64.go",
++        "ztypes_netbsd_arm.go",
++        "ztypes_netbsd_arm64.go",
++        "ztypes_openbsd_386.go",
++        "ztypes_openbsd_amd64.go",
++        "ztypes_openbsd_arm.go",
++        "ztypes_openbsd_arm64.go",
++        "ztypes_solaris_amd64.go",
++    ],
++    cgo = True,
++    importpath = "golang.org/x/sys/unix",
++    visibility = ["//visibility:public"],
++    deps = select({
++        "@io_bazel_rules_go//go/platform:aix": [
++            "//internal/unsafeheader",
++        ],
++        "@io_bazel_rules_go//go/platform:android": [
++            "//internal/unsafeheader",
++        ],
++        "@io_bazel_rules_go//go/platform:darwin": [
++            "//internal/unsafeheader",
++        ],
++        "@io_bazel_rules_go//go/platform:dragonfly": [
++            "//internal/unsafeheader",
++        ],
++        "@io_bazel_rules_go//go/platform:freebsd": [
++            "//internal/unsafeheader",
++        ],
++        "@io_bazel_rules_go//go/platform:ios": [
++            "//internal/unsafeheader",
++        ],
++        "@io_bazel_rules_go//go/platform:linux": [
++            "//internal/unsafeheader",
++        ],
++        "@io_bazel_rules_go//go/platform:netbsd": [
++            "//internal/unsafeheader",
++        ],
++        "@io_bazel_rules_go//go/platform:openbsd": [
++            "//internal/unsafeheader",
++        ],
++        "@io_bazel_rules_go//go/platform:solaris": [
++            "//internal/unsafeheader",
++        ],
++        "//conditions:default": [],
++    }),
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":unix",
++    visibility = ["//visibility:public"],
++)
++
++go_test(
++    name = "unix_test",
++    srcs = [
++        "creds_test.go",
++        "darwin_test.go",
++        "dev_linux_test.go",
++        "dirent_test.go",
++        "example_exec_test.go",
++        "example_flock_test.go",
++        "export_test.go",
++        "fdset_test.go",
++        "getdirentries_test.go",
++        "mmap_unix_test.go",
++        "openbsd_test.go",
++        "pipe2_test.go",
++        "sendfile_test.go",
++        "syscall_aix_test.go",
++        "syscall_bsd_test.go",
++        "syscall_darwin_test.go",
++        "syscall_freebsd_test.go",
++        "syscall_internal_bsd_test.go",
++        "syscall_internal_darwin_test.go",
++        "syscall_internal_linux_test.go",
++        "syscall_linux_test.go",
++        "syscall_netbsd_test.go",
++        "syscall_openbsd_test.go",
++        "syscall_solaris_test.go",
++        "syscall_test.go",
++        "syscall_unix_test.go",
++        "timestruct_test.go",
++        "xattr_test.go",
++    ],
++    embed = [":unix"],
++)
+diff -urN a/windows/BUILD.bazel b/windows/BUILD.bazel
+--- a/windows/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/windows/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,57 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "windows",
++    srcs = [
++        "aliases.go",
++        "dll_windows.go",
++        "empty.s",
++        "env_windows.go",
++        "eventlog.go",
++        "exec_windows.go",
++        "memory_windows.go",
++        "race.go",
++        "race0.go",
++        "security_windows.go",
++        "service.go",
++        "setupapierrors_windows.go",
++        "str.go",
++        "syscall.go",
++        "syscall_windows.go",
++        "types_windows.go",
++        "types_windows_386.go",
++        "types_windows_amd64.go",
++        "types_windows_arm.go",
++        "zerrors_windows.go",
++        "zknownfolderids_windows.go",
++        "zsyscall_windows.go",
++    ],
++    importpath = "golang.org/x/sys/windows",
++    visibility = ["//visibility:public"],
++    deps = select({
++        "@io_bazel_rules_go//go/platform:windows": [
++            "//internal/unsafeheader",
++        ],
++        "//conditions:default": [],
++    }),
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":windows",
++    visibility = ["//visibility:public"],
++)
++
++go_test(
++    name = "windows_test",
++    srcs = [
++        "syscall_test.go",
++        "syscall_windows_test.go",
++    ],
++    deps = select({
++        "@io_bazel_rules_go//go/platform:windows": [
++            ":windows",
++        ],
++        "//conditions:default": [],
++    }),
++)
+diff -urN a/windows/mkwinsyscall/BUILD.bazel b/windows/mkwinsyscall/BUILD.bazel
+--- a/windows/mkwinsyscall/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/windows/mkwinsyscall/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,14 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
++
++go_library(
++    name = "mkwinsyscall_lib",
++    srcs = ["mkwinsyscall.go"],
++    importpath = "golang.org/x/sys/windows/mkwinsyscall",
++    visibility = ["//visibility:private"],
++)
++
++go_binary(
++    name = "mkwinsyscall",
++    embed = [":mkwinsyscall_lib"],
++    visibility = ["//visibility:public"],
++)
+diff -urN a/windows/registry/BUILD.bazel b/windows/registry/BUILD.bazel
+--- a/windows/registry/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/windows/registry/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,34 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "registry",
++    srcs = [
++        "key.go",
++        "syscall.go",
++        "value.go",
++        "zsyscall_windows.go",
++    ],
++    importpath = "golang.org/x/sys/windows/registry",
++    visibility = ["//visibility:public"],
++    deps = select({
++        "@io_bazel_rules_go//go/platform:windows": [
++            "//windows",
++        ],
++        "//conditions:default": [],
++    }),
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":registry",
++    visibility = ["//visibility:public"],
++)
++
++go_test(
++    name = "registry_test",
++    srcs = [
++        "export_test.go",
++        "registry_test.go",
++    ],
++    embed = [":registry"],
++)
+diff -urN a/windows/svc/BUILD.bazel b/windows/svc/BUILD.bazel
+--- a/windows/svc/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/windows/svc/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,42 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "svc",
++    srcs = [
++        "event.go",
++        "go12.go",
++        "go13.go",
++        "security.go",
++        "service.go",
++        "sys_windows_386.s",
++        "sys_windows_amd64.s",
++        "sys_windows_arm.s",
++    ],
++    importpath = "golang.org/x/sys/windows/svc",
++    visibility = ["//visibility:public"],
++    deps = select({
++        "@io_bazel_rules_go//go/platform:windows": [
++            "//internal/unsafeheader",
++            "//windows",
++        ],
++        "//conditions:default": [],
++    }),
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":svc",
++    visibility = ["//visibility:public"],
++)
++
++go_test(
++    name = "svc_test",
++    srcs = ["svc_test.go"],
++    deps = select({
++        "@io_bazel_rules_go//go/platform:windows": [
++            ":svc",
++            "//windows/svc/mgr",
++        ],
++        "//conditions:default": [],
++    }),
++)
+diff -urN a/windows/svc/debug/BUILD.bazel b/windows/svc/debug/BUILD.bazel
+--- a/windows/svc/debug/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/windows/svc/debug/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,23 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "debug",
++    srcs = [
++        "log.go",
++        "service.go",
++    ],
++    importpath = "golang.org/x/sys/windows/svc/debug",
++    visibility = ["//visibility:public"],
++    deps = select({
++        "@io_bazel_rules_go//go/platform:windows": [
++            "//windows/svc",
++        ],
++        "//conditions:default": [],
++    }),
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":debug",
++    visibility = ["//visibility:public"],
++)
+diff -urN a/windows/svc/eventlog/BUILD.bazel b/windows/svc/eventlog/BUILD.bazel
+--- a/windows/svc/eventlog/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/windows/svc/eventlog/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,35 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "eventlog",
++    srcs = [
++        "install.go",
++        "log.go",
++    ],
++    importpath = "golang.org/x/sys/windows/svc/eventlog",
++    visibility = ["//visibility:public"],
++    deps = select({
++        "@io_bazel_rules_go//go/platform:windows": [
++            "//windows",
++            "//windows/registry",
++        ],
++        "//conditions:default": [],
++    }),
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":eventlog",
++    visibility = ["//visibility:public"],
++)
++
++go_test(
++    name = "eventlog_test",
++    srcs = ["log_test.go"],
++    deps = select({
++        "@io_bazel_rules_go//go/platform:windows": [
++            ":eventlog",
++        ],
++        "//conditions:default": [],
++    }),
++)
+diff -urN a/windows/svc/example/BUILD.bazel b/windows/svc/example/BUILD.bazel
+--- a/windows/svc/example/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/windows/svc/example/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,29 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
++
++go_library(
++    name = "example_lib",
++    srcs = [
++        "beep.go",
++        "install.go",
++        "main.go",
++        "manage.go",
++        "service.go",
++    ],
++    importpath = "golang.org/x/sys/windows/svc/example",
++    visibility = ["//visibility:private"],
++    deps = select({
++        "@io_bazel_rules_go//go/platform:windows": [
++            "//windows/svc",
++            "//windows/svc/debug",
++            "//windows/svc/eventlog",
++            "//windows/svc/mgr",
++        ],
++        "//conditions:default": [],
++    }),
++)
++
++go_binary(
++    name = "example",
++    embed = [":example_lib"],
++    visibility = ["//visibility:public"],
++)
+diff -urN a/windows/svc/mgr/BUILD.bazel b/windows/svc/mgr/BUILD.bazel
+--- a/windows/svc/mgr/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ b/windows/svc/mgr/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,38 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "mgr",
++    srcs = [
++        "config.go",
++        "mgr.go",
++        "recovery.go",
++        "service.go",
++    ],
++    importpath = "golang.org/x/sys/windows/svc/mgr",
++    visibility = ["//visibility:public"],
++    deps = select({
++        "@io_bazel_rules_go//go/platform:windows": [
++            "//internal/unsafeheader",
++            "//windows",
++            "//windows/svc",
++        ],
++        "//conditions:default": [],
++    }),
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":mgr",
++    visibility = ["//visibility:public"],
++)
++
++go_test(
++    name = "mgr_test",
++    srcs = ["mgr_test.go"],
++    deps = select({
++        "@io_bazel_rules_go//go/platform:windows": [
++            ":mgr",
++        ],
++        "//conditions:default": [],
++    }),
++)

--- a/third_party/org_golang_x_tools-deletegopls.patch
+++ b/third_party/org_golang_x_tools-deletegopls.patch
@@ -1,8 +1,10 @@
 diff -urN a/gopls/README.md b/gopls/README.md
 --- a/gopls/README.md	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/README.md	1969-12-31 19:00:00.000000000 -0500
-@@ -1,71 +0,0 @@
+@@ -1,73 +0,0 @@
 -# gopls documentation
+-
+-[![PkgGoDev](https://pkg.go.dev/badge/golang.org/x/tools/gopls)](https://pkg.go.dev/golang.org/x/tools/gopls)
 -
 -gopls (pronounced: "go please") is the official [language server] for the Go language.
 -
@@ -79,76 +81,70 @@ diff -urN a/gopls/doc/acme.md b/gopls/doc/acme.md
 @@ -1,7 +0,0 @@
 -# Acme
 -
--Use the experimental [`acme-lsp`], simply follow the [install steps]
+-Use the experimental [`acme-lsp`] plugin.
+-Get started by following the[installation guide].
 -
 -[`acme-lsp`]: https://github.com/fhs/acme-lsp
--[install steps]: https://github.com/fhs/acme-lsp#gopls
--
+-[installation guide]: https://github.com/fhs/acme-lsp#gopls
 diff -urN a/gopls/doc/analyzers.md b/gopls/doc/analyzers.md
 --- a/gopls/doc/analyzers.md	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/doc/analyzers.md	1969-12-31 19:00:00.000000000 -0500
-@@ -1,491 +0,0 @@
+@@ -1,540 +0,0 @@
 -# Analyzers
--
--<!--TODO: Generate this file from the documentation in golang/org/x/tools/go/analysis/passes and golang/org/x/tools/go/lsp/source/options.go.-->
 -
 -This document describes the analyzers that `gopls` uses inside the editor.
 -
--A value of `true` means that the analyzer is enabled by default and a value of `false` means it is disabled by default.
+-Details about how to enable/disable these analyses can be found
+-[here](settings.md#analyses).
 -
--Details about how to enable/disable these analyses can be found [here](settings.md#analyses).
--
--## Go vet suite
--
--Below is the list of general analyzers that are used in `go vet`.
--
--### **asmdecl**
+-<!-- BEGIN Analyzers: DO NOT MANUALLY EDIT THIS SECTION -->
+-## **asmdecl**
 -
 -report mismatches between assembly files and Go declarations
 -
--Default value: `true`.
+-**Enabled by default.**
 -
--### **assign**
+-## **assign**
 -
 -check for useless assignments
 -
--This checker reports assignments of the form `x = x` or `a[i] = a[i]`.
+-This checker reports assignments of the form x = x or a[i] = a[i].
 -These are almost always useless, and even when they aren't they are
 -usually a mistake.
 -
--Default value: `true`.
+-**Enabled by default.**
 -
--### **atomic**
+-## **atomic**
 -
 -check for common mistakes using the sync/atomic package
 -
 -The atomic checker looks for assignment statements of the form:
 -
--`x = atomic.AddUint64(&x, 1)`
+-	x = atomic.AddUint64(&x, 1)
 -
 -which are not atomic.
 -
--Default value: `true`.
+-**Enabled by default.**
 -
--### **atomicalign**
+-## **atomicalign**
 -
 -check for non-64-bits-aligned arguments to sync/atomic functions
 -
--Default value: `true`.
+-**Enabled by default.**
 -
--### **bools**
+-## **bools**
 -
 -check for common mistakes involving boolean operators
 -
--Default value: `true`.
+-**Enabled by default.**
 -
--### **buildtag**
+-## **buildtag**
 -
 -check that +build tags are well-formed and correctly located
 -
--Default value: `true`.
+-**Enabled by default.**
 -
--### **cgocall**
+-## **cgocall**
 -
 -detect some violations of the cgo pointer passing rules
 -
@@ -159,9 +155,9 @@ diff -urN a/gopls/doc/analyzers.md b/gopls/doc/analyzers.md
 -Specifically, it warns about attempts to pass a Go chan, map, func,
 -or slice to C, either directly, or via a pointer, array, or struct.
 -
--Default value: `true`.
+-**Enabled by default.**
 -
--### **composites**
+-## **composites**
 -
 -check for unkeyed composite literals
 -
@@ -171,14 +167,17 @@ diff -urN a/gopls/doc/analyzers.md b/gopls/doc/analyzers.md
 -(even if unexported) to the struct will cause compilation to fail.
 -
 -As an example,
--`err = &net.DNSConfigError{err}`
+-
+-	err = &net.DNSConfigError{err}
 -
 -should be replaced by:
--`err = &net.DNSConfigError{Err: err}`
 -
--Default value: `true`.
+-	err = &net.DNSConfigError{Err: err}
 -
--### **copylock**
+-
+-**Enabled by default.**
+-
+-## **copylocks**
 -
 -check for locks erroneously passed by value
 -
@@ -186,18 +185,41 @@ diff -urN a/gopls/doc/analyzers.md b/gopls/doc/analyzers.md
 -sync.WaitGroup, may cause both copies to malfunction. Generally such
 -values should be referred to through a pointer.
 -
--Default value: `true`.
+-**Enabled by default.**
 -
--### **errorsas**
+-## **deepequalerrors**
+-
+-check for calls of reflect.DeepEqual on error values
+-
+-The deepequalerrors checker looks for calls of the form:
+-
+-    reflect.DeepEqual(err1, err2)
+-
+-where err1 and err2 are errors. Using reflect.DeepEqual to compare
+-errors is discouraged.
+-
+-**Enabled by default.**
+-
+-## **errorsas**
 -
 -report passing non-pointer or non-error values to errors.As
 -
 -The errorsas analysis reports calls to errors.As where the type
 -of the second argument is not a pointer to a type implementing error.
 -
--Default value: `true`.
+-**Enabled by default.**
 -
--### **httpresponse**
+-## **fieldalignment**
+-
+-find structs that would take less memory if their fields were sorted
+-
+-This analyzer find structs that can be rearranged to take less memory, and provides
+-a suggested edit with the optimal order.
+-
+-
+-**Disabled by default. Enable it by setting `"analyses": {"fieldalignment": true}`.**
+-
+-## **httpresponse**
 -
 -check for mistakes using HTTP responses
 -
@@ -205,21 +227,39 @@ diff -urN a/gopls/doc/analyzers.md b/gopls/doc/analyzers.md
 -call to close the http.Response Body before checking the error that
 -determines whether the response is valid:
 -
--```go
--resp, err := http.Head(url)
--defer resp.Body.Close()
--if err != nil {
--  log.Fatal(err)
--}
--// (defer statement belongs here)
--```
+-	resp, err := http.Head(url)
+-	defer resp.Body.Close()
+-	if err != nil {
+-		log.Fatal(err)
+-	}
+-	// (defer statement belongs here)
 -
 -This checker helps uncover latent nil dereference bugs by reporting a
 -diagnostic for such mistakes.
 -
--Default value: `true`.
+-**Enabled by default.**
 -
--### **loopclosure**
+-## **ifaceassert**
+-
+-detect impossible interface-to-interface type assertions
+-
+-This checker flags type assertions v.(T) and corresponding type-switch cases
+-in which the static type V of v is an interface that cannot possibly implement
+-the target interface T. This occurs when V and T contain methods with the same
+-name but different signatures. Example:
+-
+-	var v interface {
+-		Read()
+-	}
+-	_ = v.(io.Reader)
+-
+-The Read method in v has a different signature than the Read method in
+-io.Reader, so this assertion cannot succeed.
+-
+-
+-**Enabled by default.**
+-
+-## **loopclosure**
 -
 -check references to loop variables from within nested functions
 -
@@ -230,19 +270,18 @@ diff -urN a/gopls/doc/analyzers.md b/gopls/doc/analyzers.md
 -program analysis.
 -
 -For example:
--```go
--for i, v := range s {
--  go func() {
--    println(i, v) // not what you might expect
--  }()
--}
--```
+-
+-	for i, v := range s {
+-		go func() {
+-			println(i, v) // not what you might expect
+-		}()
+-	}
 -
 -See: https://golang.org/doc/go_faq.html#closures_and_goroutines
 -
--Default value: `true`.
+-**Enabled by default.**
 -
--### **lostcancel**
+-## **lostcancel**
 -
 -check cancel func returned by context.WithCancel is called
 -
@@ -251,17 +290,17 @@ diff -urN a/gopls/doc/analyzers.md b/gopls/doc/analyzers.md
 -until its parent context is cancelled.
 -(The background context is never cancelled.)
 -
--Default value: `true`.
+-**Enabled by default.**
 -
--### **nilfunc**
+-## **nilfunc**
 -
 -check for useless comparisons between functions and nil
 -
 -A useless comparison is one like f == nil as opposed to f() == nil.
 -
--Default value: `true`.
+-**Enabled by default.**
 -
--### **printf**
+-## **printf**
 -
 -check consistency of Printf format strings and arguments
 -
@@ -272,21 +311,17 @@ diff -urN a/gopls/doc/analyzers.md b/gopls/doc/analyzers.md
 -found by this analyzer's heuristics (for example, due to use of
 -dynamic calls) can insert a bogus call:
 -
--```go
--if false {
--  _ = fmt.Sprintf(format, args...) // enable printf checking
--}
--```
+-	if false {
+-		_ = fmt.Sprintf(format, args...) // enable printf checking
+-	}
 -
 -The -funcs flag specifies a comma-separated list of names of additional
 -known formatting functions or methods. If the name contains a period,
 -it must denote a specific function using one of the following forms:
 -
--```
 -	dir/pkg.Function
 -	dir/pkg.Type.Method
 -	(*dir/pkg.Type).Method
--```
 -
 -Otherwise the name is interpreted as a case-insensitive unqualified
 -identifier such as "errorf". Either way, if a listed name ends in f, the
@@ -294,15 +329,99 @@ diff -urN a/gopls/doc/analyzers.md b/gopls/doc/analyzers.md
 -argument list. Otherwise it is assumed to be Print-like, taking a list
 -of arguments with no format string.
 -
--Default value: `true`.
 -
--### **shift**
+-**Enabled by default.**
+-
+-## **shadow**
+-
+-check for possible unintended shadowing of variables
+-
+-This analyzer check for shadowed variables.
+-A shadowed variable is a variable declared in an inner scope
+-with the same name and type as a variable in an outer scope,
+-and where the outer variable is mentioned after the inner one
+-is declared.
+-
+-(This definition can be refined; the module generates too many
+-false positives and is not yet enabled by default.)
+-
+-For example:
+-
+-	func BadRead(f *os.File, buf []byte) error {
+-		var err error
+-		for {
+-			n, err := f.Read(buf) // shadows the function variable 'err'
+-			if err != nil {
+-				break // causes return of wrong value
+-			}
+-			foo(buf)
+-		}
+-		return err
+-	}
+-
+-
+-**Disabled by default. Enable it by setting `"analyses": {"shadow": true}`.**
+-
+-## **shift**
 -
 -check for shifts that equal or exceed the width of the integer
 -
--Default value: `true`.
+-**Enabled by default.**
 -
--### **stdmethods**
+-## **simplifycompositelit**
+-
+-check for composite literal simplifications
+-
+-An array, slice, or map composite literal of the form:
+-	[]T{T{}, T{}}
+-will be simplified to:
+-	[]T{{}, {}}
+-
+-This is one of the simplifications that "gofmt -s" applies.
+-
+-**Enabled by default.**
+-
+-## **simplifyrange**
+-
+-check for range statement simplifications
+-
+-A range of the form:
+-	for x, _ = range v {...}
+-will be simplified to:
+-	for x = range v {...}
+-
+-A range of the form:
+-	for _ = range v {...}
+-will be simplified to:
+-	for range v {...}
+-
+-This is one of the simplifications that "gofmt -s" applies.
+-
+-**Enabled by default.**
+-
+-## **simplifyslice**
+-
+-check for slice simplifications
+-
+-A slice expression of the form:
+-	s[a:len(s)]
+-will be simplified to:
+-	s[a:]
+-
+-This is one of the simplifications that "gofmt -s" applies.
+-
+-**Enabled by default.**
+-
+-## **sortslice**
+-
+-check the argument type of sort.Slice
+-
+-sort.Slice requires an argument of a slice type. Check that
+-the interface{} value passed to sort.Slice is actually a slice.
+-
+-**Enabled by default.**
+-
+-## **stdmethods**
 -
 -check signature of methods of well-known interfaces
 -
@@ -311,10 +430,8 @@ diff -urN a/gopls/doc/analyzers.md b/gopls/doc/analyzers.md
 -For example, the result of this WriteTo method should be (int64, error),
 -not error, to satisfy io.WriterTo:
 -
--```go
 -	type myWriterTo struct{...}
 -        func (myWriterTo) WriteTo(w io.Writer) error { ... }
--```
 -
 -This check ensures that each method whose name matches one of several
 -well-known interface methods from the standard library has the correct
@@ -326,17 +443,53 @@ diff -urN a/gopls/doc/analyzers.md b/gopls/doc/analyzers.md
 -	UnmarshalJSON UnreadByte UnreadRune WriteByte
 -	WriteTo
 -
--Default value: `true`.
 -
--### **structtag**
+-**Enabled by default.**
+-
+-## **stringintconv**
+-
+-check for string(int) conversions
+-
+-This checker flags conversions of the form string(x) where x is an integer
+-(but not byte or rune) type. Such conversions are discouraged because they
+-return the UTF-8 representation of the Unicode code point x, and not a decimal
+-string representation of x as one might expect. Furthermore, if x denotes an
+-invalid code point, the conversion cannot be statically rejected.
+-
+-For conversions that intend on using the code point, consider replacing them
+-with string(rune(x)). Otherwise, strconv.Itoa and its equivalents return the
+-string representation of the value in the desired base.
+-
+-
+-**Enabled by default.**
+-
+-## **structtag**
 -
 -check that struct field tags conform to reflect.StructTag.Get
 -
 -Also report certain struct tags (json, xml) used with unexported fields.
 -
--Default value: `true`.
+-**Enabled by default.**
 -
--### **tests**
+-## **testinggoroutine**
+-
+-report calls to (*testing.T).Fatal from goroutines started by a test.
+-
+-Functions that abruptly terminate a test, such as the Fatal, Fatalf, FailNow, and
+-Skip{,f,Now} methods of *testing.T, must be called from the test goroutine itself.
+-This checker detects calls to these functions that occur within a goroutine
+-started by the test. For example:
+-
+-func TestFoo(t *testing.T) {
+-    go func() {
+-        t.Fatal("oops") // error: (*T).Fatal called from non-test goroutine
+-    }()
+-}
+-
+-
+-**Enabled by default.**
+-
+-## **tests**
 -
 -check for common mistaken usages of tests and examples
 -
@@ -347,18 +500,18 @@ diff -urN a/gopls/doc/analyzers.md b/gopls/doc/analyzers.md
 -Please see the documentation for package testing in golang.org/pkg/testing
 -for the conventions that are enforced for Tests, Benchmarks, and Examples.
 -
--Default value: `true`.
+-**Enabled by default.**
 -
--### **unmarshal**
+-## **unmarshal**
 -
 -report passing non-pointer or non-interface values to unmarshal
 -
 -The unmarshal analysis reports calls to functions such as json.Unmarshal
 -in which the argument type is not a pointer or an interface.
 -
--Default value: `true`.
+-**Enabled by default.**
 -
--### **unreachable**
+-## **unreachable**
 -
 -check for unreachable code
 -
@@ -366,9 +519,9 @@ diff -urN a/gopls/doc/analyzers.md b/gopls/doc/analyzers.md
 -because they are preceded by an return statement, a call to panic, an
 -infinite loop, or similar constructs.
 -
--Default value: `true`.
+-**Enabled by default.**
 -
--### **unsafeptr**
+-## **unsafeptr**
 -
 -check for invalid conversions of uintptr to unsafe.Pointer
 -
@@ -378,194 +531,9 @@ diff -urN a/gopls/doc/analyzers.md b/gopls/doc/analyzers.md
 -word in memory that holds a pointer value, because that word will be
 -invisible to stack copying and to the garbage collector.
 -
--Default value: `true`.
+-**Enabled by default.**
 -
--### **unusedresult**
--
--check for unused results of calls to some functions
--
--Some functions like fmt.Errorf return a result and have no side effects,
--so it is always a mistake to discard the result. This analyzer reports
--calls to certain functions in which the result of the call is ignored.
--
--The set of functions may be controlled using flags.
--
--Default value: `true`.
--
--## gopls suite
--
--Below is the list of analyzers that are used by `gopls`.
--
--### **deepequalerrors**
--
--check for calls of reflect.DeepEqual on error values
--
--The deepequalerrors checker looks for calls of the form:
--
--```go
--    reflect.DeepEqual(err1, err2)
--```
--
--where err1 and err2 are errors. Using reflect.DeepEqual to compare
--errors is discouraged.
--
--Default value: `true`.
--
--### **fillreturns**
--
--suggested fixes for "wrong number of return values (want %d, got %d)"
--
--This checker provides suggested fixes for type errors of the
--type "wrong number of return values (want %d, got %d)". For example:
--```go
--func m() (int, string, *bool, error) {
--  return
--}
--```
--will turn into
--```go
--func m() (int, string, *bool, error) {
--  return 0, "", nil, nil
--}
--```
--
--This functionality is similar to [goreturns](https://github.com/sqs/goreturns).
--
--Default value: `false`.
--
--### **nonewvars**
--
--suggested fixes for "no new vars on left side of :="
--
--This checker provides suggested fixes for type errors of the
--type "no new vars on left side of :=". For example:
--```go
--z := 1
--z := 2
--```
--will turn into
--```go
--z := 1
--z = 2
--```
--
--Default value: `false`.
--
--### **noresultvalues**
--
--suggested fixes for "no result values expected"
--
--This checker provides suggested fixes for type errors of the
--type "no result values expected". For example:
--```go
--func z() { return nil }
--```
--will turn into
--```go
--func z() { return }
--```
--
--Default value: `true`.
--
--### **simplifycompositelit**
--
--check for composite literal simplifications
--
--An array, slice, or map composite literal of the form:
--```go
--[]T{T{}, T{}}
--```
--will be simplified to:
--```go
--[]T{{}, {}}
--```
--
--This is one of the simplifications that "gofmt -s" applies.
--
--Default value: `true`.
--
--### **simplifyrange**
--
--check for range statement simplifications
--
--A range of the form:
--```go
--for x, _ = range v {...}
--```
--will be simplified to:
--```go
--for x = range v {...}
--```
--
--A range of the form:
--```go
--for _ = range v {...}
--```
--will be simplified to:
--```go
--for range v {...}
--```
--
--This is one of the simplifications that "gofmt -s" applies.
--
--Default value: `true`.
--
--### **simplifyslice**
--
--check for slice simplifications
--
--A slice expression of the form:
--```go
--s[a:len(s)]
--```
--will be simplified to:
--```go
--s[a:]
--```
--
--This is one of the simplifications that "gofmt -s" applies.
--
--Default value: `true`.
--
--### **sortslice**
--
--check the argument type of sort.Slice
--
--sort.Slice requires an argument of a slice type. Check that
--the interface{} value passed to sort.Slice is actually a slice.
--
--Default value: `true`.
--
--### **testinggoroutine**
--
--report calls to (*testing.T).Fatal from goroutines started by a test.
--
--Functions that abruptly terminate a test, such as the Fatal, Fatalf, FailNow, and
--Skip{,f,Now} methods of *testing.T, must be called from the test goroutine itself.
--This checker detects calls to these functions that occur within a goroutine
--started by the test. For example:
--
--```go
--func TestFoo(t *testing.T) {
--    go func() {
--        t.Fatal("oops") // error: (*T).Fatal called from non-test goroutine
--    }()
--}
--```
--
--Default value: `true`.
--
--### **undeclaredname**
--
--suggested fixes for "undeclared name: <>"
--
--This checker provides suggested fixes for type errors of the
--type `undeclared name: <>`. It will insert a new statement:
--`<> := `.
--
--Default value: `false`.
--
--### **unusedparams**
+-## **unusedparams**
 -
 -check for unused parameters of functions
 -
@@ -578,14 +546,97 @@ diff -urN a/gopls/doc/analyzers.md b/gopls/doc/analyzers.md
 -- functions in test files
 -- functions with empty bodies or those with just a return stmt
 -
--Default value: `false`.
+-**Disabled by default. Enable it by setting `"analyses": {"unusedparams": true}`.**
+-
+-## **unusedresult**
+-
+-check for unused results of calls to some functions
+-
+-Some functions like fmt.Errorf return a result and have no side effects,
+-so it is always a mistake to discard the result. This analyzer reports
+-calls to certain functions in which the result of the call is ignored.
+-
+-The set of functions may be controlled using flags.
+-
+-**Enabled by default.**
+-
+-## **fillreturns**
+-
+-suggested fixes for "wrong number of return values (want %d, got %d)"
+-
+-This checker provides suggested fixes for type errors of the
+-type "wrong number of return values (want %d, got %d)". For example:
+-	func m() (int, string, *bool, error) {
+-		return
+-	}
+-will turn into
+-	func m() (int, string, *bool, error) {
+-		return 0, "", nil, nil
+-	}
+-
+-This functionality is similar to https://github.com/sqs/goreturns.
+-
+-
+-**Enabled by default.**
+-
+-## **nonewvars**
+-
+-suggested fixes for "no new vars on left side of :="
+-
+-This checker provides suggested fixes for type errors of the
+-type "no new vars on left side of :=". For example:
+-	z := 1
+-	z := 2
+-will turn into
+-	z := 1
+-	z = 2
+-
+-
+-**Enabled by default.**
+-
+-## **noresultvalues**
+-
+-suggested fixes for "no result values expected"
+-
+-This checker provides suggested fixes for type errors of the
+-type "no result values expected". For example:
+-	func z() { return nil }
+-will turn into
+-	func z() { return }
+-
+-
+-**Enabled by default.**
+-
+-## **undeclaredname**
+-
+-suggested fixes for "undeclared name: <>"
+-
+-This checker provides suggested fixes for type errors of the
+-type "undeclared name: <>". It will insert a new statement:
+-"<> := ".
+-
+-**Enabled by default.**
+-
+-## **fillstruct**
+-
+-note incomplete struct initializations
+-
+-This analyzer provides diagnostics for any struct literals that do not have
+-any fields initialized. Because the suggested fix for this analysis is
+-expensive to compute, callers should compute it separately, using the
+-SuggestedFix function below.
+-
+-
+-**Enabled by default.**
+-
+-<!-- END Analyzers: DO NOT MANUALLY EDIT THIS SECTION -->
 diff -urN a/gopls/doc/atom.md b/gopls/doc/atom.md
 --- a/gopls/doc/atom.md	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/doc/atom.md	1969-12-31 19:00:00.000000000 -0500
 @@ -1,7 +0,0 @@
 -# Atom
 -
--Install the [`ide-gopls`] package.
+-Use the [`ide-gopls`] package.
 -You will also need to install the [`atom-ide-ui`] package.
 -
 -[`ide-gopls`]: https://github.com/MordFustang21/ide-gopls
@@ -593,27 +644,28 @@ diff -urN a/gopls/doc/atom.md b/gopls/doc/atom.md
 diff -urN a/gopls/doc/command-line.md b/gopls/doc/command-line.md
 --- a/gopls/doc/command-line.md	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/doc/command-line.md	1969-12-31 19:00:00.000000000 -0500
-@@ -1,15 +0,0 @@
+@@ -1,17 +0,0 @@
 -# Command line
 -
--## Flags
+-**Note: The `gopls` command-line is still experimental and subject to change at any point.**
 -
--## Commands
+-`gopls` exposes some (but not all) features on the command-line. This can be useful for debugging `gopls` itself.
 -
--### Serve
+-<!--TODO(rstambler): Generate this file.-->
 -
--### Check
+-Learn about available commands and flags by running `gopls help`.
 -
--### Format
+-Much of the functionality of `gopls` is available through a command line interface.
 -
--<!--- TODO: command line
--detailed command line instructions, use cases and flags
----->
-\ No newline at end of file
+-There are two main reasons for this. The first is that we do not want users to rely on separate command line tools when they wish to do some task outside of an editor. The second is that the CLI assists in debugging. It is easier to reproduce behavior via single command.
+-
+-It is not a goal of `gopls` to be a high performance command line tool. Its command line is intended for single file/package user interaction speeds, not bulk processing.
+-
+-For more information, see the `gopls` [command line page](command-line.md).
 diff -urN a/gopls/doc/commands.md b/gopls/doc/commands.md
 --- a/gopls/doc/commands.md	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/doc/commands.md	1969-12-31 19:00:00.000000000 -0500
-@@ -1,92 +0,0 @@
+@@ -1,104 +0,0 @@
 -# Commands
 -
 -This document describes the LSP-level commands supported by `gopls`. They cannot be invoked directly by users, and all the details are subject to change, so nobody should rely on this information.
@@ -650,11 +702,23 @@ diff -urN a/gopls/doc/commands.md b/gopls/doc/commands.md
 -tidy runs `go mod tidy` for a module.
 -
 -
+-### **Update go.sum**
+-Identifier: `gopls.update_go_sum`
+-
+-update_go_sum updates the go.sum file for a module.
+-
+-
 -### **Undeclared name**
 -Identifier: `gopls.undeclared_name`
 -
 -undeclared_name adds a variable declaration for an undeclared
 -name.
+-
+-
+-### **go get package**
+-Identifier: `gopls.go_get_package`
+-
+-go_get_package runs `go get` to fetch a package.
 -
 -
 -### **Add dependency**
@@ -709,37 +773,122 @@ diff -urN a/gopls/doc/commands.md b/gopls/doc/commands.md
 diff -urN a/gopls/doc/contributing.md b/gopls/doc/contributing.md
 --- a/gopls/doc/contributing.md	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/doc/contributing.md	1969-12-31 19:00:00.000000000 -0500
-@@ -1,25 +0,0 @@
+@@ -1,111 +0,0 @@
 -# Documentation for contributors
 -
--Contributions are welcome, but since development is so active, we request that you file an issue and claim it before starting to work on something. Otherwise, it is likely that we might already be working on a fix for your issue.
+-This documentation augments the general documentation for contributing to the
+-x/tools repository, described at the [repository root](../CONTRIBUTING.md).
+-
+-Contributions are welcome, but since development is so active, we request that
+-you file an issue and claim it before starting to work on something. Otherwise,
+-it is likely that we might already be working on a fix for your issue.
 -
 -## Finding issues
 -
--All `gopls` issues are labeled as such (see the [`gopls` label][issue-gopls]). Issues that are suitable for contributors are additionally tagged with the [`help-wanted` label][issue-wanted].
+-All `gopls` issues are labeled as such (see the [`gopls` label][issue-gopls]).
+-Issues that are suitable for contributors are additionally tagged with the
+-[`help-wanted` label][issue-wanted].
 -
--Before you begin working on an issue, please leave a comment that you are claiming it.
+-Before you begin working on an issue, please leave a comment that you are
+-claiming it.
 -
 -## Getting started
 -
--<!--- TODO: getting started
--Provide information to get contributors up and running here
----->
+-Most of the `gopls` logic is actually in the `golang.org/x/tools/internal/lsp`
+-directory, so you are most likely to develop in the golang.org/x/tools module.
+-
+-## Build
+-
+-To build a version of `gopls` with your changes applied:
+-
+-```bash
+-cd /path/to/tools/gopls
+-go install
+-```
+-
+-To confirm that you are testing with the correct `gopls` version, check that
+-your `gopls` version looks like this:
+-
+-```bash
+-$ gopls version
+-golang.org/x/tools/gopls master
+-    golang.org/x/tools/gopls@(devel)
+-```
+-
+-## Getting help
+-
+-The best way to contact the gopls team directly is via the
+-[#gopls-dev](https://app.slack.com/client/T029RQSE6/CRWSN9NCD) channel on the
+-gophers slack. Please feel free to ask any questions about your contribution or
+-about contributing in general.
+-
+-## Testing
+-
+-To run tests for just `gopls/`, run,
+-
+-```bash
+-cd /path/to/tools/gopls
+-go test ./...
+-```
+-
+-But, much of the gopls work involves `internal/lsp` too, so you will want to
+-run both:
+-
+-```bash
+-cd /path/to/tools
+-cd gopls && go test ./...
+-cd ..
+-go test ./internal/lsp/...
+-```
+-
+-There is additional information about the `internal/lsp` tests in the
+-[internal/lsp/tests `README`](https://github.com/golang/tools/blob/master/internal/lsp/tests/README.md).
+-
+-### Regtests
+-
+-gopls has a suite of regression tests defined in the `./gopls/internal/regtest`
+-directory. Each of these tests writes files to a temporary directory, starts a
+-separate gopls session, and scripts interactions using an editor-like API. As a
+-result of this overhead they can be quite slow, particularly on systems where
+-file operations are costly.
+-
+-Due to the asynchronous nature of the LSP, regtests assertions are written
+-as 'expectations' that the editor state must achieve _eventually_. This can
+-make debugging the regtests difficult. To aid with debugging, the regtests
+-output their LSP logs on any failure. If your CL gets a test failure while
+-running the regtests, please do take a look at the description of the error and
+-the LSP logs, but don't hesitate to [reach out](#getting-help) to the gopls
+-team if you need help.
+-
+-### CI
+-
+-When you mail your CL and you or a fellow contributor assigns the
+-`Run-TryBot=1` label in Gerrit, the
+-[TryBots](https://golang.org/doc/contribute.html#trybots) will run tests in
+-both the `golang.org/x/tools` and `golang.org/x/tools/gopls` modules, as
+-described above.
+-
+-Furthermore, an additional "gopls-CI" pass will be run by _Kokoro_, which is a
+-Jenkins-like Google infrastructure for running Dockerized tests. This allows us
+-to run gopls tests in various environments that would be difficult to add to
+-the TryBots. Notably, Kokoro runs tests on
+-[older Go versions](user.md#supported-go-versions) that are no longer supported
+-by the TryBots.
 -
 -## Debugging
 -
--<!--- TODO: debugging
--actual debugging steps
--viewing telemetry
----->
+-The easiest way to debug your change is to run can run a single `gopls` test
+-with a debugger.
+-
+-<!--TODO(rstambler): Add more details about the debug server and viewing
+-telemetry.-->
 -
 -[issue-gopls]: https://github.com/golang/go/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3Agopls "gopls issues"
 -[issue-wanted]: https://github.com/golang/go/issues?utf8=✓&q=is%3Aissue+is%3Aopen+label%3Agopls+label%3A"help+wanted" "help wanted"
-\ No newline at end of file
 diff -urN a/gopls/doc/daemon.md b/gopls/doc/daemon.md
 --- a/gopls/doc/daemon.md	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/doc/daemon.md	1969-12-31 19:00:00.000000000 -0500
-@@ -1,176 +0,0 @@
+@@ -1,182 +0,0 @@
 -# Running gopls as a daemon
 -
 -**Note: this feature is new. If you encounter bugs, please [file an
@@ -782,8 +931,9 @@ diff -urN a/gopls/doc/daemon.md b/gopls/doc/daemon.md
 -cause this process to auto-start the gopls daemon if needed, connect to it, and
 -forward the LSP. For example, here is a reasonable gopls invocation, that sets
 -some additional flags for easier [debugging](#debugging):
--```
--$ gopls -remote=auto -logfile=auto -debug=:0 -remote.debug=:0 -rpc.trace
+-
+-```bash
+-gopls -remote=auto -logfile=auto -debug=:0 -remote.debug=:0 -rpc.trace
 -```
 -
 -Note that the shared gopls process will automatically shut down after one
@@ -797,23 +947,28 @@ diff -urN a/gopls/doc/daemon.md b/gopls/doc/daemon.md
 -started by your editor.
 -
 -For example, to host the daemon on the TCP port `37374`, do:
--```
--$ gopls -listen=:37374 -logfile=auto -debug=:0
+-
+-```bash
+-gopls -listen=:37374 -logfile=auto -debug=:0
 -```
 -
 -And then from the editor, run
--```
--$ gopls -remote=:37374 -logfile=auto -debug=:0 -rpc.trace
+-
+-```bash
+-gopls -remote=:37374 -logfile=auto -debug=:0 -rpc.trace
 -```
 -
 -If you are on a POSIX system, you can also use unix domain sockets by prefixing
 -the flag values with `unix;`. For example:
+-
+-```bash
+-gopls -listen="unix;/tmp/gopls-daemon-socket" -logfile=auto -debug=:0
 -```
--$ gopls -listen="unix;/tmp/gopls-daemon-socket" -logfile=auto -debug=:0
--```
+-
 -And connect via:
--```
--$ gopls -remote="unix;/tmp/gopls-daemon-socket" -logfile=auto -debug=:0 -rpc.trace
+-
+-```bash
+-gopls -remote="unix;/tmp/gopls-daemon-socket" -logfile=auto -debug=:0 -rpc.trace
 -```
 -
 -(Note that these flag values MUST be enclosed in quotes, because ';' is a
@@ -916,11 +1071,11 @@ diff -urN a/gopls/doc/daemon.md b/gopls/doc/daemon.md
 -Note that once the daemon is already running, setting these flags will not
 -change its configuration. These flags only matter for the forwarder process
 -that actually starts the daemon.
-diff -urN a/gopls/doc/design.md b/gopls/doc/design.md
---- a/gopls/doc/design.md	2000-01-01 00:00:00.000000000 -0000
-+++ b/gopls/doc/design.md	1969-12-31 19:00:00.000000000 -0500
-@@ -1,400 +0,0 @@
--# gopls design documentation
+diff -urN a/gopls/doc/design/design.md b/gopls/doc/design/design.md
+--- a/gopls/doc/design/design.md	2000-01-01 00:00:00.000000000 -0000
++++ b/gopls/doc/design/design.md	1969-12-31 19:00:00.000000000 -0500
+@@ -1,394 +0,0 @@
+-# `gopls` design documentation
 -
 -## Goals
 -
@@ -928,7 +1083,6 @@ diff -urN a/gopls/doc/design.md b/gopls/doc/design.md
 -* `gopls` will be a **full implementation of LSP**, as described in the [LSP specification], to standardize as many of its features as possible.
 -* `gopls` will be **clean and extensible** so that it can encompass additional features in the future, allowing Go tooling to become best in class once more.
 -* `gopls` will **support alternate build systems and file layouts**, allowing Go development to be simpler and more powerful in any environment.
--
 -
 -## Context
 -
@@ -1092,7 +1246,6 @@ diff -urN a/gopls/doc/design.md b/gopls/doc/design.md
 -
 -There needs to be easy ways for users to report what information they can, and ways to attempt to reproduce problems without their entire state. This is also needed to produce regression tests.
 -
--
 -## Basic design decisions
 -
 -There are some fundamental architecture decisions that affect much of the rest of the design of the tool, making fundamental trade offs that impact the user experience.
@@ -1130,6 +1283,8 @@ diff -urN a/gopls/doc/design.md b/gopls/doc/design.md
 -
 -## Features
 -
+-<!--TODO(rstambler): Generate a file that lists all of the supported features.-->
+-
 -There is a set of features that gopls needs to expose to be a comprehensive IDE solution.
 -The following is the minimum set of features, along with their existing solutions and how they should map to the LSP.
 -
@@ -1160,7 +1315,6 @@ diff -urN a/gopls/doc/design.md b/gopls/doc/design.md
 -LSP            | [`textDocument/signatureHelp`]
 -Previous       | [gogetdoc]
 -|              | As a function call is being typed into code, it is helpful to know the parameters of that call to enable the developer to call it correctly.
--
 -
 -### Navigation
 -
@@ -1200,7 +1354,6 @@ diff -urN a/gopls/doc/design.md b/gopls/doc/design.md
 -Previous   | [guru]
 -|          | This requires knowledge of every package that could possible depend on any packages the current file is part of. In the past this has been implemented either by global knowledge, which does not scale, or by specifying a "scope" which confused users to the point where they just did not use the tools. gopls is probably going to need a more powerful solution in the long term, but to start with automatically limiting the scope may produce acceptable results. This would probably be the module if known, or some sensible parent directory otherwise.
 -
--
 ----
 -Folding  | Report logical hierarchies of blocks
 --------- | ---
@@ -1236,7 +1389,6 @@ diff -urN a/gopls/doc/design.md b/gopls/doc/design.md
 -Previous | [gofmt], [goimports], [goreturns]
 -|        | It will use the standard format package. <br/> Current limitations are that it does not work on malformed code. It may need some very careful changes to the formatter to allow for formatting an invalid AST or changes to force the AST to a valid mode. These changes would improve range and file mode as well, but are basically vital to onTypeFormatting
 -
--
 ----
 -Imports  | Rewrite the imports block automatically to match the symbols used.
 --------- | ---
@@ -1244,7 +1396,6 @@ diff -urN a/gopls/doc/design.md b/gopls/doc/design.md
 -LSP      | [`textDocument/codeAction`]
 -Previous | [goimports], [goreturns]
 -|        | This needs knowledge of packages that are not yet in use, and the ability to find those packages by name. <br/> It also needs exported symbol information for all the packages it discovers. <br/> It should be implemented using the standard imports package, but there may need to be exposed a more fine grained API than just a file rewrite for some of the interactions.
--
 -
 ----
 -Autocompletion | Makes suggestions to complete the entity currently being typed.
@@ -1272,7 +1423,6 @@ diff -urN a/gopls/doc/design.md b/gopls/doc/design.md
 -Previous        | N/A
 -|               | This is a brand new feature powered by the new go/analysis engine, and it should allow a huge amount of automated refactoring.
 -
--
 -[LSP specification]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/
 -[talk]: TODO
 -[slides]: https://github.com/gophercon/2019-talks/blob/master/RebeccaStambler-GoPleaseStopBreakingMyEditor/slides.pdf "Go, please stop breaking my editor!"
@@ -1297,7 +1447,6 @@ diff -urN a/gopls/doc/design.md b/gopls/doc/design.md
 -[go/ast]: https://golang.org/pkg/go/ast/
 -[go/token]: https://golang.org/pkg/go/token/
 -
--
 -[`completionItem/resolve`]:https://github.com/Microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-14.md#completionItem_resolve
 -[`textDocument/codeAction`]: https://github.com/Microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-14.md#textDocument_codeAction
 -[`textDocument/completion`]: https://github.com/Microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-14.md#textDocument_completion
@@ -1320,246 +1469,9 @@ diff -urN a/gopls/doc/design.md b/gopls/doc/design.md
 -[`textDocument/signatureHelp`]: https://github.com/Microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-14.md#textDocument_signatureHelp
 -[`textDocument/typeDefinition`]: https://github.com/Microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-14.md#textDocument_typeDefinition
 -[`workspace/didChangeWatchedFiles`]: https://github.com/Microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-14.md#workspace_didChangeWatchedFiles
-diff -urN a/gopls/doc/emacs.md b/gopls/doc/emacs.md
---- a/gopls/doc/emacs.md	2000-01-01 00:00:00.000000000 -0000
-+++ b/gopls/doc/emacs.md	1969-12-31 19:00:00.000000000 -0500
-@@ -1,70 +0,0 @@
--# Emacs
--
--Use [lsp-mode]. gopls is built in as a client. You first must install `gopls` and put it somewhere in your `PATH`. Here is a basic config to get you started (assuming you are using [use-package]):
--
--```lisp
--(use-package lsp-mode
--  :ensure t
--  :commands (lsp lsp-deferred)
--  :hook (go-mode . lsp-deferred))
--
--;; Set up before-save hooks to format buffer and add/delete imports.
--;; Make sure you don't have other gofmt/goimports hooks enabled.
--(defun lsp-go-install-save-hooks ()
--  (add-hook 'before-save-hook #'lsp-format-buffer t t)
--  (add-hook 'before-save-hook #'lsp-organize-imports t t))
--(add-hook 'go-mode-hook #'lsp-go-install-save-hooks)
--
--;; Optional - provides fancier overlays.
--(use-package lsp-ui
--  :ensure t
--  :commands lsp-ui-mode)
--
--;; Company mode is a standard completion package that works well with lsp-mode.
--(use-package company
--  :ensure t
--  :config
--  ;; Optionally enable completion-as-you-type behavior.
--  (setq company-idle-delay 0)
--  (setq company-minimum-prefix-length 1))
--
--;; Optional - provides snippet support.
--(use-package yasnippet
--  :ensure t
--  :commands yas-minor-mode
--  :hook (go-mode . yas-minor-mode))
--```
--
--lsp-mode integrates with xref. By default `lsp-find-definition` is bound to `M-.`. To go back, use `M-,`. Explore other `lsp-*` commands (not everything is supported by gopls).
--
--## Gopls Configuration
--
--Stable gopls settings have first-class support in [lsp-mode]. For example, `(setq lsp-gopls-use-placeholders nil)` will disable placeholders in completion snippets. See [lsp-go] for a list of available variables.
--
--Experimental settings can be configured via `lsp-register-custom-settings`:
--
--```lisp
--(lsp-register-custom-settings
-- '(("gopls.completeUnimported" t t)
--   ("gopls.staticcheck" t t)))
--```
--
--See [settings] for information about gopls settings.
--
--Note that after changing settings you must restart gopls using e.g. `M-x lsp-restart-workspace`.
--
--## Troubleshooting
--
--Common errors:
--- When prompted by Emacs for your project folder, if you are using modules you must select the module's root folder (i.e. the directory with the "go.mod"). If you are using GOPATH, select your $GOPATH as your folder.
--- Emacs must have your environment set properly (PATH, GOPATH, etc). You can run `M-x getenv <RET> PATH <RET>` to see if your PATH is set in Emacs. If not, you can try starting Emacs from your terminal, using [this package][exec-path-from-shell], or moving your shell config from .bashrc into .bashenv (or .zshenv).
--- Make sure `lsp-mode` and `lsp-ui` are up-to-date, also make sure `lsp-go` and `company-lsp` are _not_ installed.
--- Look for errors in the `*lsp-log*` buffer.
--- Ask for help in the #emacs channel on the [Gophers slack].
--
--[lsp-mode]: https://github.com/emacs-lsp/lsp-mode
--[use-package]: https://github.com/jwiegley/use-package
--[exec-path-from-shell]: https://github.com/purcell/exec-path-from-shell
--[settings]: settings.md
--[lsp-go]: https://github.com/emacs-lsp/lsp-mode/blob/master/lsp-go.el
--[Gophers slack]: https://invite.slack.golangbridge.org/
-diff -urN a/gopls/doc/faq.md b/gopls/doc/faq.md
---- a/gopls/doc/faq.md	2000-01-01 00:00:00.000000000 -0000
-+++ b/gopls/doc/faq.md	1969-12-31 19:00:00.000000000 -0500
-@@ -1,7 +0,0 @@
--# gopls FAQ
--
--## Why is it called gopls?
--
--Since gopls works both as a language server and as a command line tool, we wanted a name that could be used as a verb. For example, gopls check should read as "go please check." See: [cl/158197].
--
--[cl/158197]: https://golang.org/cl/158197
-\ No newline at end of file
-diff -urN a/gopls/doc/generate.go b/gopls/doc/generate.go
---- a/gopls/doc/generate.go	2000-01-01 00:00:00.000000000 -0000
-+++ b/gopls/doc/generate.go	1969-12-31 19:00:00.000000000 -0500
-@@ -1,120 +0,0 @@
--// Copyright 2020 The Go Authors. All rights reserved.
--// Use of this source code is governed by a BSD-style
--// license that can be found in the LICENSE file.
--
--// Command generate updates settings.md from the UserOptions struct.
--package main
--
--import (
--	"bytes"
--	"encoding/json"
--	"fmt"
--	"io/ioutil"
--	"os"
--	"path/filepath"
--	"regexp"
--	"strings"
--
--	"golang.org/x/tools/internal/lsp/source"
--)
--
--func main() {
--	if _, err := doMain(".", true); err != nil {
--		fmt.Fprintf(os.Stderr, "Generation failed: %v\n", err)
--		os.Exit(1)
--	}
--}
--
--func doMain(baseDir string, write bool) (bool, error) {
--	api := &source.APIJSON{}
--	if err := json.Unmarshal([]byte(source.GeneratedAPIJSON), api); err != nil {
--		return false, err
--	}
--
--	if ok, err := rewriteFile(filepath.Join(baseDir, "gopls/doc/settings.md"), api, write, rewriteSettings); !ok || err != nil {
--		return ok, err
--	}
--	if ok, err := rewriteFile(filepath.Join(baseDir, "gopls/doc/commands.md"), api, write, rewriteCommands); !ok || err != nil {
--		return ok, err
--	}
--
--	return true, nil
--}
--
--func rewriteFile(file string, api *source.APIJSON, write bool, rewrite func([]byte, *source.APIJSON) ([]byte, error)) (bool, error) {
--	doc, err := ioutil.ReadFile(file)
--	if err != nil {
--		return false, err
--	}
--
--	content, err := rewrite(doc, api)
--	if err != nil {
--		return false, fmt.Errorf("rewriting %q: %v", file, err)
--	}
--
--	if !bytes.Equal(doc, content) && !write {
--		return false, nil
--	}
--
--	if err := ioutil.WriteFile(file, content, 0); err != nil {
--		return false, err
--	}
--
--	return true, nil
--}
--
--var parBreakRE = regexp.MustCompile("\n{2,}")
--
--func rewriteSettings(doc []byte, api *source.APIJSON) ([]byte, error) {
--	result := doc
--	for category, opts := range api.Options {
--		section := bytes.NewBuffer(nil)
--		for _, opt := range opts {
--			var enumValues strings.Builder
--			if len(opt.EnumValues) > 0 {
--				enumValues.WriteString("Must be one of:\n\n")
--				for _, val := range opt.EnumValues {
--					if val.Doc != "" {
--						// Don't break the list item by starting a new paragraph.
--						unbroken := parBreakRE.ReplaceAllString(val.Doc, "\\\n")
--						fmt.Fprintf(&enumValues, " * %s\n", unbroken)
--					} else {
--						fmt.Fprintf(&enumValues, " * `%s`\n", val.Value)
--					}
--				}
--			}
--			fmt.Fprintf(section, "### **%v** *%v*\n%v%v\n\nDefault: `%v`.\n", opt.Name, opt.Type, opt.Doc, enumValues.String(), opt.Default)
--		}
--		var err error
--		result, err = replaceSection(result, category, section.Bytes())
--		if err != nil {
--			return nil, err
--		}
--	}
--
--	section := bytes.NewBuffer(nil)
--	for _, lens := range api.Lenses {
--		fmt.Fprintf(section, "### **%v**\nIdentifier: `%v`\n\n%v\n\n", lens.Title, lens.Lens, lens.Doc)
--	}
--	return replaceSection(result, "Lenses", section.Bytes())
--}
--
--func rewriteCommands(doc []byte, api *source.APIJSON) ([]byte, error) {
--	section := bytes.NewBuffer(nil)
--	for _, command := range api.Commands {
--		fmt.Fprintf(section, "### **%v**\nIdentifier: `%v`\n\n%v\n\n", command.Title, command.Command, command.Doc)
--	}
--	return replaceSection(doc, "Commands", section.Bytes())
--}
--
--func replaceSection(doc []byte, sectionName string, replacement []byte) ([]byte, error) {
--	re := regexp.MustCompile(fmt.Sprintf(`(?s)<!-- BEGIN %v.* -->\n(.*?)<!-- END %v.* -->`, sectionName, sectionName))
--	idx := re.FindSubmatchIndex(doc)
--	if idx == nil {
--		return nil, fmt.Errorf("could not find section %q", sectionName)
--	}
--	result := append([]byte(nil), doc[:idx[2]]...)
--	result = append(result, replacement...)
--	result = append(result, doc[idx[3]:]...)
--	return result, nil
--}
-diff -urN a/gopls/doc/generate_test.go b/gopls/doc/generate_test.go
---- a/gopls/doc/generate_test.go	2000-01-01 00:00:00.000000000 -0000
-+++ b/gopls/doc/generate_test.go	1969-12-31 19:00:00.000000000 -0500
-@@ -1,23 +0,0 @@
--// Copyright 2020 The Go Authors. All rights reserved.
--// Use of this source code is governed by a BSD-style
--// license that can be found in the LICENSE file.
--
--package main
--
--import (
--	"testing"
--
--	"golang.org/x/tools/internal/testenv"
--)
--
--func TestGenerated(t *testing.T) {
--	testenv.NeedsGoBuild(t) // This is a lie. We actually need the source code.
--
--	ok, err := doMain("../..", false)
--	if err != nil {
--		t.Fatal(err)
--	}
--	if !ok {
--		t.Error("documentation needs updating. run: `go run gopls/doc/generate.go` from the root of tools.")
--	}
--}
-diff -urN a/gopls/doc/implementation.md b/gopls/doc/implementation.md
---- a/gopls/doc/implementation.md	2000-01-01 00:00:00.000000000 -0000
-+++ b/gopls/doc/implementation.md	1969-12-31 19:00:00.000000000 -0500
+diff -urN a/gopls/doc/design/implementation.md b/gopls/doc/design/implementation.md
+--- a/gopls/doc/design/implementation.md	2000-01-01 00:00:00.000000000 -0000
++++ b/gopls/doc/design/implementation.md	1969-12-31 19:00:00.000000000 -0500
 @@ -1,48 +0,0 @@
 -# gopls implementation documentation
 -
@@ -1609,9 +1521,9 @@ diff -urN a/gopls/doc/implementation.md b/gopls/doc/implementation.md
 -[internal/memoize]: https://github.com/golang/tools/tree/master/internal/memoize
 -[internal/span]: https://github.com/golang/tools/tree/master/internal/span
 -[x/tools]: https://github.com/golang/tools
-diff -urN a/gopls/doc/integrating.md b/gopls/doc/integrating.md
---- a/gopls/doc/integrating.md	2000-01-01 00:00:00.000000000 -0000
-+++ b/gopls/doc/integrating.md	1969-12-31 19:00:00.000000000 -0500
+diff -urN a/gopls/doc/design/integrating.md b/gopls/doc/design/integrating.md
+--- a/gopls/doc/design/integrating.md	2000-01-01 00:00:00.000000000 -0000
++++ b/gopls/doc/design/integrating.md	1969-12-31 19:00:00.000000000 -0500
 @@ -1,91 +0,0 @@
 -# Documentation for plugin authors
 -
@@ -1704,22 +1616,1032 @@ diff -urN a/gopls/doc/integrating.md b/gopls/doc/integrating.md
 -[#31080]: https://github.com/golang/go/issues/31080
 -[#31553]: https://github.com/golang/go/issues/31553
 -[#31526]: https://github.com/golang/go/issues/31526
+diff -urN a/gopls/doc/emacs.md b/gopls/doc/emacs.md
+--- a/gopls/doc/emacs.md	2000-01-01 00:00:00.000000000 -0000
++++ b/gopls/doc/emacs.md	1969-12-31 19:00:00.000000000 -0500
+@@ -1,177 +0,0 @@
+-# Emacs
+-
+-## Installing `gopls`
+-
+-To use `gopls` with Emacs, you must first
+-[install the `gopls` binary](user.md#installation) and ensure that the directory
+-containing the resulting binary (either `$(go env GOBIN)` or `$(go env
+-GOPATH)/bin`) is in your `PATH`.
+-
+-## Choosing an Emacs LSP client
+-
+-To use `gopls` with Emacs, you will need to choose and install an Emacs LSP
+-client package. Two popular client packages are [LSP Mode] and [Eglot].
+-
+-LSP Mode takes a batteries-included approach, with many integrations enabled
+-“out of the box” and several additional behaviors provided by `lsp-mode` itself.
+-
+-Eglot takes a minimally-intrusive approach, focusing on smooth integration with
+-other established packages. It provides a few of its own `eglot-` commands but
+-no additional keybindings by default.
+-
+-Once you have selected which client you want to use, install it per the packages
+-instructions: see [Eglot 1-2-3](https://github.com/joaotavora/eglot#1-2-3) or
+-[LSP Mode Installation](https://emacs-lsp.github.io/lsp-mode/page/installation/).
+-
+-## Common configuration
+-
+-Both Eglot and LSP Mode can integrate with popular packages in the Emacs
+-ecosystem:
+-
+-* The built-in [`xref`] package provides cross-references.
+-* The built-in [Flymake] package provides an on-the-fly diagnostic overlay.
+-* [Company] mode displays code completion candidates (with a richer UI than
+-  the built-in [`completion-at-point`]).
+-
+-Eglot provides documentation using the built-in [ElDoc] minor mode, while LSP
+-Mode by default provides documentation using its own [`lsp-ui`] mode.
+-
+-Eglot by default locates the project root using the [`project`] package. In LSP
+-Mode, this behavior can be configured using the `lsp-auto-guess-root` setting.
+-
+-## Configuring LSP Mode
+-
+-### Loading LSP Mode in `.emacs`
+-
+-```elisp
+-(require 'lsp-mode)
+-(add-hook 'go-mode-hook #'lsp-deferred)
+-
+-;; Set up before-save hooks to format buffer and add/delete imports.
+-;; Make sure you don't have other gofmt/goimports hooks enabled.
+-(defun lsp-go-install-save-hooks ()
+-  (add-hook 'before-save-hook #'lsp-format-buffer t t)
+-  (add-hook 'before-save-hook #'lsp-organize-imports t t))
+-(add-hook 'go-mode-hook #'lsp-go-install-save-hooks)
+-```
+-
+-### Configuring `gopls` via LSP Mode
+-
+-See [settings] for information about available gopls settings.
+-
+-Stable gopls settings have corresponding configuration variables in `lsp-mode`.
+-For example, `(setq lsp-gopls-use-placeholders nil)` will disable placeholders
+-in completion snippets. See [`lsp-go`] for a list of available variables.
+-
+-Experimental settings can be configured via `lsp-register-custom-settings`:
+-
+-```lisp
+-(lsp-register-custom-settings
+- '(("gopls.completeUnimported" t t)
+-   ("gopls.staticcheck" t t)))
+-```
+-
+-Note that after changing settings you must restart gopls using e.g. `M-x
+-lsp-restart-workspace`.
+-
+-## Configuring Eglot
+-
+-### Configuring `project` for Go modules in `.emacs`
+-
+-Eglot uses the built-in `project` package to identify the LSP workspace for a
+-newly-opened buffer. The `project` package does not natively know about `GOPATH`
+-or Go modules. Fortunately, you can give it a custom hook to tell it to look for
+-the nearest parent `go.mod` file (that is, the root of the Go module) as the
+-project root.
+-
+-```elisp
+-(require 'project)
+-
+-(defun project-find-go-module (dir)
+-  (when-let ((root (locate-dominating-file dir "go.mod")))
+-    (cons 'go-module root)))
+-
+-(cl-defmethod project-root ((project (head go-module)))
+-  (cdr project))
+-
+-(add-hook 'project-find-functions #'project-find-go-module)
+-```
+-
+-### Loading Eglot in `.emacs`
+-
+-```elisp
+-;; Optional: load other packages before eglot to enable eglot integrations.
+-(require 'company)
+-(require 'yasnippet)
+-
+-(require 'go-mode)
+-(require 'eglot)
+-(add-hook 'go-mode-hook 'eglot-ensure)
+-
+-;; Optional: install eglot-format-buffer as a save hook.
+-;; The depth of -10 places this before eglot's willSave notification,
+-;; so that that notification reports the actual contents that will be saved.
+-(defun eglot-format-buffer-on-save ()
+-  (add-hook 'before-save-hook #'eglot-format-buffer -10 t))
+-(add-hook 'go-mode-hook #'eglot-format-buffer-on-save)
+-```
+-
+-### Configuring `gopls` via Eglot
+-
+-See [settings] for information about available gopls settings.
+-
+-LSP server settings are controlled by the `eglot-workspace-configuration`
+-variable, which can be set either globally in `.emacs` (as below) or in a
+-`.dir-locals.el` file in the project root.
+-
+-```elisp
+-(setq-default eglot-workspace-configuration
+-    '((:gopls .
+-        ((staticcheck . t)
+-         (matcher . "CaseSensitive")))))
+-```
+-
+-### Organizing imports with Eglot
+-
+-`gopls` provides the import-organizing functionality of `goimports` as an LSP
+-code action, which you can invoke as needed by running `M-x eglot-code-actions`
+-(or a key of your choice bound to the `eglot-code-actions` function) and
+-selecting `Organize Imports` at the prompt.
+-
+-Eglot does not currently support a standalone function to execute a specific
+-code action (see
+-[joaotavora/eglot#411](https://github.com/joaotavora/eglot/issues/411)), nor an
+-option to organize imports as a `before-save-hook` (see
+-[joaotavora/eglot#574](https://github.com/joaotavora/eglot/issues/574)). In the
+-meantime, see those issues for discussion and possible workarounds.
+-
+-## Troubleshooting
+-
+-Common errors:
+-
+-* When prompted by Emacs for your project folder, if you are using modules you
+-  must select the module's root folder (i.e. the directory with the "go.mod").
+-  If you are using GOPATH, select your $GOPATH as your folder.
+-* Emacs must have your environment set properly (PATH, GOPATH, etc). You can
+-  run `M-x getenv <RET> PATH <RET>` to see if your PATH is set in Emacs. If
+-  not, you can try starting Emacs from your terminal, using [this
+-  package][exec-path-from-shell], or moving your shell config from `.bashrc`
+-  into `.profile` and logging out and back in.
+-* Make sure only one LSP client mode is installed. (For example, if using
+-  `lsp-mode`, ensure that you are not _also_ enabling `eglot`.)
+-* Look for errors in the `*lsp-log*` buffer or run `M-x eglot-events-buffer`.
+-* Ask for help in the `#emacs` channel on the [Gophers slack].
+-
+-[LSP Mode]: https://emacs-lsp.github.io/lsp-mode/
+-[Eglot]: https://github.com/joaotavora/eglot/blob/master/README.md
+-[`xref`]: https://www.gnu.org/software/emacs/manual/html_node/emacs/Xref.html
+-[Flymake]: https://www.gnu.org/software/emacs/manual/html_node/flymake/Using-Flymake.html#Using-Flymake
+-[Company]: https://company-mode.github.io/
+-[`completion-at-point`]: https://www.gnu.org/software/emacs/manual/html_node/elisp/Completion-in-Buffers.html
+-[ElDoc]: https://elpa.gnu.org/packages/eldoc.html
+-[`lsp-ui`]: https://emacs-lsp.github.io/lsp-ui/
+-[`lsp-go`]: https://github.com/emacs-lsp/lsp-mode/blob/master/clients/lsp-go.el
+-[`use-package`]: https://github.com/jwiegley/use-package
+-[`exec-path-from-shell`]: https://github.com/purcell/exec-path-from-shell
+-[settings]: settings.md
+-[Gophers slack]: https://invite.slack.golangbridge.org/
+diff -urN a/gopls/doc/features.md b/gopls/doc/features.md
+--- a/gopls/doc/features.md	2000-01-01 00:00:00.000000000 -0000
++++ b/gopls/doc/features.md	1969-12-31 19:00:00.000000000 -0500
+@@ -1,24 +0,0 @@
+-# Features
+-
+-This document describes some of the features supported by `gopls`. It is
+-currently under construction, so, for a comprehensive list, see the
+-[Language Server Protocol](https://microsoft.github.io/language-server-protocol/).
+-
+-For now, only special features outside of the LSP are described below.
+-
+-## Special features
+-
+-### Symbol Queries
+-
+-Gopls supports some extended syntax for `workspace/symbol` requests, when using
+-the `fuzzy` symbol matcher (the default). Inspired by the popular fuzzy matcher
+-[FZF](https://github.com/junegunn/fzf), the following special characters are
+-supported within symbol queries:
+-
+-| Character | Usage     | Match        |
+-| --------- | --------- | ------------ |
+-| `'`       | `'abc`    | exact        |
+-| `^`       | `^printf` | exact prefix |
+-| `$`       | `printf$` | exact suffix |
+-
+-<!--TODO(rstambler): Automatically generate a list of supported features.-->
+diff -urN a/gopls/doc/generate.go b/gopls/doc/generate.go
+--- a/gopls/doc/generate.go	2000-01-01 00:00:00.000000000 -0000
++++ b/gopls/doc/generate.go	1969-12-31 19:00:00.000000000 -0500
+@@ -1,766 +0,0 @@
+-// Copyright 2020 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-// Command generate creates API (settings, etc) documentation in JSON and
+-// Markdown for machine and human consumption.
+-package main
+-
+-import (
+-	"bytes"
+-	"encoding/json"
+-	"fmt"
+-	"go/ast"
+-	"go/format"
+-	"go/token"
+-	"go/types"
+-	"io"
+-	"io/ioutil"
+-	"os"
+-	"path/filepath"
+-	"reflect"
+-	"regexp"
+-	"sort"
+-	"strconv"
+-	"strings"
+-	"time"
+-	"unicode"
+-
+-	"github.com/sanity-io/litter"
+-	"golang.org/x/tools/go/ast/astutil"
+-	"golang.org/x/tools/go/packages"
+-	"golang.org/x/tools/internal/lsp/mod"
+-	"golang.org/x/tools/internal/lsp/source"
+-)
+-
+-func main() {
+-	if _, err := doMain("..", true); err != nil {
+-		fmt.Fprintf(os.Stderr, "Generation failed: %v\n", err)
+-		os.Exit(1)
+-	}
+-}
+-
+-func doMain(baseDir string, write bool) (bool, error) {
+-	api, err := loadAPI()
+-	if err != nil {
+-		return false, err
+-	}
+-
+-	if ok, err := rewriteFile(filepath.Join(baseDir, "internal/lsp/source/api_json.go"), api, write, rewriteAPI); !ok || err != nil {
+-		return ok, err
+-	}
+-	if ok, err := rewriteFile(filepath.Join(baseDir, "gopls/doc/settings.md"), api, write, rewriteSettings); !ok || err != nil {
+-		return ok, err
+-	}
+-	if ok, err := rewriteFile(filepath.Join(baseDir, "gopls/doc/commands.md"), api, write, rewriteCommands); !ok || err != nil {
+-		return ok, err
+-	}
+-	if ok, err := rewriteFile(filepath.Join(baseDir, "gopls/doc/analyzers.md"), api, write, rewriteAnalyzers); !ok || err != nil {
+-		return ok, err
+-	}
+-
+-	return true, nil
+-}
+-
+-func loadAPI() (*source.APIJSON, error) {
+-	pkgs, err := packages.Load(
+-		&packages.Config{
+-			Mode: packages.NeedTypes | packages.NeedTypesInfo | packages.NeedSyntax | packages.NeedDeps,
+-		},
+-		"golang.org/x/tools/internal/lsp/source",
+-	)
+-	if err != nil {
+-		return nil, err
+-	}
+-	pkg := pkgs[0]
+-
+-	api := &source.APIJSON{
+-		Options: map[string][]*source.OptionJSON{},
+-	}
+-	defaults := source.DefaultOptions()
+-
+-	api.Commands, err = loadCommands(pkg)
+-	if err != nil {
+-		return nil, err
+-	}
+-	api.Lenses = loadLenses(api.Commands)
+-
+-	// Transform the internal command name to the external command name.
+-	for _, c := range api.Commands {
+-		c.Command = source.CommandPrefix + c.Command
+-	}
+-	for _, m := range []map[string]source.Analyzer{
+-		defaults.DefaultAnalyzers,
+-		defaults.TypeErrorAnalyzers,
+-		defaults.ConvenienceAnalyzers,
+-		// Don't yet add staticcheck analyzers.
+-	} {
+-		api.Analyzers = append(api.Analyzers, loadAnalyzers(m)...)
+-	}
+-	for _, category := range []reflect.Value{
+-		reflect.ValueOf(defaults.UserOptions),
+-	} {
+-		// Find the type information and ast.File corresponding to the category.
+-		optsType := pkg.Types.Scope().Lookup(category.Type().Name())
+-		if optsType == nil {
+-			return nil, fmt.Errorf("could not find %v in scope %v", category.Type().Name(), pkg.Types.Scope())
+-		}
+-		opts, err := loadOptions(category, optsType, pkg, "")
+-		if err != nil {
+-			return nil, err
+-		}
+-		catName := strings.TrimSuffix(category.Type().Name(), "Options")
+-		api.Options[catName] = opts
+-
+-		// Hardcode the expected values for the analyses and code lenses
+-		// settings, since their keys are not enums.
+-		for _, opt := range opts {
+-			switch opt.Name {
+-			case "analyses":
+-				for _, a := range api.Analyzers {
+-					opt.EnumKeys.Keys = append(opt.EnumKeys.Keys, source.EnumKey{
+-						Name:    fmt.Sprintf("%q", a.Name),
+-						Doc:     a.Doc,
+-						Default: strconv.FormatBool(a.Default),
+-					})
+-				}
+-			case "codelenses":
+-				// Hack: Lenses don't set default values, and we don't want to
+-				// pass in the list of expected lenses to loadOptions. Instead,
+-				// format the defaults using reflection here. The hackiest part
+-				// is reversing lowercasing of the field name.
+-				reflectField := category.FieldByName(upperFirst(opt.Name))
+-				for _, l := range api.Lenses {
+-					def, err := formatDefaultFromEnumBoolMap(reflectField, l.Lens)
+-					if err != nil {
+-						return nil, err
+-					}
+-					opt.EnumKeys.Keys = append(opt.EnumKeys.Keys, source.EnumKey{
+-						Name:    fmt.Sprintf("%q", l.Lens),
+-						Doc:     l.Doc,
+-						Default: def,
+-					})
+-				}
+-			}
+-		}
+-	}
+-	return api, nil
+-}
+-
+-func loadOptions(category reflect.Value, optsType types.Object, pkg *packages.Package, hierarchy string) ([]*source.OptionJSON, error) {
+-	file, err := fileForPos(pkg, optsType.Pos())
+-	if err != nil {
+-		return nil, err
+-	}
+-
+-	enums, err := loadEnums(pkg)
+-	if err != nil {
+-		return nil, err
+-	}
+-
+-	var opts []*source.OptionJSON
+-	optsStruct := optsType.Type().Underlying().(*types.Struct)
+-	for i := 0; i < optsStruct.NumFields(); i++ {
+-		// The types field gives us the type.
+-		typesField := optsStruct.Field(i)
+-
+-		// If the field name ends with "Options", assume it is a struct with
+-		// additional options and process it recursively.
+-		if h := strings.TrimSuffix(typesField.Name(), "Options"); h != typesField.Name() {
+-			// Keep track of the parent structs.
+-			if hierarchy != "" {
+-				h = hierarchy + "." + h
+-			}
+-			options, err := loadOptions(category, typesField, pkg, strings.ToLower(h))
+-			if err != nil {
+-				return nil, err
+-			}
+-			opts = append(opts, options...)
+-			continue
+-		}
+-		path, _ := astutil.PathEnclosingInterval(file, typesField.Pos(), typesField.Pos())
+-		if len(path) < 2 {
+-			return nil, fmt.Errorf("could not find AST node for field %v", typesField)
+-		}
+-		// The AST field gives us the doc.
+-		astField, ok := path[1].(*ast.Field)
+-		if !ok {
+-			return nil, fmt.Errorf("unexpected AST path %v", path)
+-		}
+-
+-		// The reflect field gives us the default value.
+-		reflectField := category.FieldByName(typesField.Name())
+-		if !reflectField.IsValid() {
+-			return nil, fmt.Errorf("could not find reflect field for %v", typesField.Name())
+-		}
+-
+-		def, err := formatDefault(reflectField)
+-		if err != nil {
+-			return nil, err
+-		}
+-
+-		typ := typesField.Type().String()
+-		if _, ok := enums[typesField.Type()]; ok {
+-			typ = "enum"
+-		}
+-		name := lowerFirst(typesField.Name())
+-
+-		var enumKeys source.EnumKeys
+-		if m, ok := typesField.Type().(*types.Map); ok {
+-			e, ok := enums[m.Key()]
+-			if ok {
+-				typ = strings.Replace(typ, m.Key().String(), m.Key().Underlying().String(), 1)
+-			}
+-			keys, err := collectEnumKeys(name, m, reflectField, e)
+-			if err != nil {
+-				return nil, err
+-			}
+-			if keys != nil {
+-				enumKeys = *keys
+-			}
+-		}
+-
+-		// Get the status of the field by checking its struct tags.
+-		reflectStructField, ok := category.Type().FieldByName(typesField.Name())
+-		if !ok {
+-			return nil, fmt.Errorf("no struct field for %s", typesField.Name())
+-		}
+-		status := reflectStructField.Tag.Get("status")
+-
+-		opts = append(opts, &source.OptionJSON{
+-			Name:       name,
+-			Type:       typ,
+-			Doc:        lowerFirst(astField.Doc.Text()),
+-			Default:    def,
+-			EnumKeys:   enumKeys,
+-			EnumValues: enums[typesField.Type()],
+-			Status:     status,
+-			Hierarchy:  hierarchy,
+-		})
+-	}
+-	return opts, nil
+-}
+-
+-func loadEnums(pkg *packages.Package) (map[types.Type][]source.EnumValue, error) {
+-	enums := map[types.Type][]source.EnumValue{}
+-	for _, name := range pkg.Types.Scope().Names() {
+-		obj := pkg.Types.Scope().Lookup(name)
+-		cnst, ok := obj.(*types.Const)
+-		if !ok {
+-			continue
+-		}
+-		f, err := fileForPos(pkg, cnst.Pos())
+-		if err != nil {
+-			return nil, fmt.Errorf("finding file for %q: %v", cnst.Name(), err)
+-		}
+-		path, _ := astutil.PathEnclosingInterval(f, cnst.Pos(), cnst.Pos())
+-		spec := path[1].(*ast.ValueSpec)
+-		value := cnst.Val().ExactString()
+-		doc := valueDoc(cnst.Name(), value, spec.Doc.Text())
+-		v := source.EnumValue{
+-			Value: value,
+-			Doc:   doc,
+-		}
+-		enums[obj.Type()] = append(enums[obj.Type()], v)
+-	}
+-	return enums, nil
+-}
+-
+-func collectEnumKeys(name string, m *types.Map, reflectField reflect.Value, enumValues []source.EnumValue) (*source.EnumKeys, error) {
+-	// Make sure the value type gets set for analyses and codelenses
+-	// too.
+-	if len(enumValues) == 0 && !hardcodedEnumKeys(name) {
+-		return nil, nil
+-	}
+-	keys := &source.EnumKeys{
+-		ValueType: m.Elem().String(),
+-	}
+-	// We can get default values for enum -> bool maps.
+-	var isEnumBoolMap bool
+-	if basic, ok := m.Elem().(*types.Basic); ok && basic.Kind() == types.Bool {
+-		isEnumBoolMap = true
+-	}
+-	for _, v := range enumValues {
+-		var def string
+-		if isEnumBoolMap {
+-			var err error
+-			def, err = formatDefaultFromEnumBoolMap(reflectField, v.Value)
+-			if err != nil {
+-				return nil, err
+-			}
+-		}
+-		keys.Keys = append(keys.Keys, source.EnumKey{
+-			Name:    v.Value,
+-			Doc:     v.Doc,
+-			Default: def,
+-		})
+-	}
+-	return keys, nil
+-}
+-
+-func formatDefaultFromEnumBoolMap(reflectMap reflect.Value, enumKey string) (string, error) {
+-	if reflectMap.Kind() != reflect.Map {
+-		return "", nil
+-	}
+-	name := enumKey
+-	if unquoted, err := strconv.Unquote(name); err == nil {
+-		name = unquoted
+-	}
+-	for _, e := range reflectMap.MapKeys() {
+-		if e.String() == name {
+-			value := reflectMap.MapIndex(e)
+-			if value.Type().Kind() == reflect.Bool {
+-				return formatDefault(value)
+-			}
+-		}
+-	}
+-	// Assume that if the value isn't mentioned in the map, it defaults to
+-	// the default value, false.
+-	return formatDefault(reflect.ValueOf(false))
+-}
+-
+-// formatDefault formats the default value into a JSON-like string.
+-// VS Code exposes settings as JSON, so showing them as JSON is reasonable.
+-// TODO(rstambler): Reconsider this approach, as the VS Code Go generator now
+-// marshals to JSON.
+-func formatDefault(reflectField reflect.Value) (string, error) {
+-	def := reflectField.Interface()
+-
+-	// Durations marshal as nanoseconds, but we want the stringy versions,
+-	// e.g. "100ms".
+-	if t, ok := def.(time.Duration); ok {
+-		def = t.String()
+-	}
+-	defBytes, err := json.Marshal(def)
+-	if err != nil {
+-		return "", err
+-	}
+-
+-	// Nil values format as "null" so print them as hardcoded empty values.
+-	switch reflectField.Type().Kind() {
+-	case reflect.Map:
+-		if reflectField.IsNil() {
+-			defBytes = []byte("{}")
+-		}
+-	case reflect.Slice:
+-		if reflectField.IsNil() {
+-			defBytes = []byte("[]")
+-		}
+-	}
+-	return string(defBytes), err
+-}
+-
+-// valueDoc transforms a docstring documenting an constant identifier to a
+-// docstring documenting its value.
+-//
+-// If doc is of the form "Foo is a bar", it returns '`"fooValue"` is a bar'. If
+-// doc is non-standard ("this value is a bar"), it returns '`"fooValue"`: this
+-// value is a bar'.
+-func valueDoc(name, value, doc string) string {
+-	if doc == "" {
+-		return ""
+-	}
+-	if strings.HasPrefix(doc, name) {
+-		// docstring in standard form. Replace the subject with value.
+-		return fmt.Sprintf("`%s`%s", value, doc[len(name):])
+-	}
+-	return fmt.Sprintf("`%s`: %s", value, doc)
+-}
+-
+-func loadCommands(pkg *packages.Package) ([]*source.CommandJSON, error) {
+-	// The code that defines commands is much more complicated than the
+-	// code that defines options, so reading comments for the Doc is very
+-	// fragile. If this causes problems, we should switch to a dynamic
+-	// approach and put the doc in the Commands struct rather than reading
+-	// from the source code.
+-
+-	// Find the Commands slice.
+-	typesSlice := pkg.Types.Scope().Lookup("Commands")
+-	f, err := fileForPos(pkg, typesSlice.Pos())
+-	if err != nil {
+-		return nil, err
+-	}
+-	path, _ := astutil.PathEnclosingInterval(f, typesSlice.Pos(), typesSlice.Pos())
+-	vspec := path[1].(*ast.ValueSpec)
+-	var astSlice *ast.CompositeLit
+-	for i, name := range vspec.Names {
+-		if name.Name == "Commands" {
+-			astSlice = vspec.Values[i].(*ast.CompositeLit)
+-		}
+-	}
+-
+-	var commands []*source.CommandJSON
+-
+-	// Parse the objects it contains.
+-	for _, elt := range astSlice.Elts {
+-		// Find the composite literal of the Command.
+-		typesCommand := pkg.TypesInfo.ObjectOf(elt.(*ast.Ident))
+-		path, _ := astutil.PathEnclosingInterval(f, typesCommand.Pos(), typesCommand.Pos())
+-		vspec := path[1].(*ast.ValueSpec)
+-
+-		var astCommand ast.Expr
+-		for i, name := range vspec.Names {
+-			if name.Name == typesCommand.Name() {
+-				astCommand = vspec.Values[i]
+-			}
+-		}
+-
+-		// Read the Name and Title fields of the literal.
+-		var name, title string
+-		ast.Inspect(astCommand, func(n ast.Node) bool {
+-			kv, ok := n.(*ast.KeyValueExpr)
+-			if ok {
+-				k := kv.Key.(*ast.Ident).Name
+-				switch k {
+-				case "Name":
+-					name = strings.Trim(kv.Value.(*ast.BasicLit).Value, `"`)
+-				case "Title":
+-					title = strings.Trim(kv.Value.(*ast.BasicLit).Value, `"`)
+-				}
+-			}
+-			return true
+-		})
+-
+-		if title == "" {
+-			title = name
+-		}
+-
+-		// Conventionally, the doc starts with the name of the variable.
+-		// Replace it with the name of the command.
+-		doc := vspec.Doc.Text()
+-		doc = strings.Replace(doc, typesCommand.Name(), name, 1)
+-
+-		commands = append(commands, &source.CommandJSON{
+-			Command: name,
+-			Title:   title,
+-			Doc:     doc,
+-		})
+-	}
+-	return commands, nil
+-}
+-
+-func loadLenses(commands []*source.CommandJSON) []*source.LensJSON {
+-	lensNames := map[string]struct{}{}
+-	for k := range source.LensFuncs() {
+-		lensNames[k] = struct{}{}
+-	}
+-	for k := range mod.LensFuncs() {
+-		lensNames[k] = struct{}{}
+-	}
+-
+-	var lenses []*source.LensJSON
+-
+-	for _, cmd := range commands {
+-		if _, ok := lensNames[cmd.Command]; ok {
+-			lenses = append(lenses, &source.LensJSON{
+-				Lens:  cmd.Command,
+-				Title: cmd.Title,
+-				Doc:   cmd.Doc,
+-			})
+-		}
+-	}
+-	return lenses
+-}
+-
+-func loadAnalyzers(m map[string]source.Analyzer) []*source.AnalyzerJSON {
+-	var sorted []string
+-	for _, a := range m {
+-		sorted = append(sorted, a.Analyzer.Name)
+-	}
+-	sort.Strings(sorted)
+-	var json []*source.AnalyzerJSON
+-	for _, name := range sorted {
+-		a := m[name]
+-		json = append(json, &source.AnalyzerJSON{
+-			Name:    a.Analyzer.Name,
+-			Doc:     a.Analyzer.Doc,
+-			Default: a.Enabled,
+-		})
+-	}
+-	return json
+-}
+-
+-func lowerFirst(x string) string {
+-	if x == "" {
+-		return x
+-	}
+-	return strings.ToLower(x[:1]) + x[1:]
+-}
+-
+-func upperFirst(x string) string {
+-	if x == "" {
+-		return x
+-	}
+-	return strings.ToUpper(x[:1]) + x[1:]
+-}
+-
+-func fileForPos(pkg *packages.Package, pos token.Pos) (*ast.File, error) {
+-	fset := pkg.Fset
+-	for _, f := range pkg.Syntax {
+-		if fset.Position(f.Pos()).Filename == fset.Position(pos).Filename {
+-			return f, nil
+-		}
+-	}
+-	return nil, fmt.Errorf("no file for pos %v", pos)
+-}
+-
+-func rewriteFile(file string, api *source.APIJSON, write bool, rewrite func([]byte, *source.APIJSON) ([]byte, error)) (bool, error) {
+-	old, err := ioutil.ReadFile(file)
+-	if err != nil {
+-		return false, err
+-	}
+-
+-	new, err := rewrite(old, api)
+-	if err != nil {
+-		return false, fmt.Errorf("rewriting %q: %v", file, err)
+-	}
+-
+-	if !write {
+-		return bytes.Equal(old, new), nil
+-	}
+-
+-	if err := ioutil.WriteFile(file, new, 0); err != nil {
+-		return false, err
+-	}
+-
+-	return true, nil
+-}
+-
+-func rewriteAPI(_ []byte, api *source.APIJSON) ([]byte, error) {
+-	buf := bytes.NewBuffer(nil)
+-	apiStr := litter.Options{
+-		HomePackage: "source",
+-	}.Sdump(api)
+-	// Massive hack: filter out redundant types from the composite literal.
+-	apiStr = strings.ReplaceAll(apiStr, "&OptionJSON", "")
+-	apiStr = strings.ReplaceAll(apiStr, ": []*OptionJSON", ":")
+-	apiStr = strings.ReplaceAll(apiStr, "&CommandJSON", "")
+-	apiStr = strings.ReplaceAll(apiStr, "&LensJSON", "")
+-	apiStr = strings.ReplaceAll(apiStr, "&AnalyzerJSON", "")
+-	apiStr = strings.ReplaceAll(apiStr, "  EnumValue{", "{")
+-	apiStr = strings.ReplaceAll(apiStr, "  EnumKey{", "{")
+-	apiBytes, err := format.Source([]byte(apiStr))
+-	if err != nil {
+-		return nil, err
+-	}
+-	fmt.Fprintf(buf, "// Code generated by \"golang.org/x/tools/gopls/doc/generate\"; DO NOT EDIT.\n\npackage source\n\nvar GeneratedAPIJSON = %s\n", apiBytes)
+-	return buf.Bytes(), nil
+-}
+-
+-var parBreakRE = regexp.MustCompile("\n{2,}")
+-
+-type optionsGroup struct {
+-	title   string
+-	final   string
+-	level   int
+-	options []*source.OptionJSON
+-}
+-
+-func rewriteSettings(doc []byte, api *source.APIJSON) ([]byte, error) {
+-	result := doc
+-	for category, opts := range api.Options {
+-		groups := collectGroups(opts)
+-
+-		// First, print a table of contents.
+-		section := bytes.NewBuffer(nil)
+-		fmt.Fprintln(section, "")
+-		for _, h := range groups {
+-			writeBullet(section, h.final, h.level)
+-		}
+-		fmt.Fprintln(section, "")
+-
+-		// Currently, the settings document has a title and a subtitle, so
+-		// start at level 3 for a header beginning with "###".
+-		baseLevel := 3
+-		for _, h := range groups {
+-			level := baseLevel + h.level
+-			writeTitle(section, h.final, level)
+-			for _, opt := range h.options {
+-				header := strMultiply("#", level+1)
+-				fmt.Fprintf(section, "%s **%v** *%v*\n\n", header, opt.Name, opt.Type)
+-				writeStatus(section, opt.Status)
+-				enumValues := collectEnums(opt)
+-				fmt.Fprintf(section, "%v%v\nDefault: `%v`.\n\n", opt.Doc, enumValues, opt.Default)
+-			}
+-		}
+-		var err error
+-		result, err = replaceSection(result, category, section.Bytes())
+-		if err != nil {
+-			return nil, err
+-		}
+-	}
+-
+-	section := bytes.NewBuffer(nil)
+-	for _, lens := range api.Lenses {
+-		fmt.Fprintf(section, "### **%v**\n\nIdentifier: `%v`\n\n%v\n", lens.Title, lens.Lens, lens.Doc)
+-	}
+-	return replaceSection(result, "Lenses", section.Bytes())
+-}
+-
+-func collectGroups(opts []*source.OptionJSON) []optionsGroup {
+-	optsByHierarchy := map[string][]*source.OptionJSON{}
+-	for _, opt := range opts {
+-		optsByHierarchy[opt.Hierarchy] = append(optsByHierarchy[opt.Hierarchy], opt)
+-	}
+-
+-	// As a hack, assume that uncategorized items are less important to
+-	// users and force the empty string to the end of the list.
+-	var containsEmpty bool
+-	var sorted []string
+-	for h := range optsByHierarchy {
+-		if h == "" {
+-			containsEmpty = true
+-			continue
+-		}
+-		sorted = append(sorted, h)
+-	}
+-	sort.Strings(sorted)
+-	if containsEmpty {
+-		sorted = append(sorted, "")
+-	}
+-	var groups []optionsGroup
+-	baseLevel := 0
+-	for _, h := range sorted {
+-		split := strings.SplitAfter(h, ".")
+-		last := split[len(split)-1]
+-		// Hack to capitalize all of UI.
+-		if last == "ui" {
+-			last = "UI"
+-		}
+-		// A hierarchy may look like "ui.formatting". If "ui" has no
+-		// options of its own, it may not be added to the map, but it
+-		// still needs a heading.
+-		components := strings.Split(h, ".")
+-		for i := 1; i < len(components); i++ {
+-			parent := strings.Join(components[0:i], ".")
+-			if _, ok := optsByHierarchy[parent]; !ok {
+-				groups = append(groups, optionsGroup{
+-					title: parent,
+-					final: last,
+-					level: baseLevel + i,
+-				})
+-			}
+-		}
+-		groups = append(groups, optionsGroup{
+-			title:   h,
+-			final:   last,
+-			level:   baseLevel + strings.Count(h, "."),
+-			options: optsByHierarchy[h],
+-		})
+-	}
+-	return groups
+-}
+-
+-func collectEnums(opt *source.OptionJSON) string {
+-	var b strings.Builder
+-	write := func(name, doc string, index, len int) {
+-		if doc != "" {
+-			unbroken := parBreakRE.ReplaceAllString(doc, "\\\n")
+-			fmt.Fprintf(&b, "* %s", unbroken)
+-		} else {
+-			fmt.Fprintf(&b, "* `%s`", name)
+-		}
+-		if index < len-1 {
+-			fmt.Fprint(&b, "\n")
+-		}
+-	}
+-	if len(opt.EnumValues) > 0 && opt.Type == "enum" {
+-		b.WriteString("\nMust be one of:\n\n")
+-		for i, val := range opt.EnumValues {
+-			write(val.Value, val.Doc, i, len(opt.EnumValues))
+-		}
+-	} else if len(opt.EnumKeys.Keys) > 0 && shouldShowEnumKeysInSettings(opt.Name) {
+-		b.WriteString("\nCan contain any of:\n\n")
+-		for i, val := range opt.EnumKeys.Keys {
+-			write(val.Name, val.Doc, i, len(opt.EnumKeys.Keys))
+-		}
+-	}
+-	return b.String()
+-}
+-
+-func shouldShowEnumKeysInSettings(name string) bool {
+-	// Both of these fields have too many possible options to print.
+-	return !hardcodedEnumKeys(name)
+-}
+-
+-func hardcodedEnumKeys(name string) bool {
+-	return name == "analyses" || name == "codelenses"
+-}
+-
+-func writeBullet(w io.Writer, title string, level int) {
+-	if title == "" {
+-		return
+-	}
+-	// Capitalize the first letter of each title.
+-	prefix := strMultiply("  ", level)
+-	fmt.Fprintf(w, "%s* [%s](#%s)\n", prefix, capitalize(title), strings.ToLower(title))
+-}
+-
+-func writeTitle(w io.Writer, title string, level int) {
+-	if title == "" {
+-		return
+-	}
+-	// Capitalize the first letter of each title.
+-	fmt.Fprintf(w, "%s %s\n\n", strMultiply("#", level), capitalize(title))
+-}
+-
+-func writeStatus(section io.Writer, status string) {
+-	switch status {
+-	case "":
+-	case "advanced":
+-		fmt.Fprint(section, "**This is an advanced setting and should not be configured by most `gopls` users.**\n\n")
+-	case "debug":
+-		fmt.Fprint(section, "**This setting is for debugging purposes only.**\n\n")
+-	case "experimental":
+-		fmt.Fprint(section, "**This setting is experimental and may be deleted.**\n\n")
+-	default:
+-		fmt.Fprintf(section, "**Status: %s.**\n\n", status)
+-	}
+-}
+-
+-func capitalize(s string) string {
+-	return string(unicode.ToUpper(rune(s[0]))) + s[1:]
+-}
+-
+-func strMultiply(str string, count int) string {
+-	var result string
+-	for i := 0; i < count; i++ {
+-		result += string(str)
+-	}
+-	return result
+-}
+-
+-func rewriteCommands(doc []byte, api *source.APIJSON) ([]byte, error) {
+-	section := bytes.NewBuffer(nil)
+-	for _, command := range api.Commands {
+-		fmt.Fprintf(section, "### **%v**\nIdentifier: `%v`\n\n%v\n\n", command.Title, command.Command, command.Doc)
+-	}
+-	return replaceSection(doc, "Commands", section.Bytes())
+-}
+-
+-func rewriteAnalyzers(doc []byte, api *source.APIJSON) ([]byte, error) {
+-	section := bytes.NewBuffer(nil)
+-	for _, analyzer := range api.Analyzers {
+-		fmt.Fprintf(section, "## **%v**\n\n", analyzer.Name)
+-		fmt.Fprintf(section, "%s\n\n", analyzer.Doc)
+-		switch analyzer.Default {
+-		case true:
+-			fmt.Fprintf(section, "**Enabled by default.**\n\n")
+-		case false:
+-			fmt.Fprintf(section, "**Disabled by default. Enable it by setting `\"analyses\": {\"%s\": true}`.**\n\n", analyzer.Name)
+-		}
+-	}
+-	return replaceSection(doc, "Analyzers", section.Bytes())
+-}
+-
+-func replaceSection(doc []byte, sectionName string, replacement []byte) ([]byte, error) {
+-	re := regexp.MustCompile(fmt.Sprintf(`(?s)<!-- BEGIN %v.* -->\n(.*?)<!-- END %v.* -->`, sectionName, sectionName))
+-	idx := re.FindSubmatchIndex(doc)
+-	if idx == nil {
+-		return nil, fmt.Errorf("could not find section %q", sectionName)
+-	}
+-	result := append([]byte(nil), doc[:idx[2]]...)
+-	result = append(result, replacement...)
+-	result = append(result, doc[idx[3]:]...)
+-	return result, nil
+-}
+diff -urN a/gopls/doc/generate_test.go b/gopls/doc/generate_test.go
+--- a/gopls/doc/generate_test.go	2000-01-01 00:00:00.000000000 -0000
++++ b/gopls/doc/generate_test.go	1969-12-31 19:00:00.000000000 -0500
+@@ -1,23 +0,0 @@
+-// Copyright 2020 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-package main
+-
+-import (
+-	"testing"
+-
+-	"golang.org/x/tools/internal/testenv"
+-)
+-
+-func TestGenerated(t *testing.T) {
+-	testenv.NeedsGoBuild(t) // This is a lie. We actually need the source code.
+-
+-	ok, err := doMain("../..", false)
+-	if err != nil {
+-		t.Fatal(err)
+-	}
+-	if !ok {
+-		t.Error("documentation needs updating. run: `go run doc/generate.go` from the gopls module.")
+-	}
+-}
 diff -urN a/gopls/doc/settings.md b/gopls/doc/settings.md
 --- a/gopls/doc/settings.md	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/doc/settings.md	1969-12-31 19:00:00.000000000 -0500
-@@ -1,313 +0,0 @@
+@@ -1,429 +0,0 @@
 -# Settings
 -
 -<!--TODO: Generate this file from the documentation in golang/org/x/tools/internal/lsp/source/options.go.-->
 -
--This document describes the global settings for `gopls` inside the editor. The settings block will be called `"gopls"` and contains a collection of controls for `gopls` that the editor is not expected to understand or control. These settings can also be configured differently per workspace folder.
+-This document describes the global settings for `gopls` inside the editor.
+-The settings block will be called `"gopls"` and contains a collection of
+-controls for `gopls` that the editor is not expected to understand or control.
+-These settings can also be configured differently per workspace folder.
 -
--In VSCode, this would be a section in your `settings.json` file that might look like this:
+-In VSCode, this would be a section in your `settings.json` file that might look
+-like this:
 -
 -```json5
 -  "gopls": {
--    "usePlaceholders": true,
--    "completeUnimported": true
+-    "ui.completion.usePlaceholders": true,
+-     ...
 -  },
 -```
 -
@@ -1727,88 +2649,137 @@ diff -urN a/gopls/doc/settings.md b/gopls/doc/settings.md
 -
 -Below is the list of settings that are officially supported for `gopls`.
 -
+-Any settings that are experimental or for debugging purposes are marked as
+-such.
+-
 -To enable all experimental features, use **allExperiments: `true`**. You will
 -still be able to independently override specific experimental features.
 -
 -<!-- BEGIN User: DO NOT MANUALLY EDIT THIS SECTION -->
--### **buildFlags** *[]string*
+-
+-* [Build](#build)
+-* [Formatting](#formatting)
+-* [UI](#ui)
+-  * [Completion](#completion)
+-  * [Diagnostic](#diagnostic)
+-  * [Documentation](#documentation)
+-  * [Navigation](#navigation)
+-
+-### Build
+-
+-#### **buildFlags** *[]string*
+-
 -buildFlags is the set of flags passed on to the build system when invoked.
 -It is applied to queries like `go list`, which is used when discovering files.
 -The most common use is to set `-tags`.
 -
--
 -Default: `[]`.
--### **env** *map[string]string*
+-
+-#### **env** *map[string]string*
+-
 -env adds environment variables to external commands run by `gopls`, most notably `go list`.
 -
--
 -Default: `{}`.
--### **hoverKind** *enum*
--hoverKind controls the information that appears in the hover text.
--SingleLine and Structured are intended for use only by authors of editor plugins.
--Must be one of:
 -
-- * `"FullDocumentation"`
-- * `"NoDocumentation"`
-- * `"SingleLine"`
-- * `"Structured"` is an experimental setting that returns a structured hover format.
--This format separates the signature from the documentation, so that the client
--can do more manipulation of these fields.\
--This should only be used by clients that support this behavior.
+-#### **directoryFilters** *[]string*
 -
-- * `"SynopsisDocumentation"`
+-directoryFilters can be used to exclude unwanted directories from the
+-workspace. By default, all directories are included. Filters are an
+-operator, `+` to include and `-` to exclude, followed by a path prefix
+-relative to the workspace folder. They are evaluated in order, and
+-the last filter that applies to a path controls whether it is included.
+-The path prefix can be empty, so an initial `-` excludes everything.
 -
+-Examples:
+-Exclude node_modules: `-node_modules`
+-Include only project_a: `-` (exclude everything), `+project_a`
+-Include only project_a, but not node_modules inside it: `-`, `+project_a`, `-project_a/node_modules`
 -
--Default: `"FullDocumentation"`.
--### **usePlaceholders** *bool*
--placeholders enables placeholders for function parameters or struct fields in completion responses.
+-Default: `[]`.
 -
+-#### **expandWorkspaceToModule** *bool*
+-
+-**This setting is experimental and may be deleted.**
+-
+-expandWorkspaceToModule instructs `gopls` to adjust the scope of the
+-workspace to find the best available module root. `gopls` first looks for
+-a go.mod file in any parent directory of the workspace folder, expanding
+-the scope to that directory if it exists. If no viable parent directory is
+-found, gopls will check if there is exactly one child directory containing
+-a go.mod file, narrowing the scope to that directory if it exists.
+-
+-Default: `true`.
+-
+-#### **experimentalWorkspaceModule** *bool*
+-
+-**This setting is experimental and may be deleted.**
+-
+-experimentalWorkspaceModule opts a user into the experimental support
+-for multi-module workspaces.
 -
 -Default: `false`.
--### **linkTarget** *string*
--linkTarget controls where documentation links go.
--It might be one of:
 -
--* `"godoc.org"`
--* `"pkg.go.dev"`
+-#### **experimentalPackageCacheKey** *bool*
 -
--If company chooses to use its own `godoc.org`, its address can be used as well.
+-**This setting is experimental and may be deleted.**
 -
+-experimentalPackageCacheKey controls whether to use a coarser cache key
+-for package type information to increase cache hits. This setting removes
+-the user's environment, build flags, and working directory from the cache
+-key, which should be a safe change as all relevant inputs into the type
+-checking pass are already hashed into the key. This is temporarily guarded
+-by an experiment because caching behavior is subtle and difficult to
+-comprehensively test.
 -
--Default: `"pkg.go.dev"`.
--### **local** *string*
--local is the equivalent of the `goimports -local` flag, which puts imports beginning with this string after 3rd-party packages.
--It should be the prefix of the import path whose imports should be grouped separately.
+-Default: `true`.
 -
+-#### **allowModfileModifications** *bool*
+-
+-**This setting is experimental and may be deleted.**
+-
+-allowModfileModifications disables -mod=readonly, allowing imports from
+-out-of-scope modules. This option will eventually be removed.
+-
+-Default: `false`.
+-
+-#### **allowImplicitNetworkAccess** *bool*
+-
+-**This setting is experimental and may be deleted.**
+-
+-allowImplicitNetworkAccess disables GOPROXY=off, allowing implicit module
+-downloads rather than requiring user action. This option will eventually
+-be removed.
+-
+-Default: `false`.
+-
+-### Formatting
+-
+-#### **local** *string*
+-
+-local is the equivalent of the `goimports -local` flag, which puts
+-imports beginning with this string after third-party packages. It should
+-be the prefix of the import path whose imports should be grouped
+-separately.
 -
 -Default: `""`.
--### **gofumpt** *bool*
+-
+-#### **gofumpt** *bool*
+-
 -gofumpt indicates if we should run gofumpt formatting.
 -
--
 -Default: `false`.
--### **analyses** *map[string]bool*
--analyses specify analyses that the user would like to enable or disable.
--A map of the names of analysis passes that should be enabled/disabled.
--A full list of analyzers that gopls uses can be found [here](analyzers.md)
+-
+-### UI
+-
+-#### **codelenses** *map[string]bool*
+-
+-codelenses overrides the enabled/disabled state of code lenses. See the
+-"Code Lenses" section of the
+-[Settings page](https://github.com/golang/tools/blob/master/gopls/doc/settings.md)
+-for the list of supported lenses.
 -
 -Example Usage:
--```json5
--...
--"analyses": {
--  "unreachable": false, // Disable the unreachable analyzer.
--  "unusedparams": true  // Enable the unusedparams analyzer.
--}
--...
--```
 -
--
--Default: `{}`.
--### **codelenses** *map[string]bool*
--codelenses overrides the enabled/disabled state of code lenses. See the "Code Lenses"
--section of settings.md for the list of supported lenses.
--
--Example Usage:
 -```json5
 -"gopls": {
 -...
@@ -1820,116 +2791,105 @@ diff -urN a/gopls/doc/settings.md b/gopls/doc/settings.md
 -}
 -```
 -
--
 -Default: `{"gc_details":false,"generate":true,"regenerate_cgo":true,"tidy":true,"upgrade_dependency":true,"vendor":true}`.
--### **linksInHover** *bool*
--linksInHover toggles the presence of links to documentation in hover.
 -
+-#### **semanticTokens** *bool*
 -
--Default: `true`.
--### **importShortcut** *enum*
--importShortcut specifies whether import statements should link to
--documentation or go to definitions.
--Must be one of:
+-**This setting is experimental and may be deleted.**
 -
-- * `"Both"`
-- * `"Definition"`
-- * `"Link"`
--
--
--Default: `"Both"`.
--### **matcher** *enum*
--matcher sets the algorithm that is used when calculating completion candidates.
--Must be one of:
--
-- * `"CaseInsensitive"`
-- * `"CaseSensitive"`
-- * `"Fuzzy"`
--
--
--Default: `"Fuzzy"`.
--### **symbolMatcher** *enum*
--symbolMatcher sets the algorithm that is used when finding workspace symbols.
--Must be one of:
--
-- * `"CaseInsensitive"`
-- * `"CaseSensitive"`
-- * `"Fuzzy"`
--
--
--Default: `"Fuzzy"`.
--### **symbolStyle** *enum*
--symbolStyle controls how symbols are qualified in symbol responses.
--
--Example Usage:
--```json5
--"gopls": {
--...
--  "symbolStyle": "dynamic",
--...
--}
--```
--Must be one of:
--
-- * `"Dynamic"` uses whichever qualifier results in the highest scoring
--match for the given symbol query. Here a "qualifier" is any "/" or "."
--delimited suffix of the fully qualified symbol. i.e. "to/pkg.Foo.Field" or
--just "Foo.Field".
--
-- * `"Full"` is fully qualified symbols, i.e.
--"path/to/pkg.Foo.Field".
--
-- * `"Package"` is package qualified symbols i.e.
--"pkg.Foo.Field".
--
--
--
--Default: `"Dynamic"`.
--<!-- END User: DO NOT MANUALLY EDIT THIS SECTION -->
--
--## Experimental
--
--The below settings are considered experimental. They may be deprecated or changed in the future. They are typically used to test experimental opt-in features or to disable features.
--
--<!-- BEGIN Experimental: DO NOT MANUALLY EDIT THIS SECTION -->
--### **annotations** *map[string]bool*
--annotations suppress various kinds of optimization diagnostics
--that would be reported by the gc_details command.
-- * noNilcheck suppresses display of nilchecks.
-- * noEscape suppresses escape choices.
-- * noInline suppresses inlining choices.
-- * noBounds suppresses bounds checking diagnostics.
--
--
--Default: `{}`.
--### **staticcheck** *bool*
--staticcheck enables additional analyses from staticcheck.io.
--
--
--Default: `false`.
--### **semanticTokens** *bool*
 -semanticTokens controls whether the LSP server will send
 -semantic tokens to the client.
 -
+-Default: `false`.
+-
+-#### Completion
+-
+-##### **usePlaceholders** *bool*
+-
+-placeholders enables placeholders for function parameters or struct
+-fields in completion responses.
 -
 -Default: `false`.
--### **expandWorkspaceToModule** *bool*
--expandWorkspaceToModule instructs `gopls` to adjust the scope of the
--workspace to find the best available module root. `gopls` first looks for
--a go.mod file in any parent directory of the workspace folder, expanding
--the scope to that directory if it exists. If no viable parent directory is
--found, gopls will check if there is exactly one child directory containing
--a go.mod file, narrowing the scope to that directory if it exists.
 -
+-##### **completionBudget** *time.Duration*
 -
--Default: `true`.
--### **experimentalWorkspaceModule** *bool*
--experimentalWorkspaceModule opts a user into the experimental support
--for multi-module workspaces.
+-**This setting is for debugging purposes only.**
 -
+-completionBudget is the soft latency goal for completion requests. Most
+-requests finish in a couple milliseconds, but in some cases deep
+-completions can take much longer. As we use up our budget we
+-dynamically reduce the search scope to ensure we return timely
+-results. Zero means unlimited.
+-
+-Default: `"100ms"`.
+-
+-##### **matcher** *enum*
+-
+-**This is an advanced setting and should not be configured by most `gopls` users.**
+-
+-matcher sets the algorithm that is used when calculating completion
+-candidates.
+-
+-Must be one of:
+-
+-* `"CaseInsensitive"`
+-* `"CaseSensitive"`
+-* `"Fuzzy"`
+-Default: `"Fuzzy"`.
+-
+-#### Diagnostic
+-
+-##### **analyses** *map[string]bool*
+-
+-analyses specify analyses that the user would like to enable or disable.
+-A map of the names of analysis passes that should be enabled/disabled.
+-A full list of analyzers that gopls uses can be found
+-[here](https://github.com/golang/tools/blob/master/gopls/doc/analyzers.md).
+-
+-Example Usage:
+-
+-```json5
+-...
+-"analyses": {
+-  "unreachable": false, // Disable the unreachable analyzer.
+-  "unusedparams": true  // Enable the unusedparams analyzer.
+-}
+-...
+-```
+-
+-Default: `{}`.
+-
+-##### **staticcheck** *bool*
+-
+-**This setting is experimental and may be deleted.**
+-
+-staticcheck enables additional analyses from staticcheck.io.
 -
 -Default: `false`.
--### **experimentalDiagnosticsDelay** *time.Duration*
+-
+-##### **annotations** *map[string]bool*
+-
+-**This setting is experimental and may be deleted.**
+-
+-annotations specifies the various kinds of optimization diagnostics
+-that should be reported by the gc_details command.
+-
+-Can contain any of:
+-
+-* `"bounds"` controls bounds checking diagnostics.
+-
+-* `"escape"` controls diagnostics about escape choices.
+-
+-* `"inline"` controls diagnostics about inlining choices.
+-
+-* `"nil"` controls nil checks.
+-
+-Default: `{"bounds":true,"escape":true,"inline":true,"nil":true}`.
+-
+-##### **experimentalDiagnosticsDelay** *time.Duration*
+-
+-**This setting is experimental and may be deleted.**
+-
 -experimentalDiagnosticsDelay controls the amount of time that gopls waits
 -after the most recent file modification before computing deep diagnostics.
 -Simple diagnostics (parsing and type-checking) are always run immediately
@@ -1937,131 +2897,164 @@ diff -urN a/gopls/doc/settings.md b/gopls/doc/settings.md
 -
 -This option must be set to a valid duration string, for example `"250ms"`.
 -
+-Default: `"250ms"`.
 -
--Default: `"0s"`.
--### **experimentalPackageCacheKey** *bool*
--experimentalPackageCacheKey controls whether to use a coarser cache key
--for package type information to increase cache hits. This setting removes
--the user's environment, build flags, and working directory from the cache
--key, which should be a safe change as all relevant inputs into the type
--checking pass are already hashed into the key. This is temporarily guarded
--by an experiment because caching behavior is subtle and difficult to
--comprehensively test.
+-#### Documentation
 -
+-##### **hoverKind** *enum*
+-
+-hoverKind controls the information that appears in the hover text.
+-SingleLine and Structured are intended for use only by authors of editor plugins.
+-
+-Must be one of:
+-
+-* `"FullDocumentation"`
+-* `"NoDocumentation"`
+-* `"SingleLine"`
+-* `"Structured"` is an experimental setting that returns a structured hover format.
+-This format separates the signature from the documentation, so that the client
+-can do more manipulation of these fields.\
+-This should only be used by clients that support this behavior.
+-
+-* `"SynopsisDocumentation"`
+-Default: `"FullDocumentation"`.
+-
+-##### **linkTarget** *string*
+-
+-linkTarget controls where documentation links go.
+-It might be one of:
+-
+-* `"godoc.org"`
+-* `"pkg.go.dev"`
+-
+-If company chooses to use its own `godoc.org`, its address can be used as well.
+-
+-Default: `"pkg.go.dev"`.
+-
+-##### **linksInHover** *bool*
+-
+-linksInHover toggles the presence of links to documentation in hover.
 -
 -Default: `true`.
--<!-- END Experimental: DO NOT MANUALLY EDIT THIS SECTION -->
 -
--## Debugging
+-#### Navigation
 -
--The below settings are for use in debugging `gopls`. Like the experimental options, they may be deprecated or changed in the future.
+-##### **importShortcut** *enum*
 -
--<!-- BEGIN Debugging: DO NOT MANUALLY EDIT THIS SECTION -->
--### **verboseOutput** *bool*
+-importShortcut specifies whether import statements should link to
+-documentation or go to definitions.
+-
+-Must be one of:
+-
+-* `"Both"`
+-* `"Definition"`
+-* `"Link"`
+-Default: `"Both"`.
+-
+-##### **symbolMatcher** *enum*
+-
+-**This is an advanced setting and should not be configured by most `gopls` users.**
+-
+-symbolMatcher sets the algorithm that is used when finding workspace symbols.
+-
+-Must be one of:
+-
+-* `"CaseInsensitive"`
+-* `"CaseSensitive"`
+-* `"Fuzzy"`
+-Default: `"Fuzzy"`.
+-
+-##### **symbolStyle** *enum*
+-
+-**This is an advanced setting and should not be configured by most `gopls` users.**
+-
+-symbolStyle controls how symbols are qualified in symbol responses.
+-
+-Example Usage:
+-
+-```json5
+-"gopls": {
+-...
+-  "symbolStyle": "dynamic",
+-...
+-}
+-```
+-
+-Must be one of:
+-
+-* `"Dynamic"` uses whichever qualifier results in the highest scoring
+-match for the given symbol query. Here a "qualifier" is any "/" or "."
+-delimited suffix of the fully qualified symbol. i.e. "to/pkg.Foo.Field" or
+-just "Foo.Field".
+-
+-* `"Full"` is fully qualified symbols, i.e.
+-"path/to/pkg.Foo.Field".
+-
+-* `"Package"` is package qualified symbols i.e.
+-"pkg.Foo.Field".
+-
+-Default: `"Dynamic"`.
+-
+-#### **verboseOutput** *bool*
+-
+-**This setting is for debugging purposes only.**
+-
 -verboseOutput enables additional debug logging.
 -
--
 -Default: `false`.
--### **completionBudget** *time.Duration*
--completionBudget is the soft latency goal for completion requests. Most
--requests finish in a couple milliseconds, but in some cases deep
--completions can take much longer. As we use up our budget we
--dynamically reduce the search scope to ensure we return timely
--results. Zero means unlimited.
 -
--
--Default: `"100ms"`.
--<!-- END Debugging: DO NOT MANUALLY EDIT THIS SECTION -->
+-<!-- END User: DO NOT MANUALLY EDIT THIS SECTION -->
 -
 -## Code Lenses
 -
--These are the code lenses that `gopls` currently supports. They can be enabled and disabled using the `codeLenses` setting, documented above. The names and features are subject to change.
+-These are the code lenses that `gopls` currently supports. They can be enabled
+-and disabled using the `codelenses` setting, documented above. Their names and
+-features are subject to change.
 -
 -<!-- BEGIN Lenses: DO NOT MANUALLY EDIT THIS SECTION -->
 -### **Run go generate**
+-
 -Identifier: `generate`
 -
 -generate runs `go generate` for a given directory.
 -
--
 -### **Regenerate cgo**
+-
 -Identifier: `regenerate_cgo`
 -
 -regenerate_cgo regenerates cgo definitions.
 -
--
 -### **Run test(s)**
+-
 -Identifier: `test`
 -
 -test runs `go test` for a specific test function.
 -
--
 -### **Run go mod tidy**
+-
 -Identifier: `tidy`
 -
 -tidy runs `go mod tidy` for a module.
 -
--
 -### **Upgrade dependency**
+-
 -Identifier: `upgrade_dependency`
 -
 -upgrade_dependency upgrades a dependency.
 -
--
 -### **Run go mod vendor**
+-
 -Identifier: `vendor`
 -
 -vendor runs `go mod vendor` for a module.
 -
--
 -### **Toggle gc_details**
+-
 -Identifier: `gc_details`
 -
 -gc_details controls calculation of gc annotations.
 -
--
 -<!-- END Lenses: DO NOT MANUALLY EDIT THIS SECTION -->
-diff -urN a/gopls/doc/status.md b/gopls/doc/status.md
---- a/gopls/doc/status.md	2000-01-01 00:00:00.000000000 -0000
-+++ b/gopls/doc/status.md	1969-12-31 19:00:00.000000000 -0500
-@@ -1,37 +0,0 @@
--# Status
--
--gopls is currently in **alpha**, so it is **not stable**.
--
--gopls is currently under active development by the Go team. The code is in the [x/tools] repository, in [golang.org/x/tools/internal/lsp] and [golang.org/x/tools/gopls].
--
--## Supported features
--
--<!--- TODO: supported features
--details and status for the features
--missing features
----->
--
--### Autocompletion
--### Jump to definition
--### Signature help
--### Hover
--### Document symbols
--### References
--### Rename
--
--## Known issues
--
--1. Editing multiple modules in one editor window: [#32394]
--1. Type checking does not work in cgo packages: [#35721]
--1. Does not work with build tags: [#29202]
--1. Find references and rename only work in a single package: [#32877]
--
--[x/tools]: https://github.com/golang/tools
--[golang.org/x/tools/gopls]: https://github.com/golang/tools/tree/master/gopls
--[golang.org/x/tools/internal/lsp]: https://github.com/golang/tools/tree/master/internal/lsp
--
--
--[#32394]: https://github.com/golang/go/issues/32394
--[#35721]: https://github.com/golang/go/issues/35721
--[#29202]: https://github.com/golang/go/issues/29202
--[#32877]: https://github.com/golang/go/issues/32877
 diff -urN a/gopls/doc/subl.md b/gopls/doc/subl.md
 --- a/gopls/doc/subl.md	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/doc/subl.md	1969-12-31 19:00:00.000000000 -0500
@@ -2080,106 +3073,67 @@ diff -urN a/gopls/doc/subl.md b/gopls/doc/subl.md
 diff -urN a/gopls/doc/troubleshooting.md b/gopls/doc/troubleshooting.md
 --- a/gopls/doc/troubleshooting.md	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/doc/troubleshooting.md	1969-12-31 19:00:00.000000000 -0500
-@@ -1,85 +0,0 @@
+@@ -1,48 +0,0 @@
 -# Troubleshooting
 -
--If you suspect that `gopls` is crashing or not working correctly, please follow the [troubleshooting steps](#steps) below.
+-If you suspect that `gopls` is crashing or not working correctly, please follow the troubleshooting steps below.
 -
--If `gopls` is using too much memory, please follow the steps under [Memory usage](#memory-usage).
+-If `gopls` is using too much memory, please follow the steps under [Memory usage](#debug-memory-usage).
 -
 -## Steps
 -
--<!--- TODO: troubleshooting
--describe more basic and optional trouble shooting steps
--  like checking you opened the module root
--  and using the debug pages
----->
+-VS Code users should follow [their troubleshooting guide](https://github.com/golang/vscode-go/blob/master/docs/troubleshooting.md), which has more a more specific version of these instructions.
 -
--1. Make sure your `gopls` is [up to date](user.md#installing).
--1. Check the [known issues](status.md#known-issues).
--1. [Report the issue](#file-an-issue).
+-1. Verify that your project is in good shape by working with it outside of your editor. Running a command like `go build ./...` in the workspace directory will compile everything. For modules, `go mod tidy` is another good check, though it may modify your `go.mod`.
+-1. Check that your editor isn't showing any diagnostics that indicate a problem with your workspace. They may appear as diagnostics on a Go file's package declaration, diagnostics in a go.mod file, or as a status or progress message. Problems in the workspace configuration can cause many different symptoms. See the [workspace setup instructions](workspace.md) for help.
+-1. Make sure `gopls` is up to date by following the [installation instructions](user.md#installing), then [restarting gopls](#restart-gopls).
+-1. Optionally, [ask for help](#ask-for-help) on Gophers Slack.
+-1. Finally, [report the issue](#file-an-issue) to the `gopls` developers.
+-
+-## Restart `gopls`
+-
+-`gopls` has no persistent state, so restarting it will fix transient problems. This is good and bad: good, because you can keep working, and bad, because you won't be able to debug the issue until it recurs.
+-
+-In most cases, closing all your open editors will guarantee that `gopls` is killed and restarted. If you don't want to do that, there may be an editor command you can use to restart only `gopls`. Note that some `vim` configurations keep the server alive for a while after the editor exits; you may need to explicitly kill `gopls` if you use `vim`.
+-
+-## Ask for help
+-
+-Gophers Slack has active editor-specific channels like [#emacs](https://gophers.slack.com/archives/C0HKHULEM), [#vim](https://gophers.slack.com/archives/C07GBR52P), and [#vscode](https://gophers.slack.com/archives/C2B4L99RS) that can help debug further. If you're confident the problem is with `gopls`, you can go straight to [#gopls](https://gophers.slack.com/archives/CJZH85XCZ). Invites are [available to everyone](https://invite.slack.golangbridge.org). Come prepared with a short description of the issue, and try to be available to answer questions for a while afterward.
 -
 -## File an issue
 -
--You can use:
--
--* Your editor's bug submission integration (if available). For instance, `:GoReportGitHubIssue` in [`vim-go`](vim.md#vim-go).
--* `gopls bug` on the command line.
--* The [Go issue tracker](https://github.com/golang/go/issues/new?title=x%2Ftools%2Fgopls%3A%20%3Cfill%20this%20in%3E).
--
--Along with an explanation of the issue, please share the information listed here:
+-We can't diagnose a problem from just a description. When filing an issue, please include as much as possible of the following information:
 -
 -1. Your editor and any settings you have configured (for example, your VSCode `settings.json` file).
 -1. A sample program that reproduces the issue, if possible.
 -1. The output of `gopls version` on the command line.
--1. The output of `gopls -rpc.trace -v check /path/to/file.go`.
--1. gopls logs from when the issue occurred, as well as a timestamp for when the issue began to occur. See the [instructions](#capturing-gopls-logs) for information on how to capture gopls logs.
+-1. A complete gopls log file from a session where the issue occurred. It should have a `go env for <workspace folder>` log line near the beginning. It's also helpful to tell us the timestamp the problem occurred, so we can find it the log. See the [instructions](#capture-logs) for information on how to capture gopls logs.
 -
--Much of this information is filled in for you if you use `gopls bug` to file the issue.
+-Your editor may have a command that fills out some of the necessary information, such as `:GoReportGitHubIssue` in `vim-go`. Otherwise, you can use `gopls bug` on the command line. If neither of those work you can start from scratch directly on the [Go issue tracker](https://github.com/golang/go/issues/new?title=x%2Ftools%2Fgopls%3A%20%3Cfill%20this%20in%3E).
 -
--### Capturing logs
+-## Capture logs
 -
--#### VS Code
--
--For VSCode users, the gopls log can be found by navigating to `View` -> `Output` (or `Ctrl+K Ctrl+H`). There will be a drop-down menu titled `Tasks` in the top-right corner. Select the `gopls (server)` item, which will contain the `gopls` logs.
--
--To increase the level of detail in your logs, add the following to your VS Code settings:
--
--```json5
--"go.languageServerFlags": [
--  "-rpc.trace"
--]
--```
--
--To start a debug server that will allow you to see profiles and memory usage, add the following to your VS Code settings:
--
--```json5
--"go.languageServerFlags": [
--  "serve",
--  "-rpc.trace",
--  "--debug=localhost:6060",
--],
--```
--
--You will then be able to view debug information by navigating to `localhost:6060`.
--
--#### Other editors
--
--For other editors, you may have to directly pass a `-logfile` flag to gopls.
+-You may have to change your editor's configuration to pass a `-logfile` flag to gopls.
 -
 -To increase the level of detail in your logs, start `gopls` with the `-rpc.trace` flag. To start a debug server that will allow you to see profiles and memory usage, start `gopls` with `serve --debug=localhost:6060`. You will then be able to view debug information by navigating to `localhost:6060`.
 -
 -If you are unsure of how to pass a flag to `gopls` through your editor, please see the [documentation for your editor](user.md#editors).
 -
--### Restart your editor
+-## Debug memory usage
 -
--Once you have filed an issue, you can then try to restart your `gopls` instance by restarting your editor. In many cases, this will correct the problem. In VSCode, the easiest way to restart the language server is by opening the command palette (Ctrl + Shift + P) and selecting `"Go: Restart Language Server"`. You can also reload the VSCode instance by selecting `"Developer: Reload Window"`.
--
--## Memory usage
--
--`gopls` automatically writes out memory debug information when your usage
--exceeds 1GB. This information can be found in your temporary directory with
--names like `gopls.1234-5GiB-withnames.zip`. On Windows, your temporary
--directory will be located at `%TMP%`, and on Unixes, it will be `$TMPDIR`,
--which is usually `/tmp`. Please create a
--[new issue](https://github.com/golang/go/issues/new?title=x%2Ftools%2Fgopls%3A%20%3Cfill%20this%20in%3E)
--with your editor settings and memory debug information attached. If you are
--uncomfortable sharing the package names of your code, you can share the
--`-nonames` zip instead.
+-`gopls` automatically writes out memory debug information when your usage exceeds 1GB. This information can be found in your temporary directory with names like `gopls.1234-5GiB-withnames.zip`. On Windows, your temporary directory will be located at `%TMP%`, and on Unixes, it will be `$TMPDIR`, which is usually `/tmp`. Please [file an issue](#file-an-issue) with this memory debug information attached. If you are uncomfortable sharing the package names of your code, you can share the `-nonames` zip instead, but it's much less useful.
 diff -urN a/gopls/doc/user.md b/gopls/doc/user.md
 --- a/gopls/doc/user.md	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/doc/user.md	1969-12-31 19:00:00.000000000 -0500
-@@ -1,156 +0,0 @@
+@@ -1,165 +0,0 @@
 -# User guide
 -
--##### If you're having issues with `gopls`, please see the [troubleshooting guide](troubleshooting.md).
--
--This document focuses on VSCode, as at the time of writing, VSCode is the most popular Go editor. However, most of the features described here work in any editor. The settings should be easy to translate to those of another editor's LSP client. The differences will be in the place where you define the settings and the syntax with which you declare them.
+-**If you're having issues with `gopls`, please see the
+-[troubleshooting guide](troubleshooting.md).**
 -
 -## Editors
 -
--The following is the list of editors with known integrations.
--If you use `gopls` with an editor that is not on this list, please let us know by [filing an issue](#new-issue) or [modifying this documentation](#contribute).
+-The following is the list of editors with known integrations for `gopls`.
 -
 -* [VSCode](vscode.md)
 -* [Vim / Neovim](vim.md)
@@ -2187,6 +3141,19 @@ diff -urN a/gopls/doc/user.md b/gopls/doc/user.md
 -* [Acme](acme.md)
 -* [Sublime Text](subl.md)
 -* [Atom](atom.md)
+-
+-If you use `gopls` with an editor that is not on this list, please let us know
+-by [filing an issue](#new-issue) or [modifying this documentation](contributing.md).
+-
+-## Overview
+-
+-* [Installation](#installation)
+-* [Configuration](#configuration)
+-
+-Learn more at the following pages:
+-
+-* [Features](features.md)
+-* [Command-line](command-line.md)
 -
 -## Installation
 -
@@ -2244,35 +3211,51 @@ diff -urN a/gopls/doc/user.md b/gopls/doc/user.md
 -verify that the `gopls` tests pass for the last 4 major Go releases, but do not
 -prioritize issues only affecting legacy Go release (3 or 4 releases ago).
 -
--## Configurations
+-## Configuration
 -
 -### Environment variables
 -
--These are often inherited from the editor that launches `gopls`, and sometimes the editor has a way to add or replace values before launching. For example, VSCode allows you to configure `go.toolsEnvVars`.
+-These are often inherited from the editor that launches `gopls`, and sometimes
+-the editor has a way to add or replace values before launching. For example,
+-VSCode allows you to configure `go.toolsEnvVars`.
 -
--Configuring your environment correctly is important, as `gopls` relies on the `go` command.
+-Configuring your environment correctly is important, as `gopls` relies on the
+-`go` command.
 -
--### Command line flags
+-### Command-line flags
 -
--See the [command line page](command-line.md) for more information about the flags you might specify.
--All editors support some way of adding flags to `gopls`, for the most part you should not need to do this unless you have very unusual requirements or are trying to [troubleshoot](troubleshooting.md#steps) `gopls` behavior.
+-See the [command-line page](command-line.md) for more information about the
+-flags you might specify. All editors support some way of adding flags to
+-`gopls`, for the most part you should not need to do this unless you have very
+-unusual requirements or are trying to [troubleshoot](troubleshooting.md#steps)
+-`gopls` behavior.
 -
 -### Editor settings
 -
--For the most part these will be settings that control how the editor interacts with or uses the results of `gopls`, not modifications to `gopls` itself. This means they are not standardized across editors, and you will have to look at the specific instructions for your editor integration to change them.
+-For the most part these will be settings that control how the editor interacts
+-with or uses the results of `gopls`, not modifications to `gopls` itself. This
+-means they are not standardized across editors, and you will have to look at
+-the specific instructions for your editor integration to change them.
 -
 -#### The set of workspace folders
 -
--This is one of the most important pieces of configuration. It is the set of folders that gopls considers to be "roots" that it should consider files to be a part of.
+-This is one of the most important pieces of configuration. It is the set of
+-folders that gopls considers to be "roots" that it should consider files to
+-be a part of.
 -
--If you are using modules there should be one of these per go.mod that you are working on.
--If you do not open the right folders, very little will work. **This is the most common misconfiguration of `gopls` that we see**.
+-If you are using modules there should be one of these per go.mod that you
+-are working on. If you do not open the right folders, very little will work.
+-**This is the most common misconfiguration of `gopls` that we see**.
 -
 -#### Global configuration
 -
--There should be a way of declaring global settings for `gopls` inside the editor. The settings block will be called `"gopls"` and contains a collection of controls for `gopls` that the editor is not expected to understand or control.
+-There should be a way of declaring global settings for `gopls` inside the
+-editor. The settings block will be called `"gopls"` and contains a collection
+-of controls for `gopls` that the editor is not expected to understand or
+-control.
 -
--In VSCode, this would be a section in your settings file that might look like this:
+-In VSCode, this would be a section in your settings file that might look like
+-this:
 -
 -```json5
 -  "gopls": {
@@ -2281,30 +3264,22 @@ diff -urN a/gopls/doc/user.md b/gopls/doc/user.md
 -  },
 -```
 -
--See [Settings](settings.md) for more information about the available configurations.
+-See [Settings](settings.md) for more information about the available
+-configurations.
 -
 -#### Workspace folder configuration
 -
--This contains exactly the same set of values that are in the global configuration, but it is fetched for every workspace folder separately. The editor can choose to respond with different values per-folder.
--
--## Special Features
--
--### Symbol Queries
--
--Gopls supports some extended syntax for `workspace/symbol` requests, when using
--the `fuzzy` symbol matcher (the default). Inspired by the popular fuzzy matcher
--[FZF](https://github.com/junegunn/fzf), the following special characters are
--supported within symbol queries:
--
--| Character | Usage     | Match        |
--| --------- | --------- | ------------ |
--| `'`       | `'abc`    | exact        |
--| `^`       | `^printf` | exact prefix |
--| `$`       | `printf$` | exact suffix |
+-This contains exactly the same set of values that are in the global
+-configuration, but it is fetched for every workspace folder separately.
+-The editor can choose to respond with different values per-folder.
 -
 -### Working on the Go source distribution
 -
--If you are working on the [Go project](https://go.googlesource.com/go) itself, your `go` command will have to correspond to the version of the source you are working on. That is, if you have downloaded the code to `$HOME/go`, your `go` command should be the `$HOME/go/bin/go` executable that you built with `make.bash` or equivalent.
+-If you are working on the [Go project](https://go.googlesource.com/go) itself,
+-your `go` command will have to correspond to the version of the source you are
+-working on. That is, if you have downloaded the code to `$HOME/go`, your `go`
+-command should be the `$HOME/go/bin/go` executable that you built with
+-`make.bash` or equivalent.
 -
 -You can achieve this by adding the right version of `go` to your `PATH` (`export PATH=$HOME/go/bin:$PATH` on Unix systems) or by configuring your editor. In VS Code, you can use the `go.alternateTools` setting to point to the correct version of `go`:
 -
@@ -2316,36 +3291,40 @@ diff -urN a/gopls/doc/user.md b/gopls/doc/user.md
 -    }
 -}
 -```
--
--## Command line support
--
--Much of the functionality of `gopls` is available through a command line interface.
--
--There are two main reasons for this. The first is that we do not want users to rely on separate command line tools when they wish to do some task outside of an editor. The second is that the CLI assists in debugging. It is easier to reproduce behavior via single command.
--
--It is not a goal of `gopls` to be a high performance command line tool. Its command line is intended for single file/package user interaction speeds, not bulk processing.
--
--For more information, see the `gopls` [command line page](command-line.md).
 diff -urN a/gopls/doc/vim.md b/gopls/doc/vim.md
 --- a/gopls/doc/vim.md	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/doc/vim.md	1969-12-31 19:00:00.000000000 -0500
-@@ -1,193 +0,0 @@
+@@ -1,219 +0,0 @@
 -# Vim / Neovim
 -
--## vim-go
+-* [vim-go](#vimgo)
+-* [LanguageClient-neovim](#lcneovim)
+-* [Ale](#ale)
+-* [vim-lsp](#vimlsp)
+-* [vim-lsc](#vimlsc)
+-* [coc.nvim](#cocnvim)
+-* [govim](#govim)
+-* [Neovim v0.5.0+](#neovim)
+-  * [Installation](#neovim-install)
+-  * [Custom Configuration](#neovim-config)
+-  * [Imports](#neovim-imports)
+-  * [Omnifunc](#neovim-omnifunc)
+-  * [Additional Links](#neovim-links)
+-
+-## <a href="#vimgo" id="vimgo">vim-go</a>
 -
 -Use [vim-go] ver 1.20+, with the following configuration:
 -
--```
+-```vim
 -let g:go_def_mode='gopls'
 -let g:go_info_mode='gopls'
 -```
 -
--## LanguageClient-neovim
+-## <a href="#lcneovim" id="lcneovim">LanguageClient-neovim</a>
 -
 -Use [LanguageClient-neovim], with the following configuration:
 -
--```
+-```vim
 -" Launch gopls when Go files are in use
 -let g:LanguageClient_serverCommands = {
 -       \ 'go': ['gopls']
@@ -2354,19 +3333,19 @@ diff -urN a/gopls/doc/vim.md b/gopls/doc/vim.md
 -autocmd BufWritePre *.go :call LanguageClient#textDocument_formatting_sync()
 -```
 -
--## Ale
+-## <a href="#ale" id="ale">Ale</a>
 -
 -Use [ale]:
 -
 -```vim
 -let g:ale_linters = {
--	\ 'go': ['gopls'],
--	\}
+-  \ 'go': ['gopls'],
+-  \}
 -```
 -
 -see [this issue][ale-issue-2179]
 -
--## vim-lsp
+-## <a href="#vimlsp" id="vimlsp">vim-lsp</a>
 -
 -Use [prabirshrestha/vim-lsp], with the following configuration:
 -
@@ -2385,7 +3364,7 @@ diff -urN a/gopls/doc/vim.md b/gopls/doc/vim.md
 -augroup END
 -```
 -
--## vim-lsc
+-## <a href="#vimlsc" id="vimlsc">vim-lsc</a>
 -
 -Use [natebosch/vim-lsc], with the following configuration:
 -
@@ -2403,7 +3382,7 @@ diff -urN a/gopls/doc/vim.md b/gopls/doc/vim.md
 -issues [#180](https://github.com/natebosch/vim-lsc/issues/180) and
 -[#213](https://github.com/natebosch/vim-lsc/issues/213).
 -
--## coc.nvim
+-## <a href="#cocnvim" id="cocnvim">coc.nvim</a>
 -
 -Use [coc.nvim], with the following `coc-settings.json` configuration:
 -
@@ -2428,26 +3407,38 @@ diff -urN a/gopls/doc/vim.md b/gopls/doc/vim.md
 -autocmd BufWritePre *.go :call CocAction('runCommand', 'editor.action.organizeImport')
 -```
 -
--## govim
+-## <a href="#govim" id="govim">govim</a>
 -
 -In vim classic only, use the experimental [`govim`], simply follow the [install steps][govim-install].
 -
--## Neovim v0.5.0+
+-## <a href="#neovim" id="neovim">Neovim v0.5.0+</a>
 -
 -To use the new (still experimental) native LSP client in Neovim, make sure you
 -[install][nvim-install] the prerelease v0.5.0 version of Neovim (aka “nightly”),
 -the `nvim-lspconfig` configuration helper plugin, and check the
 -[`gopls` configuration section][nvim-lspconfig] there.
 -
--### Custom configuration
+-### <a href="#neovim-install" id="neovim-install">Installation</a>
+-
+-You can use Neovim's native plugin system.  On a Unix system, you can do that by
+-cloning the `nvim-lspconfig` repository into the correct directory:
+-
+-```sh
+-dir="${HOME}/.local/share/nvim/site/pack/nvim-lspconfig/opt/nvim-lspconfig/"
+-mkdir -p "$dir"
+-cd "$dir"
+-git clone 'https://github.com/neovim/nvim-lspconfig.git' .
+-```
+-
+-### <a href="#neovim-config" id="neovim-config">Custom Configuration</a>
 -
 -You can add custom configuration using Lua.  Here is an example of enabling the
 -`unusedparams` check as well as `staticcheck`:
 -
 -```vim
 -lua <<EOF
--  nvim_lsp = require "lspconfig"
--  nvim_lsp.gopls.setup {
+-  lspconfig = require "lspconfig"
+-  lspconfig.gopls.setup {
 -    cmd = {"gopls", "serve"},
 -    settings = {
 -      gopls = {
@@ -2461,7 +3452,7 @@ diff -urN a/gopls/doc/vim.md b/gopls/doc/vim.md
 -EOF
 -```
 -
--### Imports
+-### <a href="#neovim-imports" id="neovim-imports">Imports</a>
 -
 -To get your imports ordered on save, like `goimports` does, you can define
 -a helper function in Lua:
@@ -2496,7 +3487,7 @@ diff -urN a/gopls/doc/vim.md b/gopls/doc/vim.md
 -
 -(Taken from the [discussion][nvim-lspconfig-imports] on Neovim issue tracker.)
 -
--### Omnifunc
+-### <a href="#neovim-omnifunc" id="neovim-omnifunc">Omnifunc</a>
 -
 -To make your <kbd>Ctrl</kbd>+<kbd>x</kbd>,<kbd>Ctrl</kbd>+<kbd>o</kbd> work, add
 -this to your `init.vim`:
@@ -2505,7 +3496,7 @@ diff -urN a/gopls/doc/vim.md b/gopls/doc/vim.md
 -autocmd FileType go setlocal omnifunc=v:lua.vim.lsp.omnifunc
 -```
 -
--### Additional Links
+-### <a href="#neovim-links" id="neovim-links">Additional Links</a>
 -
 -* [Neovim's official LSP documentation][nvim-docs].
 -
@@ -2521,49 +3512,35 @@ diff -urN a/gopls/doc/vim.md b/gopls/doc/vim.md
 -[govim-install]: https://github.com/myitcv/govim/blob/master/README.md#govim---go-development-plugin-for-vim8
 -[nvim-docs]: https://neovim.io/doc/user/lsp.html
 -[nvim-install]: https://github.com/neovim/neovim/wiki/Installing-Neovim
--[nvim-lspconfig]: https://github.com/neovim/nvim-lspconfig#gopls
+-[nvim-lspconfig]: https://github.com/neovim/nvim-lspconfig/blob/master/CONFIG.md#gopls
 -[nvim-lspconfig-imports]: https://github.com/neovim/nvim-lspconfig/issues/115
 diff -urN a/gopls/doc/vscode.md b/gopls/doc/vscode.md
 --- a/gopls/doc/vscode.md	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/doc/vscode.md	1969-12-31 19:00:00.000000000 -0500
-@@ -1,74 +0,0 @@
--# VSCode
+@@ -1,66 +0,0 @@
+-# VS Code
 -
--Use the [VSCode-Go] plugin, with the following configuration:
+-Use the [VS Code Go] plugin, with the following configuration:
 -
 -```json5
 -"go.useLanguageServer": true,
--"[go]": {
--    "editor.formatOnSave": true,
--    "editor.codeActionsOnSave": {
--        "source.organizeImports": true,
--    },
--    // Optional: Disable snippets, as they conflict with completion ranking.
--    "editor.snippetSuggestions": "none",
--},
--"[go.mod]": {
--    "editor.formatOnSave": true,
--    "editor.codeActionsOnSave": {
--        "source.organizeImports": true,
--    },
--},
+-```
+-
+-As of February 2020, `gopls` will be enabled by default in [VS Code Go].
+-To learn more, follow along with
+-[golang.vscode-go#1037](https://github.com/golang/vscode-go/issues/1037).
+-
+-```json5
 -"gopls": {
--     // Add parameter placeholders when completing a function.
--    "usePlaceholders": true,
+-    // Add parameter placeholders when completing a function.
+-    "ui.completion.usePlaceholders": true,
 -
 -    // If true, enable additional analyses with staticcheck.
 -    // Warning: This will significantly increase memory usage.
--    "staticcheck": false,
--}
--```
--
--VSCode will complain about the `"gopls"` settings, but they will still work. Once we have a consistent set of settings, we will make the changes in the VSCode plugin necessary to remove the errors.
--
--If you encounter problems with import organization, please try setting a higher code action timeout (any value greater than 750ms), for example:
--
--```json5
--"[go]": {
--  "editor.codeActionsOnSaveTimeout": 3000
+-    "ui.diagnostic.staticcheck": false,
+-    
+-    // For more customization, see
+-    // see https://github.com/golang/vscode-go/blob/master/docs/settings.md.
 -}
 -```
 -
@@ -2573,48 +3550,137 @@ diff -urN a/gopls/doc/vscode.md b/gopls/doc/vscode.md
 -"go.languageServerFlags": [
 -    "-rpc.trace", // for more detailed debug logging
 -    "serve",
--    "--debug=localhost:6060", // to investigate memory usage, see profiles
+-    "--debug=localhost:6060", // Optional: investigate memory usage, see profiles
 -],
 -```
 -
--See the section on [command line](command-line.md) arguments for more information about what these do, along with other things like `--logfile=auto` that you might want to use.
+-See the section on [command line](command-line.md) arguments for more
+-information about what these do, along with other things like
+-`--logfile=auto` that you might want to use.
 -
--You can disable features through the `"go.languageServerExperimentalFeatures"` section of the config. An example of a feature you may want to disable is `"documentLink"`, which opens [`pkg.go.dev`](https://pkg.go.dev) links when you click on import statements in your file.
+-## Build tags and flags
 -
--### Build tags
+-Build tags and flags will be automatically picked up from `"go.buildTags"` and
+-`"go.buildFlags"` settings. In the rare case that you don't want that default
+-behavior, you can still override the settings from the `gopls` section, using
+-`"gopls": { "build.buildFlags": [] }`.
 -
--build tags will not be picked from `go.buildTags` configuration section, instead they should be specified as part of the`GOFLAGS` environment variable:
+-## Remote Development with `gopls`
 -
--```json5
--"go.toolsEnvVars": {
--    "GOFLAGS": "-tags=<yourtag>"
--}
--```
+-You can also make use of `gopls` with the
+-[VS Code Remote Development](https://code.visualstudio.com/docs/remote/remote-overview)
+-extensions to enable full-featured Go development on a lightweight client
+-machine, while connected to a more powerful server machine.
 -
+-First, install the Remote Development extension of your choice, such as the
+-[Remote - SSH](https://code.visualstudio.com/docs/remote/ssh) extension. Once
+-you open a remote session in a new window, open the Extensions pane
+-(Ctrl+Shift+X) and you will see several different sections listed. In the
+-"Local - Installed" section, navigate to the Go extension and click
+-"Install in SSH: hostname".
 -
--[VSCode-Go]: https://github.com/golang/vscode-go
+-Once you have reloaded VS Code, you will be prompted to install `gopls` and other
+-Go-related tools. After one more reload, you should be ready to develop remotely
+-with VS Code and the Go extension.
 -
--# VSCode Remote Development with gopls
+-[VS Code Go]: https://github.com/golang/vscode-go
+diff -urN a/gopls/doc/workspace.md b/gopls/doc/workspace.md
+--- a/gopls/doc/workspace.md	2000-01-01 00:00:00.000000000 -0000
++++ b/gopls/doc/workspace.md	1969-12-31 19:00:00.000000000 -0500
+@@ -1,75 +0,0 @@
+-# Setting up your workspace
 -
--You can also make use of `gopls` with the [VSCode Remote Development](https://code.visualstudio.com/docs/remote/remote-overview) extensions to enable full-featured Go development on a lightweight client machine, while connected to a more powerful server machine.
+-`gopls` supports both Go module and GOPATH modes. However, it needs a defined
+-scope in which language features like references, rename, and implementation
+-should operate.
 -
--First, install the Remote Development extension of your choice, such as the [Remote - SSH](https://code.visualstudio.com/docs/remote/ssh) extension. Once you open a remote session in a new window, open the Extensions pane (Ctrl+Shift+X) and you will see several different sections listed. In the "Local - Installed" section, navigate to the Go extension and click "Install in SSH: hostname".
+-The following options are available for configuring this scope:
 -
--Once you have reloaded VSCode, you will be prompted to install `gopls` and other Go-related tools. After one more reload, you should be ready to develop remotely with VSCode and the Go extension.
+-## Module mode
+-
+-### One module
+-
+-If you are working with a single module, you can open the module root (the
+-directory containing the `go.mod` file), a subdirectory within the module,
+-or a parent directory containing the module.
+-
+-**Note**: If you open a parent directory containing a module, it must **only**
+-contain that single module. Otherwise, you are working with multiple modules.
+-
+-### Multiple modules
+-
+-As of Jan 2020, if you are working with multiple modules, you will need to
+-create a "workspace folder" for each module. This means that each module has
+-its own scope, and features will not work across modules. We are currently
+-working on addressing this limitation--see details about
+-[experimental workspace module mode](#experimental-workspace-module-mode)
+-below.
+-
+-In VS Code, you can create a workspace folder by setting up a
+-[multi-root workspace](https://code.visualstudio.com/docs/editor/multi-root-workspaces).
+-View the [documentation for your editor plugin](user.md#editor) to learn how to
+-configure a workspace folder in your editor.
+-
+-#### Workspace module (experimental)
+-
+-Many `gopls` users would like to work with multiple modules at the same time
+-([golang/go#32394](https://github.com/golang/go/issues/32394)), and
+-specifically, have features that work across modules. We plan to add support
+-for this via a concept called the "workspace module", which is described in
+-[this design document](https://github.com/golang/proposal/blob/master/design/37720-gopls-workspaces.md).
+-This feature works by creating a temporary module that requires all of your
+-workspace modules, meaning all of their dependencies must be compatible.
+-
+-The workspace module feature is currently available as an opt-in experiment,
+-and it will allow you to work with multiple modules without creating workspace
+-folders for each module. You can try it out by configuring the
+-[experimentalWorkspaceModule](settings.md#experimentalworkspacemodule-bool)
+-setting. If you try it and encounter issues, please
+-[report them](https://github.com/golang/go/issues/new) so we can address them
+-before the feature is enabled by default.
+-
+-You can follow our progress on the workspace module work by looking at the
+-open issues in the
+-[gopls/workspace-module milestone](https://github.com/golang/go/milestone/179).
+-
+-### GOPATH mode
+-
+-When opening a directory within your GOPATH, the workspace scope will be just
+-that directory.
+-
+-### At your own risk
+-
+-Some users or companies may have projects that encompass one `$GOPATH`. If you
+-open your entire `$GOPATH` or `$GOPATH/src` folder, the workspace scope will be
+-your entire `GOPATH`. If your GOPATH is large, `gopls` to be very slow to start
+-because it will try to find all of the Go files in the directory you have
+-opened. It will then load all of the files it has found.
+-
+-To work around this case, you can create a new `$GOPATH` that contains only the
+-packages you want to work on.
+-
+----
+-
+-If you have additional use cases that are not mentioned above, please
+-[file a new issue](https://github.com/golang/go/issues/new).
 diff -urN a/gopls/go.mod b/gopls/go.mod
 --- a/gopls/go.mod	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/go.mod	1969-12-31 19:00:00.000000000 -0500
-@@ -1,14 +0,0 @@
+@@ -1,18 +0,0 @@
 -module golang.org/x/tools/gopls
 -
 -go 1.12
 -
 -require (
+-	github.com/jba/templatecheck v0.5.0
+-	github.com/sanity-io/litter v1.3.0
 -	github.com/sergi/go-diff v1.1.0
--	golang.org/x/tools v0.0.0-20201021214918-23787c007979
+-	golang.org/x/mod v0.4.0
+-	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4
+-	golang.org/x/tools v0.0.0-20210104081019-d8d6ddbec6ee
 -	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 -	honnef.co/go/tools v0.0.1-2020.1.6
--	mvdan.cc/gofumpt v0.0.0-20200927160801-5bfeb2e70dd6
+-	mvdan.cc/gofumpt v0.1.0
 -	mvdan.cc/xurls/v2 v2.2.0
 -)
 -
@@ -2622,29 +3688,38 @@ diff -urN a/gopls/go.mod b/gopls/go.mod
 diff -urN a/gopls/go.sum b/gopls/go.sum
 --- a/gopls/go.sum	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/go.sum	1969-12-31 19:00:00.000000000 -0500
-@@ -1,58 +0,0 @@
+@@ -1,71 +0,0 @@
 -github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 -github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+-github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 -github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 -github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 -github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
--github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
--github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+-github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
+-github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 -github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+-github.com/google/safehtml v0.0.2 h1:ZOt2VXg4x24bW0m2jtzAOkhoXV0iM8vNKc0paByCZqM=
+-github.com/google/safehtml v0.0.2/go.mod h1:L4KWwDsUJdECRAEpZoBn3O64bQaywRscowZjJAzjHnU=
+-github.com/jba/templatecheck v0.5.0 h1:sZwNjXG3xNApuwKmgUWEo2JuxmG0sgNaELl0zwRQ9x8=
+-github.com/jba/templatecheck v0.5.0/go.mod h1:/1k7EajoSErFI9GLHAsiIJEaNLt3ALKNw2TV7z2SYv4=
 -github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 -github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 -github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 -github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 -github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 -github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+-github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 -github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 -github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 -github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 -github.com/rogpeppe/go-internal v1.5.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
--github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
+-github.com/rogpeppe/go-internal v1.6.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
+-github.com/sanity-io/litter v1.3.0 h1:5ZO+weUsqdSWMUng5JnpkW/Oz8iTXiIdeumhQr1sSjs=
+-github.com/sanity-io/litter v1.3.0/go.mod h1:5Z71SvaYy5kcGtyglXOC9rrUi3c1E8CamFWjQsazTh0=
 -github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 -github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 -github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+-github.com/stretchr/testify v0.0.0-20161117074351-18a02ba4a312/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 -github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 -github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 -github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -2652,8 +3727,9 @@ diff -urN a/gopls/go.sum b/gopls/go.sum
 -golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 -golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 -golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
--golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 -golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+-golang.org/x/mod v0.4.0 h1:8pl+sMODzuvGJkmj2W4kZihvVb5mKm8pB/X44PIQHv8=
+-golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 -golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 -golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 -golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
@@ -2661,7 +3737,10 @@ diff -urN a/gopls/go.sum b/gopls/go.sum
 -golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 -golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 -golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+-golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 h1:myAQVi0cGEoqQVR5POX+8RR2mrocKqNN1hmeMqhX27k=
+-golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 -golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+-golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 -golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 -golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 -golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -2677,8 +3756,8 @@ diff -urN a/gopls/go.sum b/gopls/go.sum
 -gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 -honnef.co/go/tools v0.0.1-2020.1.6 h1:W18jzjh8mfPez+AwGLxmOImucz/IFjpNlrKVnaj2YVc=
 -honnef.co/go/tools v0.0.1-2020.1.6/go.mod h1:pyyisuGw24ruLjrr1ddx39WE0y9OooInRzEYLhQB2YY=
--mvdan.cc/gofumpt v0.0.0-20200927160801-5bfeb2e70dd6 h1:z+/YqapuV7VZPvBb3GYmuEJbA88M3PFUxaHilHYVCpQ=
--mvdan.cc/gofumpt v0.0.0-20200927160801-5bfeb2e70dd6/go.mod h1:bzrjFmaD6+xqohD3KYP0H2FEuxknnBmyyOxdhLdaIws=
+-mvdan.cc/gofumpt v0.1.0 h1:hsVv+Y9UsZ/mFZTxJZuHVI6shSQCtzZ11h1JEFPAZLw=
+-mvdan.cc/gofumpt v0.1.0/go.mod h1:yXG1r1WqZVKWbVRtBWKWX9+CxGYfA51nSomhM0woR48=
 -mvdan.cc/xurls/v2 v2.2.0 h1:NSZPykBXJFCetGZykLAxaL6SIpvbVy/UFEniIfHAa8A=
 -mvdan.cc/xurls/v2 v2.2.0/go.mod h1:EV1RMtya9D6G5DMYPGD8zTQzaHet6Jh8gFlRgGRJeO8=
 diff -urN a/gopls/integration/govim/Dockerfile b/gopls/integration/govim/Dockerfile
@@ -3822,9 +4901,9 @@ diff -urN a/gopls/integration/replay/main.go b/gopls/integration/replay/main.go
 -	"context"
 -	"flag"
 -	"fmt"
+-	exec "golang.org/x/sys/execabs"
 -	"log"
 -	"os"
--	"os/exec"
 -	"sort"
 -	"strconv"
 -	"strings"
@@ -4148,7 +5227,7 @@ diff -urN a/gopls/internal/hooks/analysis.go b/gopls/internal/hooks/analysis.go
 diff -urN a/gopls/internal/hooks/diff.go b/gopls/internal/hooks/diff.go
 --- a/gopls/internal/hooks/diff.go	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/internal/hooks/diff.go	1969-12-31 19:00:00.000000000 -0500
-@@ -1,30 +0,0 @@
+@@ -1,41 +0,0 @@
 -// Copyright 2019 The Go Authors. All rights reserved.
 -// Use of this source code is governed by a BSD-style
 -// license that can be found in the LICENSE file.
@@ -4156,14 +5235,25 @@ diff -urN a/gopls/internal/hooks/diff.go b/gopls/internal/hooks/diff.go
 -package hooks
 -
 -import (
+-	"fmt"
+-
 -	"github.com/sergi/go-diff/diffmatchpatch"
 -	"golang.org/x/tools/internal/lsp/diff"
 -	"golang.org/x/tools/internal/span"
 -)
 -
--func ComputeEdits(uri span.URI, before, after string) []diff.TextEdit {
+-func ComputeEdits(uri span.URI, before, after string) (edits []diff.TextEdit, err error) {
+-	// The go-diff library has an unresolved panic (see golang/go#278774).
+-	// TOOD(rstambler): Remove the recover once the issue has been fixed
+-	// upstream.
+-	defer func() {
+-		if r := recover(); r != nil {
+-			edits = nil
+-			err = fmt.Errorf("unable to compute edits for %s: %s", uri.Filename(), r)
+-		}
+-	}()
 -	diffs := diffmatchpatch.New().DiffMain(before, after, true)
--	edits := make([]diff.TextEdit, 0, len(diffs))
+-	edits = make([]diff.TextEdit, 0, len(diffs))
 -	offset := 0
 -	for _, d := range diffs {
 -		start := span.NewPoint(0, 0, offset)
@@ -4177,7 +5267,7 @@ diff -urN a/gopls/internal/hooks/diff.go b/gopls/internal/hooks/diff.go
 -			edits = append(edits, diff.TextEdit{Span: span.New(uri, start, span.Point{}), NewText: d.Text})
 -		}
 -	}
--	return edits
+-	return edits, nil
 -}
 diff -urN a/gopls/internal/hooks/diff_test.go b/gopls/internal/hooks/diff_test.go
 --- a/gopls/internal/hooks/diff_test.go	2000-01-01 00:00:00.000000000 -0000
@@ -4199,10 +5289,60 @@ diff -urN a/gopls/internal/hooks/diff_test.go b/gopls/internal/hooks/diff_test.g
 -func TestDiff(t *testing.T) {
 -	difftest.DiffTest(t, hooks.ComputeEdits)
 -}
+diff -urN a/gopls/internal/hooks/gen-licenses.sh b/gopls/internal/hooks/gen-licenses.sh
+--- a/gopls/internal/hooks/gen-licenses.sh	2000-01-01 00:00:00.000000000 -0000
++++ b/gopls/internal/hooks/gen-licenses.sh	1969-12-31 19:00:00.000000000 -0500
+@@ -1,45 +0,0 @@
+-#!/bin/bash -eu
+-
+-# Copyright 2020 The Go Authors. All rights reserved.
+-# Use of this source code is governed by a BSD-style
+-# license that can be found in the LICENSE file.
+-
+-set -o pipefail
+-
+-tempfile=$(mktemp)
+-cd $(dirname $0)
+-
+-modhash=$(sha256sum ../../go.sum | awk '{print $1}')
+-# Make sure we have the code for all the modules we depend on.
+-go mod download
+-
+-cat > $tempfile <<END
+-// Copyright 2020 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:generate ./gen-licenses.sh licenses.go
+-package hooks
+-
+-const licensesText = \`
+-END
+-
+-# List all the modules gopls depends on, except other golang.org modules, which
+-# are known to have the same license.
+-mods=$(go list -deps -f '{{with .Module}}{{.Path}}{{end}}' golang.org/x/tools/gopls | sort -u | grep -v golang.org)
+-for mod in $mods; do
+-  # Find the license file, either LICENSE or COPYING, and add it to the result.
+-  dir=$(go list -m -f {{.Dir}} $mod)
+-  license=$(ls -1 $dir | egrep -i '^(LICENSE|COPYING)$')
+-  echo "-- $mod $license --" >> $tempfile
+-  echo >> $tempfile
+-  sed 's/^-- / &/' $dir/$license >> $tempfile
+-  echo >> $tempfile
+-done
+-
+-cat >> $tempfile << END
+-\`
+-
+-const licensesGeneratedFrom = "$modhash"
+-END
+-mv $tempfile licenses.go
+\ No newline at end of file
 diff -urN a/gopls/internal/hooks/hooks.go b/gopls/internal/hooks/hooks.go
 --- a/gopls/internal/hooks/hooks.go	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/internal/hooks/hooks.go	1969-12-31 19:00:00.000000000 -0500
-@@ -1,35 +0,0 @@
+@@ -1,36 +0,0 @@
 -// Copyright 2019 The Go Authors. All rights reserved.
 -// Use of this source code is governed by a BSD-style
 -// license that can be found in the LICENSE file.
@@ -4222,6 +5362,7 @@ diff -urN a/gopls/internal/hooks/hooks.go b/gopls/internal/hooks/hooks.go
 -)
 -
 -func Options(options *source.Options) {
+-	options.LicensesText = licensesText
 -	if options.GoDiff {
 -		options.ComputeEdits = ComputeEdits
 -	}
@@ -4237,6 +5378,208 @@ diff -urN a/gopls/internal/hooks/hooks.go b/gopls/internal/hooks/hooks.go
 -	re := regexp.MustCompile(`\b(` + xurls.Relaxed().String() + `)\b`)
 -	re.Longest()
 -	return re
+-}
+diff -urN a/gopls/internal/hooks/licenses.go b/gopls/internal/hooks/licenses.go
+--- a/gopls/internal/hooks/licenses.go	2000-01-01 00:00:00.000000000 -0000
++++ b/gopls/internal/hooks/licenses.go	1969-12-31 19:00:00.000000000 -0500
+@@ -1,171 +0,0 @@
+-// Copyright 2020 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:generate ./gen-licenses.sh licenses.go
+-package hooks
+-
+-const licensesText = `
+--- github.com/BurntSushi/toml COPYING --
+-
+-The MIT License (MIT)
+-
+-Copyright (c) 2013 TOML authors
+-
+-Permission is hereby granted, free of charge, to any person obtaining a copy
+-of this software and associated documentation files (the "Software"), to deal
+-in the Software without restriction, including without limitation the rights
+-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-copies of the Software, and to permit persons to whom the Software is
+-furnished to do so, subject to the following conditions:
+-
+-The above copyright notice and this permission notice shall be included in
+-all copies or substantial portions of the Software.
+-
+-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+-THE SOFTWARE.
+-
+--- github.com/google/go-cmp LICENSE --
+-
+-Copyright (c) 2017 The Go Authors. All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are
+-met:
+-
+-   * Redistributions of source code must retain the above copyright
+-notice, this list of conditions and the following disclaimer.
+-   * Redistributions in binary form must reproduce the above
+-copyright notice, this list of conditions and the following disclaimer
+-in the documentation and/or other materials provided with the
+-distribution.
+-   * Neither the name of Google Inc. nor the names of its
+-contributors may be used to endorse or promote products derived from
+-this software without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-
+--- github.com/sergi/go-diff LICENSE --
+-
+-Copyright (c) 2012-2016 The go-diff Authors. All rights reserved.
+-
+-Permission is hereby granted, free of charge, to any person obtaining a
+-copy of this software and associated documentation files (the "Software"),
+-to deal in the Software without restriction, including without limitation
+-the rights to use, copy, modify, merge, publish, distribute, sublicense,
+-and/or sell copies of the Software, and to permit persons to whom the
+-Software is furnished to do so, subject to the following conditions:
+-
+-The above copyright notice and this permission notice shall be included
+-in all copies or substantial portions of the Software.
+-
+-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+-DEALINGS IN THE SOFTWARE.
+-
+-
+--- honnef.co/go/tools LICENSE --
+-
+-Copyright (c) 2016 Dominik Honnef
+-
+-Permission is hereby granted, free of charge, to any person obtaining
+-a copy of this software and associated documentation files (the
+-"Software"), to deal in the Software without restriction, including
+-without limitation the rights to use, copy, modify, merge, publish,
+-distribute, sublicense, and/or sell copies of the Software, and to
+-permit persons to whom the Software is furnished to do so, subject to
+-the following conditions:
+-
+-The above copyright notice and this permission notice shall be
+-included in all copies or substantial portions of the Software.
+-
+-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+-
+--- mvdan.cc/gofumpt LICENSE --
+-
+-Copyright (c) 2019, Daniel Martí. All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are
+-met:
+-
+-   * Redistributions of source code must retain the above copyright
+-notice, this list of conditions and the following disclaimer.
+-   * Redistributions in binary form must reproduce the above
+-copyright notice, this list of conditions and the following disclaimer
+-in the documentation and/or other materials provided with the
+-distribution.
+-   * Neither the name of the copyright holder nor the names of its
+-contributors may be used to endorse or promote products derived from
+-this software without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-
+--- mvdan.cc/xurls/v2 LICENSE --
+-
+-Copyright (c) 2015, Daniel Martí. All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are
+-met:
+-
+-   * Redistributions of source code must retain the above copyright
+-notice, this list of conditions and the following disclaimer.
+-   * Redistributions in binary form must reproduce the above
+-copyright notice, this list of conditions and the following disclaimer
+-in the documentation and/or other materials provided with the
+-distribution.
+-   * Neither the name of the copyright holder nor the names of its
+-contributors may be used to endorse or promote products derived from
+-this software without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-
+-`
+-
+-const licensesGeneratedFrom = "029a0f934a7bad22a7d47185055bc554b1ea23ce427351caa87d9a088fcfba4e"
+diff -urN a/gopls/internal/hooks/licenses_test.go b/gopls/internal/hooks/licenses_test.go
+--- a/gopls/internal/hooks/licenses_test.go	2000-01-01 00:00:00.000000000 -0000
++++ b/gopls/internal/hooks/licenses_test.go	1969-12-31 19:00:00.000000000 -0500
+@@ -1,23 +0,0 @@
+-// Copyright 2020 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-package hooks
+-
+-import (
+-	"crypto/sha256"
+-	"encoding/hex"
+-	"io/ioutil"
+-	"testing"
+-)
+-
+-func TestLicenses(t *testing.T) {
+-	sumBytes, err := ioutil.ReadFile("../../go.sum")
+-	if err != nil {
+-		t.Fatal(err)
+-	}
+-	sumSum := sha256.Sum256(sumBytes)
+-	if licensesGeneratedFrom != hex.EncodeToString(sumSum[:]) {
+-		t.Error("combined license text needs updating. Run: `go generate ./internal/hooks` from the gopls module.")
+-	}
 -}
 diff -urN a/gopls/internal/regtest/bench_test.go b/gopls/internal/regtest/bench_test.go
 --- a/gopls/internal/regtest/bench_test.go	2000-01-01 00:00:00.000000000 -0000
@@ -4349,7 +5692,7 @@ diff -urN a/gopls/internal/regtest/bench_test.go b/gopls/internal/regtest/bench_
 diff -urN a/gopls/internal/regtest/codelens_test.go b/gopls/internal/regtest/codelens_test.go
 --- a/gopls/internal/regtest/codelens_test.go	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/internal/regtest/codelens_test.go	1969-12-31 19:00:00.000000000 -0500
-@@ -1,285 +0,0 @@
+@@ -1,319 +0,0 @@
 -// Copyright 2020 The Go Authors. All rights reserved.
 -// Use of this source code is governed by a BSD-style
 -// license that can be found in the LICENSE file.
@@ -4373,6 +5716,8 @@ diff -urN a/gopls/internal/regtest/codelens_test.go b/gopls/internal/regtest/cod
 -	const workspace = `
 --- go.mod --
 -module codelens.test
+-
+-go 1.12
 --- lib.go --
 -package lib
 -
@@ -4422,7 +5767,7 @@ diff -urN a/gopls/internal/regtest/codelens_test.go b/gopls/internal/regtest/cod
 -// dependencies in a go.mod file. It checks for the code lens that suggests
 -// an update and then executes the command associated with that code lens. A
 -// regression test for golang/go#39446.
--func TestUpdateCodelens(t *testing.T) {
+-func TestUpgradeCodelens(t *testing.T) {
 -	const proxyWithLatest = `
 --- golang.org/x/hello@v1.3.3/go.mod --
 -module golang.org/x/hello
@@ -4461,21 +5806,46 @@ diff -urN a/gopls/internal/regtest/codelens_test.go b/gopls/internal/regtest/cod
 -	_ = hi.Goodbye
 -}
 -`
--	runner.Run(t, shouldUpdateDep, func(t *testing.T, env *Env) {
--		env.OpenFile("go.mod")
--		env.ExecuteCodeLensCommand("go.mod", source.CommandUpgradeDependency)
--		env.Await(CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidChangeWatchedFiles), 1))
--		got := env.Editor.BufferText("go.mod")
--		const wantGoMod = `module mod.com
+-	for _, commandTitle := range []string{
+-		"Upgrade transitive dependencies",
+-		"Upgrade direct dependencies",
+-	} {
+-		t.Run(commandTitle, func(t *testing.T) {
+-			withOptions(
+-				ProxyFiles(proxyWithLatest),
+-			).run(t, shouldUpdateDep, func(t *testing.T, env *Env) {
+-				env.OpenFile("go.mod")
+-				var lens protocol.CodeLens
+-				var found bool
+-				for _, l := range env.CodeLens("go.mod") {
+-					if l.Command.Title == commandTitle {
+-						lens = l
+-						found = true
+-					}
+-				}
+-				if !found {
+-					t.Fatalf("found no command with the title %s", commandTitle)
+-				}
+-				if _, err := env.Editor.ExecuteCommand(env.Ctx, &protocol.ExecuteCommandParams{
+-					Command:   lens.Command.Command,
+-					Arguments: lens.Command.Arguments,
+-				}); err != nil {
+-					t.Fatal(err)
+-				}
+-				env.Await(CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidChangeWatchedFiles), 1))
+-				got := env.Editor.BufferText("go.mod")
+-				const wantGoMod = `module mod.com
 -
 -go 1.12
 -
 -require golang.org/x/hello v1.3.3
 -`
--		if got != wantGoMod {
--			t.Fatalf("go.mod upgrade failed:\n%s", tests.Diff(wantGoMod, got))
--		}
--	}, WithProxyFiles(proxyWithLatest))
+-				if got != wantGoMod {
+-					t.Fatalf("go.mod upgrade failed:\n%s", tests.Diff(t, wantGoMod, got))
+-				}
+-			})
+-		})
+-	}
 -}
 -
 -func TestUnusedDependenciesCodelens(t *testing.T) {
@@ -4507,6 +5877,11 @@ diff -urN a/gopls/internal/regtest/codelens_test.go b/gopls/internal/regtest/cod
 -
 -require golang.org/x/hello v1.0.0
 -require golang.org/x/unused v1.0.0
+--- go.sum --
+-golang.org/x/hello v1.0.0 h1:qbzE1/qT0/zojAMd/JcPsO2Vb9K4Bkeyq0vB2JGMmsw=
+-golang.org/x/hello v1.0.0/go.mod h1:WW7ER2MRNXWA6c8/4bDIek4Hc/+DofTrMaQQitGXcco=
+-golang.org/x/unused v1.0.0 h1:LecSbCn5P3vTcxubungSt1Pn4D/WocCaiWOPDC0y0rw=
+-golang.org/x/unused v1.0.0/go.mod h1:ihoW8SgWzugwwj0N2SfLfPZCxTB1QOVfhMfB5PWTQ8U=
 --- main.go --
 -package main
 -
@@ -4528,9 +5903,9 @@ diff -urN a/gopls/internal/regtest/codelens_test.go b/gopls/internal/regtest/cod
 -require golang.org/x/hello v1.0.0
 -`
 -		if got != wantGoMod {
--			t.Fatalf("go.mod tidy failed:\n%s", tests.Diff(wantGoMod, got))
+-			t.Fatalf("go.mod tidy failed:\n%s", tests.Diff(t, wantGoMod, got))
 -		}
--	}, WithProxyFiles(proxy))
+-	}, ProxyFiles(proxy))
 -}
 -
 -func TestRegenerateCgo(t *testing.T) {
@@ -4540,6 +5915,8 @@ diff -urN a/gopls/internal/regtest/codelens_test.go b/gopls/internal/regtest/cod
 -	const workspace = `
 --- go.mod --
 -module example.com
+-
+-go 1.12
 --- cgo.go --
 -package x
 -
@@ -4842,7 +6219,7 @@ diff -urN a/gopls/internal/regtest/completion_bench_test.go b/gopls/internal/reg
 diff -urN a/gopls/internal/regtest/completion_test.go b/gopls/internal/regtest/completion_test.go
 --- a/gopls/internal/regtest/completion_test.go	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/internal/regtest/completion_test.go	1969-12-31 19:00:00.000000000 -0500
-@@ -1,213 +0,0 @@
+@@ -1,325 +0,0 @@
 -// Copyright 2020 The Go Authors. All rights reserved.
 -// Use of this source code is governed by a BSD-style
 -// license that can be found in the LICENSE file.
@@ -4866,6 +6243,7 @@ diff -urN a/gopls/internal/regtest/completion_test.go b/gopls/internal/regtest/c
 --- go.mod --
 -module mod.com
 -
+-go 1.12
 --- fruits/apple.go --
 -package apple
 -
@@ -5019,6 +6397,7 @@ diff -urN a/gopls/internal/regtest/completion_test.go b/gopls/internal/regtest/c
 --- go.mod --
 -module mod.com
 -
+-go 1.12
 --- math/add.go --
 -package ma
 -`
@@ -5055,6 +6434,116 @@ diff -urN a/gopls/internal/regtest/completion_test.go b/gopls/internal/regtest/c
 -	}
 -
 -	return ""
+-}
+-
+-func TestUnimportedCompletion(t *testing.T) {
+-	testenv.NeedsGo1Point(t, 14)
+-
+-	const mod = `
+--- go.mod --
+-module mod.com
+-
+-go 1.14
+-
+-require example.com v1.2.3
+--- go.sum --
+-example.com v1.2.3 h1:ihBTGWGjTU3V4ZJ9OmHITkU9WQ4lGdQkMjgyLFk0FaY=
+-example.com v1.2.3/go.mod h1:Y2Rc5rVWjWur0h3pd9aEvK5Pof8YKDANh9gHA2Maujo=
+--- main.go --
+-package main
+-
+-func main() {
+-	_ = blah
+-}
+--- main2.go --
+-package main
+-
+-import "example.com/blah"
+-
+-func _() {
+-	_ = blah.Hello
+-}
+-`
+-	withOptions(
+-		ProxyFiles(proxy),
+-	).run(t, mod, func(t *testing.T, env *Env) {
+-		// Make sure the dependency is in the module cache and accessible for
+-		// unimported completions, and then remove it before proceeding.
+-		env.RemoveWorkspaceFile("main2.go")
+-		env.RunGoCommand("mod", "tidy")
+-		env.Await(CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidChangeWatchedFiles), 2))
+-
+-		// Trigger unimported completions for the example.com/blah package.
+-		env.OpenFile("main.go")
+-		env.Await(CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidOpen), 1))
+-		pos := env.RegexpSearch("main.go", "ah")
+-		completions := env.Completion("main.go", pos)
+-		if len(completions.Items) == 0 {
+-			t.Fatalf("no completion items")
+-		}
+-		env.AcceptCompletion("main.go", pos, completions.Items[0])
+-		env.Await(CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidChange), 1))
+-
+-		// Trigger completions once again for the blah.<> selector.
+-		env.RegexpReplace("main.go", "_ = blah", "_ = blah.")
+-		env.Await(
+-			CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidChange), 2),
+-		)
+-		pos = env.RegexpSearch("main.go", "\n}")
+-		completions = env.Completion("main.go", pos)
+-		if len(completions.Items) != 1 {
+-			t.Fatalf("expected 1 completion item, got %v", len(completions.Items))
+-		}
+-		item := completions.Items[0]
+-		if item.Label != "Name" {
+-			t.Fatalf("expected completion item blah.Name, got %v", item.Label)
+-		}
+-		env.AcceptCompletion("main.go", pos, item)
+-
+-		// Await the diagnostics to add example.com/blah to the go.mod file.
+-		env.SaveBufferWithoutActions("main.go")
+-		env.Await(
+-			env.DiagnosticAtRegexp("go.mod", "module mod.com"),
+-			env.DiagnosticAtRegexp("main.go", `"example.com/blah"`),
+-		)
+-	})
+-}
+-
+-// Test that completions still work with an undownloaded module, golang/go#43333.
+-func TestUndownloadedModule(t *testing.T) {
+-	// mod.com depends on example.com, but only in a file that's hidden by a
+-	// build tag, so the IWL won't download example.com. That will cause errors
+-	// in the go list -m call performed by the imports package.
+-	const files = `
+--- go.mod --
+-module mod.com
+-
+-go 1.14
+-
+-require example.com v1.2.3
+--- go.sum --
+-example.com v1.2.3 h1:ihBTGWGjTU3V4ZJ9OmHITkU9WQ4lGdQkMjgyLFk0FaY=
+-example.com v1.2.3/go.mod h1:Y2Rc5rVWjWur0h3pd9aEvK5Pof8YKDANh9gHA2Maujo=
+--- useblah.go --
+-// +build hidden
+-
+-package pkg
+-import "example.com/blah"
+-var _ = blah.Name
+--- mainmod/mainmod.go --
+-package mainmod
+-
+-const Name = "mainmod"
+-`
+-	withOptions(ProxyFiles(proxy)).run(t, files, func(t *testing.T, env *Env) {
+-		env.CreateBuffer("import.go", "package pkg\nvar _ = mainmod.Name\n")
+-		env.SaveBuffer("import.go")
+-		content := env.ReadWorkspaceFile("import.go")
+-		if !strings.Contains(content, `import "mod.com/mainmod`) {
+-			t.Errorf("expected import of mod.com/mainmod in %q", content)
+-		}
+-	})
+-
 -}
 diff -urN a/gopls/internal/regtest/configuration_test.go b/gopls/internal/regtest/configuration_test.go
 --- a/gopls/internal/regtest/configuration_test.go	2000-01-01 00:00:00.000000000 -0000
@@ -5105,7 +6594,7 @@ diff -urN a/gopls/internal/regtest/configuration_test.go b/gopls/internal/regtes
 diff -urN a/gopls/internal/regtest/definition_test.go b/gopls/internal/regtest/definition_test.go
 --- a/gopls/internal/regtest/definition_test.go	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/internal/regtest/definition_test.go	1969-12-31 19:00:00.000000000 -0500
-@@ -1,131 +0,0 @@
+@@ -1,134 +0,0 @@
 -// Copyright 2020 The Go Authors. All rights reserved.
 -// Use of this source code is governed by a BSD-style
 -// license that can be found in the LICENSE file.
@@ -5156,6 +6645,7 @@ diff -urN a/gopls/internal/regtest/definition_test.go b/gopls/internal/regtest/d
 --- go.mod --
 -module mod.com
 -
+-go 1.12
 --- main.go --
 -package main
 -
@@ -5218,6 +6708,8 @@ diff -urN a/gopls/internal/regtest/definition_test.go b/gopls/internal/regtest/d
 -	const mod = `
 --- go.mod --
 -module mod.com
+-
+-go 1.12
 --- main.go --
 -package main
 -
@@ -5233,14 +6725,14 @@ diff -urN a/gopls/internal/regtest/definition_test.go b/gopls/internal/regtest/d
 -		}
 -		want := "```go\nfunc (error).Error() string\n```"
 -		if content.Value != want {
--			t.Fatalf("hover failed:\n%s", tests.Diff(want, content.Value))
+-			t.Fatalf("hover failed:\n%s", tests.Diff(t, want, content.Value))
 -		}
 -	})
 -}
 diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/diagnostics_test.go
 --- a/gopls/internal/regtest/diagnostics_test.go	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/internal/regtest/diagnostics_test.go	1969-12-31 19:00:00.000000000 -0500
-@@ -1,1596 +0,0 @@
+@@ -1,1791 +0,0 @@
 -// Copyright 2020 The Go Authors. All rights reserved.
 -// Use of this source code is governed by a BSD-style
 -// license that can be found in the LICENSE file.
@@ -5253,7 +6745,6 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 -	"log"
 -	"os"
 -	"testing"
--	"time"
 -
 -	"golang.org/x/tools/internal/lsp"
 -	"golang.org/x/tools/internal/lsp/fake"
@@ -5426,8 +6917,11 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 --- go.mod --
 -module foo
 -
+-go 1.12
 --- a.go --
 -package x
+-
+-// import "fmt"
 -
 -func f() {}
 -
@@ -5441,28 +6935,33 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 -}
 -`
 -
--func TestRmTest38878Close(t *testing.T) {
+-// Tests golang/go#38878: deleting a test file should clear its errors, and
+-// not break the workspace.
+-func TestDeleteTestVariant(t *testing.T) {
 -	runner.Run(t, test38878, func(t *testing.T, env *Env) {
--		env.OpenFile("a_test.go")
--		env.Await(DiagnosticAt("a_test.go", 5, 3))
--		env.CloseBuffer("a_test.go")
+-		env.Await(env.DiagnosticAtRegexp("a_test.go", `f\((3)\)`))
 -		env.RemoveWorkspaceFile("a_test.go")
--		// diagnostics go away
 -		env.Await(EmptyDiagnostics("a_test.go"))
+-
+-		// Make sure the test variant has been removed from the workspace by
+-		// triggering a metadata load.
+-		env.OpenFile("a.go")
+-		env.RegexpReplace("a.go", `// import`, "import")
+-		env.Await(env.DiagnosticAtRegexp("a.go", `"fmt"`))
 -	})
 -}
 -
--func TestRmTest38878(t *testing.T) {
+-// Tests golang/go#38878: deleting a test file on disk while it's still open
+-// should not clear its errors.
+-func TestDeleteTestVariant_DiskOnly(t *testing.T) {
 -	log.SetFlags(log.Lshortfile)
 -	runner.Run(t, test38878, func(t *testing.T, env *Env) {
 -		env.OpenFile("a_test.go")
 -		env.Await(DiagnosticAt("a_test.go", 5, 3))
 -		env.Sandbox.Workdir.RemoveFile(context.Background(), "a_test.go")
--		// diagnostics remain after giving gopls a chance to do something
--		// (there is not yet a better way to decide gopls isn't going
--		// to do anything)
--		time.Sleep(time.Second)
--		env.Await(DiagnosticAt("a_test.go", 5, 3))
+-		env.Await(OnceMet(
+-			CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidChangeWatchedFiles), 1),
+-			DiagnosticAt("a_test.go", 5, 3)))
 -	})
 -}
 -
@@ -5526,7 +7025,7 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 -
 -	t.Run("without workspace module", func(t *testing.T) {
 -		withOptions(
--			WithModes(WithoutExperiments),
+-			Modes(Singleton),
 -		).run(t, noMod, func(t *testing.T, env *Env) {
 -			env.Await(
 -				env.DiagnosticAtRegexp("main.go", `"mod.com/bob"`),
@@ -5595,6 +7094,8 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 -	const packageChange = `
 --- go.mod --
 -module fake
+-
+-go 1.12
 --- a.go --
 -package foo
 -func main() {}
@@ -5622,9 +7123,10 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 -
 -go 1.12
 -
--require (
--	foo.test v1.2.3
--)
+-require foo.test v1.2.3
+--- go.sum --
+-foo.test v1.2.3 h1:TMA+lyd1ck0TqjSFpNe4T6cf/K6TYkoHwOOcMBMjaEw=
+-foo.test v1.2.3/go.mod h1:Ij3kyLIe5lzjycjh13NL8I2gX0quZuTdW0MnmlwGBL4=
 --- print.go --
 -package lib
 -
@@ -5657,7 +7159,7 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 -		// diagnostic for the wrong formatting type.
 -		// TODO: we should be able to easily also match the diagnostic message.
 -		env.Await(env.DiagnosticAtRegexp("print.go", "fmt.Printf"))
--	}, WithProxyFiles(testPackageWithRequireProxy))
+-	}, ProxyFiles(testPackageWithRequireProxy))
 -}
 -
 -func TestMissingDependency(t *testing.T) {
@@ -5693,8 +7195,13 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 -	fmt.Println("Hello World")
 -}
 -`
--	editorConfig := EditorConfig{Env: map[string]string{"GOPATH": ""}}
--	withOptions(editorConfig).run(t, files, func(t *testing.T, env *Env) {
+-	withOptions(
+-		EditorConfig{
+-			Env: map[string]string{
+-				"GOPATH":      "",
+-				"GO111MODULE": "off",
+-			},
+-		}).run(t, files, func(t *testing.T, env *Env) {
 -		env.OpenFile("main.go")
 -		env.Await(env.DiagnosticAtRegexp("main.go", "fmt"))
 -		env.SaveBuffer("main.go")
@@ -5708,6 +7215,7 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 --- go.mod --
 -module mod.com
 -
+-go 1.12
 --- main.go --
 -package main
 -
@@ -5731,6 +7239,7 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 --- go.mod --
 -module mod.com
 -
+-go 1.12
 --- main.go --
 -package main
 -
@@ -5757,50 +7266,33 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 -		env.SaveBuffer("main.go")
 -		fixed := env.ReadWorkspaceFile("main.go")
 -		if original != fixed {
--			t.Fatalf("generated file was changed by quick fixes:\n%s", tests.Diff(original, fixed))
+-			t.Fatalf("generated file was changed by quick fixes:\n%s", tests.Diff(t, original, fixed))
 -		}
 -	})
 -}
 -
 -// Expect a module/GOPATH error if there is an error in the file at startup.
 -// Tests golang/go#37279.
--func TestShowMessage_Issue37279(t *testing.T) {
+-func TestShowCriticalError_Issue37279(t *testing.T) {
 -	const noModule = `
 --- a.go --
 -package foo
 -
--func f() {
--	fmt.Printl()
--}
--`
--	runner.Run(t, noModule, func(t *testing.T, env *Env) {
--		env.OpenFile("a.go")
--		env.Await(env.DiagnosticAtRegexp("a.go", "fmt.Printl"), ShownMessage(""))
--	})
--}
--
--// Expect no module/GOPATH error if there is no error in the file.
--// Tests golang/go#37279.
--func TestNoShowMessage_Issue37279(t *testing.T) {
--	const noModule = `
---- a.go --
--package foo
+-import "mod.com/hello"
 -
 -func f() {
+-	hello.Goodbye()
 -}
 -`
 -	runner.Run(t, noModule, func(t *testing.T, env *Env) {
 -		env.OpenFile("a.go")
 -		env.Await(
--			OnceMet(
--				CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidOpen), 1),
--				NoDiagnostics("a.go"),
--			),
--			NoShowMessage(),
+-			OutstandingWork(lsp.WorkspaceLoadFailure, "outside of a module"),
 -		)
--		// introduce an error, expect no Show Message
--		env.RegexpReplace("a.go", "func", "fun")
--		env.Await(env.DiagnosticAtRegexp("a.go", "fun"), NoShowMessage())
+-		env.RegexpReplace("a.go", `import "mod.com/hello"`, "")
+-		env.Await(
+-			NoOutstandingWork(),
+-		)
 -	})
 -}
 -
@@ -5898,7 +7390,7 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 -}
 -`
 -	withOptions(
--		WithProxyFiles(ardanLabsProxy),
+-		ProxyFiles(ardanLabsProxy),
 -	).run(t, ardanLabs, func(t *testing.T, env *Env) {
 -		// Expect a diagnostic with a suggested fix to add
 -		// "github.com/ardanlabs/conf" to the go.mod file.
@@ -5956,7 +7448,7 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 --- main.go --
 -`
 -	withOptions(
--		WithProxyFiles(ardanLabsProxy),
+-		ProxyFiles(ardanLabsProxy),
 -	).run(t, emptyFile, func(t *testing.T, env *Env) {
 -		env.OpenFile("main.go")
 -		env.EditBuffer("main.go", fake.NewEdit(0, 0, 0, 0, `package main
@@ -5971,7 +7463,7 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 -		var d protocol.PublishDiagnosticsParams
 -		env.Await(
 -			OnceMet(
--				env.DiagnosticAtRegexp("main.go", `"github.com/ardanlabs/conf"`),
+-				env.DiagnosticAtRegexpWithMessage("main.go", `"github.com/ardanlabs/conf"`, "your go.mod file"),
 -				ReadDiagnostics("main.go", &d),
 -			),
 -		)
@@ -6003,9 +7495,7 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 -	runner.Run(t, simplePackage, func(t *testing.T, env *Env) {
 -		env.OpenFile("a/a1.go")
 -		env.CreateBuffer("a/a2.go", ``)
--		if err := env.Editor.SaveBufferWithoutActions(env.Ctx, "a/a2.go"); err != nil {
--			t.Fatal(err)
--		}
+-		env.SaveBufferWithoutActions("a/a2.go")
 -		env.Await(
 -			OnceMet(
 -				CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidSave), 1),
@@ -6068,7 +7558,7 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 -		env.CreateBuffer("hello/hello_x_test.go", ``)
 -
 -		// Save the empty file (no actions since formatting will fail).
--		env.Editor.SaveBufferWithoutActions(env.Ctx, "hello/hello_x_test.go")
+-		env.SaveBufferWithoutActions("hello/hello_x_test.go")
 -
 -		// Add the content. The missing import is for the package under test.
 -		env.EditBuffer("hello/hello_x_test.go", fake.NewEdit(0, 0, 0, 0, `package hello_test
@@ -6095,9 +7585,13 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 -
 -// Reproduce golang/go#40690.
 -func TestCreateOnlyXTest(t *testing.T) {
+-	testenv.NeedsGo1Point(t, 13)
+-
 -	const mod = `
 --- go.mod --
 -module mod.com
+-
+-go 1.12
 --- foo/foo.go --
 -package foo
 --- foo/bar_test.go --
@@ -6128,6 +7622,8 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 -	const mod = `
 --- go.mod --
 -module mod.com
+-
+-go 1.12
 --- foo/foo.go --
 -package foo
 --- foo/bar_test.go --
@@ -6173,7 +7669,7 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 --- go.mod --
 -module mod.com
 -
--go 1.15
+-go 1.12
 --- _foo/x.go --
 -package x
 -
@@ -6330,12 +7826,15 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 -	var x int
 -}
 -`
--	runner.Run(t, mod, func(t *testing.T, env *Env) {
+-	withOptions(
+-		// Empty workspace folders.
+-		WorkspaceFolders(),
+-	).run(t, mod, func(t *testing.T, env *Env) {
 -		env.OpenFile("a/a.go")
 -		env.Await(
 -			env.DiagnosticAtRegexp("a/a.go", "x"),
 -		)
--	}, WithoutWorkspaceFolders())
+-	})
 -}
 -
 -// Reproduces the case described in
@@ -6414,7 +7913,7 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 -		env.CreateBuffer("main.go", "")
 -		env.Await(CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidOpen), 1))
 -
--		env.Editor.SaveBufferWithoutActions(env.Ctx, "main.go")
+-		env.SaveBufferWithoutActions("main.go")
 -		env.Await(
 -			CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidSave), 1),
 -			CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidChangeWatchedFiles), 1),
@@ -6455,6 +7954,8 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 -	const pkgDefault = `
 --- go.mod --
 -module mod.com
+-
+-go 1.12
 --- main.go --
 -package default
 -
@@ -6473,6 +7974,8 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 -	const mod = `
 --- go.mod --
 -module mod.com
+-
+-go 1.12
 --- a/main.go --
 -package main
 -
@@ -6484,13 +7987,18 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 -	var x int
 -}
 -`
--	withOptions(WithRootPath("a")).run(t, mod, func(t *testing.T, env *Env) {
+-	withOptions(
+-		WorkspaceFolders("a"),
+-	).run(t, mod, func(t *testing.T, env *Env) {
 -		env.OpenFile("a/main.go")
 -		env.Await(
 -			env.DiagnosticAtRegexp("main.go", "x"),
 -		)
 -	})
--	withOptions(WithRootPath("a"), LimitWorkspaceScope()).run(t, mod, func(t *testing.T, env *Env) {
+-	withOptions(
+-		WorkspaceFolders("a"),
+-		LimitWorkspaceScope(),
+-	).run(t, mod, func(t *testing.T, env *Env) {
 -		env.OpenFile("a/main.go")
 -		env.Await(
 -			NoDiagnostics("main.go"),
@@ -6502,6 +8010,8 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 -	const files = `
 --- go.mod --
 -module mod.com
+-
+-go 1.12
 --- main.go --
 -package main
 -
@@ -6531,6 +8041,8 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 -	const dir = `
 --- go.mod --
 -module mod.com
+-
+-go 1.12
 --- main.go --
 -package main
 -func main() {
@@ -6608,6 +8120,7 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 --- go.mod --
 -module mod.com
 -
+-go 1.12
 --- main.go --
 -package main
 -
@@ -6633,6 +8146,8 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 -	const mod = `
 --- go.mod --
 -module mod.com
+-
+-go 1.12
 --- pkg/simple/export_swig.go --
 -package simple
 -
@@ -6677,22 +8192,44 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 -// have no more complaints about it.
 -// https://github.com/golang/go/issues/41061
 -func TestRenamePackage(t *testing.T) {
--	t.Skip("Waiting for the fix that makes this pass: https://github.com/golang/go/issues/41061")
+-	testenv.NeedsGo1Point(t, 16)
 -
 -	const contents = `
 --- go.mod --
 -module mod.com
---- foo.go --
--package foo
---- foo_test.go --
--package foo_`
 -
--	runner.Run(t, contents, func(t *testing.T, env *Env) {
--		env.OpenFile("foo_test.go")
--		env.RegexpReplace("foo_test.go", "foo_", "foo_test")
--		env.SaveBuffer("foo_test.go")
+-go 1.12
+--- main.go --
+-package main
+-
+-import "example.com/blah"
+-
+-func main() {
+-	blah.Hello()
+-}
+--- bob.go --
+-package main
+--- foo/foo.go --
+-package foo
+--- foo/foo_test.go --
+-package foo_
+-`
+-
+-	withOptions(
+-		ProxyFiles(proxy),
+-		InGOPATH(),
+-	).run(t, contents, func(t *testing.T, env *Env) {
+-		// Simulate typing character by character.
+-		env.OpenFile("foo/foo_test.go")
+-		env.Await(CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidOpen), 1))
+-		env.RegexpReplace("foo/foo_test.go", "_", "_t")
+-		env.Await(CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidChange), 1))
+-		env.RegexpReplace("foo/foo_test.go", "_t", "_test")
+-		env.Await(CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidChange), 2))
+-
 -		env.Await(
--			EmptyDiagnostics("foo_test.go"),
+-			EmptyDiagnostics("foo/foo_test.go"),
+-			NoOutstandingWork(),
 -		)
 -	})
 -}
@@ -6713,16 +8250,20 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 -	run(t, pkg, func(t *testing.T, env *Env) {
 -		env.OpenFile("go.mod")
 -		env.Await(
--			OutstandingWork("Error loading workspace", "unknown directive"),
+-			OutstandingWork(lsp.WorkspaceLoadFailure, "unknown directive"),
 -		)
 -		env.EditBuffer("go.mod", fake.NewEdit(0, 0, 3, 0, `module mod.com
 -
 -go 1.hello
 -`))
+-		// As of golang/go#42529, go.mod changes do not reload the workspace until
+-		// they are saved.
+-		env.SaveBufferWithoutActions("go.mod")
 -		env.Await(
--			OutstandingWork("Error loading workspace", "invalid go version"),
+-			OutstandingWork(lsp.WorkspaceLoadFailure, "invalid go version"),
 -		)
 -		env.RegexpReplace("go.mod", "go 1.hello", "go 1.12")
+-		env.SaveBufferWithoutActions("go.mod")
 -		env.Await(
 -			NoOutstandingWork(),
 -		)
@@ -6829,12 +8370,158 @@ diff -urN a/gopls/internal/regtest/diagnostics_test.go b/gopls/internal/regtest/
 -			EditorConfig{
 -				Env: map[string]string{"GO111MODULE": "off"},
 -			},
--			WithModes(WithoutExperiments),
+-			Modes(Singleton),
 -		).run(t, mod, func(t *testing.T, env *Env) {
 -			env.Await(
 -				env.DiagnosticAtRegexpWithMessage("main.go", `"nosuchpkg"`, `cannot find package "nosuchpkg" in any of`),
 -			)
 -		})
+-	})
+-}
+-
+-func TestMultipleModules_Warning(t *testing.T) {
+-	const modules = `
+--- a/go.mod --
+-module a.com
+-
+-go 1.12
+--- a/a.go --
+-package a
+--- b/go.mod --
+-module b.com
+-
+-go 1.12
+--- b/b.go --
+-package b
+-`
+-	for _, go111module := range []string{"on", "auto"} {
+-		t.Run("GO111MODULE="+go111module, func(t *testing.T) {
+-			withOptions(
+-				Modes(Singleton),
+-				EditorConfig{
+-					Env: map[string]string{
+-						"GO111MODULE": go111module,
+-					},
+-				},
+-			).run(t, modules, func(t *testing.T, env *Env) {
+-				env.OpenFile("a/a.go")
+-				env.OpenFile("b/go.mod")
+-				env.Await(
+-					env.DiagnosticAtRegexp("a/a.go", "package a"),
+-					env.DiagnosticAtRegexp("b/go.mod", "module b.com"),
+-					OutstandingWork(lsp.WorkspaceLoadFailure, "gopls requires a module at the root of your workspace."),
+-				)
+-			})
+-		})
+-	}
+-
+-	// Expect no warning if GO111MODULE=auto in a directory in GOPATH.
+-	t.Run("GOPATH_GO111MODULE_auto", func(t *testing.T) {
+-		withOptions(
+-			Modes(Singleton),
+-			EditorConfig{
+-				Env: map[string]string{
+-					"GO111MODULE": "auto",
+-				},
+-			},
+-			InGOPATH(),
+-		).run(t, modules, func(t *testing.T, env *Env) {
+-			env.OpenFile("a/a.go")
+-			env.Await(
+-				OnceMet(
+-					CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidOpen), 1),
+-					NoDiagnostics("a/a.go"),
+-				),
+-				NoOutstandingWork(),
+-			)
+-		})
+-	})
+-}
+-
+-func TestNestedModules(t *testing.T) {
+-	const proxy = `
+--- nested.com@v1.0.0/go.mod --
+-module nested.com
+-
+-go 1.12
+--- nested.com@v1.0.0/hello/hello.go --
+-package hello
+-
+-func Hello() {}
+-`
+-
+-	const nested = `
+--- go.mod --
+-module mod.com
+-
+-go 1.12
+-
+-require nested.com v1.0.0
+--- go.sum --
+-nested.com v1.0.0 h1:I6spLE4CgFqMdBPc+wTV2asDO2QJ3tU0YAT+jkLeN1I=
+-nested.com v1.0.0/go.mod h1:ly53UzXQgVjSlV7wicdBB4p8BxfytuGT1Xcyv0ReJfI=
+--- main.go --
+-package main
+-
+-import "nested.com/hello"
+-
+-func main() {
+-	hello.Hello()
+-}
+--- nested/go.mod --
+-module nested.com
+-
+--- nested/hello/hello.go --
+-package hello
+-
+-func Hello() {
+-	helloHelper()
+-}
+--- nested/hello/hello_helper.go --
+-package hello
+-
+-func helloHelper() {}
+-`
+-	withOptions(
+-		ProxyFiles(proxy),
+-		Modes(Singleton),
+-	).run(t, nested, func(t *testing.T, env *Env) {
+-		// Expect a diagnostic in a nested module.
+-		env.OpenFile("nested/hello/hello.go")
+-		didOpen := CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidOpen), 1)
+-		env.Await(
+-			OnceMet(
+-				didOpen,
+-				env.DiagnosticAtRegexp("nested/hello/hello.go", "helloHelper"),
+-			),
+-			OnceMet(
+-				didOpen,
+-				env.DiagnosticAtRegexpWithMessage("nested/hello/hello.go", "package hello", "nested module"),
+-			),
+-			OnceMet(
+-				didOpen,
+-				OutstandingWork(lsp.WorkspaceLoadFailure, "nested module"),
+-			),
+-		)
+-	})
+-}
+-
+-func TestAdHocPackagesReloading(t *testing.T) {
+-	const nomod = `
+--- main.go --
+-package main
+-
+-func main() {}
+-`
+-	run(t, nomod, func(t *testing.T, env *Env) {
+-		env.OpenFile("main.go")
+-		env.RegexpReplace("main.go", "{}", "{ var x int; }") // simulate typing
+-		env.Await(
+-			OnceMet(
+-				CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidChange), 1),
+-				NoLogMatching(protocol.Info, "packages=1"),
+-			),
+-		)
 -	})
 -}
 diff -urN a/gopls/internal/regtest/doc.go b/gopls/internal/regtest/doc.go
@@ -7269,7 +8956,7 @@ diff -urN a/gopls/internal/regtest/env_test.go b/gopls/internal/regtest/env_test
 diff -urN a/gopls/internal/regtest/expectation.go b/gopls/internal/regtest/expectation.go
 --- a/gopls/internal/regtest/expectation.go	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/internal/regtest/expectation.go	1969-12-31 19:00:00.000000000 -0500
-@@ -1,547 +0,0 @@
+@@ -1,568 +0,0 @@
 -// Copyright 2020 The Go Authors. All rights reserved.
 -// Use of this source code is governed by a BSD-style
 -// license that can be found in the LICENSE file.
@@ -7455,6 +9142,27 @@ diff -urN a/gopls/internal/regtest/expectation.go b/gopls/internal/regtest/expec
 -		check:       check,
 -		description: "received ShowMessageRequest",
 -	}
+-}
+-
+-// DoneWithOpen expects all didOpen notifications currently sent by the editor
+-// to be completely processed.
+-func (e *Env) DoneWithOpen() Expectation {
+-	opens := e.Editor.Stats().DidOpen
+-	return CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidOpen), opens)
+-}
+-
+-// DoneWithChange expects all didChange notifications currently sent by the
+-// editor to be completely processed.
+-func (e *Env) DoneWithChange() Expectation {
+-	changes := e.Editor.Stats().DidChange
+-	return CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidChange), changes)
+-}
+-
+-// DoneWithChangeWatchedFiles expects all didChangeWatchedFiles notifications
+-// currently sent by the editor to be completely processed.
+-func (e *Env) DoneWithChangeWatchedFiles() Expectation {
+-	changes := e.Editor.Stats().DidChangeWatchedFiles
+-	return CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidChangeWatchedFiles), changes)
 -}
 -
 -// CompletedWork expects a work item to have been completed >= atLeast times.
@@ -7820,7 +9528,7 @@ diff -urN a/gopls/internal/regtest/expectation.go b/gopls/internal/regtest/expec
 diff -urN a/gopls/internal/regtest/failures_test.go b/gopls/internal/regtest/failures_test.go
 --- a/gopls/internal/regtest/failures_test.go	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/internal/regtest/failures_test.go	1969-12-31 19:00:00.000000000 -0500
-@@ -1,70 +0,0 @@
+@@ -1,74 +0,0 @@
 -// Copyright 2020 The Go Authors. All rights reserved.
 -// Use of this source code is governed by a BSD-style
 -// license that can be found in the LICENSE file.
@@ -7838,6 +9546,8 @@ diff -urN a/gopls/internal/regtest/failures_test.go b/gopls/internal/regtest/fai
 -	const mod = `
 --- go.mod --
 -module mod.com
+-
+-go 1.12
 --- a.y --
 -DWIM(main)
 -
@@ -7864,6 +9574,8 @@ diff -urN a/gopls/internal/regtest/failures_test.go b/gopls/internal/regtest/fai
 -const badPackageDup = `
 --- go.mod --
 -module mod.com
+-
+-go 1.12
 --- a.go --
 -package consts
 -
@@ -7955,14 +9667,18 @@ diff -urN a/gopls/internal/regtest/fix_test.go b/gopls/internal/regtest/fix_test
 -}
 -`
 -		if got := env.Editor.BufferText("main.go"); got != want {
--			t.Fatalf("TestFillStruct failed:\n%s", tests.Diff(want, got))
+-			t.Fatalf("TestFillStruct failed:\n%s", tests.Diff(t, want, got))
 -		}
 -	})
 -}
 diff -urN a/gopls/internal/regtest/formatting_test.go b/gopls/internal/regtest/formatting_test.go
 --- a/gopls/internal/regtest/formatting_test.go	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/internal/regtest/formatting_test.go	1969-12-31 19:00:00.000000000 -0500
-@@ -1,225 +0,0 @@
+@@ -1,241 +0,0 @@
+-// Copyright 2020 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
 -package regtest
 -
 -import (
@@ -7997,7 +9713,7 @@ diff -urN a/gopls/internal/regtest/formatting_test.go b/gopls/internal/regtest/f
 -		got := env.Editor.BufferText("main.go")
 -		want := env.ReadWorkspaceFile("main.go.golden")
 -		if got != want {
--			t.Errorf("unexpected formatting result:\n%s", tests.Diff(want, got))
+-			t.Errorf("unexpected formatting result:\n%s", tests.Diff(t, want, got))
 -		}
 -	})
 -}
@@ -8019,7 +9735,7 @@ diff -urN a/gopls/internal/regtest/formatting_test.go b/gopls/internal/regtest/f
 -		got := env.Editor.BufferText("a.go")
 -		want := env.ReadWorkspaceFile("a.go.formatted")
 -		if got != want {
--			t.Errorf("unexpected formatting result:\n%s", tests.Diff(want, got))
+-			t.Errorf("unexpected formatting result:\n%s", tests.Diff(t, want, got))
 -		}
 -	})
 -}
@@ -8043,7 +9759,7 @@ diff -urN a/gopls/internal/regtest/formatting_test.go b/gopls/internal/regtest/f
 -		got := env.Editor.BufferText("a.go")
 -		want := env.ReadWorkspaceFile("a.go.imported")
 -		if got != want {
--			t.Errorf("unexpected formatting result:\n%s", tests.Diff(want, got))
+-			t.Errorf("unexpected formatting result:\n%s", tests.Diff(t, want, got))
 -		}
 -	})
 -}
@@ -8064,7 +9780,7 @@ diff -urN a/gopls/internal/regtest/formatting_test.go b/gopls/internal/regtest/f
 -		got := env.Editor.BufferText("a.go")
 -		want := env.ReadWorkspaceFile("a.go.imported")
 -		if got != want {
--			t.Errorf("unexpected formatting result:\n%s", tests.Diff(want, got))
+-			t.Errorf("unexpected formatting result:\n%s", tests.Diff(t, want, got))
 -		}
 -	})
 -}
@@ -8110,7 +9826,7 @@ diff -urN a/gopls/internal/regtest/formatting_test.go b/gopls/internal/regtest/f
 -		got := env.Editor.BufferText("main.go")
 -		want := env.ReadWorkspaceFile("main.go.organized")
 -		if got != want {
--			t.Errorf("unexpected formatting result:\n%s", tests.Diff(want, got))
+-			t.Errorf("unexpected formatting result:\n%s", tests.Diff(t, want, got))
 -		}
 -	})
 -}
@@ -8122,36 +9838,31 @@ diff -urN a/gopls/internal/regtest/formatting_test.go b/gopls/internal/regtest/f
 -		got := env.Editor.BufferText("main.go")
 -		want := env.ReadWorkspaceFile("main.go.formatted")
 -		if got != want {
--			t.Errorf("unexpected formatting result:\n%s", tests.Diff(want, got))
+-			t.Errorf("unexpected formatting result:\n%s", tests.Diff(t, want, got))
 -		}
 -	})
 -}
 -
--// Reproduce golang/go#41057.
--func TestCRLF(t *testing.T) {
--	runner.Run(t, "-- main.go --", func(t *testing.T, env *Env) {
--		want := `package main
+-// Tests various possibilities for comments in files with CRLF line endings.
+-// Import organization in these files has historically been a source of bugs.
+-func TestCRLFLineEndings(t *testing.T) {
+-	for _, tt := range []struct {
+-		issue, want string
+-	}{
+-		{
+-			issue: "41057",
+-			want: `package main
 -
 -/*
 -Hi description
 -*/
 -func Hi() {
 -}
--`
--		crlf := strings.ReplaceAll(want, "\n", "\r\n")
--		env.CreateBuffer("main.go", crlf)
--		env.Await(CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidOpen), 1))
--		env.SaveBuffer("main.go")
--		got := env.Editor.BufferText("main.go")
--		if want != got {
--			t.Errorf("unexpected content after save:\n%s", tests.Diff(want, got))
--		}
--	})
--}
--
--func TestCRLF_42646(t *testing.T) {
--	runner.Run(t, "-- main.go --", func(t *testing.T, env *Env) {
--		want := `package main
+-`,
+-		},
+-		{
+-			issue: "42646",
+-			want: `package main
 -
 -import (
 -	"fmt"
@@ -8176,17 +9887,34 @@ diff -urN a/gopls/internal/regtest/formatting_test.go b/gopls/internal/regtest/f
 -	const server_port = 8080
 -	fmt.Printf("port: %d\n", server_port)
 -}
--`
--		crlf := strings.ReplaceAll(want, "\n", "\r\n")
--		env.CreateBuffer("main.go", crlf)
--		env.Await(CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidOpen), 1))
--		env.OrganizeImports("main.go")
--		got := env.Editor.BufferText("main.go")
--		got = strings.ReplaceAll(got, "\r\n", "\n") // convert everything to LF for simplicity
--		if want != got {
--			t.Errorf("unexpected content after save:\n%s", tests.Diff(want, got))
--		}
--	})
+-`,
+-		},
+-		{
+-			issue: "42923",
+-			want: `package main
+-
+-// Line 1.
+-// aa
+-type Tree struct {
+-	arr []string
+-}
+-`,
+-		},
+-	} {
+-		t.Run(tt.issue, func(t *testing.T) {
+-			run(t, "-- main.go --", func(t *testing.T, env *Env) {
+-				crlf := strings.ReplaceAll(tt.want, "\n", "\r\n")
+-				env.CreateBuffer("main.go", crlf)
+-				env.Await(CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidOpen), 1))
+-				env.OrganizeImports("main.go")
+-				got := env.Editor.BufferText("main.go")
+-				got = strings.ReplaceAll(got, "\r\n", "\n") // convert everything to LF for simplicity
+-				if tt.want != got {
+-					t.Errorf("unexpected content after save:\n%s", tests.Diff(t, tt.want, got))
+-				}
+-			})
+-		})
+-	}
 -}
 diff -urN a/gopls/internal/regtest/generate_test.go b/gopls/internal/regtest/generate_test.go
 --- a/gopls/internal/regtest/generate_test.go	2000-01-01 00:00:00.000000000 -0000
@@ -8249,7 +9977,11 @@ diff -urN a/gopls/internal/regtest/generate_test.go b/gopls/internal/regtest/gen
 diff -urN a/gopls/internal/regtest/imports_test.go b/gopls/internal/regtest/imports_test.go
 --- a/gopls/internal/regtest/imports_test.go	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/internal/regtest/imports_test.go	1969-12-31 19:00:00.000000000 -0500
-@@ -1,205 +0,0 @@
+@@ -1,214 +0,0 @@
+-// Copyright 2020 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
 -package regtest
 -
 -import (
@@ -8269,6 +10001,7 @@ diff -urN a/gopls/internal/regtest/imports_test.go b/gopls/internal/regtest/impo
 --- go.mod --
 -module foo
 -
+-go 1.12
 --- a.go --
 -package main
 -func f() {}
@@ -8378,8 +10111,12 @@ diff -urN a/gopls/internal/regtest/imports_test.go b/gopls/internal/regtest/impo
 --- go.mod --
 -module mod.com
 -
--require example.com v1.2.3
+-go 1.12
 -
+-require example.com v1.2.3
+--- go.sum --
+-example.com v1.2.3 h1:6vTQqzX+pnwngZF1+5gcO3ZEWmix1jJ/h+pWS8wUxK0=
+-example.com v1.2.3/go.mod h1:Y2Rc5rVWjWur0h3pd9aEvK5Pof8YKDANh9gHA2Maujo=
 --- main.go --
 -package main
 -
@@ -8397,7 +10134,7 @@ diff -urN a/gopls/internal/regtest/imports_test.go b/gopls/internal/regtest/impo
 -	editorConfig := EditorConfig{Env: map[string]string{"GOMODCACHE": modcache}}
 -	withOptions(
 -		editorConfig,
--		WithProxyFiles(proxy),
+-		ProxyFiles(proxy),
 -	).run(t, files, func(t *testing.T, env *Env) {
 -		env.OpenFile("main.go")
 -		env.Await(env.DiagnosticAtRegexp("main.go", `y.Y`))
@@ -8458,7 +10195,7 @@ diff -urN a/gopls/internal/regtest/imports_test.go b/gopls/internal/regtest/impo
 diff -urN a/gopls/internal/regtest/link_test.go b/gopls/internal/regtest/link_test.go
 --- a/gopls/internal/regtest/link_test.go	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/internal/regtest/link_test.go	1969-12-31 19:00:00.000000000 -0500
-@@ -1,88 +0,0 @@
+@@ -1,91 +0,0 @@
 -// Copyright 2020 The Go Authors. All rights reserved.
 -// Use of this source code is governed by a BSD-style
 -// license that can be found in the LICENSE file.
@@ -8481,6 +10218,9 @@ diff -urN a/gopls/internal/regtest/link_test.go b/gopls/internal/regtest/link_te
 -go 1.12
 -
 -require import.test v1.2.3
+--- go.sum --
+-import.test v1.2.3 h1:Mu4N9BICLJFxwwn8YNg6T3frkFWW1O7evXvo0HiRjBc=
+-import.test v1.2.3/go.mod h1:KooCN1g237upRg7irU7F+3oADn5tVClU8YYW4I1xhMk=
 --- main.go --
 -package main
 -
@@ -8545,12 +10285,12 @@ diff -urN a/gopls/internal/regtest/link_test.go b/gopls/internal/regtest/link_te
 -		if len(links) != 0 {
 -			t.Errorf("documentLink: got %d document links for go.mod, want 0\nlinks: %v", len(links), links)
 -		}
--	}, WithProxyFiles(proxy))
+-	}, ProxyFiles(proxy))
 -}
 diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modfile_test.go
 --- a/gopls/internal/regtest/modfile_test.go	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/internal/regtest/modfile_test.go	1969-12-31 19:00:00.000000000 -0500
-@@ -1,652 +0,0 @@
+@@ -1,1023 +0,0 @@
 -// Copyright 2020 The Go Authors. All rights reserved.
 -// Use of this source code is governed by a BSD-style
 -// license that can be found in the LICENSE file.
@@ -8558,6 +10298,7 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -package regtest
 -
 -import (
+-	"path/filepath"
 -	"strings"
 -	"testing"
 -
@@ -8586,23 +10327,14 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -const Name = "Hello"
 -`
 -
--func runModfileTest(t *testing.T, files, proxy string, f TestFunc) {
--	t.Run("normal", func(t *testing.T) {
--		withOptions(WithProxyFiles(proxy)).run(t, files, f)
--	})
--	t.Run("nested", func(t *testing.T) {
--		withOptions(WithProxyFiles(proxy), NestWorkdir(), WithModes(Singleton|Experimental)).run(t, files, f)
--	})
--}
--
 -func TestModFileModification(t *testing.T) {
 -	testenv.NeedsGo1Point(t, 14)
 -
 -	const untidyModule = `
---- go.mod --
+--- a/go.mod --
 -module mod.com
 -
---- main.go --
+--- a/main.go --
 -package main
 -
 -import "example.com/blah"
@@ -8611,26 +10343,32 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -	println(blah.Name)
 -}
 -`
+-
+-	runner := runMultiple{
+-		{"default", withOptions(ProxyFiles(proxy), WorkspaceFolders("a"))},
+-		{"nested", withOptions(ProxyFiles(proxy))},
+-	}
+-
 -	t.Run("basic", func(t *testing.T) {
--		runModfileTest(t, untidyModule, proxy, func(t *testing.T, env *Env) {
+-		runner.run(t, untidyModule, func(t *testing.T, env *Env) {
 -			// Open the file and make sure that the initial workspace load does not
 -			// modify the go.mod file.
--			goModContent := env.ReadWorkspaceFile("go.mod")
--			env.OpenFile("main.go")
+-			goModContent := env.ReadWorkspaceFile("a/go.mod")
+-			env.OpenFile("a/main.go")
 -			env.Await(
--				env.DiagnosticAtRegexp("main.go", "\"example.com/blah\""),
+-				env.DiagnosticAtRegexp("a/main.go", "\"example.com/blah\""),
 -			)
--			if got := env.ReadWorkspaceFile("go.mod"); got != goModContent {
--				t.Fatalf("go.mod changed on disk:\n%s", tests.Diff(goModContent, got))
+-			if got := env.ReadWorkspaceFile("a/go.mod"); got != goModContent {
+-				t.Fatalf("go.mod changed on disk:\n%s", tests.Diff(t, goModContent, got))
 -			}
 -			// Save the buffer, which will format and organize imports.
 -			// Confirm that the go.mod file still does not change.
--			env.SaveBuffer("main.go")
+-			env.SaveBuffer("a/main.go")
 -			env.Await(
--				env.DiagnosticAtRegexp("main.go", "\"example.com/blah\""),
+-				env.DiagnosticAtRegexp("a/main.go", "\"example.com/blah\""),
 -			)
--			if got := env.ReadWorkspaceFile("go.mod"); got != goModContent {
--				t.Fatalf("go.mod changed on disk:\n%s", tests.Diff(goModContent, got))
+-			if got := env.ReadWorkspaceFile("a/go.mod"); got != goModContent {
+-				t.Fatalf("go.mod changed on disk:\n%s", tests.Diff(t, goModContent, got))
 -			}
 -		})
 -	})
@@ -8639,13 +10377,13 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -	t.Run("delete main.go", func(t *testing.T) {
 -		t.Skip("This test will be flaky until golang/go#40269 is resolved.")
 -
--		runModfileTest(t, untidyModule, proxy, func(t *testing.T, env *Env) {
--			goModContent := env.ReadWorkspaceFile("go.mod")
--			mainContent := env.ReadWorkspaceFile("main.go")
--			env.OpenFile("main.go")
--			env.SaveBuffer("main.go")
+-		runner.run(t, untidyModule, func(t *testing.T, env *Env) {
+-			goModContent := env.ReadWorkspaceFile("a/go.mod")
+-			mainContent := env.ReadWorkspaceFile("a/main.go")
+-			env.OpenFile("a/main.go")
+-			env.SaveBuffer("a/main.go")
 -
--			env.RemoveWorkspaceFile("main.go")
+-			env.RemoveWorkspaceFile("a/main.go")
 -			env.Await(
 -				CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidOpen), 1),
 -				CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidSave), 1),
@@ -8657,9 +10395,60 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -				env.DiagnosticAtRegexp("main.go", "\"example.com/blah\""),
 -			)
 -			if got := env.ReadWorkspaceFile("go.mod"); got != goModContent {
--				t.Fatalf("go.mod changed on disk:\n%s", tests.Diff(goModContent, got))
+-				t.Fatalf("go.mod changed on disk:\n%s", tests.Diff(t, goModContent, got))
 -			}
 -		})
+-	})
+-}
+-
+-func TestGoGetFix(t *testing.T) {
+-	testenv.NeedsGo1Point(t, 14)
+-	const mod = `
+--- a/go.mod --
+-module mod.com
+-
+-go 1.12
+-
+--- a/main.go --
+-package main
+-
+-import "example.com/blah"
+-
+-var _ = blah.Name
+-`
+-
+-	const want = `module mod.com
+-
+-go 1.12
+-
+-require example.com v1.2.3
+-`
+-
+-	runMultiple{
+-		{"default", withOptions(ProxyFiles(proxy), WorkspaceFolders("a"))},
+-		{"nested", withOptions(ProxyFiles(proxy))},
+-	}.run(t, mod, func(t *testing.T, env *Env) {
+-		if strings.Contains(t.Name(), "workspace_module") {
+-			t.Skip("workspace module mode doesn't set -mod=readonly")
+-		}
+-		env.OpenFile("a/main.go")
+-		var d protocol.PublishDiagnosticsParams
+-		env.Await(
+-			OnceMet(
+-				env.DiagnosticAtRegexp("a/main.go", `"example.com/blah"`),
+-				ReadDiagnostics("a/main.go", &d),
+-			),
+-		)
+-		var goGetDiag protocol.Diagnostic
+-		for _, diag := range d.Diagnostics {
+-			if strings.Contains(diag.Message, "could not import") {
+-				goGetDiag = diag
+-			}
+-		}
+-		env.ApplyQuickFixes("a/main.go", []protocol.Diagnostic{goGetDiag})
+-		if got := env.ReadWorkspaceFile("a/go.mod"); got != want {
+-			t.Fatalf("unexpected go.mod content:\n%s", tests.Diff(t, want, got))
+-		}
 -	})
 -}
 -
@@ -8667,12 +10456,12 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -func TestMissingDependencyFixes(t *testing.T) {
 -	testenv.NeedsGo1Point(t, 14)
 -	const mod = `
---- go.mod --
+--- a/go.mod --
 -module mod.com
 -
 -go 1.12
 -
---- main.go --
+--- a/main.go --
 -package main
 -
 -import "example.com/blah"
@@ -8688,13 +10477,16 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -require random.org v1.2.3
 -`
 -
--	runModfileTest(t, mod, proxy, func(t *testing.T, env *Env) {
--		env.OpenFile("main.go")
+-	runMultiple{
+-		{"default", withOptions(ProxyFiles(proxy), WorkspaceFolders("a"))},
+-		{"nested", withOptions(ProxyFiles(proxy))},
+-	}.run(t, mod, func(t *testing.T, env *Env) {
+-		env.OpenFile("a/main.go")
 -		var d protocol.PublishDiagnosticsParams
 -		env.Await(
 -			OnceMet(
--				env.DiagnosticAtRegexp("main.go", `"random.org/blah"`),
--				ReadDiagnostics("main.go", &d),
+-				env.DiagnosticAtRegexp("a/main.go", `"random.org/blah"`),
+-				ReadDiagnostics("a/main.go", &d),
 -			),
 -		)
 -		var randomDiag protocol.Diagnostic
@@ -8703,9 +10495,9 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -				randomDiag = diag
 -			}
 -		}
--		env.ApplyQuickFixes("main.go", []protocol.Diagnostic{randomDiag})
--		if got := env.ReadWorkspaceFile("go.mod"); got != want {
--			t.Fatalf("unexpected go.mod content:\n%s", tests.Diff(want, got))
+-		env.ApplyQuickFixes("a/main.go", []protocol.Diagnostic{randomDiag})
+-		if got := env.ReadWorkspaceFile("a/go.mod"); got != want {
+-			t.Fatalf("unexpected go.mod content:\n%s", tests.Diff(t, want, got))
 -		}
 -	})
 -}
@@ -8714,13 +10506,16 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -	testenv.NeedsGo1Point(t, 14)
 -
 -	const mod = `
---- go.mod --
+--- a/go.mod --
 -module mod.com
 -
 -go 1.12
 -
 -require example.com v1.2.3 // indirect
---- main.go --
+--- a/go.sum --
+-example.com v1.2.3 h1:ihBTGWGjTU3V4ZJ9OmHITkU9WQ4lGdQkMjgyLFk0FaY=
+-example.com v1.2.3/go.mod h1:Y2Rc5rVWjWur0h3pd9aEvK5Pof8YKDANh9gHA2Maujo=
+--- a/main.go --
 -package main
 -
 -import "example.com/blah"
@@ -8734,18 +10529,22 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -
 -require example.com v1.2.3
 -`
--	runModfileTest(t, mod, proxy, func(t *testing.T, env *Env) {
--		env.OpenFile("go.mod")
+-
+-	runMultiple{
+-		{"default", withOptions(ProxyFiles(proxy), WorkspaceFolders("a"))},
+-		{"nested", withOptions(ProxyFiles(proxy))},
+-	}.run(t, mod, func(t *testing.T, env *Env) {
+-		env.OpenFile("a/go.mod")
 -		var d protocol.PublishDiagnosticsParams
 -		env.Await(
 -			OnceMet(
--				env.DiagnosticAtRegexp("go.mod", "// indirect"),
--				ReadDiagnostics("go.mod", &d),
+-				env.DiagnosticAtRegexp("a/go.mod", "// indirect"),
+-				ReadDiagnostics("a/go.mod", &d),
 -			),
 -		)
--		env.ApplyQuickFixes("go.mod", d.Diagnostics)
--		if got := env.Editor.BufferText("go.mod"); got != want {
--			t.Fatalf("unexpected go.mod content:\n%s", tests.Diff(want, got))
+-		env.ApplyQuickFixes("a/go.mod", d.Diagnostics)
+-		if got := env.Editor.BufferText("a/go.mod"); got != want {
+-			t.Fatalf("unexpected go.mod content:\n%s", tests.Diff(t, want, got))
 -		}
 -	})
 -}
@@ -8759,12 +10558,14 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -const X = 1
 -`
 -	const files = `
---- go.mod --
+--- a/go.mod --
 -module mod.com
 -go 1.14
 -require example.com v1.0.0
--
---- main.go --
+--- a/go.sum --
+-example.com v1.0.0 h1:38O7j5rEBajXk+Q5wzLbRN7KqMkSgEiN9NqcM1O2bBM=
+-example.com v1.0.0/go.mod h1:vUsPMGpx9ZXXzECCOsOmYCW7npJTwuA16yl89n3Mgls=
+--- a/main.go --
 -package main
 -func main() {}
 -`
@@ -8774,18 +10575,21 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -go 1.14
 -`
 -
--	runModfileTest(t, files, proxy, func(t *testing.T, env *Env) {
--		env.OpenFile("go.mod")
+-	runMultiple{
+-		{"default", withOptions(ProxyFiles(proxy), WorkspaceFolders("a"))},
+-		{"nested", withOptions(ProxyFiles(proxy))},
+-	}.run(t, files, func(t *testing.T, env *Env) {
+-		env.OpenFile("a/go.mod")
 -		var d protocol.PublishDiagnosticsParams
 -		env.Await(
 -			OnceMet(
--				env.DiagnosticAtRegexp("go.mod", `require example.com`),
--				ReadDiagnostics("go.mod", &d),
+-				env.DiagnosticAtRegexp("a/go.mod", `require example.com`),
+-				ReadDiagnostics("a/go.mod", &d),
 -			),
 -		)
--		env.ApplyQuickFixes("go.mod", d.Diagnostics)
--		if got := env.ReadWorkspaceFile("go.mod"); got != want {
--			t.Fatalf("unexpected go.mod content:\n%s", tests.Diff(want, got))
+-		env.ApplyQuickFixes("a/go.mod", d.Diagnostics)
+-		if got := env.ReadWorkspaceFile("a/go.mod"); got != want {
+-			t.Fatalf("unexpected go.mod content:\n%s", tests.Diff(t, want, got))
 -		}
 -	})
 -}
@@ -8812,13 +10616,18 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -package hello
 -`
 -	const repro = `
---- go.mod --
+--- a/go.mod --
 -module mod.com
 -
 -go 1.14
 -
 -require google.golang.org/protobuf v1.20.0
---- main.go --
+--- a/go.sum --
+-github.com/esimov/caire v1.2.5 h1:OcqDII/BYxcBYj3DuwDKjd+ANhRxRqLa2n69EGje7qw=
+-github.com/esimov/caire v1.2.5/go.mod h1:mXnjRjg3+WUtuhfSC1rKRmdZU9vJZyS1ZWU0qSvJhK8=
+-google.golang.org/protobuf v1.20.0 h1:y9T1vAtFKQg0faFNMOxJU7WuEqPWolVkjIkU6aI8qCY=
+-google.golang.org/protobuf v1.20.0/go.mod h1:FcqsytGClbtLv1ot8NvsJHjBi0h22StKVP+K/j2liKA=
+--- a/main.go --
 -package main
 -
 -import (
@@ -8828,16 +10637,20 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -func _() {
 -    caire.RemoveTempImage()
 -}`
--	runModfileTest(t, repro, proxy, func(t *testing.T, env *Env) {
--		env.OpenFile("main.go")
+-
+-	runMultiple{
+-		{"default", withOptions(ProxyFiles(proxy), WorkspaceFolders("a"))},
+-		{"nested", withOptions(ProxyFiles(proxy))},
+-	}.run(t, repro, func(t *testing.T, env *Env) {
+-		env.OpenFile("a/main.go")
 -		var d protocol.PublishDiagnosticsParams
 -		env.Await(
 -			OnceMet(
--				env.DiagnosticAtRegexp("main.go", `"github.com/esimov/caire"`),
--				ReadDiagnostics("main.go", &d),
+-				env.DiagnosticAtRegexp("a/main.go", `"github.com/esimov/caire"`),
+-				ReadDiagnostics("a/main.go", &d),
 -			),
 -		)
--		env.ApplyQuickFixes("main.go", d.Diagnostics)
+-		env.ApplyQuickFixes("a/main.go", d.Diagnostics)
 -		want := `module mod.com
 -
 -go 1.14
@@ -8847,8 +10660,8 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -	google.golang.org/protobuf v1.20.0
 -)
 -`
--		if got := env.ReadWorkspaceFile("go.mod"); got != want {
--			t.Fatalf("TestNewDepWithUnusedDep failed:\n%s", tests.Diff(want, got))
+-		if got := env.ReadWorkspaceFile("a/go.mod"); got != want {
+-			t.Fatalf("TestNewDepWithUnusedDep failed:\n%s", tests.Diff(t, want, got))
 -		}
 -	})
 -}
@@ -8860,23 +10673,29 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -	testenv.NeedsGo1Point(t, 14)
 -
 -	const mod = `
---- go.mod --
+--- a/go.mod --
 -module mod.com
 -
 -go 1.12
 -
 -require example.com v1.2.3
---- main.go --
+--- a/go.sum --
+-example.com v1.2.3 h1:ihBTGWGjTU3V4ZJ9OmHITkU9WQ4lGdQkMjgyLFk0FaY=
+-example.com v1.2.3/go.mod h1:Y2Rc5rVWjWur0h3pd9aEvK5Pof8YKDANh9gHA2Maujo=
+--- a/main.go --
 -package main
 -
 -func main() {
 -	fmt.Println(blah.Name)
 -`
--	runModfileTest(t, mod, proxy, func(t *testing.T, env *Env) {
--		env.Await(env.DiagnosticAtRegexp("go.mod", "require"))
--		env.RunGoCommand("mod", "tidy")
+-	runMultiple{
+-		{"default", withOptions(ProxyFiles(proxy), WorkspaceFolders("a"))},
+-		{"nested", withOptions(ProxyFiles(proxy))},
+-	}.run(t, mod, func(t *testing.T, env *Env) {
+-		env.Await(env.DiagnosticAtRegexp("a/go.mod", "require"))
+-		env.RunGoCommandInDir("a", "mod", "tidy")
 -		env.Await(
--			EmptyDiagnostics("go.mod"),
+-			EmptyDiagnostics("a/go.mod"),
 -		)
 -	})
 -}
@@ -8908,30 +10727,38 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -const Name = "Blah"
 -`
 -	const files = `
---- go.mod --
+--- a/go.mod --
 -module mod.com
 -
 -go 1.12
 -
 -require example.com/blah/v2 v2.0.0
---- main.go --
+--- a/go.sum --
+-example.com/blah v1.0.0 h1:kGPlWJbMsn1P31H9xp/q2mYI32cxLnCvauHN0AVaHnc=
+-example.com/blah v1.0.0/go.mod h1:PZUQaGFeVjyDmAE8ywmLbmDn3fj4Ws8epg4oLuDzW3M=
+-example.com/blah/v2 v2.0.0 h1:w5baE9JuuU11s3de3yWx2sU05AhNkgLYdZ4qukv+V0k=
+-example.com/blah/v2 v2.0.0/go.mod h1:UZiKbTwobERo/hrqFLvIQlJwQZQGxWMVY4xere8mj7w=
+--- a/main.go --
 -package main
 -
 -import "example.com/blah/v2"
 -
 -var _ = blah.Name
 -`
--	withOptions(WithProxyFiles(proxy)).run(t, files, func(t *testing.T, env *Env) {
--		env.OpenFile("main.go")
--		env.OpenFile("go.mod")
+-	runMultiple{
+-		{"default", withOptions(ProxyFiles(proxy), WorkspaceFolders("a"))},
+-		{"nested", withOptions(ProxyFiles(proxy))},
+-	}.run(t, files, func(t *testing.T, env *Env) {
+-		env.OpenFile("a/main.go")
+-		env.OpenFile("a/go.mod")
 -		var d protocol.PublishDiagnosticsParams
 -		env.Await(
 -			OnceMet(
--				DiagnosticAt("go.mod", 0, 0),
--				ReadDiagnostics("go.mod", &d),
+-				DiagnosticAt("a/go.mod", 0, 0),
+-				ReadDiagnostics("a/go.mod", &d),
 -			),
 -		)
--		env.ApplyQuickFixes("main.go", d.Diagnostics)
+-		env.ApplyQuickFixes("a/main.go", d.Diagnostics)
 -		const want = `module mod.com
 -
 -go 1.12
@@ -8941,9 +10768,9 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -	example.com/blah/v2 v2.0.0
 -)
 -`
--		env.Await(EmptyDiagnostics("go.mod"))
--		if got := env.Editor.BufferText("go.mod"); got != want {
--			t.Fatalf("suggested fixes failed:\n%s", tests.Diff(want, got))
+-		env.Await(EmptyDiagnostics("a/go.mod"))
+-		if got := env.Editor.BufferText("a/go.mod"); got != want {
+-			t.Fatalf("suggested fixes failed:\n%s", tests.Diff(t, want, got))
 -		}
 -	})
 -}
@@ -8953,13 +10780,13 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -	testenv.NeedsGo1Point(t, 14)
 -
 -	const unknown = `
---- go.mod --
+--- a/go.mod --
 -module mod.com
 -
 -require (
 -	example.com v1.2.2
 -)
---- main.go --
+--- a/main.go --
 -package main
 -
 -import "example.com/blah"
@@ -8969,29 +10796,47 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -}
 -`
 -
+-	runner := runMultiple{
+-		{"default", withOptions(ProxyFiles(proxy), WorkspaceFolders("a"))},
+-		{"nested", withOptions(ProxyFiles(proxy))},
+-	}
 -	// Start from a bad state/bad IWL, and confirm that we recover.
 -	t.Run("bad", func(t *testing.T) {
--		runModfileTest(t, unknown, proxy, func(t *testing.T, env *Env) {
--			env.OpenFile("go.mod")
+-		runner.run(t, unknown, func(t *testing.T, env *Env) {
+-			env.OpenFile("a/go.mod")
 -			env.Await(
--				env.DiagnosticAtRegexp("go.mod", "example.com v1.2.2"),
+-				env.DiagnosticAtRegexp("a/go.mod", "example.com v1.2.2"),
 -			)
--			env.RegexpReplace("go.mod", "v1.2.2", "v1.2.3")
--			env.Editor.SaveBufferWithoutActions(env.Ctx, "go.mod") // go.mod changes must be on disk
+-			env.RegexpReplace("a/go.mod", "v1.2.2", "v1.2.3")
+-			env.Editor.SaveBuffer(env.Ctx, "a/go.mod") // go.mod changes must be on disk
+-
+-			d := protocol.PublishDiagnosticsParams{}
 -			env.Await(
--				env.DiagnosticAtRegexp("main.go", "x = "),
+-				OnceMet(
+-					env.DiagnosticAtRegexpWithMessage("a/go.mod", "example.com v1.2.3", "example.com@v1.2.3"),
+-					ReadDiagnostics("a/go.mod", &d),
+-				),
+-			)
+-			env.ApplyQuickFixes("a/go.mod", d.Diagnostics)
+-
+-			env.Await(
+-				EmptyDiagnostics("a/go.mod"),
+-				env.DiagnosticAtRegexp("a/main.go", "x = "),
 -			)
 -		})
 -	})
 -
 -	const known = `
---- go.mod --
+--- a/go.mod --
 -module mod.com
 -
 -require (
 -	example.com v1.2.3
 -)
---- main.go --
+--- a/go.sum --
+-example.com v1.2.3 h1:ihBTGWGjTU3V4ZJ9OmHITkU9WQ4lGdQkMjgyLFk0FaY=
+-example.com v1.2.3/go.mod h1:Y2Rc5rVWjWur0h3pd9aEvK5Pof8YKDANh9gHA2Maujo=
+--- a/main.go --
 -package main
 -
 -import "example.com/blah"
@@ -9003,20 +10848,20 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -	// Start from a good state, transform to a bad state, and confirm that we
 -	// still recover.
 -	t.Run("good", func(t *testing.T) {
--		runModfileTest(t, known, proxy, func(t *testing.T, env *Env) {
--			env.OpenFile("go.mod")
+-		runner.run(t, known, func(t *testing.T, env *Env) {
+-			env.OpenFile("a/go.mod")
 -			env.Await(
--				env.DiagnosticAtRegexp("main.go", "x = "),
+-				env.DiagnosticAtRegexp("a/main.go", "x = "),
 -			)
--			env.RegexpReplace("go.mod", "v1.2.3", "v1.2.2")
--			env.Editor.SaveBufferWithoutActions(env.Ctx, "go.mod") // go.mod changes must be on disk
+-			env.RegexpReplace("a/go.mod", "v1.2.3", "v1.2.2")
+-			env.Editor.SaveBuffer(env.Ctx, "a/go.mod") // go.mod changes must be on disk
 -			env.Await(
--				env.DiagnosticAtRegexp("go.mod", "example.com v1.2.2"),
+-				env.DiagnosticAtRegexp("a/go.mod", "example.com v1.2.2"),
 -			)
--			env.RegexpReplace("go.mod", "v1.2.2", "v1.2.3")
--			env.Editor.SaveBufferWithoutActions(env.Ctx, "go.mod") // go.mod changes must be on disk
+-			env.RegexpReplace("a/go.mod", "v1.2.2", "v1.2.3")
+-			env.Editor.SaveBuffer(env.Ctx, "a/go.mod") // go.mod changes must be on disk
 -			env.Await(
--				env.DiagnosticAtRegexp("main.go", "x = "),
+-				env.DiagnosticAtRegexp("a/main.go", "x = "),
 -			)
 -		})
 -	})
@@ -9048,13 +10893,13 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -const Name = "Hello"
 -`
 -	const module = `
---- go.mod --
+--- a/go.mod --
 -module mod.com
 -
 -go 1.14
 -
 -require example.com v1.2.3
---- main.go --
+--- a/main.go --
 -package main
 -
 -import "example.com/blah"
@@ -9063,10 +10908,13 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -	println(blah.Name)
 -}
 -`
--	runModfileTest(t, module, badProxy, func(t *testing.T, env *Env) {
--		env.OpenFile("go.mod")
+-	runMultiple{
+-		{"default", withOptions(ProxyFiles(badProxy), WorkspaceFolders("a"))},
+-		{"nested", withOptions(ProxyFiles(badProxy))},
+-	}.run(t, module, func(t *testing.T, env *Env) {
+-		env.OpenFile("a/go.mod")
 -		env.Await(
--			env.DiagnosticAtRegexp("go.mod", "require example.com v1.2.3"),
+-			env.DiagnosticAtRegexp("a/go.mod", "require example.com v1.2.3"),
 -		)
 -	})
 -}
@@ -9093,8 +10941,8 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -				"GOFLAGS": "-mod=readonly",
 -			},
 -		},
--		WithProxyFiles(proxy),
--		WithModes(WithoutExperiments),
+-		ProxyFiles(proxy),
+-		Modes(Singleton),
 -	).run(t, mod, func(t *testing.T, env *Env) {
 -		env.OpenFile("main.go")
 -		original := env.ReadWorkspaceFile("go.mod")
@@ -9103,7 +10951,7 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -		)
 -		got := env.ReadWorkspaceFile("go.mod")
 -		if got != original {
--			t.Fatalf("go.mod file modified:\n%s", tests.Diff(original, got))
+-			t.Fatalf("go.mod file modified:\n%s", tests.Diff(t, original, got))
 -		}
 -		env.RunGoCommand("get", "example.com/blah@v1.2.3")
 -		env.RunGoCommand("mod", "tidy")
@@ -9143,8 +10991,8 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -}
 -`
 -	withOptions(
--		WithProxyFiles(workspaceProxy),
--		WithModes(Experimental),
+-		ProxyFiles(workspaceProxy),
+-		Modes(Experimental),
 -	).run(t, mod, func(t *testing.T, env *Env) {
 -		env.Await(
 -			env.DiagnosticAtRegexp("a/go.mod", "example.com v1.2.3"),
@@ -9173,7 +11021,7 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -}
 -`
 -	withOptions(
--		WithProxyFiles(workspaceProxy),
+-		ProxyFiles(workspaceProxy),
 -		EditorConfig{
 -			BuildFlags: []string{"-tags", "bob"},
 -		},
@@ -9203,10 +11051,273 @@ diff -urN a/gopls/internal/regtest/modfile_test.go b/gopls/internal/regtest/modf
 -		)
 -	})
 -}
+-
+-func TestSumUpdateFixesDiagnostics(t *testing.T) {
+-	testenv.NeedsGo1Point(t, 14)
+-
+-	const mod = `
+--- go.mod --
+-module mod.com
+-
+-go 1.12
+-
+-require (
+-	example.com v1.2.3
+-)
+--- go.sum --
+--- main.go --
+-package main
+-
+-import (
+-	"example.com/blah"
+-)
+-
+-func main() {
+-	println(blah.Name)
+-}
+-`
+-	withOptions(
+-		Modes(Singleton), // workspace modules don't use -mod=readonly (golang/go#43346)
+-		ProxyFiles(workspaceProxy),
+-	).run(t, mod, func(t *testing.T, env *Env) {
+-		d := &protocol.PublishDiagnosticsParams{}
+-		env.OpenFile("go.mod")
+-		env.Await(
+-			OnceMet(
+-				DiagnosticAt("go.mod", 0, 0),
+-				ReadDiagnostics("go.mod", d),
+-			),
+-		)
+-		env.ApplyQuickFixes("go.mod", d.Diagnostics)
+-		env.Await(
+-			EmptyDiagnostics("go.mod"),
+-		)
+-	})
+-}
+-
+-// This test confirms that editing a go.mod file only causes metadata
+-// to be invalidated when it's saved.
+-func TestGoModInvalidatesOnSave(t *testing.T) {
+-	const mod = `
+--- go.mod --
+-module mod.com
+-
+-go 1.12
+--- main.go --
+-package main
+-
+-func main() {
+-	hello()
+-}
+--- hello.go --
+-package main
+-
+-func hello() {}
+-`
+-	withOptions(
+-		// TODO(rFindley) this doesn't work in multi-module workspace mode, because
+-		// it keeps around the last parsing modfile. Update this test to also
+-		// exercise the workspace module.
+-		Modes(Singleton),
+-	).run(t, mod, func(t *testing.T, env *Env) {
+-		env.OpenFile("go.mod")
+-		env.Await(CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidOpen), 1))
+-		env.RegexpReplace("go.mod", "module", "modul")
+-		// Confirm that we still have metadata with only on-disk edits.
+-		env.OpenFile("main.go")
+-		file, _ := env.GoToDefinition("main.go", env.RegexpSearch("main.go", "hello"))
+-		if filepath.Base(file) != "hello.go" {
+-			t.Fatalf("expected definition in hello.go, got %s", file)
+-		}
+-		// Confirm that we no longer have metadata when the file is saved.
+-		env.SaveBufferWithoutActions("go.mod")
+-		_, _, err := env.Editor.GoToDefinition(env.Ctx, "main.go", env.RegexpSearch("main.go", "hello"))
+-		if err == nil {
+-			t.Fatalf("expected error, got none")
+-		}
+-	})
+-}
+-
+-func TestRemoveUnusedDependency(t *testing.T) {
+-	testenv.NeedsGo1Point(t, 14)
+-
+-	const proxy = `
+--- hasdep.com@v1.2.3/go.mod --
+-module hasdep.com
+-
+-go 1.12
+-
+-require example.com v1.2.3
+--- hasdep.com@v1.2.3/a/a.go --
+-package a
+--- example.com@v1.2.3/go.mod --
+-module example.com
+-
+-go 1.12
+--- example.com@v1.2.3/blah/blah.go --
+-package blah
+-
+-const Name = "Blah"
+--- random.com@v1.2.3/go.mod --
+-module random.com
+-
+-go 1.12
+--- random.com@v1.2.3/blah/blah.go --
+-package blah
+-
+-const Name = "Blah"
+-`
+-	t.Run("almost tidied", func(t *testing.T) {
+-		const mod = `
+--- go.mod --
+-module mod.com
+-
+-go 1.12
+-
+-require hasdep.com v1.2.3
+--- go.sum --
+-example.com v1.2.3 h1:ihBTGWGjTU3V4ZJ9OmHITkU9WQ4lGdQkMjgyLFk0FaY=
+-example.com v1.2.3/go.mod h1:Y2Rc5rVWjWur0h3pd9aEvK5Pof8YKDANh9gHA2Maujo=
+-hasdep.com v1.2.3 h1:00y+N5oD+SpKoqV1zP2VOPawcW65Zb9NebANY3GSzGI=
+-hasdep.com v1.2.3/go.mod h1:ePVZOlez+KZEOejfLPGL2n4i8qiAjrkhQZ4wcImqAes=
+--- main.go --
+-package main
+-
+-func main() {}
+-`
+-		withOptions(
+-			ProxyFiles(proxy),
+-		).run(t, mod, func(t *testing.T, env *Env) {
+-			d := &protocol.PublishDiagnosticsParams{}
+-			env.Await(
+-				OnceMet(
+-					env.DiagnosticAtRegexp("go.mod", "require hasdep.com v1.2.3"),
+-					ReadDiagnostics("go.mod", d),
+-				),
+-			)
+-			const want = `module mod.com
+-
+-go 1.12
+-`
+-			env.ApplyQuickFixes("go.mod", d.Diagnostics)
+-			if got := env.ReadWorkspaceFile("go.mod"); got != want {
+-				t.Fatalf("unexpected content in go.mod:\n%s", tests.Diff(t, want, got))
+-			}
+-		})
+-	})
+-
+-	t.Run("not tidied", func(t *testing.T) {
+-		const mod = `
+--- go.mod --
+-module mod.com
+-
+-go 1.12
+-
+-require hasdep.com v1.2.3
+-require random.com v1.2.3
+--- go.sum --
+-example.com v1.2.3 h1:ihBTGWGjTU3V4ZJ9OmHITkU9WQ4lGdQkMjgyLFk0FaY=
+-example.com v1.2.3/go.mod h1:Y2Rc5rVWjWur0h3pd9aEvK5Pof8YKDANh9gHA2Maujo=
+-hasdep.com v1.2.3 h1:00y+N5oD+SpKoqV1zP2VOPawcW65Zb9NebANY3GSzGI=
+-hasdep.com v1.2.3/go.mod h1:ePVZOlez+KZEOejfLPGL2n4i8qiAjrkhQZ4wcImqAes=
+-random.com v1.2.3 h1:PzYTykzqqH6+qU0dIgh9iPFbfb4Mm8zNBjWWreRKtx0=
+-random.com v1.2.3/go.mod h1:8EGj+8a4Hw1clAp8vbaeHAsKE4sbm536FP7nKyXO+qQ=
+--- main.go --
+-package main
+-
+-func main() {}
+-`
+-		withOptions(
+-			ProxyFiles(proxy),
+-		).run(t, mod, func(t *testing.T, env *Env) {
+-			d := &protocol.PublishDiagnosticsParams{}
+-			env.OpenFile("go.mod")
+-			pos := env.RegexpSearch("go.mod", "require hasdep.com v1.2.3")
+-			env.Await(
+-				OnceMet(
+-					DiagnosticAt("go.mod", pos.Line, pos.Column),
+-					ReadDiagnostics("go.mod", d),
+-				),
+-			)
+-			const want = `module mod.com
+-
+-go 1.12
+-
+-require random.com v1.2.3
+-`
+-			var diagnostics []protocol.Diagnostic
+-			for _, d := range d.Diagnostics {
+-				if d.Range.Start.Line != float64(pos.Line) {
+-					continue
+-				}
+-				diagnostics = append(diagnostics, d)
+-			}
+-			env.ApplyQuickFixes("go.mod", diagnostics)
+-			if got := env.Editor.BufferText("go.mod"); got != want {
+-				t.Fatalf("unexpected content in go.mod:\n%s", tests.Diff(t, want, got))
+-			}
+-		})
+-	})
+-}
+-
+-func TestSumUpdateQuickFix(t *testing.T) {
+-	// Error messages changed in 1.16 that changed the diagnostic positions.
+-	testenv.NeedsGo1Point(t, 16)
+-
+-	const mod = `
+--- go.mod --
+-module mod.com
+-
+-go 1.12
+-
+-require (
+-	example.com v1.2.3
+-)
+--- go.sum --
+--- main.go --
+-package main
+-
+-import (
+-	"example.com/blah"
+-)
+-
+-func main() {
+-	blah.Hello()
+-}
+-`
+-	withOptions(
+-		ProxyFiles(workspaceProxy),
+-		Modes(Singleton),
+-	).run(t, mod, func(t *testing.T, env *Env) {
+-		env.OpenFile("go.mod")
+-		pos := env.RegexpSearch("go.mod", "example.com")
+-		params := &protocol.PublishDiagnosticsParams{}
+-		env.Await(
+-			OnceMet(
+-				env.DiagnosticAtRegexp("go.mod", "example.com"),
+-				ReadDiagnostics("go.mod", params),
+-			),
+-		)
+-		var diagnostic protocol.Diagnostic
+-		for _, d := range params.Diagnostics {
+-			if d.Range.Start.Line == float64(pos.Line) {
+-				diagnostic = d
+-				break
+-			}
+-		}
+-		env.ApplyQuickFixes("go.mod", []protocol.Diagnostic{diagnostic})
+-		const want = `example.com v1.2.3 h1:Yryq11hF02fEf2JlOS2eph+ICE2/ceevGV3C9dl5V/c=
+-example.com v1.2.3/go.mod h1:Y2Rc5rVWjWur0h3pd9aEvK5Pof8YKDANh9gHA2Maujo=
+-`
+-		if got := env.ReadWorkspaceFile("go.sum"); got != want {
+-			t.Fatalf("unexpected go.sum contents:\n%s", tests.Diff(t, want, got))
+-		}
+-	})
+-}
 diff -urN a/gopls/internal/regtest/references_test.go b/gopls/internal/regtest/references_test.go
 --- a/gopls/internal/regtest/references_test.go	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/internal/regtest/references_test.go	1969-12-31 19:00:00.000000000 -0500
-@@ -1,41 +0,0 @@
+@@ -1,42 +0,0 @@
 -// Copyright 2020 The Go Authors. All rights reserved.
 -// Use of this source code is governed by a BSD-style
 -// license that can be found in the LICENSE file.
@@ -9222,6 +11333,7 @@ diff -urN a/gopls/internal/regtest/references_test.go b/gopls/internal/regtest/r
 --- go.mod --
 -module mod.com
 -
+-go 1.12
 --- main.go --
 -package main
 -
@@ -9251,7 +11363,7 @@ diff -urN a/gopls/internal/regtest/references_test.go b/gopls/internal/regtest/r
 diff -urN a/gopls/internal/regtest/reg_test.go b/gopls/internal/regtest/reg_test.go
 --- a/gopls/internal/regtest/reg_test.go	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/internal/regtest/reg_test.go	1969-12-31 19:00:00.000000000 -0500
-@@ -1,91 +0,0 @@
+@@ -1,107 +0,0 @@
 -// Copyright 2020 The Go Authors. All rights reserved.
 -// Use of this source code is governed by a BSD-style
 -// license that can be found in the LICENSE file.
@@ -9283,6 +11395,10 @@ diff -urN a/gopls/internal/regtest/reg_test.go b/gopls/internal/regtest/reg_test
 -
 -var runner *Runner
 -
+-type regtestRunner interface {
+-	run(t *testing.T, files string, f TestFunc)
+-}
+-
 -func run(t *testing.T, files string, f TestFunc) {
 -	runner.Run(t, files, f)
 -}
@@ -9299,6 +11415,18 @@ diff -urN a/gopls/internal/regtest/reg_test.go b/gopls/internal/regtest/reg_test
 -	runner.Run(t, files, f, r.opts...)
 -}
 -
+-type runMultiple []struct {
+-	name   string
+-	runner regtestRunner
+-}
+-
+-func (r runMultiple) run(t *testing.T, files string, f TestFunc) {
+-	for _, runner := range r {
+-		t.Run(runner.name, func(t *testing.T) {
+-			runner.runner.run(t, files, f)
+-		})
+-	}
+-}
 -func TestMain(m *testing.M) {
 -	flag.Parse()
 -	if os.Getenv("_GOPLS_TEST_BINARY_RUN_AS_GOPLS") == "true" {
@@ -9336,8 +11464,8 @@ diff -urN a/gopls/internal/regtest/reg_test.go b/gopls/internal/regtest/reg_test
 -		// Regtest cleanup is broken in go1.12 and earlier, and sometimes flakes on
 -		// Windows due to file locking, but this is OK for our CI.
 -		//
--		// Fail on non-windows go1.13+.
--		if testenv.Go1Point() >= 13 && runtime.GOOS != "windows" {
+-		// Fail on go1.13+, except for windows and android which have shutdown problems.
+-		if testenv.Go1Point() >= 13 && runtime.GOOS != "windows" && runtime.GOOS != "android" {
 -			os.Exit(1)
 -		}
 -	}
@@ -9346,7 +11474,7 @@ diff -urN a/gopls/internal/regtest/reg_test.go b/gopls/internal/regtest/reg_test
 diff -urN a/gopls/internal/regtest/runner.go b/gopls/internal/regtest/runner.go
 --- a/gopls/internal/regtest/runner.go	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/internal/regtest/runner.go	1969-12-31 19:00:00.000000000 -0500
-@@ -1,487 +0,0 @@
+@@ -1,486 +0,0 @@
 -// Copyright 2020 The Go Authors. All rights reserved.
 -// Use of this source code is governed by a BSD-style
 -// license that can be found in the LICENSE file.
@@ -9357,11 +11485,11 @@ diff -urN a/gopls/internal/regtest/runner.go b/gopls/internal/regtest/runner.go
 -	"bytes"
 -	"context"
 -	"fmt"
+-	exec "golang.org/x/sys/execabs"
 -	"io"
 -	"io/ioutil"
 -	"net"
 -	"os"
--	"os/exec"
 -	"path/filepath"
 -	"runtime/pprof"
 -	"strings"
@@ -9395,10 +11523,6 @@ diff -urN a/gopls/internal/regtest/runner.go b/gopls/internal/regtest/runner.go
 -	// Experimental enables all of the experimental configurations that are
 -	// being developed. Currently, it enables the workspace module.
 -	Experimental
--	// WithoutExperiments are the modes that run without experimental features,
--	// like the workspace module. These should be used for tests that only work
--	// in the default modes.
--	WithoutExperiments = Singleton | Forwarded
 -	// NormalModes are the global default execution modes, when unmodified by
 -	// test flags or by individual test options.
 -	NormalModes = Singleton | Experimental
@@ -9425,14 +11549,13 @@ diff -urN a/gopls/internal/regtest/runner.go b/gopls/internal/regtest/runner.go
 -}
 -
 -type runConfig struct {
--	editor      fake.EditorConfig
--	sandbox     fake.SandboxConfig
--	modes       Mode
--	timeout     time.Duration
--	debugAddr   string
--	skipLogs    bool
--	skipHooks   bool
--	nestWorkdir bool
+-	editor    fake.EditorConfig
+-	sandbox   fake.SandboxConfig
+-	modes     Mode
+-	timeout   time.Duration
+-	debugAddr string
+-	skipLogs  bool
+-	skipHooks bool
 -}
 -
 -func (r *Runner) defaultConfig() *runConfig {
@@ -9453,22 +11576,22 @@ diff -urN a/gopls/internal/regtest/runner.go b/gopls/internal/regtest/runner.go
 -	f(opts)
 -}
 -
--// WithTimeout configures a custom timeout for this test run.
--func WithTimeout(d time.Duration) RunOption {
+-// Timeout configures a custom timeout for this test run.
+-func Timeout(d time.Duration) RunOption {
 -	return optionSetter(func(opts *runConfig) {
 -		opts.timeout = d
 -	})
 -}
 -
--// WithProxyFiles configures a file proxy using the given txtar-encoded string.
--func WithProxyFiles(txt string) RunOption {
+-// ProxyFiles configures a file proxy using the given txtar-encoded string.
+-func ProxyFiles(txt string) RunOption {
 -	return optionSetter(func(opts *runConfig) {
 -		opts.sandbox.ProxyFiles = txt
 -	})
 -}
 -
--// WithModes configures the execution modes that the test should run in.
--func WithModes(modes Mode) RunOption {
+-// Modes configures the execution modes that the test should run in.
+-func Modes(modes Mode) RunOption {
 -	return optionSetter(func(opts *runConfig) {
 -		opts.modes = modes
 -	})
@@ -9487,22 +11610,17 @@ diff -urN a/gopls/internal/regtest/runner.go b/gopls/internal/regtest/runner.go
 -	opts.editor = fake.EditorConfig(c)
 -}
 -
--// WithoutWorkspaceFolders prevents workspace folders from being sent as part
--// of the sandbox's initialization. It is used to simulate opening a single
--// file in the editor, without a workspace root. In that case, the client sends
--// neither workspace folders nor a root URI.
--func WithoutWorkspaceFolders() RunOption {
+-// WorkspaceFolders configures the workdir-relative workspace folders to send
+-// to the LSP server. By default the editor sends a single workspace folder
+-// corresponding to the workdir root. To explicitly configure no workspace
+-// folders, use WorkspaceFolders with no arguments.
+-func WorkspaceFolders(relFolders ...string) RunOption {
+-	if len(relFolders) == 0 {
+-		// Use an empty non-nil slice to signal explicitly no folders.
+-		relFolders = []string{}
+-	}
 -	return optionSetter(func(opts *runConfig) {
--		opts.editor.WithoutWorkspaceFolders = true
--	})
--}
--
--// WithRootPath specifies the rootURI of the workspace folder opened in the
--// editor. By default, the sandbox opens the top-level directory, but some
--// tests need to check other cases.
--func WithRootPath(path string) RunOption {
--	return optionSetter(func(opts *runConfig) {
--		opts.editor.WorkspaceRoot = path
+-		opts.editor.WorkspaceFolders = relFolders
 -	})
 -}
 -
@@ -9514,10 +11632,10 @@ diff -urN a/gopls/internal/regtest/runner.go b/gopls/internal/regtest/runner.go
 -	})
 -}
 -
--// WithDebugAddress configures a debug server bound to addr. This option is
+-// DebugAddress configures a debug server bound to addr. This option is
 -// currently only supported when executing in Singleton mode. It is intended to
 -// be used for long-running stress tests.
--func WithDebugAddress(addr string) RunOption {
+-func DebugAddress(addr string) RunOption {
 -	return optionSetter(func(opts *runConfig) {
 -		opts.debugAddr = addr
 -	})
@@ -9549,10 +11667,10 @@ diff -urN a/gopls/internal/regtest/runner.go b/gopls/internal/regtest/runner.go
 -	})
 -}
 -
--// WithGOPROXY configures the test environment to have an explicit proxy value.
+-// GOPROXY configures the test environment to have an explicit proxy value.
 -// This is intended for stress tests -- to ensure their isolation, regtests
 -// should instead use WithProxyFiles.
--func WithGOPROXY(goproxy string) RunOption {
+-func GOPROXY(goproxy string) RunOption {
 -	return optionSetter(func(opts *runConfig) {
 -		opts.sandbox.GOPROXY = goproxy
 -	})
@@ -9565,14 +11683,6 @@ diff -urN a/gopls/internal/regtest/runner.go b/gopls/internal/regtest/runner.go
 -	})
 -}
 -
--// NestWorkdir inserts the sandbox working directory in a subdirectory of the
--// editor workspace.
--func NestWorkdir() RunOption {
--	return optionSetter(func(opts *runConfig) {
--		opts.nestWorkdir = true
--	})
--}
--
 -type TestFunc func(t *testing.T, env *Env)
 -
 -// Run executes the test function in the default configured gopls execution
@@ -9580,10 +11690,7 @@ diff -urN a/gopls/internal/regtest/runner.go b/gopls/internal/regtest/runner.go
 -// un-txtared files specified by filedata.
 -func (r *Runner) Run(t *testing.T, files string, test TestFunc, opts ...RunOption) {
 -	t.Helper()
--
--	if os.Getenv("GO_BUILDER_NAME") == "openbsd-amd64-64" && testing.Short() {
--		t.Skip("Skipping openbsd-amd64-64 due to golang.org/issues/42789.")
--	}
+-	checkBuilder(t)
 -
 -	tests := []struct {
 -		name      string
@@ -9627,20 +11734,11 @@ diff -urN a/gopls/internal/regtest/runner.go b/gopls/internal/regtest/runner.go
 -			if err := os.MkdirAll(rootDir, 0755); err != nil {
 -				t.Fatal(err)
 -			}
--			if config.nestWorkdir {
--				config.sandbox.Workdir = "work/nested"
--			}
 -			config.sandbox.Files = files
 -			config.sandbox.RootDir = rootDir
 -			sandbox, err := fake.NewSandbox(&config.sandbox)
 -			if err != nil {
 -				t.Fatal(err)
--			}
--			workdir := sandbox.Workdir.RootURI().SpanURI().Filename()
--			if config.nestWorkdir {
--				// Now that we know the actual workdir, set our workspace to be the
--				// parent directory.
--				config.editor.WorkspaceRoot = filepath.Clean(filepath.Join(workdir, ".."))
 -			}
 -			// Deferring the closure of ws until the end of the entire test suite
 -			// has, in testing, given the LSP server time to properly shutdown and
@@ -9670,6 +11768,35 @@ diff -urN a/gopls/internal/regtest/runner.go b/gopls/internal/regtest/runner.go
 -			env.Await(InitialWorkspaceLoad)
 -			test(t, env)
 -		})
+-	}
+-}
+-
+-// longBuilders maps builders that are skipped when -short is set to a
+-// (possibly empty) justification.
+-var longBuilders = map[string]string{
+-	"openbsd-amd64-64":        "golang.org/issues/42789",
+-	"openbsd-386-64":          "golang.org/issues/42789",
+-	"openbsd-386-68":          "golang.org/issues/42789",
+-	"openbsd-amd64-68":        "golang.org/issues/42789",
+-	"linux-arm":               "golang.org/issues/43355",
+-	"darwin-amd64-10_12":      "",
+-	"freebsd-amd64-race":      "",
+-	"illumos-amd64":           "",
+-	"netbsd-arm-bsiegert":     "",
+-	"solaris-amd64-oraclerel": "",
+-	"windows-arm-zx2c4":       "",
+-	"android-amd64-emu":       "golang.org/issue/43554",
+-}
+-
+-func checkBuilder(t *testing.T) {
+-	t.Helper()
+-	builder := os.Getenv("GO_BUILDER_NAME")
+-	if reason, ok := longBuilders[builder]; ok && testing.Short() {
+-		if reason != "" {
+-			t.Skipf("Skipping %s with -short due to %s", builder, reason)
+-		} else {
+-			t.Skipf("Skipping %s with -short", builder)
+-		}
 -	}
 -}
 -
@@ -9870,7 +11997,7 @@ diff -urN a/gopls/internal/regtest/shared_test.go b/gopls/internal/regtest/share
 -		// as the first.
 -		env2 := NewEnv(env1.Ctx, t, env1.Sandbox, env1.Server, env1.Editor.Config, true)
 -		testFunc(env1, env2)
--	}, WithModes(modes))
+-	}, Modes(modes))
 -}
 -
 -func TestSimultaneousEdits(t *testing.T) {
@@ -9930,20 +12057,20 @@ diff -urN a/gopls/internal/regtest/stress_test.go b/gopls/internal/regtest/stres
 -		InExistingDir(dir),
 -
 -		// Enable live debugging.
--		WithDebugAddress(":8087"),
+-		DebugAddress(":8087"),
 -
 -		// Skip logs as they buffer up memory unnaturally.
 -		SkipLogs(),
 -		// Similarly to logs: disable hooks so that they don't affect performance.
 -		SkipHooks(true),
 -		// The Debug server only makes sense if running in singleton mode.
--		WithModes(Singleton),
+-		Modes(Singleton),
 -		// Set a generous timeout. Individual tests should control their own
 -		// graceful termination.
--		WithTimeout(20 * time.Minute),
+-		Timeout(20 * time.Minute),
 -
 -		// Use the actual proxy, since we want our builds to succeed.
--		WithGOPROXY("https://proxy.golang.org"),
+-		GOPROXY("https://proxy.golang.org"),
 -	}
 -}
 -
@@ -9983,46 +12110,14 @@ diff -urN a/gopls/internal/regtest/stress_test.go b/gopls/internal/regtest/stres
 -		}
 -	})
 -}
-diff -urN a/gopls/internal/regtest/unix_test.go b/gopls/internal/regtest/unix_test.go
---- a/gopls/internal/regtest/unix_test.go	2000-01-01 00:00:00.000000000 -0000
-+++ b/gopls/internal/regtest/unix_test.go	1969-12-31 19:00:00.000000000 -0500
-@@ -1,32 +0,0 @@
+diff -urN a/gopls/internal/regtest/vendor_test.go b/gopls/internal/regtest/vendor_test.go
+--- a/gopls/internal/regtest/vendor_test.go	2000-01-01 00:00:00.000000000 -0000
++++ b/gopls/internal/regtest/vendor_test.go	1969-12-31 19:00:00.000000000 -0500
+@@ -1,82 +0,0 @@
 -// Copyright 2020 The Go Authors. All rights reserved.
 -// Use of this source code is governed by a BSD-style
 -// license that can be found in the LICENSE file.
 -
--// +build !windows,!plan9
--
--package regtest
--
--import (
--	"testing"
--)
--
--func TestBadGOPATH(t *testing.T) {
--	const files = `
---- main.go --
--package main
--
--func _() {
--	fmt.Println("Hello World")
--}
--`
--	// https://github.com/fatih/vim-go/issues/2673#issuecomment-622307211.
--	withOptions(
--		EditorConfig{Env: map[string]string{"GOPATH": ":/path/to/gopath"}},
--	).run(t, files, func(t *testing.T, env *Env) {
--		env.OpenFile("main.go")
--		env.Await(env.DiagnosticAtRegexp("main.go", "fmt"))
--		if err := env.Editor.OrganizeImports(env.Ctx, "main.go"); err != nil {
--			t.Fatal(err)
--		}
--	})
--}
-diff -urN a/gopls/internal/regtest/vendor_test.go b/gopls/internal/regtest/vendor_test.go
---- a/gopls/internal/regtest/vendor_test.go	2000-01-01 00:00:00.000000000 -0000
-+++ b/gopls/internal/regtest/vendor_test.go	1969-12-31 19:00:00.000000000 -0500
-@@ -1,75 +0,0 @@
 -package regtest
 -
 -import (
@@ -10055,6 +12150,9 @@ diff -urN a/gopls/internal/regtest/vendor_test.go b/gopls/internal/regtest/vendo
 -go 1.14
 -
 -require golang.org/x/hello v1.2.3
+--- go.sum --
+-golang.org/x/hello v1.2.3 h1:EcMp5gSkIhaTkPXp8/3+VH+IFqTpk3ZbpOhqk0Ncmho=
+-golang.org/x/hello v1.2.3/go.mod h1:WW7ER2MRNXWA6c8/4bDIek4Hc/+DofTrMaQQitGXcco=
 --- vendor/modules.txt --
 --- a/a1.go --
 -package a
@@ -10068,8 +12166,8 @@ diff -urN a/gopls/internal/regtest/vendor_test.go b/gopls/internal/regtest/vendo
 -`
 -	// TODO(rstambler): Remove this when golang/go#41819 is resolved.
 -	withOptions(
--		WithModes(WithoutExperiments),
--		WithProxyFiles(basicProxy),
+-		Modes(Singleton),
+-		ProxyFiles(basicProxy),
 -	).run(t, pkgThatUsesVendoring, func(t *testing.T, env *Env) {
 -		env.OpenFile("a/a1.go")
 -		env.Await(
@@ -10518,9 +12616,9 @@ diff -urN a/gopls/internal/regtest/watch_test.go b/gopls/internal/regtest/watch_
 -	})
 -
 -	t.Run("delete then close", func(t *testing.T) {
--		withOptions(EditorConfig{
--			VerboseOutput: true,
--		}).run(t, pkg, func(t *testing.T, env *Env) {
+-		withOptions(
+-			EditorConfig{VerboseOutput: true},
+-		).run(t, pkg, func(t *testing.T, env *Env) {
 -			env.OpenFile("a/a.go")
 -			env.OpenFile("a/a_unneeded.go")
 -			env.Await(
@@ -10669,7 +12767,7 @@ diff -urN a/gopls/internal/regtest/watch_test.go b/gopls/internal/regtest/watch_
 -	blah.X()
 -}
 -`
--	withOptions(WithProxyFiles(proxy)).run(t, mod, func(t *testing.T, env *Env) {
+-	withOptions(ProxyFiles(proxy)).run(t, mod, func(t *testing.T, env *Env) {
 -		env.WriteWorkspaceFiles(map[string]string{
 -			"go.mod": `module mod.com
 -
@@ -10715,7 +12813,7 @@ diff -urN a/gopls/internal/regtest/watch_test.go b/gopls/internal/regtest/watch_
 -`
 -	withOptions(
 -		InGOPATH(),
--		WithModes(Experimental), // module is in a subdirectory
+-		Modes(Experimental), // module is in a subdirectory
 -	).run(t, files, func(t *testing.T, env *Env) {
 -		env.OpenFile("foo/main.go")
 -		env.Await(env.DiagnosticAtRegexp("foo/main.go", `"blah"`))
@@ -10860,7 +12958,7 @@ diff -urN a/gopls/internal/regtest/watch_test.go b/gopls/internal/regtest/watch_
 diff -urN a/gopls/internal/regtest/workspace_test.go b/gopls/internal/regtest/workspace_test.go
 --- a/gopls/internal/regtest/workspace_test.go	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/internal/regtest/workspace_test.go	1969-12-31 19:00:00.000000000 -0500
-@@ -1,625 +0,0 @@
+@@ -1,771 +0,0 @@
 -// Copyright 2020 The Go Authors. All rights reserved.
 -// Use of this source code is governed by a BSD-style
 -// license that can be found in the LICENSE file.
@@ -10877,6 +12975,7 @@ diff -urN a/gopls/internal/regtest/workspace_test.go b/gopls/internal/regtest/wo
 -
 -	"golang.org/x/tools/internal/lsp"
 -	"golang.org/x/tools/internal/lsp/fake"
+-	"golang.org/x/tools/internal/lsp/protocol"
 -	"golang.org/x/tools/internal/testenv"
 -)
 -
@@ -10914,6 +13013,11 @@ diff -urN a/gopls/internal/regtest/workspace_test.go b/gopls/internal/regtest/wo
 -	example.com v1.2.3
 -	random.org v1.2.3
 -)
+--- pkg/go.sum --
+-example.com v1.2.3 h1:Yryq11hF02fEf2JlOS2eph+ICE2/ceevGV3C9dl5V/c=
+-example.com v1.2.3/go.mod h1:Y2Rc5rVWjWur0h3pd9aEvK5Pof8YKDANh9gHA2Maujo=
+-random.org v1.2.3 h1:+JE2Fkp7gS0zsHXGEQJ7hraom3pNTlkxC4b2qPfA+/Q=
+-random.org v1.2.3/go.mod h1:E9KM6+bBX2g5ykHZ9H27w16sWo3QwgonyjM44Dnej3I=
 --- pkg/main.go --
 -package main
 -
@@ -10970,9 +13074,9 @@ diff -urN a/gopls/internal/regtest/workspace_test.go b/gopls/internal/regtest/wo
 -		},
 -	} {
 -		t.Run(tt.name, func(t *testing.T) {
--			opts := []RunOption{WithProxyFiles(workspaceProxy)}
+-			opts := []RunOption{ProxyFiles(workspaceProxy)}
 -			if tt.rootPath != "" {
--				opts = append(opts, WithRootPath(tt.rootPath))
+-				opts = append(opts, WorkspaceFolders(tt.rootPath))
 -			}
 -			withOptions(opts...).run(t, workspaceModule, func(t *testing.T, env *Env) {
 -				f := "pkg/inner/inner.go"
@@ -10992,7 +13096,10 @@ diff -urN a/gopls/internal/regtest/workspace_test.go b/gopls/internal/regtest/wo
 -// VS Code, where clicking on a reference result triggers a
 -// textDocument/didOpen without a corresponding textDocument/didClose.
 -func TestClearAnalysisDiagnostics(t *testing.T) {
--	withOptions(WithProxyFiles(workspaceProxy), WithRootPath("pkg/inner")).run(t, workspaceModule, func(t *testing.T, env *Env) {
+-	withOptions(
+-		ProxyFiles(workspaceProxy),
+-		WorkspaceFolders("pkg/inner"),
+-	).run(t, workspaceModule, func(t *testing.T, env *Env) {
 -		env.OpenFile("pkg/main.go")
 -		env.Await(
 -			env.DiagnosticAtRegexp("pkg/main2.go", "fmt.Print"),
@@ -11007,7 +13114,10 @@ diff -urN a/gopls/internal/regtest/workspace_test.go b/gopls/internal/regtest/wo
 -// This test checks that gopls updates the set of files it watches when a
 -// replace target is added to the go.mod.
 -func TestWatchReplaceTargets(t *testing.T) {
--	withOptions(WithProxyFiles(workspaceProxy), WithRootPath("pkg")).run(t, workspaceModule, func(t *testing.T, env *Env) {
+-	withOptions(
+-		ProxyFiles(workspaceProxy),
+-		WorkspaceFolders("pkg"),
+-	).run(t, workspaceModule, func(t *testing.T, env *Env) {
 -		// Add a replace directive and expect the files that gopls is watching
 -		// to change.
 -		dir := env.Sandbox.Workdir.URI("goodbye").SpanURI().Filename()
@@ -11073,8 +13183,8 @@ diff -urN a/gopls/internal/regtest/workspace_test.go b/gopls/internal/regtest/wo
 -}
 -`
 -	withOptions(
--		WithProxyFiles(workspaceModuleProxy),
--		WithModes(Experimental),
+-		ProxyFiles(workspaceModuleProxy),
+-		Modes(Experimental),
 -	).run(t, multiModule, func(t *testing.T, env *Env) {
 -		env.Await(
 -			env.DiagnosticAtRegexp("moda/a/a.go", "x"),
@@ -11115,8 +13225,8 @@ diff -urN a/gopls/internal/regtest/workspace_test.go b/gopls/internal/regtest/wo
 -}
 -`
 -	withOptions(
--		WithProxyFiles(workspaceModuleProxy),
--		WithModes(Experimental),
+-		ProxyFiles(workspaceModuleProxy),
+-		Modes(Experimental),
 -	).run(t, multiModule, func(t *testing.T, env *Env) {
 -		env.OpenFile("moda/a/a.go")
 -
@@ -11130,6 +13240,18 @@ diff -urN a/gopls/internal/regtest/workspace_test.go b/gopls/internal/regtest/wo
 -		env.Await(
 -			CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidChangeWatchedFiles), 2),
 -		)
+-		if testenv.Go1Point() < 14 {
+-			// On 1.14 and above, the go mod tidy diagnostics accidentally
+-			// download for us. This is the behavior we actually want.
+-			d := protocol.PublishDiagnosticsParams{}
+-			env.Await(
+-				OnceMet(
+-					env.DiagnosticAtRegexpWithMessage("moda/a/go.mod", "require b.com v1.2.3", "b.com@v1.2.3"),
+-					ReadDiagnostics("moda/a/go.mod", &d),
+-				),
+-			)
+-			env.ApplyQuickFixes("moda/a/go.mod", d.Diagnostics)
+-		}
 -		got, _ := env.GoToDefinition("moda/a/a.go", env.RegexpSearch("moda/a/a.go", "Hello"))
 -		if want := "b.com@v1.2.3/b/b.go"; !strings.HasSuffix(got, want) {
 -			t.Errorf("expected %s, got %v", want, got)
@@ -11159,8 +13281,8 @@ diff -urN a/gopls/internal/regtest/workspace_test.go b/gopls/internal/regtest/wo
 -}
 -`
 -	withOptions(
--		WithModes(Experimental),
--		WithProxyFiles(workspaceModuleProxy),
+-		Modes(Experimental),
+-		ProxyFiles(workspaceModuleProxy),
 -	).run(t, multiModule, func(t *testing.T, env *Env) {
 -		env.OpenFile("moda/a/a.go")
 -		original, _ := env.GoToDefinition("moda/a/a.go", env.RegexpSearch("moda/a/a.go", "Hello"))
@@ -11221,8 +13343,8 @@ diff -urN a/gopls/internal/regtest/workspace_test.go b/gopls/internal/regtest/wo
 -}
 -`
 -	withOptions(
--		WithProxyFiles(workspaceModuleProxy),
--		WithModes(Experimental),
+-		ProxyFiles(workspaceModuleProxy),
+-		Modes(Experimental),
 -	).run(t, multiModule, func(t *testing.T, env *Env) {
 -		env.OpenFile("modb/go.mod")
 -		env.Await(
@@ -11232,7 +13354,7 @@ diff -urN a/gopls/internal/regtest/workspace_test.go b/gopls/internal/regtest/wo
 -			),
 -		)
 -		env.RegexpReplace("modb/go.mod", "modul", "module")
--		env.Editor.SaveBufferWithoutActions(env.Ctx, "modb/go.mod")
+-		env.SaveBufferWithoutActions("modb/go.mod")
 -		env.Await(
 -			env.DiagnosticAtRegexp("modb/b/b.go", "x"),
 -		)
@@ -11281,21 +13403,33 @@ diff -urN a/gopls/internal/regtest/workspace_test.go b/gopls/internal/regtest/wo
 -replace a.com => $SANDBOX_WORKDIR/moda/a
 -`
 -	withOptions(
--		WithProxyFiles(workspaceModuleProxy),
--		WithModes(Experimental),
+-		ProxyFiles(workspaceModuleProxy),
+-		Modes(Experimental),
 -	).run(t, multiModule, func(t *testing.T, env *Env) {
 -		// Initially, the gopls.mod should cause only the a.com module to be
 -		// loaded. Validate this by jumping to a definition in b.com and ensuring
 -		// that we go to the module cache.
 -		env.OpenFile("moda/a/a.go")
--		location, _ := env.GoToDefinition("moda/a/a.go", env.RegexpSearch("moda/a/a.go", "Hello"))
--		if want := "b.com@v1.2.3/b/b.go"; !strings.HasSuffix(location, want) {
--			t.Errorf("expected %s, got %v", want, location)
+-		env.Await(env.DoneWithOpen())
+-
+-		// To verify which modules are loaded, we'll jump to the definition of
+-		// b.Hello.
+-		checkHelloLocation := func(want string) error {
+-			location, _ := env.GoToDefinition("moda/a/a.go", env.RegexpSearch("moda/a/a.go", "Hello"))
+-			if !strings.HasSuffix(location, want) {
+-				return fmt.Errorf("expected %s, got %v", want, location)
+-			}
+-			return nil
 -		}
--		workdir := env.Sandbox.Workdir.RootURI().SpanURI().Filename()
+-
+-		// Initially this should be in the module cache, as b.com is not replaced.
+-		if err := checkHelloLocation("b.com@v1.2.3/b/b.go"); err != nil {
+-			t.Fatal(err)
+-		}
 -
 -		// Now, modify the gopls.mod file on disk to activate the b.com module in
 -		// the workspace.
+-		workdir := env.Sandbox.Workdir.RootURI().SpanURI().Filename()
 -		env.WriteWorkspaceFile("gopls.mod", fmt.Sprintf(`module gopls-workspace
 -
 -require (
@@ -11306,24 +13440,30 @@ diff -urN a/gopls/internal/regtest/workspace_test.go b/gopls/internal/regtest/wo
 -replace a.com => %s/moda/a
 -replace b.com => %s/modb
 -`, workdir, workdir))
+-		env.Await(env.DoneWithChangeWatchedFiles())
+-		// Check that go.mod diagnostics picked up the newly active mod file.
+-		// The local version of modb has an extra dependency we need to download.
+-		env.OpenFile("modb/go.mod")
+-		env.Await(env.DoneWithOpen())
+-
+-		var d protocol.PublishDiagnosticsParams
 -		env.Await(
 -			OnceMet(
--				CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidChangeWatchedFiles), 1),
--				env.DiagnosticAtRegexp("modb/b/b.go", "x"),
+-				env.DiagnosticAtRegexp("modb/go.mod", `require example.com v1.2.3`),
+-				ReadDiagnostics("modb/go.mod", &d),
 -			),
 -		)
--		env.OpenFile("modb/go.mod")
--		// Check that go.mod diagnostics picked up the newly active mod file.
--		env.Await(env.DiagnosticAtRegexp("modb/go.mod", `require example.com v1.2.3`))
--		// ...and that jumping to definition now goes to b.com in the workspace.
--		location, _ = env.GoToDefinition("moda/a/a.go", env.RegexpSearch("moda/a/a.go", "Hello"))
--		if want := "modb/b/b.go"; !strings.HasSuffix(location, want) {
--			t.Errorf("expected %s, got %v", want, location)
+-		env.ApplyQuickFixes("modb/go.mod", d.Diagnostics)
+-		env.Await(env.DiagnosticAtRegexp("modb/b/b.go", "x"))
+-		// Jumping to definition should now go to b.com in the workspace.
+-		if err := checkHelloLocation("modb/b/b.go"); err != nil {
+-			t.Fatal(err)
 -		}
 -
 -		// Now, let's modify the gopls.mod *overlay* (not on disk), and verify that
--		// this change is also picked up.
+-		// this change is only picked up once it is saved.
 -		env.OpenFile("gopls.mod")
+-		env.Await(env.DoneWithOpen())
 -		env.SetBufferContent("gopls.mod", fmt.Sprintf(`module gopls-workspace
 -
 -require (
@@ -11332,16 +13472,21 @@ diff -urN a/gopls/internal/regtest/workspace_test.go b/gopls/internal/regtest/wo
 -
 -replace a.com => %s/moda/a
 -`, workdir))
--		env.Await(CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidChange), 1))
+-
+-		// Editing the gopls.mod removes modb from the workspace modules, and so
+-		// should clear outstanding diagnostics...
 -		env.Await(OnceMet(
--			CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidChange), 1),
+-			env.DoneWithChange(),
 -			EmptyDiagnostics("modb/go.mod"),
 -		))
--
--		// Just as before, check that we now jump to the module cache.
--		location, _ = env.GoToDefinition("moda/a/a.go", env.RegexpSearch("moda/a/a.go", "Hello"))
--		if want := "b.com@v1.2.3/b/b.go"; !strings.HasSuffix(location, want) {
--			t.Errorf("expected %s, got %v", want, location)
+-		// ...but does not yet cause a workspace reload, so we should still jump to modb.
+-		if err := checkHelloLocation("modb/b/b.go"); err != nil {
+-			t.Fatal(err)
+-		}
+-		// Saving should reload the workspace.
+-		env.SaveBufferWithoutActions("gopls.mod")
+-		if err := checkHelloLocation("b.com@v1.2.3/b/b.go"); err != nil {
+-			t.Fatal(err)
 -		}
 -	})
 -}
@@ -11353,6 +13498,7 @@ diff -urN a/gopls/internal/regtest/workspace_test.go b/gopls/internal/regtest/wo
 --- go.mod --
 -module mod.com
 -
+-go 1.12
 --- x.go --
 -package x
 -`
@@ -11374,7 +13520,7 @@ diff -urN a/gopls/internal/regtest/workspace_test.go b/gopls/internal/regtest/wo
 --- moda/a/go.mod --
 -module a.com
 -
--require b.com/v2 v2.0.0
+-require b.com/v2 v2.1.9
 --- moda/a/a.go --
 -package a
 -
@@ -11414,7 +13560,7 @@ diff -urN a/gopls/internal/regtest/workspace_test.go b/gopls/internal/regtest/wo
 -}
 -`
 -	withOptions(
--		WithModes(Experimental),
+-		Modes(Experimental),
 -	).run(t, multiModule, func(t *testing.T, env *Env) {
 -		env.Await(
 -			env.DiagnosticAtRegexp("moda/a/a.go", "x"),
@@ -11446,7 +13592,7 @@ diff -urN a/gopls/internal/regtest/workspace_test.go b/gopls/internal/regtest/wo
 -}
 -`
 -	withOptions(
--		WithModes(Experimental),
+-		Modes(Experimental),
 -		SendPID(),
 -	).run(t, multiModule, func(t *testing.T, env *Env) {
 -		pid := os.Getpid()
@@ -11486,10 +13632,108 @@ diff -urN a/gopls/internal/regtest/workspace_test.go b/gopls/internal/regtest/wo
 -		}
 -	})
 -}
+-
+-func TestDirectoryFiltersLoads(t *testing.T) {
+-	// exclude, and its error, should be excluded from the workspace.
+-	const files = `
+--- go.mod --
+-module example.com
+-
+-go 1.12
+--- exclude/exclude.go --
+-package exclude
+-
+-const _ = Nonexistant
+-`
+-	cfg := EditorConfig{
+-		DirectoryFilters: []string{"-exclude"},
+-	}
+-	withOptions(cfg).run(t, files, func(t *testing.T, env *Env) {
+-		env.Await(NoDiagnostics("exclude/x.go"))
+-	})
+-}
+-
+-func TestDirectoryFiltersTransitiveDep(t *testing.T) {
+-	// Even though exclude is excluded from the workspace, it should
+-	// still be importable as a non-workspace package.
+-	const files = `
+--- go.mod --
+-module example.com
+-
+-go 1.12
+--- include/include.go --
+-package include
+-import "example.com/exclude"
+-
+-const _ = exclude.X
+--- exclude/exclude.go --
+-package exclude
+-
+-const _ = Nonexistant // should be ignored, since this is a non-workspace package
+-const X = 1
+-`
+-
+-	cfg := EditorConfig{
+-		DirectoryFilters: []string{"-exclude"},
+-	}
+-	withOptions(cfg).run(t, files, func(t *testing.T, env *Env) {
+-		env.Await(
+-			NoDiagnostics("exclude/exclude.go"), // filtered out
+-			NoDiagnostics("include/include.go"), // successfully builds
+-		)
+-	})
+-}
+-
+-func TestDirectoryFiltersWorkspaceModules(t *testing.T) {
+-	// Define a module include.com which should be in the workspace, plus a
+-	// module exclude.com which should be excluded and therefore come from
+-	// the proxy.
+-	const files = `
+--- include/go.mod --
+-module include.com
+-
+-go 1.12
+-
+-require exclude.com v1.0.0
+-
+--- include/go.sum --
+-exclude.com v1.0.0 h1:Q5QSfDXY5qyNCBeUiWovUGqcLCRZKoTs9XdBeVz+w1I=
+-exclude.com v1.0.0/go.mod h1:hFox2uDlNB2s2Jfd9tHlQVfgqUiLVTmh6ZKat4cvnj4=
+-
+--- include/include.go --
+-package include
+-
+-import "exclude.com"
+-
+-var _ = exclude.X // satisfied only by the workspace version
+--- exclude/go.mod --
+-module exclude.com
+-
+-go 1.12
+--- exclude/exclude.go --
+-package exclude
+-
+-const X = 1
+-`
+-	const proxy = `
+--- exclude.com@v1.0.0/go.mod --
+-module exclude.com
+-
+-go 1.12
+--- exclude.com@v1.0.0/exclude.go --
+-package exclude
+-`
+-	cfg := EditorConfig{
+-		DirectoryFilters: []string{"-exclude"},
+-	}
+-	withOptions(cfg, Modes(Experimental), ProxyFiles(proxy)).run(t, files, func(t *testing.T, env *Env) {
+-		env.Await(env.DiagnosticAtRegexp("include/include.go", `exclude.(X)`))
+-	})
+-}
 diff -urN a/gopls/internal/regtest/wrappers.go b/gopls/internal/regtest/wrappers.go
 --- a/gopls/internal/regtest/wrappers.go	2000-01-01 00:00:00.000000000 -0000
 +++ b/gopls/internal/regtest/wrappers.go	1969-12-31 19:00:00.000000000 -0500
-@@ -1,353 +0,0 @@
+@@ -1,391 +0,0 @@
 -// Copyright 2020 The Go Authors. All rights reserved.
 -// Use of this source code is governed by a BSD-style
 -// license that can be found in the LICENSE file.
@@ -11498,6 +13742,7 @@ diff -urN a/gopls/internal/regtest/wrappers.go b/gopls/internal/regtest/wrappers
 -
 -import (
 -	"io"
+-	"path"
 -	"testing"
 -
 -	"golang.org/x/tools/internal/lsp/fake"
@@ -11638,6 +13883,13 @@ diff -urN a/gopls/internal/regtest/wrappers.go b/gopls/internal/regtest/wrappers
 -	}
 -}
 -
+-func (e *Env) SaveBufferWithoutActions(name string) {
+-	e.T.Helper()
+-	if err := e.Editor.SaveBufferWithoutActions(e.Ctx, name); err != nil {
+-		e.T.Fatal(err)
+-	}
+-}
+-
 -// GoToDefinition goes to definition in the editor, calling t.Fatal on any
 -// error.
 -func (e *Env) GoToDefinition(name string, pos fake.Pos) (string, fake.Pos) {
@@ -11734,9 +13986,30 @@ diff -urN a/gopls/internal/regtest/wrappers.go b/gopls/internal/regtest/wrappers
 -// RunGoCommand runs the given command in the sandbox's default working
 -// directory.
 -func (e *Env) RunGoCommand(verb string, args ...string) {
+-	e.T.Helper()
 -	if err := e.Sandbox.RunGoCommand(e.Ctx, "", verb, args); err != nil {
 -		e.T.Fatal(err)
 -	}
+-}
+-
+-// RunGoCommandInDir is like RunGoCommand, but executes in the given
+-// relative directory of the sandbox.
+-func (e *Env) RunGoCommandInDir(dir, verb string, args ...string) {
+-	e.T.Helper()
+-	if err := e.Sandbox.RunGoCommand(e.Ctx, dir, verb, args); err != nil {
+-		e.T.Fatal(err)
+-	}
+-}
+-
+-func (e *Env) DumpGoSum(dir string) {
+-	e.T.Helper()
+-
+-	if err := e.Sandbox.RunGoCommand(e.Ctx, dir, "list", []string{"-mod=mod", "..."}); err != nil {
+-		e.T.Fatal(err)
+-	}
+-	sumFile := path.Join(dir, "/go.sum")
+-	e.T.Log("\n\n-- " + sumFile + " --\n" + e.ReadWorkspaceFile(sumFile))
+-	e.T.Fatal("see contents above")
 -}
 -
 -// CheckForFileChanges triggers a manual poll of the workspace for any file
@@ -11804,6 +14077,15 @@ diff -urN a/gopls/internal/regtest/wrappers.go b/gopls/internal/regtest/wrappers
 -	return completions
 -}
 -
+-// AcceptCompletion accepts a completion for the given item at the given
+-// position.
+-func (e *Env) AcceptCompletion(path string, pos fake.Pos, item protocol.CompletionItem) {
+-	e.T.Helper()
+-	if err := e.Editor.AcceptCompletion(e.Ctx, path, pos, item); err != nil {
+-		e.T.Fatal(err)
+-	}
+-}
+-
 -// CodeAction calls testDocument/codeAction for the given path, and calls
 -// t.Fatal if there are errors.
 -func (e *Env) CodeAction(path string) []protocol.CodeAction {
@@ -11851,13 +14133,13 @@ diff -urN a/gopls/main.go b/gopls/main.go
 -// Use of this source code is governed by a BSD-style
 -// license that can be found in the LICENSE file.
 -
--// The gopls command is an LSP server for Go.
+-// Gopls (pronounced “go please”) is an LSP server for Go.
 -// The Language Server Protocol allows any text editor
 -// to be extended with IDE-like features;
 -// see https://langserver.org/ for details.
 -//
--// See https://github.com/golang/tools/tree/master/gopls
--// for the most up-to-date information on the gopls status.
+-// See https://github.com/golang/tools/blob/master/gopls/README.md
+-// for the most up-to-date documentation.
 -package main // import "golang.org/x/tools/gopls"
 -
 -import (
@@ -11872,6 +14154,408 @@ diff -urN a/gopls/main.go b/gopls/main.go
 -func main() {
 -	ctx := context.Background()
 -	tool.Main(ctx, cmd.New("gopls", "", nil, hooks.Options), os.Args[1:])
+-}
+diff -urN a/gopls/release/release.go b/gopls/release/release.go
+--- a/gopls/release/release.go	2000-01-01 00:00:00.000000000 -0000
++++ b/gopls/release/release.go	1969-12-31 19:00:00.000000000 -0500
+@@ -1,213 +0,0 @@
+-// Copyright 2020 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-//
+-// Package release checks that the a given version of gopls is ready for
+-// release. It can also tag and publish the release.
+-//
+-// To run:
+-//
+-// $ cd $GOPATH/src/golang.org/x/tools/gopls
+-// $ go run release/release.go -version=<version>
+-package main
+-
+-import (
+-	"flag"
+-	"fmt"
+-	"go/types"
+-	exec "golang.org/x/sys/execabs"
+-	"io/ioutil"
+-	"log"
+-	"os"
+-	"os/user"
+-	"path/filepath"
+-	"strconv"
+-	"strings"
+-
+-	"golang.org/x/mod/modfile"
+-	"golang.org/x/mod/semver"
+-	"golang.org/x/tools/go/packages"
+-)
+-
+-var (
+-	versionFlag = flag.String("version", "", "version to tag")
+-	remoteFlag  = flag.String("remote", "", "remote to which to push the tag")
+-	releaseFlag = flag.Bool("release", false, "release is true if you intend to tag and push a release")
+-)
+-
+-func main() {
+-	flag.Parse()
+-
+-	if *versionFlag == "" {
+-		log.Fatalf("must provide -version flag")
+-	}
+-	if !semver.IsValid(*versionFlag) {
+-		log.Fatalf("invalid version %s", *versionFlag)
+-	}
+-	if semver.Major(*versionFlag) != "v0" {
+-		log.Fatalf("expected major version v0, got %s", semver.Major(*versionFlag))
+-	}
+-	if semver.Build(*versionFlag) != "" {
+-		log.Fatalf("unexpected build suffix: %s", *versionFlag)
+-	}
+-	if *releaseFlag && *remoteFlag == "" {
+-		log.Fatalf("must provide -remote flag if releasing")
+-	}
+-	user, err := user.Current()
+-	if err != nil {
+-		log.Fatal(err)
+-	}
+-	// Validate that the user is running the program from the gopls module.
+-	wd, err := os.Getwd()
+-	if err != nil {
+-		log.Fatal(err)
+-	}
+-	if filepath.Base(wd) != "gopls" {
+-		log.Fatalf("must run from the gopls module")
+-	}
+-	// Confirm that they are running on a branch with a name following the
+-	// format of "gopls-release-branch.<major>.<minor>".
+-	if err := validateBranchName(*versionFlag); err != nil {
+-		log.Fatal(err)
+-	}
+-	// Confirm that they have updated the hardcoded version.
+-	if err := validateHardcodedVersion(wd, *versionFlag); err != nil {
+-		log.Fatal(err)
+-	}
+-	// Confirm that the versions in the go.mod file are correct.
+-	if err := validateGoModFile(wd); err != nil {
+-		log.Fatal(err)
+-	}
+-	earlyExitMsg := "Validated that the release is ready. Exiting without tagging and publishing."
+-	if !*releaseFlag {
+-		fmt.Println(earlyExitMsg)
+-		os.Exit(0)
+-	}
+-	fmt.Println(`Proceeding to tagging and publishing the release...
+-Please enter Y if you wish to proceed or anything else if you wish to exit.`)
+-	// Accept and process user input.
+-	var input string
+-	fmt.Scanln(&input)
+-	switch input {
+-	case "Y":
+-		fmt.Println("Proceeding to tagging and publishing the release.")
+-	default:
+-		fmt.Println(earlyExitMsg)
+-		os.Exit(0)
+-	}
+-	// To tag the release:
+-	// $ git -c user.email=username@google.com tag -a -m “<message>” gopls/v<major>.<minor>.<patch>-<pre-release>
+-	goplsVersion := fmt.Sprintf("gopls/%s", *versionFlag)
+-	cmd := exec.Command("git", "-c", fmt.Sprintf("user.email=%s@google.com", user.Username), "tag", "-a", "-m", fmt.Sprintf("%q", goplsVersion), goplsVersion)
+-	if err := cmd.Run(); err != nil {
+-		log.Fatal(err)
+-	}
+-	// Push the tag to the remote:
+-	// $ git push <remote> gopls/v<major>.<minor>.<patch>-pre.1
+-	cmd = exec.Command("git", "push", *remoteFlag, goplsVersion)
+-	if err := cmd.Run(); err != nil {
+-		log.Fatal(err)
+-	}
+-}
+-
+-// validateBranchName reports whether the user's current branch name is of the
+-// form "gopls-release-branch.<major>.<minor>". It reports an error if not.
+-func validateBranchName(version string) error {
+-	cmd := exec.Command("git", "branch", "--show-current")
+-	stdout, err := cmd.Output()
+-	if err != nil {
+-		return err
+-	}
+-	branch := strings.TrimSpace(string(stdout))
+-	expectedBranch := fmt.Sprintf("gopls-release-branch.%s", strings.TrimPrefix(semver.MajorMinor(version), "v"))
+-	if branch != expectedBranch {
+-		return fmt.Errorf("expected release branch %s, got %s", expectedBranch, branch)
+-	}
+-	return nil
+-}
+-
+-// validateHardcodedVersion reports whether the version hardcoded in the gopls
+-// binary is equivalent to the version being published. It reports an error if
+-// not.
+-func validateHardcodedVersion(wd string, version string) error {
+-	pkgs, err := packages.Load(&packages.Config{
+-		Dir: filepath.Dir(wd),
+-		Mode: packages.NeedName | packages.NeedFiles |
+-			packages.NeedCompiledGoFiles | packages.NeedImports |
+-			packages.NeedTypes | packages.NeedTypesSizes,
+-	}, "golang.org/x/tools/internal/lsp/debug")
+-	if err != nil {
+-		return err
+-	}
+-	if len(pkgs) != 1 {
+-		return fmt.Errorf("expected 1 package, got %v", len(pkgs))
+-	}
+-	pkg := pkgs[0]
+-	obj := pkg.Types.Scope().Lookup("Version")
+-	c, ok := obj.(*types.Const)
+-	if !ok {
+-		return fmt.Errorf("no constant named Version")
+-	}
+-	hardcodedVersion, err := strconv.Unquote(c.Val().ExactString())
+-	if err != nil {
+-		return err
+-	}
+-	if semver.Prerelease(hardcodedVersion) != "" {
+-		return fmt.Errorf("unexpected pre-release for hardcoded version: %s", hardcodedVersion)
+-	}
+-	// Don't worry about pre-release tags and expect that there is no build
+-	// suffix.
+-	version = strings.TrimSuffix(version, semver.Prerelease(version))
+-	if hardcodedVersion != version {
+-		return fmt.Errorf("expected version to be %s, got %s", *versionFlag, hardcodedVersion)
+-	}
+-	return nil
+-}
+-
+-func validateGoModFile(wd string) error {
+-	filename := filepath.Join(wd, "go.mod")
+-	data, err := ioutil.ReadFile(filename)
+-	if err != nil {
+-		return err
+-	}
+-	gomod, err := modfile.Parse(filename, data, nil)
+-	if err != nil {
+-		return err
+-	}
+-	// Confirm that there is no replace directive in the go.mod file.
+-	if len(gomod.Replace) > 0 {
+-		return fmt.Errorf("expected no replace directives, got %v", len(gomod.Replace))
+-	}
+-	// Confirm that the version of x/tools in the gopls/go.mod file points to
+-	// the second-to-last commit. (The last commit will be the one to update the
+-	// go.mod file.)
+-	cmd := exec.Command("git", "rev-parse", "@~")
+-	stdout, err := cmd.Output()
+-	if err != nil {
+-		return err
+-	}
+-	hash := string(stdout)
+-	// Find the golang.org/x/tools require line and compare the versions.
+-	var version string
+-	for _, req := range gomod.Require {
+-		if req.Mod.Path == "golang.org/x/tools" {
+-			version = req.Mod.Version
+-			break
+-		}
+-	}
+-	if version == "" {
+-		return fmt.Errorf("no require for golang.org/x/tools")
+-	}
+-	split := strings.Split(version, "-")
+-	if len(split) != 3 {
+-		return fmt.Errorf("unexpected pseudoversion format %s", version)
+-	}
+-	last := split[len(split)-1]
+-	if last == "" {
+-		return fmt.Errorf("unexpected pseudoversion format %s", version)
+-	}
+-	if !strings.HasPrefix(hash, last) {
+-		return fmt.Errorf("golang.org/x/tools pseudoversion should be at commit %s, instead got %s", hash, last)
+-	}
+-	return nil
+-}
+diff -urN a/gopls/test/debug/debug_test.go b/gopls/test/debug/debug_test.go
+--- a/gopls/test/debug/debug_test.go	2000-01-01 00:00:00.000000000 -0000
++++ b/gopls/test/debug/debug_test.go	1969-12-31 19:00:00.000000000 -0500
+@@ -1,181 +0,0 @@
+-// Copyright 2020 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-package debug_test
+-
+-// Provide 'static type checking' of the templates. This guards against changes is various
+-// gopls datastructures causing template execution to fail. The checking is done by
+-// the github.com/jba/templatecheck pacakge. Before that is run, the test checks that
+-// its list of templates and their arguments corresponds to the arguments in
+-// calls to render(). The test assumes that all uses of templates are done through render().
+-
+-import (
+-	"go/ast"
+-	"html/template"
+-	"log"
+-	"runtime"
+-	"sort"
+-	"strings"
+-	"testing"
+-
+-	"github.com/jba/templatecheck"
+-	"golang.org/x/tools/go/packages"
+-	"golang.org/x/tools/internal/lsp/cache"
+-	"golang.org/x/tools/internal/lsp/debug"
+-	"golang.org/x/tools/internal/lsp/source"
+-	"golang.org/x/tools/internal/span"
+-)
+-
+-type tdata struct {
+-	tmpl *template.Template
+-	data interface{} // a value of the needed type
+-}
+-
+-var templates = map[string]tdata{
+-	"MainTmpl":    {debug.MainTmpl, &debug.Instance{}},
+-	"DebugTmpl":   {debug.DebugTmpl, nil},
+-	"RPCTmpl":     {debug.RPCTmpl, &debug.Rpcs{}},
+-	"TraceTmpl":   {debug.TraceTmpl, debug.TraceResults{}},
+-	"CacheTmpl":   {debug.CacheTmpl, &cache.Cache{}},
+-	"SessionTmpl": {debug.SessionTmpl, &cache.Session{}},
+-	"ViewTmpl":    {debug.ViewTmpl, &cache.View{}},
+-	"ClientTmpl":  {debug.ClientTmpl, &debug.Client{}},
+-	"ServerTmpl":  {debug.ServerTmpl, &debug.Server{}},
+-	//"FileTmpl":    {FileTmpl, source.Overlay{}}, // need to construct a source.Overlay in init
+-	"InfoTmpl":   {debug.InfoTmpl, "something"},
+-	"MemoryTmpl": {debug.MemoryTmpl, runtime.MemStats{}},
+-}
+-
+-// construct a source.Overlay for fileTmpl
+-type fakeOverlay struct{}
+-
+-func (fakeOverlay) Version() float64 {
+-	return 0
+-}
+-func (fakeOverlay) Session() string {
+-	return ""
+-}
+-func (fakeOverlay) VersionedFileIdentity() source.VersionedFileIdentity {
+-	return source.VersionedFileIdentity{}
+-}
+-func (fakeOverlay) FileIdentity() source.FileIdentity {
+-	return source.FileIdentity{}
+-}
+-func (fakeOverlay) Kind() source.FileKind {
+-	return 0
+-}
+-func (fakeOverlay) Read() ([]byte, error) {
+-	return nil, nil
+-}
+-func (fakeOverlay) Saved() bool {
+-	return true
+-}
+-func (fakeOverlay) URI() span.URI {
+-	return ""
+-}
+-
+-var _ source.Overlay = fakeOverlay{}
+-
+-func init() {
+-	log.SetFlags(log.Lshortfile)
+-	var v fakeOverlay
+-	templates["FileTmpl"] = tdata{debug.FileTmpl, v}
+-}
+-
+-func TestTemplates(t *testing.T) {
+-	if runtime.GOOS == "android" {
+-		t.Skip("this test is not supported for Android")
+-	}
+-	cfg := &packages.Config{
+-		Mode: packages.NeedTypesInfo | packages.LoadAllSyntax, // figure out what's necessary PJW
+-	}
+-	pkgs, err := packages.Load(cfg, "golang.org/x/tools/internal/lsp/debug")
+-	if err != nil {
+-		t.Fatal(err)
+-	}
+-	if len(pkgs) != 1 {
+-		t.Fatalf("expected a single package, but got %d", len(pkgs))
+-	}
+-	p := pkgs[0]
+-	if len(p.Errors) != 0 {
+-		t.Fatalf("compiler error, e.g. %v", p.Errors[0])
+-	}
+-	// find the calls to render in serve.go
+-	tree := treeOf(p, "serve.go")
+-	if tree == nil {
+-		t.Fatalf("found no syntax tree for %s", "serve.go")
+-	}
+-	renders := callsOf(p, tree, "render")
+-	if len(renders) == 0 {
+-		t.Fatalf("found no calls to render")
+-	}
+-	var found = make(map[string]bool)
+-	for _, r := range renders {
+-		if len(r.Args) != 2 {
+-			// template, func
+-			t.Fatalf("got %d args, expected 2", len(r.Args))
+-		}
+-		t0, ok := p.TypesInfo.Types[r.Args[0]]
+-		if !ok || !t0.IsValue() || t0.Type.String() != "*html/template.Template" {
+-			t.Fatalf("no type info for template")
+-		}
+-		if id, ok := r.Args[0].(*ast.Ident); !ok {
+-			t.Errorf("expected *ast.Ident, got %T", r.Args[0])
+-		} else {
+-			found[id.Name] = true
+-		}
+-	}
+-	// make sure found and templates have the same templates
+-	for k := range found {
+-		if _, ok := templates[k]; !ok {
+-			t.Errorf("code has template %s, but test does not", k)
+-		}
+-	}
+-	for k := range templates {
+-		if _, ok := found[k]; !ok {
+-			t.Errorf("test has template %s, code does not", k)
+-		}
+-	}
+-	// now check all the known templates, in alphabetic order, for determinacy
+-	keys := []string{}
+-	for k := range templates {
+-		keys = append(keys, k)
+-	}
+-	sort.Strings(keys)
+-	for _, k := range keys {
+-		v := templates[k]
+-		// the FuncMap is an annoyance; should not be necessary
+-		if err := templatecheck.CheckHTML(v.tmpl, v.data); err != nil {
+-			t.Errorf("%s: %v", k, err)
+-		}
+-	}
+-}
+-
+-func callsOf(p *packages.Package, tree *ast.File, name string) []*ast.CallExpr {
+-	var ans []*ast.CallExpr
+-	f := func(n ast.Node) bool {
+-		x, ok := n.(*ast.CallExpr)
+-		if !ok {
+-			return true
+-		}
+-		if y, ok := x.Fun.(*ast.Ident); ok {
+-			if y.Name == name {
+-				ans = append(ans, x)
+-			}
+-		}
+-		return true
+-	}
+-	ast.Inspect(tree, f)
+-	return ans
+-}
+-func treeOf(p *packages.Package, fname string) *ast.File {
+-	for _, tree := range p.Syntax {
+-		loc := tree.Package
+-		pos := p.Fset.PositionFor(loc, false)
+-		if strings.HasSuffix(pos.Filename, fname) {
+-			return tree
+-		}
+-	}
+-	return nil
 -}
 diff -urN a/gopls/test/gopls_test.go b/gopls/test/gopls_test.go
 --- a/gopls/test/gopls_test.go	2000-01-01 00:00:00.000000000 -0000

--- a/third_party/org_golang_x_tools-gazelle.patch
+++ b/third_party/org_golang_x_tools-gazelle.patch
@@ -71,7 +71,7 @@ diff -urN b/blog/atom/BUILD.bazel c/blog/atom/BUILD.bazel
 diff -urN b/cmd/auth/authtest/BUILD.bazel c/cmd/auth/authtest/BUILD.bazel
 --- b/cmd/auth/authtest/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/cmd/auth/authtest/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,14 @@
+@@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 +
 +go_library(
@@ -79,6 +79,7 @@ diff -urN b/cmd/auth/authtest/BUILD.bazel c/cmd/auth/authtest/BUILD.bazel
 +    srcs = ["authtest.go"],
 +    importpath = "golang.org/x/tools/cmd/auth/authtest",
 +    visibility = ["//visibility:private"],
++    deps = ["@org_golang_x_sys//execabs:go_default_library"],
 +)
 +
 +go_binary(
@@ -107,7 +108,7 @@ diff -urN b/cmd/auth/cookieauth/BUILD.bazel c/cmd/auth/cookieauth/BUILD.bazel
 diff -urN b/cmd/auth/gitauth/BUILD.bazel c/cmd/auth/gitauth/BUILD.bazel
 --- b/cmd/auth/gitauth/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/cmd/auth/gitauth/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,14 @@
+@@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 +
 +go_library(
@@ -115,6 +116,7 @@ diff -urN b/cmd/auth/gitauth/BUILD.bazel c/cmd/auth/gitauth/BUILD.bazel
 +    srcs = ["gitauth.go"],
 +    importpath = "golang.org/x/tools/cmd/auth/gitauth",
 +    visibility = ["//visibility:private"],
++    deps = ["@org_golang_x_sys//execabs:go_default_library"],
 +)
 +
 +go_binary(
@@ -343,7 +345,7 @@ diff -urN b/cmd/callgraph/testdata/src/pkg/BUILD.bazel c/cmd/callgraph/testdata/
 diff -urN b/cmd/compilebench/BUILD.bazel c/cmd/compilebench/BUILD.bazel
 --- b/cmd/compilebench/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/cmd/compilebench/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,14 @@
+@@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 +
 +go_library(
@@ -351,6 +353,7 @@ diff -urN b/cmd/compilebench/BUILD.bazel c/cmd/compilebench/BUILD.bazel
 +    srcs = ["main.go"],
 +    importpath = "golang.org/x/tools/cmd/compilebench",
 +    visibility = ["//visibility:private"],
++    deps = ["@org_golang_x_sys//execabs:go_default_library"],
 +)
 +
 +go_binary(
@@ -361,7 +364,7 @@ diff -urN b/cmd/compilebench/BUILD.bazel c/cmd/compilebench/BUILD.bazel
 diff -urN b/cmd/cover/BUILD.bazel c/cmd/cover/BUILD.bazel
 --- b/cmd/cover/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/cmd/cover/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,67 @@
+@@ -0,0 +1,70 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 +
 +go_library(
@@ -374,7 +377,10 @@ diff -urN b/cmd/cover/BUILD.bazel c/cmd/cover/BUILD.bazel
 +    ],
 +    importpath = "golang.org/x/tools/cmd/cover",
 +    visibility = ["//visibility:private"],
-+    deps = ["//cover"],
++    deps = [
++        "//cover",
++        "@org_golang_x_sys//execabs:go_default_library",
++    ],
 +)
 +
 +go_binary(
@@ -477,7 +483,7 @@ diff -urN b/cmd/digraph/BUILD.bazel c/cmd/digraph/BUILD.bazel
 diff -urN b/cmd/eg/BUILD.bazel c/cmd/eg/BUILD.bazel
 --- b/cmd/eg/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/cmd/eg/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 +
 +go_library(
@@ -489,6 +495,7 @@ diff -urN b/cmd/eg/BUILD.bazel c/cmd/eg/BUILD.bazel
 +        "//go/buildutil",
 +        "//go/loader",
 +        "//refactor/eg",
++        "@org_golang_x_sys//execabs:go_default_library",
 +    ],
 +)
 +
@@ -500,7 +507,7 @@ diff -urN b/cmd/eg/BUILD.bazel c/cmd/eg/BUILD.bazel
 diff -urN b/cmd/fiximports/BUILD.bazel c/cmd/fiximports/BUILD.bazel
 --- b/cmd/fiximports/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/cmd/fiximports/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,62 @@
+@@ -0,0 +1,63 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 +
 +go_library(
@@ -508,6 +515,7 @@ diff -urN b/cmd/fiximports/BUILD.bazel c/cmd/fiximports/BUILD.bazel
 +    srcs = ["main.go"],
 +    importpath = "golang.org/x/tools/cmd/fiximports",
 +    visibility = ["//visibility:private"],
++    deps = ["@org_golang_x_sys//execabs:go_default_library"],
 +)
 +
 +go_binary(
@@ -710,7 +718,7 @@ diff -urN b/cmd/fiximports/testdata/src/titanic.biz/foo/BUILD.bazel c/cmd/fiximp
 diff -urN b/cmd/getgo/BUILD.bazel c/cmd/getgo/BUILD.bazel
 --- b/cmd/getgo/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/cmd/getgo/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,74 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 +
 +go_library(
@@ -726,6 +734,48 @@ diff -urN b/cmd/getgo/BUILD.bazel c/cmd/getgo/BUILD.bazel
 +    ],
 +    importpath = "golang.org/x/tools/cmd/getgo",
 +    visibility = ["//visibility:private"],
++    deps = select({
++        "@io_bazel_rules_go//go/platform:aix": [
++            "@org_golang_x_sys//execabs:go_default_library",
++        ],
++        "@io_bazel_rules_go//go/platform:android": [
++            "@org_golang_x_sys//execabs:go_default_library",
++        ],
++        "@io_bazel_rules_go//go/platform:darwin": [
++            "@org_golang_x_sys//execabs:go_default_library",
++        ],
++        "@io_bazel_rules_go//go/platform:dragonfly": [
++            "@org_golang_x_sys//execabs:go_default_library",
++        ],
++        "@io_bazel_rules_go//go/platform:freebsd": [
++            "@org_golang_x_sys//execabs:go_default_library",
++        ],
++        "@io_bazel_rules_go//go/platform:illumos": [
++            "@org_golang_x_sys//execabs:go_default_library",
++        ],
++        "@io_bazel_rules_go//go/platform:ios": [
++            "@org_golang_x_sys//execabs:go_default_library",
++        ],
++        "@io_bazel_rules_go//go/platform:js": [
++            "@org_golang_x_sys//execabs:go_default_library",
++        ],
++        "@io_bazel_rules_go//go/platform:linux": [
++            "@org_golang_x_sys//execabs:go_default_library",
++        ],
++        "@io_bazel_rules_go//go/platform:netbsd": [
++            "@org_golang_x_sys//execabs:go_default_library",
++        ],
++        "@io_bazel_rules_go//go/platform:openbsd": [
++            "@org_golang_x_sys//execabs:go_default_library",
++        ],
++        "@io_bazel_rules_go//go/platform:solaris": [
++            "@org_golang_x_sys//execabs:go_default_library",
++        ],
++        "@io_bazel_rules_go//go/platform:windows": [
++            "@org_golang_x_sys//execabs:go_default_library",
++        ],
++        "//conditions:default": [],
++    }),
 +)
 +
 +go_binary(
@@ -764,7 +814,7 @@ diff -urN b/cmd/getgo/server/BUILD.bazel c/cmd/getgo/server/BUILD.bazel
 diff -urN b/cmd/go-contrib-init/BUILD.bazel c/cmd/go-contrib-init/BUILD.bazel
 --- b/cmd/go-contrib-init/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/cmd/go-contrib-init/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,20 @@
+@@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 +
 +go_library(
@@ -772,6 +822,7 @@ diff -urN b/cmd/go-contrib-init/BUILD.bazel c/cmd/go-contrib-init/BUILD.bazel
 +    srcs = ["contrib.go"],
 +    importpath = "golang.org/x/tools/cmd/go-contrib-init",
 +    visibility = ["//visibility:private"],
++    deps = ["@org_golang_x_sys//execabs:go_default_library"],
 +)
 +
 +go_binary(
@@ -816,7 +867,7 @@ diff -urN b/cmd/godex/BUILD.bazel c/cmd/godex/BUILD.bazel
 diff -urN b/cmd/godoc/BUILD.bazel c/cmd/godoc/BUILD.bazel
 --- b/cmd/godoc/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/cmd/godoc/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,41 @@
+@@ -0,0 +1,42 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 +
 +go_library(
@@ -840,6 +891,7 @@ diff -urN b/cmd/godoc/BUILD.bazel c/cmd/godoc/BUILD.bazel
 +        "//godoc/vfs/zipfs",
 +        "//internal/gocommand",
 +        "//playground",
++        "@org_golang_x_sys//execabs:go_default_library",
 +        "@org_golang_x_xerrors//:go_default_library",
 +    ],
 +)
@@ -861,7 +913,7 @@ diff -urN b/cmd/godoc/BUILD.bazel c/cmd/godoc/BUILD.bazel
 diff -urN b/cmd/goimports/BUILD.bazel c/cmd/goimports/BUILD.bazel
 --- b/cmd/goimports/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/cmd/goimports/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,22 @@
+@@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 +
 +go_library(
@@ -876,6 +928,7 @@ diff -urN b/cmd/goimports/BUILD.bazel c/cmd/goimports/BUILD.bazel
 +    deps = [
 +        "//internal/gocommand",
 +        "//internal/imports",
++        "@org_golang_x_sys//execabs:go_default_library",
 +    ],
 +)
 +
@@ -1733,7 +1786,7 @@ diff -urN b/cmd/ssadump/BUILD.bazel c/cmd/ssadump/BUILD.bazel
 diff -urN b/cmd/stress/BUILD.bazel c/cmd/stress/BUILD.bazel
 --- b/cmd/stress/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/cmd/stress/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,14 @@
+@@ -0,0 +1,56 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 +
 +go_library(
@@ -1741,6 +1794,48 @@ diff -urN b/cmd/stress/BUILD.bazel c/cmd/stress/BUILD.bazel
 +    srcs = ["stress.go"],
 +    importpath = "golang.org/x/tools/cmd/stress",
 +    visibility = ["//visibility:private"],
++    deps = select({
++        "@io_bazel_rules_go//go/platform:aix": [
++            "@org_golang_x_sys//execabs:go_default_library",
++        ],
++        "@io_bazel_rules_go//go/platform:android": [
++            "@org_golang_x_sys//execabs:go_default_library",
++        ],
++        "@io_bazel_rules_go//go/platform:darwin": [
++            "@org_golang_x_sys//execabs:go_default_library",
++        ],
++        "@io_bazel_rules_go//go/platform:dragonfly": [
++            "@org_golang_x_sys//execabs:go_default_library",
++        ],
++        "@io_bazel_rules_go//go/platform:freebsd": [
++            "@org_golang_x_sys//execabs:go_default_library",
++        ],
++        "@io_bazel_rules_go//go/platform:illumos": [
++            "@org_golang_x_sys//execabs:go_default_library",
++        ],
++        "@io_bazel_rules_go//go/platform:ios": [
++            "@org_golang_x_sys//execabs:go_default_library",
++        ],
++        "@io_bazel_rules_go//go/platform:js": [
++            "@org_golang_x_sys//execabs:go_default_library",
++        ],
++        "@io_bazel_rules_go//go/platform:linux": [
++            "@org_golang_x_sys//execabs:go_default_library",
++        ],
++        "@io_bazel_rules_go//go/platform:netbsd": [
++            "@org_golang_x_sys//execabs:go_default_library",
++        ],
++        "@io_bazel_rules_go//go/platform:openbsd": [
++            "@org_golang_x_sys//execabs:go_default_library",
++        ],
++        "@io_bazel_rules_go//go/platform:solaris": [
++            "@org_golang_x_sys//execabs:go_default_library",
++        ],
++        "@io_bazel_rules_go//go/platform:windows": [
++            "@org_golang_x_sys//execabs:go_default_library",
++        ],
++        "//conditions:default": [],
++    }),
 +)
 +
 +go_binary(
@@ -1812,7 +1907,7 @@ diff -urN b/cmd/stringer/testdata/BUILD.bazel c/cmd/stringer/testdata/BUILD.baze
 diff -urN b/cmd/toolstash/BUILD.bazel c/cmd/toolstash/BUILD.bazel
 --- b/cmd/toolstash/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/cmd/toolstash/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 +
 +go_library(
@@ -1823,6 +1918,7 @@ diff -urN b/cmd/toolstash/BUILD.bazel c/cmd/toolstash/BUILD.bazel
 +    ],
 +    importpath = "golang.org/x/tools/cmd/toolstash",
 +    visibility = ["//visibility:private"],
++    deps = ["@org_golang_x_sys//execabs:go_default_library"],
 +)
 +
 +go_binary(
@@ -1862,6 +1958,30 @@ diff -urN b/container/intsets/BUILD.bazel c/container/intsets/BUILD.bazel
 +        "util_test.go",
 +    ],
 +    embed = [":intsets"],
++)
+diff -urN b/copyright/BUILD.bazel c/copyright/BUILD.bazel
+--- b/copyright/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ c/copyright/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,20 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "copyright",
++    srcs = ["copyright.go"],
++    importpath = "golang.org/x/tools/copyright",
++    visibility = ["//visibility:public"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":copyright",
++    visibility = ["//visibility:public"],
++)
++
++go_test(
++    name = "copyright_test",
++    srcs = ["copyright_test.go"],
++    embed = [":copyright"],
 +)
 diff -urN b/cover/BUILD.bazel c/cover/BUILD.bazel
 --- b/cover/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -3086,19 +3206,40 @@ diff -urN b/go/analysis/passes/fieldalignment/BUILD.bazel c/go/analysis/passes/f
 +        "//go/analysis/analysistest",
 +    ],
 +)
+diff -urN b/go/analysis/passes/fieldalignment/cmd/fieldalignment/BUILD.bazel c/go/analysis/passes/fieldalignment/cmd/fieldalignment/BUILD.bazel
+--- b/go/analysis/passes/fieldalignment/cmd/fieldalignment/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ c/go/analysis/passes/fieldalignment/cmd/fieldalignment/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,18 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
++
++go_library(
++    name = "fieldalignment_lib",
++    srcs = ["main.go"],
++    importpath = "golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment",
++    visibility = ["//visibility:private"],
++    deps = [
++        "//go/analysis/passes/fieldalignment",
++        "//go/analysis/singlechecker",
++    ],
++)
++
++go_binary(
++    name = "fieldalignment",
++    embed = [":fieldalignment_lib"],
++    visibility = ["//visibility:public"],
++)
 diff -urN b/go/analysis/passes/fieldalignment/testdata/src/a/BUILD.bazel c/go/analysis/passes/fieldalignment/testdata/src/a/BUILD.bazel
 --- b/go/analysis/passes/fieldalignment/testdata/src/a/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/go/analysis/passes/fieldalignment/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
 +    name = "a",
 +    srcs = [
 +        "a.go",
-+        "ptr_386.go",
-+        "ptr_amd64.go",
-+        "zero.go",
++        "a_386.go",
++        "a_amd64.go",
 +    ],
 +    importpath = "golang.org/x/tools/go/analysis/passes/fieldalignment/testdata/src/a",
 +    visibility = ["//visibility:public"],
@@ -5515,7 +5656,7 @@ diff -urN b/go/gcexportdata/BUILD.bazel c/go/gcexportdata/BUILD.bazel
 diff -urN b/go/internal/cgo/BUILD.bazel c/go/internal/cgo/BUILD.bazel
 --- b/go/internal/cgo/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/go/internal/cgo/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -5526,6 +5667,7 @@ diff -urN b/go/internal/cgo/BUILD.bazel c/go/internal/cgo/BUILD.bazel
 +    ],
 +    importpath = "golang.org/x/tools/go/internal/cgo",
 +    visibility = ["//go:__subpackages__"],
++    deps = ["@org_golang_x_sys//execabs:go_default_library"],
 +)
 +
 +alias(
@@ -5536,7 +5678,7 @@ diff -urN b/go/internal/cgo/BUILD.bazel c/go/internal/cgo/BUILD.bazel
 diff -urN b/go/internal/gccgoimporter/BUILD.bazel c/go/internal/gccgoimporter/BUILD.bazel
 --- b/go/internal/gccgoimporter/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/go/internal/gccgoimporter/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -5552,6 +5694,7 @@ diff -urN b/go/internal/gccgoimporter/BUILD.bazel c/go/internal/gccgoimporter/BU
 +    ],
 +    importpath = "golang.org/x/tools/go/internal/gccgoimporter",
 +    visibility = ["//go:__subpackages__"],
++    deps = ["@org_golang_x_sys//execabs:go_default_library"],
 +)
 +
 +alias(
@@ -5733,7 +5876,7 @@ diff -urN b/go/loader/testdata/BUILD.bazel c/go/loader/testdata/BUILD.bazel
 diff -urN b/go/packages/BUILD.bazel c/go/packages/BUILD.bazel
 --- b/go/packages/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/go/packages/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,46 @@
+@@ -0,0 +1,47 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -5755,6 +5898,7 @@ diff -urN b/go/packages/BUILD.bazel c/go/packages/BUILD.bazel
 +        "//internal/gocommand",
 +        "//internal/packagesinternal",
 +        "//internal/typesinternal",
++        "@org_golang_x_sys//execabs:go_default_library",
 +        "@org_golang_x_xerrors//:go_default_library",
 +    ],
 +)
@@ -6085,7 +6229,7 @@ diff -urN b/go/packages/packagestest/testdata/groups/two/primarymod/expect/BUILD
 diff -urN b/go/pointer/BUILD.bazel c/go/pointer/BUILD.bazel
 --- b/go/pointer/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/go/pointer/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,107 @@
+@@ -0,0 +1,108 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -6114,6 +6258,7 @@ diff -urN b/go/pointer/BUILD.bazel c/go/pointer/BUILD.bazel
 +        "//go/callgraph",
 +        "//go/ssa",
 +        "//go/types/typeutil",
++        "@org_golang_x_sys//execabs:go_default_library",
 +    ],
 +)
 +
@@ -6805,7 +6950,7 @@ diff -urN b/go/types/typeutil/BUILD.bazel c/go/types/typeutil/BUILD.bazel
 diff -urN b/go/vcs/BUILD.bazel c/go/vcs/BUILD.bazel
 --- b/go/vcs/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/go/vcs/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,25 @@
+@@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -6818,6 +6963,7 @@ diff -urN b/go/vcs/BUILD.bazel c/go/vcs/BUILD.bazel
 +    ],
 +    importpath = "golang.org/x/tools/go/vcs",
 +    visibility = ["//visibility:public"],
++    deps = ["@org_golang_x_sys//execabs:go_default_library"],
 +)
 +
 +alias(
@@ -7643,7 +7789,7 @@ diff -urN b/internal/fastwalk/BUILD.bazel c/internal/fastwalk/BUILD.bazel
 diff -urN b/internal/gocommand/BUILD.bazel c/internal/gocommand/BUILD.bazel
 --- b/internal/gocommand/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/internal/gocommand/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,28 @@
+@@ -0,0 +1,29 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -7658,6 +7804,7 @@ diff -urN b/internal/gocommand/BUILD.bazel c/internal/gocommand/BUILD.bazel
 +    deps = [
 +        "//internal/event",
 +        "@org_golang_x_mod//semver:go_default_library",
++        "@org_golang_x_sys//execabs:go_default_library",
 +    ],
 +)
 +
@@ -7824,7 +7971,7 @@ diff -urN b/internal/jsonrpc2/servertest/BUILD.bazel c/internal/jsonrpc2/servert
 diff -urN b/internal/lsp/BUILD.bazel c/internal/lsp/BUILD.bazel
 --- b/internal/lsp/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/internal/lsp/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,80 @@
+@@ -0,0 +1,81 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -7867,6 +8014,7 @@ diff -urN b/internal/lsp/BUILD.bazel c/internal/lsp/BUILD.bazel
 +        "//internal/jsonrpc2",
 +        "//internal/lsp/cache",
 +        "//internal/lsp/debug",
++        "//internal/lsp/debug/log",
 +        "//internal/lsp/debug/tag",
 +        "//internal/lsp/mod",
 +        "//internal/lsp/protocol",
@@ -8382,7 +8530,7 @@ diff -urN b/internal/lsp/analysis/unusedparams/testdata/src/a/BUILD.bazel c/inte
 diff -urN b/internal/lsp/browser/BUILD.bazel c/internal/lsp/browser/BUILD.bazel
 --- b/internal/lsp/browser/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/internal/lsp/browser/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,14 @@
+@@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -8390,6 +8538,7 @@ diff -urN b/internal/lsp/browser/BUILD.bazel c/internal/lsp/browser/BUILD.bazel
 +    srcs = ["browser.go"],
 +    importpath = "golang.org/x/tools/internal/lsp/browser",
 +    visibility = ["//:__subpackages__"],
++    deps = ["@org_golang_x_sys//execabs:go_default_library"],
 +)
 +
 +alias(
@@ -8400,7 +8549,7 @@ diff -urN b/internal/lsp/browser/BUILD.bazel c/internal/lsp/browser/BUILD.bazel
 diff -urN b/internal/lsp/cache/BUILD.bazel c/internal/lsp/cache/BUILD.bazel
 --- b/internal/lsp/cache/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/internal/lsp/cache/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,74 @@
+@@ -0,0 +1,76 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -8435,6 +8584,7 @@ diff -urN b/internal/lsp/cache/BUILD.bazel c/internal/lsp/cache/BUILD.bazel
 +        "//internal/event/label",
 +        "//internal/gocommand",
 +        "//internal/imports",
++        "//internal/lsp/debug/log",
 +        "//internal/lsp/debug/tag",
 +        "//internal/lsp/diff",
 +        "//internal/lsp/protocol",
@@ -8448,6 +8598,7 @@ diff -urN b/internal/lsp/cache/BUILD.bazel c/internal/lsp/cache/BUILD.bazel
 +        "@org_golang_x_mod//module:go_default_library",
 +        "@org_golang_x_mod//semver:go_default_library",
 +        "@org_golang_x_sync//errgroup:go_default_library",
++        "@org_golang_x_sys//execabs:go_default_library",
 +        "@org_golang_x_xerrors//:go_default_library",
 +    ],
 +)
@@ -8555,7 +8706,7 @@ diff -urN b/internal/lsp/cmd/BUILD.bazel c/internal/lsp/cmd/BUILD.bazel
 diff -urN b/internal/lsp/cmd/test/BUILD.bazel c/internal/lsp/cmd/test/BUILD.bazel
 --- b/internal/lsp/cmd/test/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/internal/lsp/cmd/test/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,48 @@
+@@ -0,0 +1,49 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -8596,6 +8747,7 @@ diff -urN b/internal/lsp/cmd/test/BUILD.bazel c/internal/lsp/cmd/test/BUILD.baze
 +        "//internal/span",
 +        "//internal/testenv",
 +        "//internal/tool",
++        "@org_golang_x_sys//execabs:go_default_library",
 +    ],
 +)
 +
@@ -8607,7 +8759,7 @@ diff -urN b/internal/lsp/cmd/test/BUILD.bazel c/internal/lsp/cmd/test/BUILD.baze
 diff -urN b/internal/lsp/debug/BUILD.bazel c/internal/lsp/debug/BUILD.bazel
 --- b/internal/lsp/debug/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/internal/lsp/debug/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,35 @@
+@@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -8631,6 +8783,7 @@ diff -urN b/internal/lsp/debug/BUILD.bazel c/internal/lsp/debug/BUILD.bazel
 +        "//internal/event/keys",
 +        "//internal/event/label",
 +        "//internal/lsp/cache",
++        "//internal/lsp/debug/log",
 +        "//internal/lsp/debug/tag",
 +        "//internal/lsp/protocol",
 +        "//internal/lsp/source",
@@ -8641,6 +8794,29 @@ diff -urN b/internal/lsp/debug/BUILD.bazel c/internal/lsp/debug/BUILD.bazel
 +alias(
 +    name = "go_default_library",
 +    actual = ":debug",
++    visibility = ["//:__subpackages__"],
++)
+diff -urN b/internal/lsp/debug/log/BUILD.bazel c/internal/lsp/debug/log/BUILD.bazel
+--- b/internal/lsp/debug/log/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
++++ c/internal/lsp/debug/log/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "log",
++    srcs = ["log.go"],
++    importpath = "golang.org/x/tools/internal/lsp/debug/log",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//internal/event",
++        "//internal/event/label",
++        "//internal/lsp/debug/tag",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":log",
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN b/internal/lsp/debug/tag/BUILD.bazel c/internal/lsp/debug/tag/BUILD.bazel
@@ -8865,7 +9041,7 @@ diff -urN b/internal/lsp/helper/BUILD.bazel c/internal/lsp/helper/BUILD.bazel
 diff -urN b/internal/lsp/lsprpc/BUILD.bazel c/internal/lsp/lsprpc/BUILD.bazel
 --- b/internal/lsp/lsprpc/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/internal/lsp/lsprpc/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,45 @@
+@@ -0,0 +1,46 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -8886,6 +9062,7 @@ diff -urN b/internal/lsp/lsprpc/BUILD.bazel c/internal/lsp/lsprpc/BUILD.bazel
 +        "//internal/lsp/debug",
 +        "//internal/lsp/debug/tag",
 +        "//internal/lsp/protocol",
++        "@org_golang_x_sys//execabs:go_default_library",
 +        "@org_golang_x_xerrors//:go_default_library",
 +    ],
 +)
@@ -9040,7 +9217,7 @@ diff -urN b/internal/lsp/snippet/BUILD.bazel c/internal/lsp/snippet/BUILD.bazel
 diff -urN b/internal/lsp/source/BUILD.bazel c/internal/lsp/source/BUILD.bazel
 --- b/internal/lsp/source/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/internal/lsp/source/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,121 @@
+@@ -0,0 +1,122 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -9093,6 +9270,7 @@ diff -urN b/internal/lsp/source/BUILD.bazel c/internal/lsp/source/BUILD.bazel
 +        "//go/analysis/passes/lostcancel",
 +        "//go/analysis/passes/nilfunc",
 +        "//go/analysis/passes/printf",
++        "//go/analysis/passes/shadow",
 +        "//go/analysis/passes/shift",
 +        "//go/analysis/passes/sortslice",
 +        "//go/analysis/passes/stdmethods",
@@ -9215,37 +9393,6 @@ diff -urN b/internal/lsp/source/completion/BUILD.bazel c/internal/lsp/source/com
 +        "util_test.go",
 +    ],
 +    embed = [":completion"],
-+)
-diff -urN b/internal/lsp/source/genapijson/BUILD.bazel c/internal/lsp/source/genapijson/BUILD.bazel
---- b/internal/lsp/source/genapijson/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
-+++ c/internal/lsp/source/genapijson/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,27 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
-+
-+go_library(
-+    name = "genapijson_lib",
-+    srcs = ["generate.go"],
-+    importpath = "golang.org/x/tools/internal/lsp/source/genapijson",
-+    visibility = ["//visibility:private"],
-+    deps = [
-+        "//go/ast/astutil",
-+        "//go/packages",
-+        "//internal/lsp/mod",
-+        "//internal/lsp/source",
-+    ],
-+)
-+
-+go_binary(
-+    name = "genapijson",
-+    embed = [":genapijson_lib"],
-+    visibility = ["//:__subpackages__"],
-+)
-+
-+go_test(
-+    name = "genapijson_test",
-+    srcs = ["generate_test.go"],
-+    embed = [":genapijson_lib"],
-+    deps = ["//internal/testenv"],
 +)
 diff -urN b/internal/lsp/testdata/%percent/BUILD.bazel c/internal/lsp/testdata/%percent/BUILD.bazel
 --- b/internal/lsp/testdata/%percent/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
@@ -10925,7 +11072,7 @@ diff -urN b/internal/stack/stacktest/BUILD.bazel c/internal/stack/stacktest/BUIL
 diff -urN b/internal/testenv/BUILD.bazel c/internal/testenv/BUILD.bazel
 --- b/internal/testenv/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/internal/testenv/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -10936,6 +11083,7 @@ diff -urN b/internal/testenv/BUILD.bazel c/internal/testenv/BUILD.bazel
 +    ],
 +    importpath = "golang.org/x/tools/internal/testenv",
 +    visibility = ["//:__subpackages__"],
++    deps = ["@org_golang_x_sys//execabs:go_default_library"],
 +)
 +
 +alias(
@@ -11023,7 +11171,7 @@ diff -urN b/playground/BUILD.bazel c/playground/BUILD.bazel
 diff -urN b/playground/socket/BUILD.bazel c/playground/socket/BUILD.bazel
 --- b/playground/socket/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/playground/socket/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,24 @@
+@@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -11034,6 +11182,7 @@ diff -urN b/playground/socket/BUILD.bazel c/playground/socket/BUILD.bazel
 +    deps = [
 +        "//txtar",
 +        "@org_golang_x_net//websocket:go_default_library",
++        "@org_golang_x_sys//execabs:go_default_library",
 +    ],
 +)
 +
@@ -11275,7 +11424,7 @@ diff -urN b/refactor/importgraph/BUILD.bazel c/refactor/importgraph/BUILD.bazel
 diff -urN b/refactor/rename/BUILD.bazel c/refactor/rename/BUILD.bazel
 --- b/refactor/rename/BUILD.bazel	1969-12-31 19:00:00.000000000 -0500
 +++ c/refactor/rename/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,41 @@
+@@ -0,0 +1,42 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -11296,6 +11445,7 @@ diff -urN b/refactor/rename/BUILD.bazel c/refactor/rename/BUILD.bazel
 +        "//go/types/typeutil",
 +        "//refactor/importgraph",
 +        "//refactor/satisfy",
++        "@org_golang_x_sys//execabs:go_default_library",
 +    ],
 +)
 +


### PR DESCRIPTION
`org_golang_x_tools` should have been updated in `v0.26.0`.

It requires `org_golang_x_sys` for the `execabs` package.

Fixes #2847
