### PR TITLE
Revert change to use resolved shared lib links

### DIFF
--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -188,10 +188,10 @@ def _cc_libs_and_flags(target):
                 libs.append(library_to_link.static_library)
             elif library_to_link.pic_static_library != None:
                 libs.append(library_to_link.pic_static_library)
-            elif library_to_link.resolved_symlink_interface_library != None:
-                libs.append(library_to_link.resolved_symlink_interface_library)
-            elif library_to_link.resolved_symlink_dynamic_library != None:
-                libs.append(library_to_link.resolved_symlink_dynamic_library)
+            elif library_to_link.interface_library != None:
+                libs.append(library_to_link.interface_library)
+            elif library_to_link.dynamic_library != None:
+                libs.append(library_to_link.dynamic_library)
     return libs, flags
 
 _DEFAULT_PLATFORM_COPTS = select({


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Reverts changes in
https://github.com/bazelbuild/rules_go/pull/2445/files#diff-1fae1aeb9bbd89e02d89a880ef0d1122bd51b265bc281978f01c14fc27f41f47R191

Instead of using resolved shared library name, depend on symlinks that use mangled name.
More details in #2906

**Which issues(s) does this PR fix?**

Fixes #2906

**Other notes for review**

Would be great to add some test case for it, but it seems it reproduces using `--remote_download_minimal` for now. Possibly the issue does not show up without this option, because code is able to escape sandbox and see actual library, but don't have good way for reproducing it atm.