### PR TITLE
-resource-dir flag for clang should be absolute

### DIFF
--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -34,7 +34,7 @@ var (
 	// cgoEnvVars is the list of all cgo environment variable
 	cgoEnvVars = []string{"CGO_CFLAGS", "CGO_CXXFLAGS", "CGO_CPPFLAGS", "CGO_LDFLAGS"}
 	// cgoAbsEnvFlags are all the flags that need absolute path in cgoEnvVars
-	cgoAbsEnvFlags = []string{"-I", "-L", "-isysroot", "-isystem", "-iquote", "-include", "-gcc-toolchain", "--sysroot"}
+	cgoAbsEnvFlags = []string{"-I", "-L", "-isysroot", "-isystem", "-iquote", "-include", "-gcc-toolchain", "--sysroot", "-resource-dir"}
 )
 
 // env holds a small amount of Go environment and toolchain information


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

A clang based toolchain controlling compiler built-in directory via `--resource-dir` will not work in tandem with cgo enabled go toolchain.

This PR adds --resource-dir to the set of cgo compiler flags the builder transforms to absolute paths.

**Which issues(s) does this PR fix?**

Fixes #2924

**Other notes for review**
