### PR TITLE
Ensure command line linkopts are added to cgo link flags

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -647,7 +647,7 @@ def _cgo_context_data_impl(ctx):
             feature_configuration = feature_configuration,
             action_name = CPP_LINK_EXECUTABLE_ACTION_NAME,
             variables = ld_executable_variables,
-        ),
+        ) + ctx.fragments.cpp.linkopts,
         _LINKER_OPTIONS_BLACKLIST,
     )
     env.update(cc_common.get_environment_variables(
@@ -688,9 +688,10 @@ def _cgo_context_data_impl(ctx):
             feature_configuration = feature_configuration,
             action_name = CPP_LINK_DYNAMIC_LIBRARY_ACTION_NAME,
             variables = ld_dynamic_lib_variables,
-        ),
+        ) + ctx.fragments.cpp.linkopts,
         _LINKER_OPTIONS_BLACKLIST,
     )
+
     env.update(cc_common.get_environment_variables(
         feature_configuration = feature_configuration,
         action_name = CPP_LINK_DYNAMIC_LIBRARY_ACTION_NAME,


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

the cgo flag collection logic does not account for --linkopt configuration flag set for `rules_cc`. These flags are appended post-toolchain flags in bazel and are not expanded as part of the toolchain logic.

this PR appends these flags (accessible via the `cpp` fragment) to the options for the executable and shared library linking options.

**Which issues(s) does this PR fix?**

Fixes #2923 

**Other notes for review**
