### PR TITLE
go/tools: add gopackagesdriver

### DIFF
--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -67,9 +67,9 @@ def _build_stdlib_list_json(go):
 
 def _sdk_stdlib(go):
     return GoStdLib(
-        root_file = go.sdk.root_file,
-        list_json = _build_stdlib_list_json(go),
+        _list_json = _build_stdlib_list_json(go),
         libs = go.sdk.libs,
+        root_file = go.sdk.root_file,
     )
 
 def _build_stdlib(go):
@@ -114,7 +114,7 @@ def _build_stdlib(go):
         env = env,
     )
     return GoStdLib(
-        root_file = root_file,
-        list_json = _build_stdlib_list_json(go),
+        _list_json = _build_stdlib_list_json(go),
         libs = [pkg],
+        root_file = root_file,
     )

--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -51,9 +51,25 @@ def _should_use_sdk_stdlib(go):
             not go.mode.pure and
             go.mode.link == LINKMODE_NORMAL)
 
+def _build_stdlib_list_json(go):
+    out = go.declare_file(go, "stdlib.pkg.json")
+    args = go.builder_args(go, "stdliblist")
+    args.add("-out", out)
+    go.actions.run(
+        inputs = go.sdk_files,
+        outputs = [out],
+        mnemonic = "GoStdlibList",
+        executable = go.toolchain._builder,
+        arguments = [args],
+        env = go.env,
+    )
+    return out
+
+
 def _sdk_stdlib(go):
     return GoStdLib(
         root_file = go.sdk.root_file,
+        list_json = _build_stdlib_list_json(go),
         libs = go.sdk.libs,
     )
 
@@ -100,5 +116,6 @@ def _build_stdlib(go):
     )
     return GoStdLib(
         root_file = root_file,
+        list_json = _build_stdlib_list_json(go),
         libs = [pkg],
     )

--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -65,7 +65,6 @@ def _build_stdlib_list_json(go):
     )
     return out
 
-
 def _sdk_stdlib(go):
     return GoStdLib(
         root_file = go.sdk.root_file,

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -35,6 +35,7 @@ filegroup(
         "read.go",
         "replicate.go",
         "stdlib.go",
+        "stdliblist.go",
     ] + select({
         "@bazel_tools//src/conditions:windows": ["path_windows.go"],
         "//conditions:default": ["path.go"],

--- a/go/tools/builders/builder.go
+++ b/go/tools/builders/builder.go
@@ -59,6 +59,8 @@ func main() {
 		action = pack
 	case "stdlib":
 		action = stdlib
+	case "stdliblist":
+		action = stdliblist
 	default:
 		log.Fatalf("unknown action: %s", verb)
 	}

--- a/go/tools/builders/stdlib.go
+++ b/go/tools/builders/stdlib.go
@@ -112,7 +112,7 @@ You may need to use the flags --cpu=x64_windows --compiler=mingw-gcc.`)
 	// we strip the build ids, since they won't be used after this.
 	installArgs := goenv.goCmd("install", "-toolexec", abs(os.Args[0])+" filterbuildid")
 	if len(build.Default.BuildTags) > 0 {
-		installArgs = append(installArgs, "-tags", strings.Join(build.Default.BuildTags, " "))
+		installArgs = append(installArgs, "-tags", strings.Join(build.Default.BuildTags, ","))
 	}
 
 	gcflags := []string{}

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -140,6 +140,8 @@ func packageToPackage(execRoot string, pkg *goListPackage) *flatPackage {
 	for _, imp := range pkg.Imports {
 		newPkg.Imports[imp] = stdlibPackageID(imp)
 	}
+	// We don't support CGo for now
+	delete(newPkg.Imports, "C")
 	return newPkg
 }
 

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -1,0 +1,201 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"go/build"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Copy and pasted from golang.org/x/tools/go/packages
+type flatPackagesError struct {
+	Pos  string // "file:line:col" or "file:line" or "" or "-"
+	Msg  string
+	Kind flatPackagesErrorKind
+}
+
+type flatPackagesErrorKind int
+
+const (
+	UnknownError flatPackagesErrorKind = iota
+	ListError
+	ParseError
+	TypeError
+)
+
+func (err flatPackagesError) Error() string {
+	pos := err.Pos
+	if pos == "" {
+		pos = "-" // like token.Position{}.String()
+	}
+	return pos + ": " + err.Msg
+}
+
+// flatPackage is the JSON form of Package
+// It drops all the type and syntax fields, and transforms the Imports
+type flatPackage struct {
+	ID              string
+	Name            string              `json:",omitempty"`
+	PkgPath         string              `json:",omitempty"`
+	Standard        bool                `json:",omitempty"`
+	Errors          []flatPackagesError `json:",omitempty"`
+	GoFiles         []string            `json:",omitempty"`
+	CompiledGoFiles []string            `json:",omitempty"`
+	OtherFiles      []string            `json:",omitempty"`
+	ExportFile      string              `json:",omitempty"`
+	Imports         map[string]string   `json:",omitempty"`
+}
+
+type goListPackage struct {
+	Dir        string // directory containing package sources
+	ImportPath string // import path of package in dir
+	Name       string // package name
+	Target     string // install path
+	Goroot     bool   // is this package in the Go root?
+	Standard   bool   // is this package part of the standard Go library?
+	Root       string // Go root or Go path dir containing this package
+	Export     string // file containing export data (when using -export)
+	// Source files
+	GoFiles           []string // .go source files (excluding CgoFiles, TestGoFiles, XTestGoFiles)
+	CgoFiles          []string // .go source files that import "C"
+	CompiledGoFiles   []string // .go files presented to compiler (when using -compiled)
+	IgnoredGoFiles    []string // .go source files ignored due to build constraints
+	IgnoredOtherFiles []string // non-.go source files ignored due to build constraints
+	CFiles            []string // .c source files
+	CXXFiles          []string // .cc, .cxx and .cpp source files
+	MFiles            []string // .m source files
+	HFiles            []string // .h, .hh, .hpp and .hxx source files
+	FFiles            []string // .f, .F, .for and .f90 Fortran source files
+	SFiles            []string // .s source files
+	SwigFiles         []string // .swig files
+	SwigCXXFiles      []string // .swigcxx files
+	SysoFiles         []string // .syso object files to add to archive
+	TestGoFiles       []string // _test.go files in package
+	XTestGoFiles      []string // _test.go files outside package
+	// Embedded files
+	EmbedPatterns      []string // //go:embed patterns
+	EmbedFiles         []string // files matched by EmbedPatterns
+	TestEmbedPatterns  []string // //go:embed patterns in TestGoFiles
+	TestEmbedFiles     []string // files matched by TestEmbedPatterns
+	XTestEmbedPatterns []string // //go:embed patterns in XTestGoFiles
+	XTestEmbedFiles    []string // files matched by XTestEmbedPatterns
+	// Dependency information
+	Imports   []string          // import paths used by this package
+	ImportMap map[string]string // map from source import to ImportPath (identity entries omitted)
+	// Error information
+	Incomplete bool                 // this package or a dependency has an error
+	Error      *flatPackagesError   // error loading package
+	DepsErrors []*flatPackagesError // errors loading dependencies
+}
+
+func stdlibPackageID(importPath string) string {
+	return "@io_bazel_rules_go//stdlib:" + importPath
+}
+
+func execRootPath(execRoot, p string) string {
+	dir, _ := filepath.Rel(execRoot, p)
+	return filepath.Join("__BAZEL_EXECROOT__", dir)
+}
+
+func absoluteSourcesPaths(execRoot, pkgDir string, srcs []string) []string {
+	ret := []string{}
+	pkgDir = execRootPath(execRoot, pkgDir)
+	for _, src := range srcs {
+		ret = append(ret, filepath.Join(pkgDir, src))
+	}
+	return ret
+}
+
+func packageToPackage(execRoot string, pkg *goListPackage) *flatPackage {
+	newPkg := &flatPackage{
+		ID:              stdlibPackageID(pkg.ImportPath),
+		Name:            pkg.Name,
+		PkgPath:         pkg.ImportPath,
+		ExportFile:      execRootPath(execRoot, pkg.Target),
+		Imports:         map[string]string{},
+		Standard:        pkg.Standard,
+		GoFiles:         absoluteSourcesPaths(execRoot, pkg.Dir, pkg.GoFiles),
+		CompiledGoFiles: absoluteSourcesPaths(execRoot, pkg.Dir, pkg.CompiledGoFiles),
+	}
+	for _, imp := range pkg.Imports {
+		newPkg.Imports[imp] = stdlibPackageID(imp)
+	}
+	return newPkg
+}
+
+// stdlib builds the standard library in the appropriate mode into a new goroot.
+func stdliblist(args []string) error {
+	// process the args
+	flags := flag.NewFlagSet("stdliblist", flag.ExitOnError)
+	goenv := envFlags(flags)
+	out := flags.String("out", "", "Path to output go list json")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if err := goenv.checkFlags(); err != nil {
+		return err
+	}
+
+	// Ensure paths are absolute.
+	absPaths := []string{}
+	for _, path := range filepath.SplitList(os.Getenv("PATH")) {
+		absPaths = append(absPaths, abs(path))
+	}
+	os.Setenv("PATH", strings.Join(absPaths, string(os.PathListSeparator)))
+	os.Setenv("GOROOT", abs(os.Getenv("GOROOT")))
+
+	execRoot := abs(".")
+
+	cachePath := abs(*out + ".gocache")
+	defer os.RemoveAll(cachePath)
+	os.Setenv("GOCACHE", cachePath)
+	os.Setenv("GOPATH", cachePath)
+
+	listArgs := goenv.goCmd("list")
+	if len(build.Default.BuildTags) > 0 {
+		listArgs = append(listArgs, "-tags", strings.Join(build.Default.BuildTags, " "))
+	}
+	listArgs = append(listArgs, "-json", "-compiled", "builtin", "std", "runtime/cgo")
+
+	jsonFile, err := os.Create(*out)
+	if err != nil {
+		return err
+	}
+	defer jsonFile.Close()
+
+	jsonData := &bytes.Buffer{}
+	if err := goenv.runCommandToFile(jsonData, listArgs); err != nil {
+		return err
+	}
+
+	encoder := json.NewEncoder(jsonFile)
+	decoder := json.NewDecoder(jsonData)
+	for decoder.More() {
+		var pkg *goListPackage
+		if err := decoder.Decode(&pkg); err != nil {
+			return err
+		}
+		if err := encoder.Encode(packageToPackage(execRoot, pkg)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -165,6 +165,9 @@ func stdliblist(args []string) error {
 	}
 	os.Setenv("PATH", strings.Join(absPaths, string(os.PathListSeparator)))
 	os.Setenv("GOROOT", abs(os.Getenv("GOROOT")))
+	// Make sure we have an absolute path to the C compiler.
+	// TODO(#1357): also take absolute paths of includes and other paths in flags.
+	os.Setenv("CC", abs(os.Getenv("CC")))
 
 	execRoot := abs(".")
 

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -174,6 +174,7 @@ func stdliblist(args []string) error {
 	cachePath := abs(*out + ".gocache")
 	defer os.RemoveAll(cachePath)
 	os.Setenv("GOCACHE", cachePath)
+	os.Setenv("GOMODCACHE", cachePath)
 	os.Setenv("GOPATH", cachePath)
 
 	listArgs := goenv.goCmd("list")

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -123,7 +123,7 @@ func absoluteSourcesPaths(execRoot, pkgDir string, srcs []string) []string {
 	return ret
 }
 
-func packageToPackage(execRoot string, pkg *goListPackage) *flatPackage {
+func flatPackageForStd(execRoot string, pkg *goListPackage) *flatPackage {
 	// Don't use generated files from the stdlib
 	goFiles := absoluteSourcesPaths(execRoot, pkg.Dir, pkg.GoFiles)
 
@@ -200,7 +200,7 @@ func stdliblist(args []string) error {
 		if err := decoder.Decode(&pkg); err != nil {
 			return err
 		}
-		if err := encoder.Encode(packageToPackage(execRoot, pkg)); err != nil {
+		if err := encoder.Encode(flatPackageForStd(execRoot, pkg)); err != nil {
 			return err
 		}
 	}

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Bazel Authors. All rights reserved.
+// Copyright 2021 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -145,7 +145,7 @@ func flatPackageForStd(execRoot string, pkg *goListPackage) *flatPackage {
 	return newPkg
 }
 
-// stdlib builds the standard library in the appropriate mode into a new goroot.
+// stdliblist runs `go list -json` on the standard library and saves it to a file.
 func stdliblist(args []string) error {
 	// process the args
 	flags := flag.NewFlagSet("stdliblist", flag.ExitOnError)

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -115,7 +115,7 @@ func execRootPath(execRoot, p string) string {
 }
 
 func absoluteSourcesPaths(execRoot, pkgDir string, srcs []string) []string {
-	ret := []string{}
+	ret := make([]string, 0, len(srcs))
 	pkgDir = execRootPath(execRoot, pkgDir)
 	for _, src := range srcs {
 		ret = append(ret, filepath.Join(pkgDir, src))

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -124,6 +124,9 @@ func absoluteSourcesPaths(execRoot, pkgDir string, srcs []string) []string {
 }
 
 func packageToPackage(execRoot string, pkg *goListPackage) *flatPackage {
+	// Don't use generated files from the stdlib
+	goFiles := absoluteSourcesPaths(execRoot, pkg.Dir, pkg.GoFiles)
+
 	newPkg := &flatPackage{
 		ID:              stdlibPackageID(pkg.ImportPath),
 		Name:            pkg.Name,
@@ -131,8 +134,8 @@ func packageToPackage(execRoot string, pkg *goListPackage) *flatPackage {
 		ExportFile:      execRootPath(execRoot, pkg.Target),
 		Imports:         map[string]string{},
 		Standard:        pkg.Standard,
-		GoFiles:         absoluteSourcesPaths(execRoot, pkg.Dir, pkg.GoFiles),
-		CompiledGoFiles: absoluteSourcesPaths(execRoot, pkg.Dir, pkg.CompiledGoFiles),
+		GoFiles:         goFiles,
+		CompiledGoFiles: goFiles,
 	}
 	for _, imp := range pkg.Imports {
 		newPkg.Imports[imp] = stdlibPackageID(imp)
@@ -172,7 +175,7 @@ func stdliblist(args []string) error {
 	if len(build.Default.BuildTags) > 0 {
 		listArgs = append(listArgs, "-tags", strings.Join(build.Default.BuildTags, " "))
 	}
-	listArgs = append(listArgs, "-json", "-compiled", "builtin", "std", "runtime/cgo")
+	listArgs = append(listArgs, "-json", "builtin", "std", "runtime/cgo")
 
 	jsonFile, err := os.Create(*out)
 	if err != nil {

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -179,7 +179,7 @@ func stdliblist(args []string) error {
 
 	listArgs := goenv.goCmd("list")
 	if len(build.Default.BuildTags) > 0 {
-		listArgs = append(listArgs, "-tags", strings.Join(build.Default.BuildTags, " "))
+		listArgs = append(listArgs, "-tags", strings.Join(build.Default.BuildTags, ","))
 	}
 	listArgs = append(listArgs, "-json", "builtin", "std", "runtime/cgo")
 

--- a/go/tools/gopackagesdriver/BUILD.bazel
+++ b/go/tools/gopackagesdriver/BUILD.bazel
@@ -3,13 +3,13 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
-        "bazel_json_builder.go",
         "bazel.go",
+        "bazel_json_builder.go",
         "driver_request.go",
         "flatpackage.go",
         "json_packages_driver.go",
-        "packageregistry.go",
         "main.go",
+        "packageregistry.go",
     ],
     importpath = "github.com/bazelbuild/rules_go/go/tools/gopackagesdriver",
     visibility = ["//visibility:private"],

--- a/go/tools/gopackagesdriver/BUILD.bazel
+++ b/go/tools/gopackagesdriver/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "bazel_json_builder.go",
+        "bazel.go",
+        "driver_request.go",
+        "flatpackage.go",
+        "json_packages_driver.go",
+        "packageregistry.go",
+        "main.go",
+    ],
+    importpath = "github.com/bazelbuild/rules_go/go/tools/gopackagesdriver",
+    visibility = ["//visibility:private"],
+    deps = ["@org_golang_x_tools//go/packages:go_default_library"],
+)
+
+go_binary(
+    name = "gopackagesdriver",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/go/tools/gopackagesdriver/BUILD.bazel
+++ b/go/tools/gopackagesdriver/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "gopackagesdriver_lib",
     srcs = [
         "bazel.go",
         "bazel_json_builder.go",
@@ -17,6 +17,6 @@ go_library(
 
 go_binary(
     name = "gopackagesdriver",
-    embed = [":go_default_library"],
+    embed = [":gopackagesdriver_lib"],
     visibility = ["//visibility:public"],
 )

--- a/go/tools/gopackagesdriver/BUILD.bazel
+++ b/go/tools/gopackagesdriver/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
     ],
     importpath = "github.com/bazelbuild/rules_go/go/tools/gopackagesdriver",
     visibility = ["//visibility:private"],
-    deps = ["@org_golang_x_tools//go/packages:go_default_library"],
 )
 
 go_binary(

--- a/go/tools/gopackagesdriver/aspect.bzl
+++ b/go/tools/gopackagesdriver/aspect.bzl
@@ -1,0 +1,113 @@
+load("//go:def.bzl", "GoArchive")
+load(
+    "//go/private:context.bzl",
+    "go_context",
+)
+load(
+    "@bazel_skylib//lib:paths.bzl",
+    "paths",
+)
+load(
+    "@bazel_skylib//lib:collections.bzl",
+    "collections",
+)
+
+GoPkgInfo = provider()
+
+def _is_file_external(f):
+    return f.owner.workspace_root != ""
+
+def _file_path(f):
+    if f.is_source and not _is_file_external(f):
+        return paths.join("__BAZEL_WORKSPACE__", f.path)
+    return paths.join("__BAZEL_EXECROOT__", f.path)
+
+def _go_pkg_info_aspect_impl(target, ctx):
+    pkg_json = None
+    x = None
+    if GoArchive in target:
+        archive = target[GoArchive]
+        x = archive.data.export_file
+        pkg = struct(
+            ID = str(archive.data.label),
+            Name = "main" if archive.source.library.is_main else paths.basename(archive.data.importpath),
+            PkgPath = archive.data.importpath,
+            ExportFile = _file_path(archive.data.export_file),
+            GoFiles = [
+                _file_path(src)
+                for src in archive.data.orig_srcs
+            ],
+            CompiledGoFiles = [
+                _file_path(src)
+                for src in archive.data.srcs
+            ],
+        )
+        pkg_json = ctx.actions.declare_file(archive.data.name + ".pkg.json")
+        ctx.actions.write(pkg_json, content = pkg.to_json())
+
+    deps_transitive_json = []
+    deps_transitive_x = []
+    if hasattr(ctx.rule.attr, "deps"):
+        for dep in ctx.rule.attr.deps:
+            if GoPkgInfo in dep:
+                pkg_info = dep[GoPkgInfo]
+                deps_transitive_json.append(pkg_info.transitive_json)
+                deps_transitive_x.append(pkg_info.transitive_x)
+    # If deps are embedded, no not gather their json or x since they are
+    # included in the current target, but do gather their deps'.
+    if hasattr(ctx.rule.attr, "embed"):
+        for dep in ctx.rule.attr.embed:
+            if GoPkgInfo in dep:
+                pkg_info = dep[GoPkgInfo]
+                deps_transitive_json.append(pkg_info.deps_transitive_json)
+                deps_transitive_x.append(pkg_info.deps_transitive_x)
+
+    pkg_info = GoPkgInfo(
+        json = pkg_json,
+        transitive_json = depset(
+            direct = [pkg_json] if pkg_json else None,
+            transitive = deps_transitive_json,
+        ),
+        deps_transitive_json = depset(
+            transitive = deps_transitive_json,
+        ),
+        x = x,
+        transitive_x = depset(
+            direct = [x] if x else None,
+            transitive = deps_transitive_x,
+        ),
+        deps_transitive_x = depset(
+            transitive = deps_transitive_x,
+        ),
+    )
+
+    return [
+        pkg_info,
+        OutputGroupInfo(
+            go_pkg_driver_json = pkg_info.transitive_json,
+            go_pkg_driver_x = pkg_info.transitive_x,
+        )
+    ]
+
+go_pkg_info_aspect = aspect(
+    implementation = _go_pkg_info_aspect_impl,
+    attr_aspects = ["embed", "deps"],
+)
+
+def _go_std_pkg_info_aspect_impl(target, ctx):
+    go = go_context(ctx, attr = ctx.rule.attr)
+    return [
+        OutputGroupInfo(
+            go_pkg_driver_stdlib_json = [go.stdlib.list_json],
+        ),
+    ]
+
+go_std_pkg_info_aspect = aspect(
+    implementation = _go_std_pkg_info_aspect_impl,
+    attrs = {
+        "_go_context_data": attr.label(
+            default = "@io_bazel_rules_go//:go_context_data",
+        ),
+    },
+    toolchains = ["@io_bazel_rules_go//go:toolchain"],
+)

--- a/go/tools/gopackagesdriver/aspect.bzl
+++ b/go/tools/gopackagesdriver/aspect.bzl
@@ -1,3 +1,17 @@
+# Copyright 2021 The Bazel Go Rules Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 load(
     "//go/private:providers.bzl",
     "GoArchive",

--- a/go/tools/gopackagesdriver/aspect.bzl
+++ b/go/tools/gopackagesdriver/aspect.bzl
@@ -46,24 +46,22 @@ def _go_pkg_info_aspect_impl(target, ctx):
 
     deps_transitive_json_file = []
     deps_transitive_export_file = []
-    if hasattr(ctx.rule.attr, "deps"):
-        for dep in ctx.rule.attr.deps:
-            if GoPkgInfo in dep:
-                pkg_info = dep[GoPkgInfo]
-                deps_transitive_json_file.append(pkg_info.transitive_json_file)
-                deps_transitive_export_file.append(pkg_info.transitive_export_file)
-                # Fetch the stdlib json from the first dependency
-                if not stdlib_json_file:
-                    stdlib_json_file = pkg_info.stdlib_json_file
+    for dep in getattr(ctx.rule.attr, "deps", []):
+        if GoPkgInfo in dep:
+            pkg_info = dep[GoPkgInfo]
+            deps_transitive_json_file.append(pkg_info.transitive_json_file)
+            deps_transitive_export_file.append(pkg_info.transitive_export_file)
+            # Fetch the stdlib json from the first dependency
+            if not stdlib_json_file:
+                stdlib_json_file = pkg_info.stdlib_json_file
 
     # If deps are embedded, do not gather their json or export_file since they
     # are included in the current target, but do gather their deps'.
-    if hasattr(ctx.rule.attr, "embed"):
-        for dep in ctx.rule.attr.embed:
-            if GoPkgInfo in dep:
-                pkg_info = dep[GoPkgInfo]
-                deps_transitive_json_file.append(pkg_info.deps_transitive_json_file)
-                deps_transitive_export_file.append(pkg_info.deps_transitive_export_file)
+    for dep in getattr(ctx.rule.attr, "embed", []):
+        if GoPkgInfo in dep:
+            pkg_info = dep[GoPkgInfo]
+            deps_transitive_json_file.append(pkg_info.deps_transitive_json_file)
+            deps_transitive_export_file.append(pkg_info.deps_transitive_export_file)
 
     pkg_json_file = None
     export_file = None

--- a/go/tools/gopackagesdriver/aspect.bzl
+++ b/go/tools/gopackagesdriver/aspect.bzl
@@ -74,7 +74,7 @@ def _go_pkg_info_aspect_impl(target, ctx):
         # If there was no stdlib json in any dependencies, fetch it from the
         # current go_ node.
         if not stdlib_json_file:
-            stdlib_json_file = ctx.attr._go_stdlib[GoStdLib].list_json
+            stdlib_json_file = ctx.attr._go_stdlib[GoStdLib]._list_json
 
     pkg_info = GoPkgInfo(
         json = pkg_json_file,

--- a/go/tools/gopackagesdriver/aspect.bzl
+++ b/go/tools/gopackagesdriver/aspect.bzl
@@ -27,7 +27,7 @@ def _file_path(f):
     return paths.join("__BAZEL_EXECROOT__", f.path)
 
 def _go_pkg_info_aspect_impl(target, ctx):
-    # Fetch the stdlib JSON file from thte inner most target
+    # Fetch the stdlib JSON file from the inner most target
     stdlib_json = None
 
     deps_transitive_json = []
@@ -42,7 +42,7 @@ def _go_pkg_info_aspect_impl(target, ctx):
                 if not stdlib_json:
                     stdlib_json = pkg_info.stdlib_json
 
-    # If deps are embedded, no not gather their json or x since they are
+    # If deps are embedded, do not gather their json or x since they are
     # included in the current target, but do gather their deps'.
     if hasattr(ctx.rule.attr, "embed"):
         for dep in ctx.rule.attr.embed:

--- a/go/tools/gopackagesdriver/aspect.bzl
+++ b/go/tools/gopackagesdriver/aspect.bzl
@@ -30,7 +30,6 @@ def _go_pkg_info_aspect_impl(target, ctx):
         x = archive.data.export_file
         pkg = struct(
             ID = str(archive.data.label),
-            Name = "main" if archive.source.library.is_main else paths.basename(archive.data.importpath),
             PkgPath = archive.data.importpath,
             ExportFile = _file_path(archive.data.export_file),
             GoFiles = [

--- a/go/tools/gopackagesdriver/aspect.bzl
+++ b/go/tools/gopackagesdriver/aspect.bzl
@@ -100,9 +100,9 @@ def _go_pkg_info_aspect_impl(target, ctx):
         pkg_info,
         OutputGroupInfo(
             go_pkg_driver_json = pkg_info.transitive_json,
-            go_pkg_driver_stdlib_json = depset([pkg_info.stdlib_json]),
             go_pkg_driver_x = pkg_info.transitive_x,
-        )
+            go_pkg_driver_stdlib_json = depset([pkg_info.stdlib_json] if pkg_info.stdlib_json else [])
+        ),
     ]
 
 go_pkg_info_aspect = aspect(

--- a/go/tools/gopackagesdriver/bazel.go
+++ b/go/tools/gopackagesdriver/bazel.go
@@ -19,8 +19,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -98,7 +100,11 @@ func (b *Bazel) Build(ctx context.Context, args ...string) ([]string, error) {
 		}
 		if namedSet.NamedSetOfFiles != nil {
 			for _, f := range namedSet.NamedSetOfFiles.Files {
-				files = append(files, strings.TrimPrefix(f.URI, "file://"))
+				fileUrl, err := url.Parse(f.URI)
+				if err != nil {
+					return nil, fmt.Errorf("unable to parse file URI: %w", err)
+				}
+				files = append(files, filepath.FromSlash(fileUrl.Path))
 			}
 		}
 	}

--- a/go/tools/gopackagesdriver/bazel.go
+++ b/go/tools/gopackagesdriver/bazel.go
@@ -47,6 +47,8 @@ func (b *Bazel) run(ctx context.Context, command string, args ...string) (string
 	cmd := exec.CommandContext(ctx, b.bazelBin, append([]string{
 		command,
 		"--tool_tag=" + toolTag,
+		"--show_result=0",
+		"--ui_actions_shown=0",
 	}, args...)...)
 	fmt.Fprintln(os.Stderr, "Running:", cmd.Args)
 	cmd.Dir = b.workspaceRoot

--- a/go/tools/gopackagesdriver/bazel.go
+++ b/go/tools/gopackagesdriver/bazel.go
@@ -1,3 +1,17 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/go/tools/gopackagesdriver/bazel.go
+++ b/go/tools/gopackagesdriver/bazel.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const (
+	toolTag = "gopackagesdriver"
+)
+
+type Bazel struct {
+	bazelBin      string
+	execRoot      string
+	workspaceRoot string
+}
+
+// Minimal BEP structs to access the build outputs
+type BEPNamedSet struct {
+	NamedSetOfFiles *struct {
+		Files []struct {
+			Name string `json:"name"`
+			URI  string `json:"uri"`
+		} `json:"files"`
+	} `json:"namedSetOfFiles"`
+}
+
+func NewBazel(ctx context.Context, bazelBin, workspaceRoot string) (*Bazel, error) {
+	b := &Bazel{
+		bazelBin:      bazelBin,
+		workspaceRoot: workspaceRoot,
+	}
+	if execRoot, err := b.run(ctx, "info", "execution_root"); err != nil {
+		return nil, err
+	} else {
+		b.execRoot = strings.TrimSpace(execRoot)
+	}
+	return b, nil
+}
+
+func (b *Bazel) run(ctx context.Context, command string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, b.bazelBin, append([]string{
+		command,
+		"--tool_tag=" + toolTag,
+	}, args...)...)
+	fmt.Fprintln(os.Stderr, "Running:", cmd.Args)
+	cmd.Dir = b.workspaceRoot
+	cmd.Stderr = os.Stderr
+	output, err := cmd.Output()
+	return string(output), err
+}
+
+func (b *Bazel) Build(ctx context.Context, args ...string) ([]string, error) {
+	jsonTmp, _ := os.CreateTemp("", "bep_")
+	jsonTmp.Close()
+	defer os.RemoveAll(jsonTmp.Name())
+
+	args = append([]string{
+		"--build_event_json_file=" + jsonTmp.Name(),
+		"--build_event_json_file_path_conversion=no",
+	}, args...)
+	if _, err := b.run(ctx, "build", args...); err != nil {
+		return nil, err
+	}
+
+	jsonFile, err := os.Open(jsonTmp.Name())
+	if err != nil {
+		return nil, err
+	}
+	defer jsonFile.Close()
+
+	files := make([]string, 0)
+	decoder := json.NewDecoder(jsonFile)
+	for decoder.More() {
+		var namedSet BEPNamedSet
+		if err := decoder.Decode(&namedSet); err != nil {
+			panic(err)
+		}
+		if namedSet.NamedSetOfFiles != nil {
+			for _, f := range namedSet.NamedSetOfFiles.Files {
+				files = append(files, strings.TrimPrefix(f.URI, "file://"))
+			}
+		}
+	}
+
+	return files, nil
+}
+
+func (b *Bazel) Query(ctx context.Context, args ...string) ([]string, error) {
+	output, err := b.run(ctx, "query", args...)
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(strings.TrimSpace(output), "\n"), nil
+}
+
+func (b *Bazel) WorkspaceRoot() string {
+	return b.workspaceRoot
+}
+
+func (b *Bazel) ExecutionRoot() string {
+	return b.execRoot
+}

--- a/go/tools/gopackagesdriver/bazel.go
+++ b/go/tools/gopackagesdriver/bazel.go
@@ -80,7 +80,7 @@ func (b *Bazel) Build(ctx context.Context, args ...string) ([]string, error) {
 	for decoder.More() {
 		var namedSet BEPNamedSet
 		if err := decoder.Decode(&namedSet); err != nil {
-			return nil, fmt.Errorf("unable to decode %s: %w", jsonFile, err)
+			return nil, fmt.Errorf("unable to decode %s: %w", jsonFile.Name(), err)
 		}
 		if namedSet.NamedSetOfFiles != nil {
 			for _, f := range namedSet.NamedSetOfFiles.Files {

--- a/go/tools/gopackagesdriver/bazel.go
+++ b/go/tools/gopackagesdriver/bazel.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -55,7 +56,7 @@ func (b *Bazel) run(ctx context.Context, command string, args ...string) (string
 }
 
 func (b *Bazel) Build(ctx context.Context, args ...string) ([]string, error) {
-	jsonTmp, _ := os.CreateTemp("", "bep_")
+	jsonTmp, _ := ioutil.TempFile("", "bep_")
 	jsonTmp.Close()
 	defer os.RemoveAll(jsonTmp.Name())
 

--- a/go/tools/gopackagesdriver/bazel.go
+++ b/go/tools/gopackagesdriver/bazel.go
@@ -47,7 +47,6 @@ func (b *Bazel) run(ctx context.Context, command string, args ...string) (string
 	cmd := exec.CommandContext(ctx, b.bazelBin, append([]string{
 		command,
 		"--tool_tag=" + toolTag,
-		"--show_result=0",
 		"--ui_actions_shown=0",
 	}, args...)...)
 	fmt.Fprintln(os.Stderr, "Running:", cmd.Args)
@@ -68,6 +67,7 @@ func (b *Bazel) Build(ctx context.Context, args ...string) ([]string, error) {
 	}()
 
 	args = append([]string{
+		"--show_result=0",
 		"--build_event_json_file=" + jsonFile.Name(),
 		"--build_event_json_file_path_conversion=no",
 	}, args...)

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -33,7 +33,6 @@ func (b *BazelJSONBuilder) Build(ctx context.Context, needExports bool) ([]strin
 	buildsArgs := []string{
 		"--aspects=@io_bazel_rules_go//go/tools/gopackagesdriver:aspect.bzl%go_pkg_info_aspect",
 		"--output_groups=" + output_groups,
-		"--show_result=0",
 	}
 
 	if b.tagFilters != "" {

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+type BazelJSONBuilder struct {
+	bazel      *Bazel
+	query      string
+	tagFilters string
+	targets    []string
+}
+
+func NewBazelJSONBuilder(bazel *Bazel, query, tagFilters string, targets []string) (*BazelJSONBuilder, error) {
+	return &BazelJSONBuilder{
+		bazel:      bazel,
+		query:      query,
+		tagFilters: tagFilters,
+		targets:    targets,
+	}, nil
+}
+
+func (b *BazelJSONBuilder) Build(ctx context.Context, needExports bool) ([]string, error) {
+	output_groups := "go_pkg_driver_json,go_pkg_driver_stdlib_json"
+
+	// Override for now
+	needExports = true
+	if needExports {
+		output_groups += ",go_pkg_driver_x"
+	}
+	buildsArgs := []string{
+		"--aspects=@io_bazel_rules_go//go/tools/gopackagesdriver:aspect.bzl%go_pkg_info_aspect",
+		"--aspects=@io_bazel_rules_go//go/tools/gopackagesdriver:aspect.bzl%go_std_pkg_info_aspect",
+		"--output_groups=" + output_groups,
+	}
+
+	if b.tagFilters != "" {
+		buildsArgs = append(buildsArgs, "--build_tag_filters="+b.tagFilters)
+	}
+
+	if b.query != "" {
+		queryTargets, err := b.bazel.Query(ctx, b.query)
+		if err != nil {
+			return nil, fmt.Errorf("unable to query %v: %w", b.query, err)
+		}
+		buildsArgs = append(buildsArgs, queryTargets...)
+	}
+
+	buildsArgs = append(buildsArgs, b.targets...)
+
+	files, err := b.bazel.Build(ctx, buildsArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("unable to bazel build %v: %w", buildsArgs, err)
+	}
+
+	ret := []string{}
+	for _, f := range files {
+		if strings.HasSuffix(f, ".pkg.json") == false {
+			continue
+		}
+		ret = append(ret, f)
+	}
+
+	return ret, nil
+}
+
+func (b *BazelJSONBuilder) PathResolver() PathResolverFunc {
+	return func(p string) string {
+		p = strings.Replace(p, "__BAZEL_EXECROOT__", b.bazel.ExecutionRoot(), 1)
+		p = strings.Replace(p, "__BAZEL_WORKSPACE__", b.bazel.WorkspaceRoot(), 1)
+		return p
+	}
+}

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -14,9 +14,9 @@ type BazelJSONBuilder struct {
 }
 
 const (
-	OutputGroupDriverJSON  = "go_pkg_driver_json"
-	OutputGroupStdLibJSON  = "go_pkg_driver_stdlib_json"
-	OutputGroupExportFiles = "go_pkg_driver_x"
+	OutputGroupDriverJSONFile = "go_pkg_driver_json_file"
+	OutputGroupStdLibJSONFile = "go_pkg_driver_stdlib_json_file"
+	OutputGroupExportFile     = "go_pkg_driver_export_file"
 )
 
 func NewBazelJSONBuilder(bazel *Bazel, query, tagFilters string, targets []string) (*BazelJSONBuilder, error) {
@@ -29,9 +29,9 @@ func NewBazelJSONBuilder(bazel *Bazel, query, tagFilters string, targets []strin
 }
 
 func (b *BazelJSONBuilder) outputGroupsForMode(mode LoadMode) string {
-	og := OutputGroupDriverJSON + "," + OutputGroupStdLibJSON
+	og := OutputGroupDriverJSONFile + "," + OutputGroupStdLibJSONFile
 	if mode&NeedExportsFile != 0 || true { // override for now
-		og += "," + OutputGroupExportFiles
+		og += "," + OutputGroupExportFile
 	}
 	return og
 }

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -48,7 +48,16 @@ func (b *BazelJSONBuilder) Build(ctx context.Context, mode LoadMode) ([]string, 
 	}
 
 	if b.query != "" {
-		queryTargets, err := b.bazel.Query(ctx, b.query)
+		queryTargets, err := b.bazel.Query(
+			ctx,
+			"--order_output=no",
+			"--output=label",
+			"--experimental_graphless_query",
+			"--nodep_deps",
+			"--noimplicit_deps",
+			"--notool_deps",
+			b.query,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("unable to query %v: %w", b.query, err)
 		}

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -34,6 +34,7 @@ func (b *BazelJSONBuilder) Build(ctx context.Context, needExports bool) ([]strin
 		"--aspects=@io_bazel_rules_go//go/tools/gopackagesdriver:aspect.bzl%go_pkg_info_aspect",
 		"--aspects=@io_bazel_rules_go//go/tools/gopackagesdriver:aspect.bzl%go_std_pkg_info_aspect",
 		"--output_groups=" + output_groups,
+		"--show_result=0",
 	}
 
 	if b.tagFilters != "" {

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -1,3 +1,17 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -33,6 +33,7 @@ func (b *BazelJSONBuilder) Build(ctx context.Context, needExports bool) ([]strin
 	buildsArgs := []string{
 		"--aspects=@io_bazel_rules_go//go/tools/gopackagesdriver:aspect.bzl%go_pkg_info_aspect",
 		"--output_groups=" + output_groups,
+		"--keep_going", // Build all possible packages
 	}
 
 	if b.tagFilters != "" {

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -87,7 +87,7 @@ func (b *BazelJSONBuilder) Build(ctx context.Context, mode LoadMode) ([]string, 
 
 	ret := []string{}
 	for _, f := range files {
-		if strings.HasSuffix(f, ".pkg.json") == false {
+		if !strings.HasSuffix(f, ".pkg.json") {
 			continue
 		}
 		ret = append(ret, f)

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -32,7 +32,6 @@ func (b *BazelJSONBuilder) Build(ctx context.Context, needExports bool) ([]strin
 	}
 	buildsArgs := []string{
 		"--aspects=@io_bazel_rules_go//go/tools/gopackagesdriver:aspect.bzl%go_pkg_info_aspect",
-		"--aspects=@io_bazel_rules_go//go/tools/gopackagesdriver:aspect.bzl%go_std_pkg_info_aspect",
 		"--output_groups=" + output_groups,
 		"--show_result=0",
 	}

--- a/go/tools/gopackagesdriver/driver_request.go
+++ b/go/tools/gopackagesdriver/driver_request.go
@@ -1,3 +1,17 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/go/tools/gopackagesdriver/driver_request.go
+++ b/go/tools/gopackagesdriver/driver_request.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 )
 
@@ -67,7 +68,7 @@ type DriverRequest struct {
 func ReadDriverRequest(r io.Reader) (*DriverRequest, error) {
 	req := &DriverRequest{}
 	if err := json.NewDecoder(r).Decode(&req); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to decode driver request: %w", err)
 	}
 	return req, nil
 }

--- a/go/tools/gopackagesdriver/driver_request.go
+++ b/go/tools/gopackagesdriver/driver_request.go
@@ -3,21 +3,65 @@ package main
 import (
 	"encoding/json"
 	"io"
-
-	"golang.org/x/tools/go/packages"
 )
 
+// From https://pkg.go.dev/golang.org/x/tools/go/packages#LoadMode
+type LoadMode int
+
+// Only NeedExportsFile is needed in our case
+const (
+	// NeedName adds Name and PkgPath.
+	NeedName LoadMode = 1 << iota
+
+	// NeedFiles adds GoFiles and OtherFiles.
+	NeedFiles
+
+	// NeedCompiledGoFiles adds CompiledGoFiles.
+	NeedCompiledGoFiles
+
+	// NeedImports adds Imports. If NeedDeps is not set, the Imports field will contain
+	// "placeholder" Packages with only the ID set.
+	NeedImports
+
+	// NeedDeps adds the fields requested by the LoadMode in the packages in Imports.
+	NeedDeps
+
+	// NeedExportsFile adds ExportFile.
+	NeedExportsFile
+
+	// NeedTypes adds Types, Fset, and IllTyped.
+	NeedTypes
+
+	// NeedSyntax adds Syntax.
+	NeedSyntax
+
+	// NeedTypesInfo adds TypesInfo.
+	NeedTypesInfo
+
+	// NeedTypesSizes adds TypesSizes.
+	NeedTypesSizes
+
+	// typecheckCgo enables full support for type checking cgo. Requires Go 1.15+.
+	// Modifies CompiledGoFiles and Types, and has no effect on its own.
+	typecheckCgo
+
+	// NeedModule adds Module.
+	NeedModule
+)
+
+// From https://github.com/golang/tools/blob/v0.1.0/go/packages/external.go#L32
+// Most fields are disabled since there are no needs for them
 type DriverRequest struct {
-	Mode packages.LoadMode `json:"mode"`
+	Mode LoadMode `json:"mode"`
 	// Env specifies the environment the underlying build system should be run in.
-	Env []string `json:"env"`
+	// Env []string `json:"env"`
 	// BuildFlags are flags that should be passed to the underlying build system.
-	BuildFlags []string `json:"build_flags"`
+	// BuildFlags []string `json:"build_flags"`
 	// Tests specifies whether the patterns should also return test packages.
-	Tests bool `json:"tests"`
+	// Tests bool `json:"tests"`
 	// Overlay maps file paths (relative to the driver's working directory) to the byte contents
 	// of overlay files.
-	Overlay map[string][]byte `json:"overlay"`
+	// Overlay map[string][]byte `json:"overlay"`
 }
 
 func ReadDriverRequest(r io.Reader) (*DriverRequest, error) {

--- a/go/tools/gopackagesdriver/driver_request.go
+++ b/go/tools/gopackagesdriver/driver_request.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+
+	"golang.org/x/tools/go/packages"
+)
+
+type DriverRequest struct {
+	Mode packages.LoadMode `json:"mode"`
+	// Env specifies the environment the underlying build system should be run in.
+	Env []string `json:"env"`
+	// BuildFlags are flags that should be passed to the underlying build system.
+	BuildFlags []string `json:"build_flags"`
+	// Tests specifies whether the patterns should also return test packages.
+	Tests bool `json:"tests"`
+	// Overlay maps file paths (relative to the driver's working directory) to the byte contents
+	// of overlay files.
+	Overlay map[string][]byte `json:"overlay"`
+}
+
+func ReadDriverRequest(r io.Reader) (*DriverRequest, error) {
+	req := &DriverRequest{}
+	if err := json.NewDecoder(r).Decode(&req); err != nil {
+		return nil, err
+	}
+	return req, nil
+}

--- a/go/tools/gopackagesdriver/flatpackage.go
+++ b/go/tools/gopackagesdriver/flatpackage.go
@@ -1,3 +1,17 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/go/tools/gopackagesdriver/flatpackage.go
+++ b/go/tools/gopackagesdriver/flatpackage.go
@@ -101,6 +101,10 @@ func (fp *FlatPackage) ResolveImports(resolve ResolvePkgFunc) {
 		if err != nil {
 			continue
 		}
+		// If the name is not provided, fetch it from the sources
+		if fp.Name == "" {
+			fp.Name = f.Name.Name
+		}
 		for _, rawImport := range f.Imports {
 			imp := strings.Trim(rawImport.Path.Value, "\"")
 			// We don't handle CGo for now

--- a/go/tools/gopackagesdriver/flatpackage.go
+++ b/go/tools/gopackagesdriver/flatpackage.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"encoding/json"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+)
+
+type ResolvePkgFunc func(importPath string) *FlatPackage
+
+// Copy and pasted from golang.org/x/tools/go/packages
+type FlatPackagesError struct {
+	Pos  string // "file:line:col" or "file:line" or "" or "-"
+	Msg  string
+	Kind FlatPackagesErrorKind
+}
+
+type FlatPackagesErrorKind int
+
+const (
+	UnknownError FlatPackagesErrorKind = iota
+	ListError
+	ParseError
+	TypeError
+)
+
+func (err FlatPackagesError) Error() string {
+	pos := err.Pos
+	if pos == "" {
+		pos = "-" // like token.Position{}.String()
+	}
+	return pos + ": " + err.Msg
+}
+
+// FlatPackage is the JSON form of Package
+// It drops all the type and syntax fields, and transforms the Imports
+type FlatPackage struct {
+	ID              string
+	Name            string              `json:",omitempty"`
+	PkgPath         string              `json:",omitempty"`
+	Errors          []FlatPackagesError `json:",omitempty"`
+	GoFiles         []string            `json:",omitempty"`
+	CompiledGoFiles []string            `json:",omitempty"`
+	OtherFiles      []string            `json:",omitempty"`
+	ExportFile      string              `json:",omitempty"`
+	Imports         map[string]string   `json:",omitempty"`
+	Standard        bool                `json:",omitempty"`
+}
+
+type PackageFunc func(pkg *FlatPackage)
+type PathResolverFunc func(path string) string
+
+func resolvePathsInPlace(prf PathResolverFunc, paths []string) {
+	for i, path := range paths {
+		paths[i] = prf(path)
+	}
+}
+
+func WalkFlatPackagesFromJSON(jsonFile string, onPkg PackageFunc) error {
+	f, err := os.Open(jsonFile)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	decoder := json.NewDecoder(f)
+	for decoder.More() {
+		pkg := &FlatPackage{}
+		if err := decoder.Decode(&pkg); err != nil {
+			return err
+		}
+		onPkg(pkg)
+	}
+	return nil
+}
+
+func (fp *FlatPackage) ResolvePaths(prf PathResolverFunc) error {
+	resolvePathsInPlace(prf, fp.CompiledGoFiles)
+	resolvePathsInPlace(prf, fp.GoFiles)
+	resolvePathsInPlace(prf, fp.OtherFiles)
+	fp.ExportFile = prf(fp.ExportFile)
+	return nil
+}
+
+func (fp *FlatPackage) IsStdlib() bool {
+	return fp.Standard
+}
+
+func (fp *FlatPackage) ResolveImports(resolve ResolvePkgFunc) {
+	// Stdlib packages are already complete import wise
+	if fp.IsStdlib() {
+		return
+	}
+
+	fset := token.NewFileSet()
+
+	for _, file := range fp.CompiledGoFiles {
+		f, err := parser.ParseFile(fset, file, nil, parser.ImportsOnly)
+		if err != nil {
+			continue
+		}
+		for _, rawImport := range f.Imports {
+			imp := strings.Trim(rawImport.Path.Value, "\"")
+			if _, ok := fp.Imports[imp]; ok {
+				continue
+			}
+			if pkg := resolve(imp); pkg != nil {
+				if fp.Imports == nil {
+					fp.Imports = map[string]string{}
+				}
+				fp.Imports[imp] = pkg.ID
+			}
+		}
+	}
+}
+
+func (fp *FlatPackage) IsRoot() bool {
+	return strings.HasPrefix(fp.ID, "//")
+}

--- a/go/tools/gopackagesdriver/flatpackage.go
+++ b/go/tools/gopackagesdriver/flatpackage.go
@@ -103,6 +103,10 @@ func (fp *FlatPackage) ResolveImports(resolve ResolvePkgFunc) {
 		}
 		for _, rawImport := range f.Imports {
 			imp := strings.Trim(rawImport.Path.Value, "\"")
+			// We don't handle CGo for now
+			if imp == "C" {
+				continue
+			}
 			if _, ok := fp.Imports[imp]; ok {
 				continue
 			}

--- a/go/tools/gopackagesdriver/flatpackage.go
+++ b/go/tools/gopackagesdriver/flatpackage.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"go/parser"
 	"go/token"
 	"os"
@@ -61,7 +62,7 @@ func resolvePathsInPlace(prf PathResolverFunc, paths []string) {
 func WalkFlatPackagesFromJSON(jsonFile string, onPkg PackageFunc) error {
 	f, err := os.Open(jsonFile)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to open package JSON file: %w", err)
 	}
 	defer f.Close()
 
@@ -69,7 +70,7 @@ func WalkFlatPackagesFromJSON(jsonFile string, onPkg PackageFunc) error {
 	for decoder.More() {
 		pkg := &FlatPackage{}
 		if err := decoder.Decode(&pkg); err != nil {
-			return err
+			return fmt.Errorf("unable to decode package in %s: %w", f.Name(), err)
 		}
 		onPkg(pkg)
 	}

--- a/go/tools/gopackagesdriver/flatpackage.go
+++ b/go/tools/gopackagesdriver/flatpackage.go
@@ -6,6 +6,7 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -107,7 +108,10 @@ func (fp *FlatPackage) ResolveImports(resolve ResolvePkgFunc) {
 			fp.Name = f.Name.Name
 		}
 		for _, rawImport := range f.Imports {
-			imp := strings.Trim(rawImport.Path.Value, "\"")
+			imp, err := strconv.Unquote(rawImport.Path.Value)
+			if err != nil {
+				continue
+			}
 			// We don't handle CGo for now
 			if imp == "C" {
 				continue

--- a/go/tools/gopackagesdriver/json_packages_driver.go
+++ b/go/tools/gopackagesdriver/json_packages_driver.go
@@ -30,7 +30,6 @@ func NewJSONPackagesDriver(jsonFiles []string, prf PathResolverFunc) (*JSONPacka
 	return jpd, nil
 }
 
-// Match matches packages based on pattern
 func (b *JSONPackagesDriver) Packages() []*FlatPackage {
 	return b.registry.ToList()
 }

--- a/go/tools/gopackagesdriver/json_packages_driver.go
+++ b/go/tools/gopackagesdriver/json_packages_driver.go
@@ -14,7 +14,10 @@
 
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"go/types"
+)
 
 type JSONPackagesDriver struct {
 	registry *PackageRegistry
@@ -44,6 +47,13 @@ func NewJSONPackagesDriver(jsonFiles []string, prf PathResolverFunc) (*JSONPacka
 	return jpd, nil
 }
 
-func (b *JSONPackagesDriver) Packages() []*FlatPackage {
-	return b.registry.ToList()
+func (b *JSONPackagesDriver) Match(pattern ...string) *driverResponse {
+	rootPkgs, packages := b.registry.Match(pattern...)
+
+	return &driverResponse{
+		NotHandled: false,
+		Sizes:      types.SizesFor("gc", "amd64").(*types.StdSizes),
+		Roots:      rootPkgs,
+		Packages:   packages,
+	}
 }

--- a/go/tools/gopackagesdriver/json_packages_driver.go
+++ b/go/tools/gopackagesdriver/json_packages_driver.go
@@ -1,0 +1,36 @@
+package main
+
+import "fmt"
+
+type JSONPackagesDriver struct {
+	registry *PackageRegistry
+}
+
+func NewJSONPackagesDriver(jsonFiles []string, prf PathResolverFunc) (*JSONPackagesDriver, error) {
+	jpd := &JSONPackagesDriver{
+		registry: NewPackageRegistry(),
+	}
+
+	for _, f := range jsonFiles {
+		if err := WalkFlatPackagesFromJSON(f, func(pkg *FlatPackage) {
+			jpd.registry.Add(pkg)
+		}); err != nil {
+			return nil, fmt.Errorf("unable to walk json: %w", err)
+		}
+	}
+
+	if err := jpd.registry.ResolvePaths(prf); err != nil {
+		return nil, err
+	}
+
+	if err := jpd.registry.ResolveImports(); err != nil {
+		return nil, err
+	}
+
+	return jpd, nil
+}
+
+// Match matches packages based on pattern
+func (b *JSONPackagesDriver) Packages() []*FlatPackage {
+	return b.registry.ToList()
+}

--- a/go/tools/gopackagesdriver/json_packages_driver.go
+++ b/go/tools/gopackagesdriver/json_packages_driver.go
@@ -1,3 +1,17 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import "fmt"

--- a/go/tools/gopackagesdriver/json_packages_driver.go
+++ b/go/tools/gopackagesdriver/json_packages_driver.go
@@ -20,11 +20,11 @@ func NewJSONPackagesDriver(jsonFiles []string, prf PathResolverFunc) (*JSONPacka
 	}
 
 	if err := jpd.registry.ResolvePaths(prf); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to resolve paths: %w", err)
 	}
 
 	if err := jpd.registry.ResolveImports(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to resolve paths: %w", err)
 	}
 
 	return jpd, nil

--- a/go/tools/gopackagesdriver/main.go
+++ b/go/tools/gopackagesdriver/main.go
@@ -1,3 +1,17 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/go/tools/gopackagesdriver/main.go
+++ b/go/tools/gopackagesdriver/main.go
@@ -126,6 +126,7 @@ func run() error {
 
 func main() {
 	if err := run(); err != nil {
-		panic(err)
+		fmt.Fprintf(os.Stderr, "error: %w", err)
+		os.Exit(1)
 	}
 }

--- a/go/tools/gopackagesdriver/main.go
+++ b/go/tools/gopackagesdriver/main.go
@@ -103,20 +103,9 @@ func run() error {
 		return fmt.Errorf("unable to load JSON files: %w", err)
 	}
 
-	pkgs := driver.Packages()
-	roots := []string{}
-	for _, pkg := range pkgs {
-		if pkg.IsRoot() {
-			roots = append(roots, pkg.ID)
-		}
-	}
+	response := driver.Match(os.Args[1:]...)
+	// return nil
 
-	response := &driverResponse{
-		NotHandled: false,
-		Sizes:      types.SizesFor("gc", "amd64").(*types.StdSizes),
-		Roots:      roots,
-		Packages:   pkgs,
-	}
 	if err := json.NewEncoder(os.Stdout).Encode(response); err != nil {
 		return fmt.Errorf("unable to encode response: %w", err)
 	}

--- a/go/tools/gopackagesdriver/main.go
+++ b/go/tools/gopackagesdriver/main.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"os/signal"
 	"strings"
-
-	"golang.org/x/tools/go/packages"
 )
 
 type driverResponse struct {
@@ -81,7 +79,7 @@ func run() error {
 		targets = strings.Split(targetsStr, " ")
 	}
 	bazelJsonBuilder, err := NewBazelJSONBuilder(bazel, targetsQueryStr, targetsTagFilters, targets)
-	jsonFiles, err := bazelJsonBuilder.Build(ctx, request.Mode&packages.NeedExportsFile != 0)
+	jsonFiles, err := bazelJsonBuilder.Build(ctx, request.Mode)
 	if err != nil {
 		return fmt.Errorf("unable to build JSON files: %w", err)
 	}

--- a/go/tools/gopackagesdriver/main.go
+++ b/go/tools/gopackagesdriver/main.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"go/types"
+	"os"
+	"os/signal"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+)
+
+type driverResponse struct {
+	NotHandled bool
+
+	// Sizes, if not nil, is the types.Sizes to use when type checking.
+	Sizes *types.StdSizes
+
+	// Roots is the set of package IDs that make up the root packages.
+	// We have to encode this separately because when we encode a single package
+	// we cannot know if it is one of the roots as that requires knowledge of the
+	// graph it is part of.
+	Roots []string `json:",omitempty"`
+
+	// Packages is the full set of packages in the graph.
+	// The packages are not connected into a graph.
+	// The Imports if populated will be stubs that only have their ID set.
+	// Imports will be connected and then type and syntax information added in a
+	// later pass (see refine).
+	Packages []*FlatPackage
+}
+
+const (
+	defaultBazelBin = "bazel"
+)
+
+var (
+	bazelBin          = os.Getenv("GOPACKAGESDRIVER_BAZEL")
+	workspaceRoot     = os.Getenv("GOPACKAGESDRIVER_BAZEL_WORKSPACE")
+	targetsStr        = os.Getenv("GOPACKAGESDRIVER_BAZEL_TARGETS")
+	targetsQueryStr   = os.Getenv("GOPACKAGESDRIVER_BAZEL_QUERY")
+	targetsTagFilters = os.Getenv("GOPACKAGESDRIVER_BAZEL_TAG_FILTERS")
+)
+
+func run() error {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	request, err := ReadDriverRequest(os.Stdin)
+	if err != nil {
+		return fmt.Errorf("unable to read request: %w", err)
+	}
+
+	if bazelBin == "" {
+		bazelBin = defaultBazelBin
+	}
+	bazel, err := NewBazel(ctx, bazelBin, workspaceRoot)
+	if err != nil {
+		return fmt.Errorf("unable to create bazel instance: %w", err)
+	}
+
+	targets := []string{}
+	if targetsStr != "" {
+		targets = strings.Split(targetsStr, " ")
+	}
+	bazelJsonBuilder, err := NewBazelJSONBuilder(bazel, targetsQueryStr, targetsTagFilters, targets)
+	jsonFiles, err := bazelJsonBuilder.Build(ctx, request.Mode&packages.NeedExportsFile != 0)
+	if err != nil {
+		return fmt.Errorf("unable to build JSON files: %w", err)
+	}
+
+	driver, err := NewJSONPackagesDriver(jsonFiles, bazelJsonBuilder.PathResolver())
+	if err != nil {
+		return fmt.Errorf("unable to load JSON files: %w", err)
+	}
+
+	pkgs := driver.Packages()
+	roots := []string{}
+	for _, pkg := range pkgs {
+		if pkg.IsRoot() {
+			roots = append(roots, pkg.ID)
+		}
+	}
+
+	response := &driverResponse{
+		NotHandled: false,
+		Sizes:      types.SizesFor("gc", "amd64").(*types.StdSizes),
+		Roots:      roots,
+		Packages:   pkgs,
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(response); err != nil {
+		return fmt.Errorf("unable to encode response: %w", err)
+	}
+
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		panic(err)
+	}
+}

--- a/go/tools/gopackagesdriver/main.go
+++ b/go/tools/gopackagesdriver/main.go
@@ -36,7 +36,7 @@ const (
 
 var (
 	bazelBin          = os.Getenv("GOPACKAGESDRIVER_BAZEL")
-	workspaceRoot     = os.Getenv("GOPACKAGESDRIVER_BAZEL_WORKSPACE")
+	workspaceRoot     = os.Getenv("BUILD_WORKSPACE_DIRECTORY")
 	targetsStr        = os.Getenv("GOPACKAGESDRIVER_BAZEL_TARGETS")
 	targetsQueryStr   = os.Getenv("GOPACKAGESDRIVER_BAZEL_QUERY")
 	targetsTagFilters = os.Getenv("GOPACKAGESDRIVER_BAZEL_TAG_FILTERS")

--- a/go/tools/gopackagesdriver/main.go
+++ b/go/tools/gopackagesdriver/main.go
@@ -79,6 +79,10 @@ func run() error {
 		targets = strings.Split(targetsStr, " ")
 	}
 	bazelJsonBuilder, err := NewBazelJSONBuilder(bazel, targetsQueryStr, targetsTagFilters, targets)
+	if err != nil {
+		return fmt.Errorf("unable to build JSON files: %w", err)
+	}
+
 	jsonFiles, err := bazelJsonBuilder.Build(ctx, request.Mode)
 	if err != nil {
 		return fmt.Errorf("unable to build JSON files: %w", err)

--- a/go/tools/gopackagesdriver/main.go
+++ b/go/tools/gopackagesdriver/main.go
@@ -33,7 +33,7 @@ type driverResponse struct {
 var (
 	bazelBin          = getenvDefault("GOPACKAGESDRIVER_BAZEL", "bazel")
 	workspaceRoot     = os.Getenv("BUILD_WORKSPACE_DIRECTORY")
-	targetsStr        = os.Getenv("GOPACKAGESDRIVER_BAZEL_TARGETS")
+	targets           = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_TARGETS"))
 	targetsQueryStr   = os.Getenv("GOPACKAGESDRIVER_BAZEL_QUERY")
 	targetsTagFilters = os.Getenv("GOPACKAGESDRIVER_BAZEL_TAG_FILTERS")
 )
@@ -74,10 +74,6 @@ func run() error {
 		return fmt.Errorf("unable to create bazel instance: %w", err)
 	}
 
-	targets := []string{}
-	if targetsStr != "" {
-		targets = strings.Split(targetsStr, " ")
-	}
 	bazelJsonBuilder, err := NewBazelJSONBuilder(bazel, targetsQueryStr, targetsTagFilters, targets)
 	if err != nil {
 		return fmt.Errorf("unable to build JSON files: %w", err)

--- a/go/tools/gopackagesdriver/main.go
+++ b/go/tools/gopackagesdriver/main.go
@@ -30,17 +30,20 @@ type driverResponse struct {
 	Packages []*FlatPackage
 }
 
-const (
-	defaultBazelBin = "bazel"
-)
-
 var (
-	bazelBin          = os.Getenv("GOPACKAGESDRIVER_BAZEL")
+	bazelBin          = getenvDefault("GOPACKAGESDRIVER_BAZEL", "bazel")
 	workspaceRoot     = os.Getenv("BUILD_WORKSPACE_DIRECTORY")
 	targetsStr        = os.Getenv("GOPACKAGESDRIVER_BAZEL_TARGETS")
 	targetsQueryStr   = os.Getenv("GOPACKAGESDRIVER_BAZEL_QUERY")
 	targetsTagFilters = os.Getenv("GOPACKAGESDRIVER_BAZEL_TAG_FILTERS")
 )
+
+func getenvDefault(key, defaultValue string) string {
+	if v, ok := os.LookupEnv(key); ok {
+		return v
+	}
+	return defaultValue
+}
 
 func signalContext(parentCtx context.Context, signals ...os.Signal) (ctx context.Context, stop context.CancelFunc) {
 	ctx, cancel := context.WithCancel(parentCtx)
@@ -66,9 +69,6 @@ func run() error {
 		return fmt.Errorf("unable to read request: %w", err)
 	}
 
-	if bazelBin == "" {
-		bazelBin = defaultBazelBin
-	}
 	bazel, err := NewBazel(ctx, bazelBin, workspaceRoot)
 	if err != nil {
 		return fmt.Errorf("unable to create bazel instance: %w", err)

--- a/go/tools/gopackagesdriver/packageregistry.go
+++ b/go/tools/gopackagesdriver/packageregistry.go
@@ -1,16 +1,12 @@
 package main
 
 type PackageRegistry struct {
-	packagesByID         map[string]*FlatPackage
 	packagesByImportPath map[string]*FlatPackage
-	packagesByFile       map[string]*FlatPackage
 }
 
 func NewPackageRegistry(pkgs ...*FlatPackage) *PackageRegistry {
 	pr := &PackageRegistry{
-		packagesByID:         map[string]*FlatPackage{},
 		packagesByImportPath: map[string]*FlatPackage{},
-		packagesByFile:       map[string]*FlatPackage{},
 	}
 	pr.Add(pkgs...)
 	return pr
@@ -18,55 +14,39 @@ func NewPackageRegistry(pkgs ...*FlatPackage) *PackageRegistry {
 
 func (pr *PackageRegistry) Add(pkgs ...*FlatPackage) *PackageRegistry {
 	for _, pkg := range pkgs {
-		pr.packagesByID[pkg.ID] = pkg
 		pr.packagesByImportPath[pkg.PkgPath] = pkg
-		for _, f := range pkg.GoFiles {
-			pr.packagesByFile[f] = pkg
-		}
 	}
 	return pr
-}
-
-func (pr *PackageRegistry) FromPkgID(pkgPath string) *FlatPackage {
-	return pr.packagesByImportPath[pkgPath]
 }
 
 func (pr *PackageRegistry) FromPkgPath(pkgPath string) *FlatPackage {
 	return pr.packagesByImportPath[pkgPath]
 }
 
-func (pr *PackageRegistry) FromFile(filePath string) *FlatPackage {
-	return pr.packagesByFile[filePath]
-}
-
 func (pr *PackageRegistry) Remove(pkgs ...*FlatPackage) *PackageRegistry {
 	for _, pkg := range pkgs {
-		delete(pr.packagesByID, pkg.ID)
 		delete(pr.packagesByImportPath, pkg.PkgPath)
-		for _, f := range pkg.GoFiles {
-			delete(pr.packagesByFile, f)
-		}
 	}
 	return pr
 }
 
 func (pr *PackageRegistry) ToList() []*FlatPackage {
-	pkgs := make([]*FlatPackage, 0, len(pr.packagesByID))
-	for _, pkg := range pr.packagesByID {
+	pkgs := make([]*FlatPackage, 0, len(pr.packagesByImportPath))
+	for _, pkg := range pr.packagesByImportPath {
 		pkgs = append(pkgs, pkg)
 	}
 	return pkgs
 }
 
 func (pr *PackageRegistry) ResolvePaths(prf PathResolverFunc) error {
-	for _, pkg := range pr.packagesByID {
+	for _, pkg := range pr.packagesByImportPath {
 		pkg.ResolvePaths(prf)
 	}
 	return nil
 }
 
 func (pr *PackageRegistry) ResolveImports() error {
-	for _, pkg := range pr.packagesByID {
+	for _, pkg := range pr.packagesByImportPath {
 		pkg.ResolveImports(func(importPath string) *FlatPackage {
 			return pr.FromPkgPath(importPath)
 		})

--- a/go/tools/gopackagesdriver/packageregistry.go
+++ b/go/tools/gopackagesdriver/packageregistry.go
@@ -1,0 +1,75 @@
+package main
+
+type PackageRegistry struct {
+	packagesByID         map[string]*FlatPackage
+	packagesByImportPath map[string]*FlatPackage
+	packagesByFile       map[string]*FlatPackage
+}
+
+func NewPackageRegistry(pkgs ...*FlatPackage) *PackageRegistry {
+	pr := &PackageRegistry{
+		packagesByID:         map[string]*FlatPackage{},
+		packagesByImportPath: map[string]*FlatPackage{},
+		packagesByFile:       map[string]*FlatPackage{},
+	}
+	pr.Add(pkgs...)
+	return pr
+}
+
+func (pr *PackageRegistry) Add(pkgs ...*FlatPackage) *PackageRegistry {
+	for _, pkg := range pkgs {
+		pr.packagesByID[pkg.ID] = pkg
+		pr.packagesByImportPath[pkg.PkgPath] = pkg
+		for _, f := range pkg.GoFiles {
+			pr.packagesByFile[f] = pkg
+		}
+	}
+	return pr
+}
+
+func (pr *PackageRegistry) FromPkgID(pkgPath string) *FlatPackage {
+	return pr.packagesByImportPath[pkgPath]
+}
+
+func (pr *PackageRegistry) FromPkgPath(pkgPath string) *FlatPackage {
+	return pr.packagesByImportPath[pkgPath]
+}
+
+func (pr *PackageRegistry) FromFile(filePath string) *FlatPackage {
+	return pr.packagesByFile[filePath]
+}
+
+func (pr *PackageRegistry) Remove(pkgs ...*FlatPackage) *PackageRegistry {
+	for _, pkg := range pkgs {
+		delete(pr.packagesByID, pkg.ID)
+		delete(pr.packagesByImportPath, pkg.PkgPath)
+		for _, f := range pkg.GoFiles {
+			delete(pr.packagesByFile, f)
+		}
+	}
+	return pr
+}
+
+func (pr *PackageRegistry) ToList() []*FlatPackage {
+	pkgs := make([]*FlatPackage, 0, len(pr.packagesByID))
+	for _, pkg := range pr.packagesByID {
+		pkgs = append(pkgs, pkg)
+	}
+	return pkgs
+}
+
+func (pr *PackageRegistry) ResolvePaths(prf PathResolverFunc) error {
+	for _, pkg := range pr.packagesByID {
+		pkg.ResolvePaths(prf)
+	}
+	return nil
+}
+
+func (pr *PackageRegistry) ResolveImports() error {
+	for _, pkg := range pr.packagesByID {
+		pkg.ResolveImports(func(importPath string) *FlatPackage {
+			return pr.FromPkgPath(importPath)
+		})
+	}
+	return nil
+}

--- a/go/tools/gopackagesdriver/packageregistry.go
+++ b/go/tools/gopackagesdriver/packageregistry.go
@@ -1,3 +1,17 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 type PackageRegistry struct {


### PR DESCRIPTION
This commit introduces an aspect based `GOPACKAGESDRIVER` for `rules_go`.

It is rather clunky, but all VSCode + `gopls` features work with it:
- Completion
- Go to definition
- Go to references
- Quick lookup
- Inline documentation

It does not support static usage at the moment (for instance by running it inside an action for codegen tools), but it could with few additions.

## Usage
The packages driver fundamentally works from the perspective of one or more targets. In order
for it to function properly, the targets must be specified in the packages driver configuration,
with environment variables.

These are:
- `GOPACKAGESDRIVER_BAZEL_TARGETS`: specifies specific targets, `//...` works too (although this is not recommended without tag filters). It is possible to set targets to something other than `go_` rules, as long as the `go_` nodes are reachable via the `deps` attribute in the graph. Such as when `go_binary(linkmode = "c-archive") -> cc_library`.
- `GOPACKAGESDRIVER_BAZEL_QUERY`: runs a `bazel query` to select targets before, common one should be `kind(go_binary, //...)`. This should work for most cases.
- `GOPACKAGESDRIVER_BAZEL_TAG_FILTERS`: makes use of the [`--build_tag_filters`](https://docs.bazel.build/versions/3.2.0/command-line-reference.html#flag--build_tag_filters) option to only build (filter) targets with certain tags. This is useful for when you want each target to define wether or not it should be part of the packages list. For instance, set `GOPACKAGESDRIVER_BAZEL_TARGETS="//..."` and `GOPACKAGESDRIVER_BAZEL_TAG_FILTERS="completion"` to only build targets with the `completion` tag in the whole workspace.

In addition, those environment variables are optional:
- `GOPACKAGESDRIVER_BAZEL`: bazel binary, defaults to `bazel`
- `BUILD_WORKSPACE_DIRECTORY`: directory of the bazel workspace (should be auto detected when using a launcher script because it invokes `bazel run`)

### 1. `gopls`
You'll need `gopls >= v0.6.10` ([released on Apr 13th 2021](https://github.com/golang/tools/releases/tag/gopls%2Fv0.6.10)). If you are using VSCode, it should be automatic.

### 2. Create a launcher script
Create a launcher script, say `tools/gopackagesdriver.sh`:
```bash
#!/usr/bin/env bash
exec bazel run -- @io_bazel_rules_go//go/tools/gopackagesdriver "${@}"
```

### 3. Sample VSCode configuration
In `.vscode/settings.json` add the following:
```json
    "go.goroot": "${workspaceFolder}/bazel-${workspaceFolderBasename}/external/go_sdk",
    "go.toolsEnvVars": {
      "GOPACKAGESDRIVER_BAZEL_QUERY": "kind(go_binary, //...)",
      "GOPACKAGESDRIVER": "${workspaceFolder}/tools/gopackagesdriver.sh"
    },
    "go.useLanguageServer": true,
```

Open VSCode, and after a while the packages should be properly detected after the build is done.

The same principles should apply for vim-go or any editor that uses `gopls`.

## Limitations
- CGo completion may not work, but at least it's not explicitly supported.
- Errors are not handled
- ~Query patterns are ignored and the whole graph is returned each time~ patterns are now used
- ~Root packages detection is probably wrong~ it should be better now

## Technical details
### Aspects
Most of the work is done by one aspect that generates a minimum package JSON entry, and extracts/forwards the Stdlib JSON packages file from the deepest `go_` target in the graph (ie once all configurations/transitions are applied).

Each JSON file can contain one or more Go packages definition. Which are then loaded, their paths expanded to real absolute paths. Then, the package files are read to get the real package name and its imports list. Imports are then resolved to other packages in the graph.

### stdlib packages
Because stdlib packages are not part of the bazel graph, the packages driver will open the `.go` files of each package and scan its imports to then resolve all packages, including of course stdlib.

The whole stdlib definition sits inside one JSON file, which is generated by the `stdliblist` builder. It executes `go list builtin std runtime/cgo` and then transforms its output to match the JSON packages.

This list file is fetched from the deepest `go_` target in the graph so that all configurations and transitions are applied.