### PR TITLE
nogo: properly check filename for inclusion/exclusion

### DIFF
--- a/go/tools/builders/nogo_main.go
+++ b/go/tools/builders/nogo_main.go
@@ -394,10 +394,10 @@ func checkAnalysisResults(actions []*action, pkg *goPackage) string {
 		for _, d := range act.diagnostics {
 			// NOTE(golang.org/issue/31008): nilness does not set positions,
 			// so don't assume the position is valid.
-			f := pkg.fset.File(d.Pos)
+			p := pkg.fset.Position(d.Pos)
 			filename := "-"
-			if f != nil {
-				filename = f.Name()
+			if p.IsValid() {
+				filename = p.Filename
 			}
 			include := true
 			if len(config.onlyFiles) > 0 {

--- a/tests/core/nogo/custom/custom_test.go
+++ b/tests/core/nogo/custom/custom_test.go
@@ -79,6 +79,13 @@ go_library(
 )
 
 go_library(
+    name = "has_errors_linedirective",
+    srcs = ["has_errors_linedirective.go"],
+    importpath = "haserrors_linedirective",
+    deps = [":dep"],
+)
+
+go_library(
     name = "no_errors",
     srcs = ["no_errors.go"],
     importpath = "noerrors",
@@ -290,8 +297,25 @@ import (
 )
 
 func Foo() bool { // This should fail foofuncname
-	dep.D()     // This should fail visibility
-	return true // This should fail boolreturn
+	dep.D() // This should fail visibility
+	return true
+}
+
+-- has_errors_linedirective.go --
+//line linedirective.go:1
+package haserrors_linedirective
+
+import (
+	/*line linedirective_importfmt.go:4*/ _ "fmt" // This should fail importfmt
+
+	"dep"
+)
+
+//line linedirective_foofuncname.go:9
+func Foo() bool { // This should fail foofuncname
+//line linedirective_visibility.go:10
+	dep.D() // This should fail visibility
+	return true
 }
 
 -- no_errors.go --
@@ -332,7 +356,17 @@ func Test(t *testing.T) {
 				`has_errors.go:.*function D is not visible in this package \(visibility\)`,
 			},
 		}, {
+			desc:        "default_config_linedirective",
+			target:      "//:has_errors_linedirective",
+			wantSuccess: false,
+			includes: []string{
+				`linedirective_importfmt.go:.*package fmt must not be imported \(importfmt\)`,
+				`linedirective_foofuncname.go:.*function must not be named Foo \(foofuncname\)`,
+				`linedirective_visibility.go:.*function D is not visible in this package \(visibility\)`,
+			},
+		}, {
 			desc:        "custom_config",
+			config:      "config.json",
 			target:      "//:has_errors",
 			wantSuccess: false,
 			includes: []string{
@@ -340,7 +374,19 @@ func Test(t *testing.T) {
 				`has_errors.go:.*function must not be named Foo \(foofuncname\)`,
 			},
 			excludes: []string{
-				"custom/has_errors.go:.*function D is not visible in this package",
+				`visib`,
+			},
+		}, {
+			desc:        "custom_config_linedirective",
+			config:      "config.json",
+			target:      "//:has_errors_linedirective",
+			wantSuccess: false,
+			includes: []string{
+				`linedirective_foofuncname.go:.*function must not be named Foo \(foofuncname\)`,
+				`linedirective_visibility.go:.*function D is not visible in this package \(visibility\)`,
+			},
+			excludes: []string{
+				`importfmt`,
 			},
 		}, {
 			desc:        "no_errors",


### PR DESCRIPTION


<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Go files could include `//line` comments that indicate the original location of the line. This functionality is used, among other things, cgo's code rewrite step. This commit changes the include/exclude_files logic to use the adjusted/original location, in order to better align with user expectations.

**Which issues(s) does this PR fix?**

Fixes #2862

**Other notes for review**
