### PR TITLE
Only depend on stamp files that are actively used

### DIFF
--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -136,16 +136,25 @@ def emit_link(
     extldflags.extend(cgo_rpaths)
 
     # Process x_defs, and record whether stamping is used.
-    stamp_x_defs = False
+    stamp_x_defs_info = False
+    stamp_x_defs_version = False
     for k, v in archive.x_defs.items():
-        if go.stamp and v.find("{") != -1 and v.find("}") != -1:
-            stamp_x_defs = True
+        start, end = v.find("{"), v.find("}")
+        if go.stamp and start != -1 and start != -1:
+            stamp_key = v[start + 1:end - 1]
+            if stamp_key.startswith("STABLE_") or stamp_key in ["BUILD_EMBED_LABEL", "BUILD_HOST", "BUILD_USER"]:
+                stamp_x_defs_info = True
+            else:
+                stamp_x_defs_version = True
         builder_args.add("-X", "%s=%s" % (k, v))
 
     # Stamping support
     stamp_inputs = []
-    if stamp_x_defs:
-        stamp_inputs = [info_file, version_file]
+    if stamp_x_defs_info:
+        stamp_inputs.append(info_file)
+    if stamp_x_defs_version:
+        stamp_inputs.append(version_file)
+    if stamp_x_defs_info or stamp_x_defs_version:
         builder_args.add_all(stamp_inputs, before_each = "-stamp")
 
     builder_args.add("-o", executable)

--- a/tests/core/go_binary/BUILD.bazel
+++ b/tests/core/go_binary/BUILD.bazel
@@ -22,6 +22,18 @@ go_bazel_test(
 )
 
 go_binary(
+    name = "stamp_workspace_status_bin",
+    srcs = ["stamp_workspace_status.go"]
+)
+
+go_bazel_test(
+    name = "stamp_volatile_test",
+    data = [":stamp_workspace_status_bin"],
+    srcs = ["stamp_volatile_test.go"],
+    deps = ["@io_bazel_rules_go//go/tools/bazel:go_default_library"],
+)
+
+go_binary(
     name = "custom_bin",
     srcs = ["custom_bin.go"],
     out = "alt_bin",

--- a/tests/core/go_binary/README.rst
+++ b/tests/core/go_binary/README.rst
@@ -45,6 +45,12 @@ Test that the `go_binary`_ ``x_defs`` attribute works correctly, both in a
 binary and in an embedded library. Tests regular stamps and stamps that
 depend on values from the workspace status script. Verifies #2000.
 
+stamp_volatile
+------
+Test that volatile workspace status stamps within an x_def don't result in
+a relink until those targets also depend on a stable attribute from the
+workspace status file.
+
 pie_test
 --------
 Tests that specifying the ``linkmode`` attribute on a `go_binary`_ target to be

--- a/tests/core/go_binary/stamp_volatile_test.go
+++ b/tests/core/go_binary/stamp_volatile_test.go
@@ -1,0 +1,157 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workspace_status_stamping
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: `
+-- BUILD.bazel --
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+
+go_binary(
+	name = "stable",
+	srcs = ["main.go"],
+	out = "stable",
+	x_defs = {
+		"Stable": "{STABLE_STAMP}",
+		"Volatile": "{VOLATILE_STAMP}",
+	},
+)
+
+go_binary(
+	name = "volatile",
+	srcs = ["main.go"],
+	out  = "volatile",
+	x_defs = {
+		"Volatile": "{VOLATILE_STAMP}",
+	}
+)
+
+-- main.go --
+package main
+
+import (
+	"fmt"
+)
+
+var Stable = "UNSTAMPED"
+var Volatile = "UNSTAMPED"
+
+func main() {
+	fmt.Println(Stable)
+	fmt.Println(Volatile)
+}
+`,
+	})
+}
+
+func setupWorkspaceStatus(t *testing.T) string {
+	wss, ok := bazel.FindBinary("tests/core/go_binary", "stamp_workspace_status_bin")
+	if !ok {
+		t.Fatal("Failed locating workspace_status binary")
+	}
+
+	return wss
+}
+
+func wssFlag(cmd, stable, volatile string) string {
+	return cmd + " " + stable + " " + volatile
+}
+
+type Stamp struct {
+	Stable, Volatile string
+}
+
+func runBuild(t *testing.T, cmd, target string, s Stamp) Stamp {
+	if err := bazel_testing.RunBazel("build", "--stamp", "--workspace_status_command", wssFlag(cmd, s.Stable, s.Volatile), target); err != nil {
+		t.Fatal("Failed to build test binary", err)
+	}
+
+	bin := strings.TrimLeft(target, "/:")
+
+	output, err := exec.Command("bazel-bin/" + bin).Output()
+	if err != nil {
+		t.Fatal("Failed running volatile binary", err)
+	}
+
+	vals := strings.Split(string(output), "\n")
+	return Stamp{
+		Stable:   vals[0],
+		Volatile: vals[1],
+	}
+}
+
+func TestStableStamp(t *testing.T) {
+	wscmd := setupWorkspaceStatus(t)
+
+	stamp1 := Stamp{
+		Stable:   "STABLE_1",
+		Volatile: "FIRST",
+	}
+
+	res1 := runBuild(t, wscmd, "//:stable", stamp1)
+	res2 := runBuild(t, wscmd, "//:stable", Stamp{
+		Stable:   "STABLE_2",
+		Volatile: "SECOND",
+	})
+	for _, v := range []string{res1.Stable, res2.Stable} {
+		if v == "UNSTAMPED" {
+			t.Fatal("Expected stable stamp, got 'UNSTAMPED'")
+		}
+	}
+
+	if res1.Stable == res2.Stable {
+		t.Fatal("Failed due to volatile stamp changing on second build")
+	}
+}
+
+func TestVolatileStamp(t *testing.T) {
+	wscmd := setupWorkspaceStatus(t)
+
+	stamp1 := Stamp{
+		Stable:   "STABLE",
+		Volatile: "FIRST",
+	}
+
+	res1 := runBuild(t, wscmd, "//:volatile", stamp1)
+	res2 := runBuild(t, wscmd, "//:volatile", Stamp{
+		Stable:   "STABLE",
+		Volatile: "SECOND",
+	})
+	for _, v := range []string{res1.Volatile, res2.Volatile} {
+		if v == "UNSTAMPED" {
+			t.Fatal("Expected volatile stamp, got 'UNSTAMPED'")
+		}
+	}
+
+	for _, v := range []string{res1.Stable, res2.Stable} {
+		if v != "UNSTAMPED" {
+			t.Fatal("Stable occured when not requested")
+		}
+	}
+
+	if res1 != res2 {
+		t.Fatal("Failed due to volatile stamp changing on second build")
+	}
+}

--- a/tests/core/go_binary/stamp_workspace_status.go
+++ b/tests/core/go_binary/stamp_workspace_status.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+  "fmt"
+  "os"
+)
+
+func main() {
+  fmt.Println("STABLE_STAMP " + os.Args[1])
+  fmt.Println("VOLATILE_STAMP " + os.Args[2])
+
+  os.Exit(0)
+}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Using stamping and x_defs results in frequent rebuilds in when remote
caching. This is because any stamp attribute results in both stable and
volatile workspace status being depended on. For builds using ephemeral
workspaces, this results in every build relinking quite often.

This fixes the bug by only depending on the specific status file that is used by the stamp variable.

Please let me know if there are specific tests updates needed, the tests as they are passed successfully.