### PR TITLE
Use absolute destination path so that the longpath windows code in st…

### DIFF
--- a/go/tools/builders/go_path.go
+++ b/go/tools/builders/go_path.go
@@ -154,7 +154,7 @@ func copyPath(out string, manifest []manifestEntry) error {
 		return err
 	}
 	for _, entry := range manifest {
-		dst := filepath.Join(out, filepath.FromSlash(entry.Dst))
+		dst := abs(filepath.Join(out, filepath.FromSlash(entry.Dst)))
 		if err := os.MkdirAll(filepath.Dir(dst), 0777); err != nil {
 			return err
 		}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This PR fixes an issue with longpaths on windows when using go_path's create mode.

**Which issues(s) does this PR fix?**

Fixes #2853 

**Other notes for review**

The standard library's GOPATH handling can only correctly fix absolute paths, as one can see here: https://github.com/golang/go/blob/master/src/os/path_windows.go#L172

Meaning, to take advantage of this, all we need to do is pass in an absolute path.
We do this by calling the already existing abs() helper.