### PR TITLE
proto/core: fix documentation typo

### DIFF
--- a/proto/core.rst
+++ b/proto/core.rst
@@ -222,7 +222,7 @@ Attributes
 | :param:`embed`      | :type:`label_list`   | :value:`[]`                                     |
 +---------------------+----------------------+-------------------------------------------------+
 | List of Go libraries that should be combined with this library. The ``srcs``                 |
-| and ``deps`` from these libraries will be incorporated this library when it                  |
+| and ``deps`` from these libraries will be incorporated into this library when it             |
 | is compiled. Embedded libraries must have the same ``importpath`` and                        |
 | Go package name.                                                                             |
 +---------------------+----------------------+-------------------------------------------------+


### PR DESCRIPTION
**What type of PR is this?**
Documentation

**What does this PR do? Why is it needed?**
Adds a missing preposition into the description of the embed attribute.