### PR TITLE
[bazel_testing] Fix off-by-one error

### DIFF
--- a/go/tools/bazel_testing/bazel_testing.go
+++ b/go/tools/bazel_testing/bazel_testing.go
@@ -132,7 +132,7 @@ func TestMain(m *testing.M, args Args) {
 		return
 	}
 	if beginFiles >= 0 {
-		files = os.Args[beginFiles+1 : endFiles-1]
+		files = os.Args[beginFiles+1 : endFiles]
 		os.Args = append(os.Args[:beginFiles:beginFiles], os.Args[endFiles+1:]...)
 	}
 


### PR DESCRIPTION
The current implementation always skips the last entry between -begin_files and -end_files

