### PR TITLE
[bazeltesting] Refactor to SpliceOSArgs utility function

### DIFF
--- a/go/tools/bazel/bazel_test.go
+++ b/go/tools/bazel/bazel_test.go
@@ -14,6 +14,7 @@
 package bazel
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -263,4 +264,83 @@ func TestPythonManifest(t *testing.T) {
 		t.Errorf("incorrect workspace for runfile. Expected: %s, actual %s", "__main__", entry.Workspace)
 	}
 
+}
+
+func TestSpliceDelimitedOSArgs(t *testing.T) {
+	testData := map[string]struct {
+		initial []string
+		want    []string
+		final   []string
+		wantErr error
+	}{
+		"no args": {
+			[]string{},
+			[]string{},
+			[]string{},
+			nil,
+		},
+		"empty splice": {
+			[]string{"-begin_files", "-end_files"},
+			[]string{},
+			[]string{},
+			nil,
+		},
+		"removes inner args": {
+			[]string{"-begin_files", "a", "-end_files"},
+			[]string{"a"},
+			[]string{},
+			nil,
+		},
+		"preserves outer args": {
+			[]string{"a", "-begin_files", "b", "-end_files", "c"},
+			[]string{"b"},
+			[]string{"a", "c"},
+			nil,
+		},
+		"complains about missing delimiter": {
+			[]string{"-begin_files"},
+			[]string{},
+			[]string{},
+			errors.New("error: -begin_files, -end_files not set together or in order"),
+		},
+		"complains about out-of-order delimiter": {
+			[]string{"-end_files", "-begin_files"},
+			[]string{},
+			[]string{},
+			errors.New("error: -begin_files, -end_files not set together or in order"),
+		},
+	}
+	for name, tc := range testData {
+		t.Run(name, func(t *testing.T) {
+			os.Args = tc.initial
+			got, err := SpliceDelimitedOSArgs("-begin_files", "-end_files")
+			if err != nil {
+				if tc.wantErr == nil {
+					t.Fatalf("unexpected err: %v", err)
+				}
+				if tc.wantErr.Error() != err.Error() {
+					t.Fatalf("err: want %v, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if len(tc.want) != len(got) {
+				t.Errorf("len(want: %d, got %d", len(tc.want), len(got))
+			}
+			for i, actual := range got {
+				expected := tc.want[i]
+				if expected != actual {
+					t.Errorf("%d: want %v, got %v", i, expected, actual)
+				}
+			}
+			if len(tc.final) != len(os.Args) {
+				t.Errorf("len(want: %d, os.Args %d", len(tc.final), len(os.Args))
+			}
+			for i, actual := range os.Args {
+				expected := tc.final[i]
+				if expected != actual {
+					t.Errorf("%d: want %v, os.Args %v", i, expected, actual)
+				}
+			}
+		})
+	}
 }

--- a/go/tools/bazel/bazel_test.go
+++ b/go/tools/bazel/bazel_test.go
@@ -292,13 +292,19 @@ func TestSpliceDelimitedOSArgs(t *testing.T) {
 			nil,
 		},
 		"preserves outer args": {
-			[]string{"a", "-begin_files", "b", "-end_files", "c"},
-			[]string{"b"},
-			[]string{"a", "c"},
+			[]string{"a", "-begin_files", "b", "c", "-end_files", "d"},
+			[]string{"b", "c"},
+			[]string{"a", "d"},
 			nil,
 		},
-		"complains about missing delimiter": {
+		"complains about missing end delimiter": {
 			[]string{"-begin_files"},
+			[]string{},
+			[]string{},
+			errors.New("error: -begin_files, -end_files not set together or in order"),
+		},
+		"complains about missing begin delimiter": {
+			[]string{"-end_files"},
 			[]string{},
 			[]string{},
 			errors.New("error: -begin_files, -end_files not set together or in order"),
@@ -308,6 +314,18 @@ func TestSpliceDelimitedOSArgs(t *testing.T) {
 			[]string{},
 			[]string{},
 			errors.New("error: -begin_files, -end_files not set together or in order"),
+		},
+		"-- at middle": {
+			[]string{"-begin_files", "a", "b", "--", "-end_files"},
+			[]string{},
+			[]string{},
+			errors.New("error: -begin_files, -end_files not set together or in order"),
+		},
+		"-- at beginning": {
+			[]string{"--", "-begin_files", "a", "-end_files"},
+			[]string{},
+			[]string{"--", "-begin_files", "a", "-end_files"},
+			nil,
 		},
 	}
 	for name, tc := range testData {
@@ -324,7 +342,7 @@ func TestSpliceDelimitedOSArgs(t *testing.T) {
 				return
 			}
 			if len(tc.want) != len(got) {
-				t.Errorf("len(want: %d, got %d", len(tc.want), len(got))
+				t.Fatalf("len(want: %d, got %d", len(tc.want), len(got))
 			}
 			for i, actual := range got {
 				expected := tc.want[i]
@@ -333,7 +351,7 @@ func TestSpliceDelimitedOSArgs(t *testing.T) {
 				}
 			}
 			if len(tc.final) != len(os.Args) {
-				t.Errorf("len(want: %d, os.Args %d", len(tc.final), len(os.Args))
+				t.Fatalf("len(want: %d, os.Args %d", len(tc.final), len(os.Args))
 			}
 			for i, actual := range os.Args {
 				expected := tc.final[i]

--- a/go/tools/bazel_testing/bazel_testing.go
+++ b/go/tools/bazel_testing/bazel_testing.go
@@ -113,27 +113,10 @@ func TestMain(m *testing.M, args Args) {
 		os.Exit(code)
 	}()
 
-	var files []string
-	beginFiles, endFiles := -1, -1
-	for i, arg := range os.Args {
-		if arg == "-begin_files" {
-			beginFiles = i
-		} else if arg == "-end_files" {
-			endFiles = i
-			break
-		} else if arg == "--" {
-			break
-		}
-	}
-	if beginFiles >= 0 && endFiles < 0 ||
-		beginFiles < 0 && endFiles >= 0 ||
-		beginFiles >= 0 && beginFiles >= endFiles {
-		fmt.Fprintf(os.Stderr, "error: -begin_files, -end_files not set together or in order\n")
+	files, err := bazel.SpliceDelimitedOSArgs("-begin_files", "-end_files")
+	if err != nil {
+		fmt.Fprint(os.Stderr, err)
 		return
-	}
-	if beginFiles >= 0 {
-		files = os.Args[beginFiles+1 : endFiles-1]
-		os.Args = append(os.Args[:beginFiles:beginFiles], os.Args[endFiles+1:]...)
 	}
 
 	flag.Parse()


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Fixes a bug 

**Which issues(s) does this PR fix?**

Fixes #2886

This PR replaces #2882 (that one was done using github editor).  Based on feedback, created this PR.

Note, this function cannot easily be put into the `bazeltesting` package because it already has a `TestMain`.  As such, I put it in the `bazel` package where a number of utility functions used by `bazeltesting` already exist.