### PR TITLE
Update Bazel and Ubuntu versions in CI configuration

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,13 +1,13 @@
 ---
 tasks:
-  ubuntu1804_bazel350:
+  ubuntu1804_bazel400:
     platform: ubuntu1804
-    bazel: 3.5.0 # test minimum supported version of bazel on ubuntu1604 only
+    bazel: 4.0.0 # test minimum supported version of bazel
     build_targets:
     - "//..."
     test_targets:
     - "//..."
-  ubuntu1804:
+  ubuntu2004:
     # enable some unflipped incompatible flags on this platform to ensure we don't regress.
     build_flags:
     - "--incompatible_load_cc_rules_from_bzl"

--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -208,7 +208,7 @@ def has_versioned_shared_lib_extension(path):
 
     return True
 
-MINIMUM_BAZEL_VERSION = "3.0.0"
+MINIMUM_BAZEL_VERSION = "4.0.0"
 
 def as_list(v):
     """Returns a list, tuple, or depset as a list."""


### PR DESCRIPTION
* Bazel 4.0.0 is now the minimum supported version.
  This is the LTS release.
* This is tested on Ubuntu 18.04, the oldest supported Ubuntu release.
* The latest version of Bazel is now tested on Ubuntu 20.04.
