### PR TITLE
Expand Make variables in c/cpp/cxx/clinkopts

### DIFF
--- a/go/private/actions/compilepkg.bzl
+++ b/go/private/actions/compilepkg.bzl
@@ -92,10 +92,7 @@ def emit_compilepkg(
     if testfilter:
         args.add("-testfilter", testfilter)
 
-    gc_flags = [
-        go._ctx.expand_make_variables("gc_goopts", f, {})
-        for f in gc_goopts
-    ]
+    gc_flags = list(gc_goopts)
     asm_flags = []
     if go.mode.race:
         gc_flags.append("-race")

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -226,14 +226,14 @@ def _library_to_source(go, attr, library, coverage_instrumented):
         "embedsrcs": embedsrcs,
         "x_defs": {},
         "deps": getattr(attr, "deps", []),
-        "gc_goopts": getattr(attr, "gc_goopts", []),
+        "gc_goopts": _expand_opts(go, "gc_goopts", getattr(attr, "gc_goopts", [])),
         "runfiles": _collect_runfiles(go, getattr(attr, "data", []), getattr(attr, "deps", [])),
         "cgo": getattr(attr, "cgo", False),
         "cdeps": getattr(attr, "cdeps", []),
-        "cppopts": getattr(attr, "cppopts", []),
-        "copts": getattr(attr, "copts", []),
-        "cxxopts": getattr(attr, "cxxopts", []),
-        "clinkopts": getattr(attr, "clinkopts", []),
+        "cppopts": _expand_opts(go, "cppopts", getattr(attr, "cppopts", [])),
+        "copts": _expand_opts(go, "copts", getattr(attr, "copts", [])),
+        "cxxopts": _expand_opts(go, "cxxopts", getattr(attr, "cxxopts", [])),
+        "clinkopts": _expand_opts(go, "clinkopts", getattr(attr, "clinkopts", [])),
         "cgo_deps": [],
         "cgo_exports": [],
     }
@@ -815,3 +815,6 @@ go_config = rule(
     configuration. Rules may depend on this instead of depending on all
     the build settings directly.""",
 )
+
+def _expand_opts(go, attribute_name, opts):
+    return [go._ctx.expand_make_variables(attribute_name, opt, {}) for opt in opts]

--- a/tests/core/cgo/BUILD.bazel
+++ b/tests/core/cgo/BUILD.bazel
@@ -7,6 +7,33 @@ go_test(
     embed = [":opts"],
 )
 
+genrule(
+    name = "generate_header_copts",
+    outs = ["generated_copts/generated_copts.h"],
+    cmd = "echo '#define GENERATED_COPTS 1' >$@",
+)
+
+genrule(
+    name = "generate_header_cppopts",
+    outs = ["generated_cppopts/generated_cppopts.h"],
+    cmd = "echo '#define GENERATED_CPPOPTS 1' >$@",
+)
+
+genrule(
+    name = "generate_header_cxxopts",
+    outs = ["generated_cxxopts/generated_cxxopts.h"],
+    cmd = "echo '#define GENERATED_CXXOPTS 1' >$@",
+)
+
+cc_library(
+    name = "generated_headers",
+    hdrs = [
+        "generated_copts/generated_copts.h",
+        "generated_cppopts/generated_cppopts.h",
+        "generated_cxxopts/generated_cxxopts.h",
+    ],
+)
+
 go_library(
     name = "opts",
     srcs = [
@@ -21,10 +48,23 @@ go_library(
         ],
         "//conditions:default": [],
     }),
+    cdeps = [":generated_headers"],
     cgo = True,
-    copts = ["-DRULES_GO_C"],
-    cppopts = ["-DRULES_GO_CPP"],
-    cxxopts = ["-DRULES_GO_CXX"],
+    copts = [
+        "-DRULES_GO_C",
+        "-I$(GENDIR)/tests/core/cgo/generated_copts",
+        "-DDOLLAR_SIGN_C=$$",  # the dollar sign should be escaped
+    ],
+    cppopts = [
+        "-DRULES_GO_CPP",
+        "-I$(GENDIR)/tests/core/cgo/generated_cppopts",
+        "-DDOLLAR_SIGN_CPP=$$",  # the dollar sign should be escaped
+    ],
+    cxxopts = [
+        "-DRULES_GO_CXX",
+        "-I$(GENDIR)/tests/core/cgo/generated_cxxopts",
+        "-DDOLLAR_SIGN_CXX=$$",  # the dollar sign should be escaped
+    ],
     importpath = "github.com/bazelbuild/rules_go/tests/core/cxx",
 )
 

--- a/tests/core/cgo/add.c
+++ b/tests/core/cgo/add.c
@@ -1,9 +1,19 @@
 #include <add.h>
+#include <generated_cppopts.h>
+#include <generated_copts.h>
 
 #if !defined(RULES_GO_C) || !defined(RULES_GO_CPP) || defined(RULES_GO_CXX)
 #error This is a C file, only RULES_GO_C and RULES_GO_CPP should be defined.
 #endif
 
+#if !defined(GENERATED_COPTS) || !defined(GENERATED_CPPOPTS) || defined(GENERATED_CXXOPTS)
+#error Generated headers should be correctly included
+#endif
+
 int add_c(int a, int b) {
-    return a + b;
+    int $ = 0;
+    int sum = a + b;
+    sum += DOLLAR_SIGN_C;
+    sum += DOLLAR_SIGN_CPP;
+    return sum;
 }

--- a/tests/core/cgo/add.cpp
+++ b/tests/core/cgo/add.cpp
@@ -1,9 +1,19 @@
 #include "add.h"
+#include <generated_cppopts.h>
+#include <generated_cxxopts.h>
 
 #if !defined(RULES_GO_CPP) || !defined(RULES_GO_CXX) || defined(RULES_GO_C)
 #error This is a C++ file, only RULES_GO_CXX and RULES_GO_CPP should be defined.
 #endif
 
+#if !defined(GENERATED_CPPOPTS) || !defined(GENERATED_CXXOPTS) || defined(GENERATED_COPTS)
+#error Generated headers should be correctly included
+#endif
+
 int add_cpp(int a, int b) {
-    return a + b;
+    int $ = 0;
+    int sum = a + b;
+    sum += DOLLAR_SIGN_CXX;
+    sum += DOLLAR_SIGN_CPP;
+    return sum;
 }

--- a/tests/core/cgo/add.m
+++ b/tests/core/cgo/add.m
@@ -1,5 +1,11 @@
 #include "add.h"
+#include <generated_cppopts.h>
+#include <generated_copts.h>
 
 #if !defined(RULES_GO_C) || !defined(RULES_GO_CPP) || defined(RULES_GO_CXX)
 #error This is an Objective-C file, only RULES_GO_C and RULES_GO_CPP should be defined.
+#endif
+
+#if !defined(GENERATED_COPTS) || !defined(GENERATED_CPPOPTS) || defined(GENERATED_CXXOPTS)
+#error Generated headers should be correctly included
 #endif

--- a/tests/core/cgo/add.mm
+++ b/tests/core/cgo/add.mm
@@ -1,5 +1,11 @@
 #include "add.h"
+#include <generated_cppopts.h>
+#include <generated_cxxopts.h>
 
 #if !defined(RULES_GO_CPP) || !defined(RULES_GO_CXX) || defined(RULES_GO_C)
 #error This is an Objective-C++ file, only RULES_GO_CXX and RULES_GO_CPP should be defined.
+#endif
+
+#if !defined(GENERATED_CPPOPTS) || !defined(GENERATED_CXXOPTS) || defined(GENERATED_COPTS)
+#error Generated headers should be correctly included
 #endif


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The documentation for `go_library`, `go_binary`, etc., claims that certain compiler options are subject to "Make variable" substitution. However, this is not the case for the majority of cases: only `gc_goopts` and `gc_linkopts` were handled correctly. This commit fixes that behavior.

**Which issues(s) does this PR fix?**

Fixes #2864

**Other notes for review**
