### PR TITLE
CGO merged directory should have usable name.

### DIFF
--- a/go/tools/builders/cgo2.go
+++ b/go/tools/builders/cgo2.go
@@ -58,6 +58,15 @@ func cgo2(goenv *env, goSrcs, cgoSrcs, cSrcs, cxxSrcs, objcSrcs, objcxxSrcs, sSr
 	}
 	defer cleanup()
 
+	// cgo2 will gather sources into a single temporary directory, since nogo
+	// scanners might want to include or exclude these sources we need to ensure
+	// that a fragment of the path is stable and human friendly enough to be
+	// referenced in nogo configuration.
+	workDir = filepath.Join(workDir, "cgo", packagePath)
+	if err := os.MkdirAll(workDir, 0700); err != nil {
+		return "", nil, nil, err
+	}
+
 	// Filter out -lstdc++ and -lc++ from ldflags if we don't have C++ sources,
 	// and set CGO_LDFLAGS. These flags get written as special comments into cgo
 	// generated sources. The compiler encodes those flags in the compiled .a

--- a/tests/core/nogo/custom/custom_test.go
+++ b/tests/core/nogo/custom/custom_test.go
@@ -424,7 +424,8 @@ func Test(t *testing.T) {
 			target:      "//:uses_cgo_with_errors",
 			wantSuccess: false,
 			includes: []string{
-				`.*/cgo\/examplepkg\/pure_src_with_err_calling_native.go:.*function must not be named Foo \(foofuncname\)`,
+				// note the cross platform regex :)
+				`.*[\\/]cgo[\\/]examplepkg[\\/]pure_src_with_err_calling_native.go:.*function must not be named Foo \(foofuncname\)`,
 			},
 		}, {
 			desc:        "no_errors",

--- a/tests/core/nogo/custom/custom_test.go
+++ b/tests/core/nogo/custom/custom_test.go
@@ -349,12 +349,14 @@ func D() {
 -- examplepkg/uses_cgo_clean.go --
 package examplepkg
 
-// #include <unistd.h>
+// #include <stdlib.h>
 import "C"
 
 func Bar() bool {
-  C.getpid()
-  return true
+  if C.rand() > 10 {
+    return true
+  }
+  return false
 }
 
 -- examplepkg/pure_src_with_err_calling_native.go --

--- a/tests/core/nogo/custom/custom_test.go
+++ b/tests/core/nogo/custom/custom_test.go
@@ -455,7 +455,7 @@ func Test(t *testing.T) {
 				if matched, err := regexp.Match(pattern, stderr.Bytes()); err != nil {
 					t.Fatal(err)
 				} else if !matched {
-					t.Errorf("output did not contain pattern: %s", pattern)
+					t.Errorf("got output:\n %s\n which does not contain pattern: %s", string(stderr.Bytes()), pattern)
 				}
 			}
 			for _, pattern := range test.excludes {


### PR DESCRIPTION
cgo2 merges sources and generated code under a common directory, however this directory is anonymous.

This breaks nogo's ability to easily include/exclude files as only the file's basename is retained.

This change embeds cgo/packagePath into the merged directory to make it easy to include/exclude sources being compiled by cgo.

Note: PR #2863 ensured that files //line: directives had their meaningful alt names included in nogo output. This is helpful, however for pure go files that are part of a package that uses cgo, there is nothing that adds //line: directives, and the builder will just copy/link pure files into the into the merged cgo folder.

**What type of PR is this?**


> Bug fix

**What does this PR do? Why is it needed?**
Makes the merged cgo temp directory include the package path for easy inclusion/exclusion from nogo rules.


**Which issues(s) does this PR fix?**

Fixes # 2862

**Other notes for review**
