### PR TITLE
Support multiple keys in x_defs

### DIFF
--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -134,15 +134,12 @@ def emit_link(
     ]))
     extldflags.extend(cgo_rpaths)
 
-    # Process x_defs, either adding them directly to linker options, or
-    # saving them to process through stamping support.
+    # Process x_defs, and record whether stamping is used.
     stamp_x_defs = False
     for k, v in archive.x_defs.items():
-        if go.stamp and v.startswith("{") and v.endswith("}"):
-            builder_args.add("-Xstamp", "%s=%s" % (k, v[1:-1]))
+        if go.stamp and v.find("{") != -1 and v.find("}") != -1:
             stamp_x_defs = True
-        else:
-            builder_args.add("-X", "%s=%s" % (k, v))
+        builder_args.add("-X", "%s=%s" % (k, v))
 
     # Stamping support
     stamp_inputs = []

--- a/tests/legacy/examples/stamped_bin/stamped_test.go
+++ b/tests/legacy/examples/stamped_bin/stamped_test.go
@@ -42,6 +42,7 @@ go_test(
         "github.com/bazelbuild/rules_go/examples/stamped_bin/stamp.BUILD_TIMESTAMP": "{BUILD_TIMESTAMP}",
         "github.com/bazelbuild/rules_go/examples/stamped_bin/stamp.PassIfEmpty": "",
         "github.com/bazelbuild/rules_go/examples/stamped_bin/stamp.XdefInvalid": "{Undefined_Var}",  # undefined should leave the var alone
+        "github.com/bazelbuild/rules_go/examples/stamped_bin/stamp.Multiple": "{BUILD_TIMESTAMP}{BUILD_TIMESTAMP}",
     },
     deps = [":stamp"],
 )
@@ -59,6 +60,9 @@ var XdefBuildTimestamp = ""
 
 // an xdef with a missing key should leave this alone
 var XdefInvalid = "pass"
+
+// an xdef with multiple keys
+var Multiple = "fail"
 
 -- stamped_bin_test.go --
 package stamped_bin_test
@@ -84,6 +88,9 @@ func TestStampedBin(t *testing.T) {
 	}
 	if stamp.XdefInvalid != "pass" {
 		t.Errorf("Expected XdefInvalid to have been left alone, got %s.", stamp.XdefInvalid)
+	}
+	if stamp.Multiple != stamp.BUILD_TIMESTAMP + stamp.BUILD_TIMESTAMP {
+		t.Errorf("Expected Multiple to have two BUILD_TIMESTAMP, got %s.", stamp.Multiple)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**

Support string interpolation in `x_defs`.

```bazel
go_binary(
  x_defs = {
    "myvar": "{BUILD_USER} built me at {BUILD_TIMESTAMP}",
  }
)
```

**Which issues(s) does this PR fix?**

Fixes #2075

**Other notes for review**
