### PR TITLE
Support python runfiles MANIFEST on windows

### DIFF
--- a/go/tools/bazel/bazel_test.go
+++ b/go/tools/bazel/bazel_test.go
@@ -221,7 +221,7 @@ func TestEnterRunfiles(t *testing.T) {
 	}
 }
 
-func TestPythonWindowsManifest(t *testing.T) {
+func TestPythonManifest(t *testing.T) {
 	cleanup, err := makeAndEnterTempdir()
 	if err != nil {
 		t.Fatal(err)
@@ -239,7 +239,9 @@ func TestPythonWindowsManifest(t *testing.T) {
 
 	originalEnvVar := os.Getenv(RUNFILES_MANIFEST_FILE)
 	defer func() {
-		os.Setenv(RUNFILES_MANIFEST_FILE, originalEnvVar)
+		if err = os.Setenv(RUNFILES_MANIFEST_FILE, originalEnvVar); err != nil {
+			t.Fatalf("Failed to reset environment: %v", err)
+		}
 	}()
 
 	if err = os.Setenv(RUNFILES_MANIFEST_FILE, "MANIFEST"); err != nil {
@@ -250,6 +252,15 @@ func TestPythonWindowsManifest(t *testing.T) {
 
 	if runfiles.err != nil {
 		t.Errorf("failed to init runfiles: %v", runfiles.err)
+	}
+
+	entry, ok := runfiles.index["important.txt"]
+	if !ok {
+		t.Errorf("failed to locate runfile %s in index", "important.txt")
+	}
+
+	if entry.Workspace != "__main__" {
+		t.Errorf("incorrect workspace for runfile. Expected: %s, actual %s", "__main__", entry.Workspace)
 	}
 
 }

--- a/go/tools/bazel/bazel_test.go
+++ b/go/tools/bazel/bazel_test.go
@@ -220,3 +220,36 @@ func TestEnterRunfiles(t *testing.T) {
 		t.Errorf("data-file not found in current directory (%s); entered invalid runfiles tree?", wd)
 	}
 }
+
+func TestPythonWindowsManifest(t *testing.T) {
+	cleanup, err := makeAndEnterTempdir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	err = ioutil.WriteFile("MANIFEST",
+		// all on one line to make sure the whitespace stays exactly as in the source file
+		[]byte("__init__.py \n__main__/external/__init__.py \n__main__/external/rules_python/__init__.py \n__main__/external/rules_python/python/__init__.py \n__main__/external/rules_python/python/runfiles/__init__.py \n__main__/external/rules_python/python/runfiles/runfiles.py C:/users/sam/_bazel_sam/pj4cl7d4/external/rules_python/python/runfiles/runfiles.py\n__main__/go_cat_/go_cat.exe C:/users/sam/_bazel_sam/pj4cl7d4/execroot/__main__/bazel-out/x64_windows-opt-exec-2B5CBBC6/bin/go_cat_/go_cat.exe\n__main__/important.txt C:/users/sam/dev/rules_go_runfiles_repro/important.txt\n__main__/parent.exe C:/users/sam/_bazel_sam/pj4cl7d4/execroot/__main__/bazel-out/x64_windows-opt-exec-2B5CBBC6/bin/parent.exe\n__main__/parent.py C:/users/sam/dev/rules_go_runfiles_repro/parent.py\n__main__/parent.zip C:/users/sam/_bazel_sam/pj4cl7d4/execroot/__main__/bazel-out/x64_windows-opt-exec-2B5CBBC6/bin/parent.zip\nrules_python/__init__.py \nrules_python/python/__init__.py \nrules_python/python/runfiles/__init__.py \nrules_python/python/runfiles/runfiles.py C:/users/sam/_bazel_sam/pj4cl7d4/external/rules_python/python/runfiles/runfiles.py"),
+		os.FileMode(0644),
+	)
+	if err != nil {
+		t.Fatalf("Failed to write sample manifest: %v", err)
+	}
+
+	originalEnvVar := os.Getenv(RUNFILES_MANIFEST_FILE)
+	defer func() {
+		os.Setenv(RUNFILES_MANIFEST_FILE, originalEnvVar)
+	}()
+
+	if err = os.Setenv(RUNFILES_MANIFEST_FILE, "MANIFEST"); err != nil {
+		t.Fatalf("Failed to set manifest file environement variable: %v", err)
+	}
+
+	initRunfiles()
+
+	if runfiles.err != nil {
+		t.Errorf("failed to init runfiles: %v", runfiles.err)
+	}
+
+}

--- a/go/tools/bazel/runfiles.go
+++ b/go/tools/bazel/runfiles.go
@@ -334,7 +334,8 @@ func initRunfiles() {
 
 			spaceIndex := bytes.IndexByte(line, ' ')
 			if spaceIndex < 0 {
-				runfiles.err = fmt.Errorf("error parsing runfiles manifest: %s:%d: no space: '%s'", manifest, lineno, line)
+				runfiles.err = fmt.Errorf(
+					"error parsing runfiles manifest: %s:%d: no space: '%s'", manifest, lineno, line)
 				return
 			}
 			shortPath := string(line[0:spaceIndex])

--- a/go/tools/bazel/runfiles.go
+++ b/go/tools/bazel/runfiles.go
@@ -325,9 +325,12 @@ func initRunfiles() {
 				data = data[i+1:]
 			}
 			lineno++
-			// don't trim whitespace here: if we are executing using python's runfiles on windows we'll have manifest
-			// lines like `__init.py__ ` note the space at the end, but no actual file after the space.
-			// https://github.com/bazelbuild/rules_go/issues/2866
+
+			// Only TrimRight newlines. Do not TrimRight() completely, because that would remove spaces too.
+			// This is necessary in order to have at least one space in every manifest line.
+			// Some manifest entries don't have any path after this space, namely the "__init__.py" entries.
+			// original comment sourced from: https://github.com/bazelbuild/bazel/blob/09c621e4cf5b968f4c6cdf905ab142d5961f9ddc/src/test/py/bazel/runfiles_test.py#L225
+			line = bytes.TrimRight(line, "\r\n")
 			if len(line) == 0 {
 				continue
 			}


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
This PR fixes compatibility with a MANIFEST file generated for a rules_python binary. Python manifests can have "one-part" entries like `__init__.py ` where a line terminates with a space and does not map to another file.

**Which issues(s) does this PR fix?**

Fixes #2866 

**Other notes for review**

I wasn't sure about how exactly this fix should be tested. I think the "proper" test is actually an integration test as written over in https://github.com/samhowes/rules_go_runfiles_repro/blob/main/BUILD.bazel since this issue is really dependent on bazel's generation of a MANIFEST for python `__init__.py` modules ([see comment on runfiles_test.py](https://github.com/bazelbuild/bazel/blob/09c621e4cf5b968f4c6cdf905ab142d5961f9ddc/src/test/py/bazel/runfiles_test.py#L225)). Since this repository does not currently have a (declared) dep on `rules_python`, I did not bring that test over here. 

