### PR TITLE
gopackagesdriver: Fix Fprintf verb

### DIFF
--- a/go/tools/gopackagesdriver/main.go
+++ b/go/tools/gopackagesdriver/main.go
@@ -115,7 +115,7 @@ func run() error {
 
 func main() {
 	if err := run(); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %w", err)
+		fmt.Fprintf(os.Stderr, "error: %v", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

In my organisation we automatically `go vet` all Bazel built code using the `nogo` feature of `go_register_toolchains`. This line was flagged by that, preventing IDE embedding. This PR changes the verb to `%v` for the Fprintf call in `main()` to satisfy `go vet`.

**Which issues(s) does this PR fix?**

No issue because minor bug fix.