### PR TITLE
go/tools/gopackagesdriver: add automatic target detection

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  // See http://go.microsoft.com/fwlink/?LinkId=827846
+  // for the documentation about the extensions.json format
+  "recommendations": [
+    "bazelbuild.vscode-bazel",
+    "golang.go",
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,32 @@
+{
+  "editor.formatOnSave": true,
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true,
+  "go.goroot": "${workspaceFolder}/bazel-${workspaceFolderBasename}/external/go_sdk",
+  "go.toolsEnvVars": {
+    "GOPACKAGESDRIVER": "${workspaceFolder}/tools/gopackagesdriver.sh"
+  },
+  "go.enableCodeLens": {
+    "references": false,
+    "runtest": false
+  },
+  "gopls": {
+    "formatting.gofumpt": true,
+    "formatting.local": "github.com/bazelbuild/rules_go",
+    "ui.completion.usePlaceholders": true,
+    "ui.semanticTokens": true,
+    "ui.codelenses": {
+      "gc_details": false,
+      "regenerate_cgo": false,
+      "generate": false,
+      "test": false,
+      "tidy": false,
+      "upgrade_dependency": false,
+      "vendor": false
+    },
+  },
+  "go.useLanguageServer": true,
+  "go.buildOnSave": "off",
+  "go.lintOnSave": "off",
+  "go.vetOnSave": "off",
+}

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -111,7 +111,7 @@ func stdlibPackageID(importPath string) string {
 
 func execRootPath(execRoot, p string) string {
 	dir, _ := filepath.Rel(execRoot, p)
-	return filepath.Join("__BAZEL_EXECROOT__", dir)
+	return filepath.Join("__BAZEL_OUTPUT_BASE__", dir)
 }
 
 func absoluteSourcesPaths(execRoot, pkgDir string, srcs []string) []string {

--- a/go/tools/gopackagesdriver/BUILD.bazel
+++ b/go/tools/gopackagesdriver/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "bazel.go",
         "bazel_json_builder.go",
+        "build_context.go",
         "driver_request.go",
         "flatpackage.go",
         "json_packages_driver.go",

--- a/go/tools/gopackagesdriver/BUILD.bazel
+++ b/go/tools/gopackagesdriver/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "json_packages_driver.go",
         "main.go",
         "packageregistry.go",
+        "utils.go",
     ],
     importpath = "github.com/bazelbuild/rules_go/go/tools/gopackagesdriver",
     visibility = ["//visibility:private"],

--- a/go/tools/gopackagesdriver/aspect.bzl
+++ b/go/tools/gopackagesdriver/aspect.bzl
@@ -28,9 +28,12 @@ def _is_file_external(f):
     return f.owner.workspace_root != ""
 
 def _file_path(f):
-    if f.is_source and not _is_file_external(f):
-        return paths.join("__BAZEL_WORKSPACE__", f.path)
-    return paths.join("__BAZEL_EXECROOT__", f.path)
+    prefix = "__BAZEL_WORKSPACE__"
+    if not f.is_source:
+        prefix = "__BAZEL_EXECROOT__"
+    elif _is_file_external(f):
+        prefix = "__BAZEL_OUTPUT_BASE__"
+    return paths.join(prefix, f.path)
 
 def _new_pkg_info(archive_data):
     return struct(

--- a/go/tools/gopackagesdriver/aspect.bzl
+++ b/go/tools/gopackagesdriver/aspect.bzl
@@ -96,11 +96,16 @@ def _go_pkg_info_aspect_impl(target, ctx):
         # if the rule is a test, we need to get the embedded go_library with the current
         # test's sources. For that, consume the dependency via GoArchive.direct so that
         # the test source files are there. Then, create the pkg json file directly. Only
-        # do that for embedded targets, and use the importpath go find which.
+        # do that for direct dependencies that are not defined as deps, and use the
+        # importpath to find which.
         if ctx.rule.kind == "go_test":
-            embedded_targets = [dep[GoArchive].data.importpath for dep in ctx.rule.attr.embed]
+            deps_targets = [
+                dep[GoArchive].data.importpath
+                for dep in ctx.rule.attr.deps
+                if GoArchive in dep
+            ]
             for archive in target[GoArchive].direct:
-                if archive.data.importpath in embedded_targets:
+                if archive.data.importpath not in deps_targets:
                     pkg = _go_archive_to_pkg(archive)
                     pkg_json_files.append(_make_pkg_json(ctx, archive, pkg))
                     compiled_go_files.extend(archive.source.srcs)

--- a/go/tools/gopackagesdriver/bazel.go
+++ b/go/tools/gopackagesdriver/bazel.go
@@ -107,7 +107,7 @@ func (b *Bazel) Build(ctx context.Context, args ...string) ([]string, error) {
 		// See https://docs.bazel.build/versions/main/guide.html#what-exit-code-will-i-get on
 		// exit codes.
 		var exerr *exec.ExitError
-		if !errors.As(err, &exerr) || (errors.As(err, &exerr) && exerr.ExitCode() != 1) {
+		if !errors.As(err, &exerr) || exerr.ExitCode() != 1 {
 			return nil, fmt.Errorf("bazel build failed: %w", err)
 		}
 	}

--- a/go/tools/gopackagesdriver/bazel.go
+++ b/go/tools/gopackagesdriver/bazel.go
@@ -35,7 +35,6 @@ const (
 
 type Bazel struct {
 	bazelBin      string
-	execRoot      string
 	workspaceRoot string
 	info          map[string]string
 }
@@ -82,7 +81,7 @@ func (b *Bazel) run(ctx context.Context, command string, args ...string) (string
 		"--ui_actions_shown=0",
 	}, args...)...)
 	fmt.Fprintln(os.Stderr, "Running:", cmd.Args)
-	cmd.Dir = b.workspaceRoot
+	cmd.Dir = b.WorkspaceRoot()
 	cmd.Stderr = os.Stderr
 	output, err := cmd.Output()
 	return string(output), err

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -35,7 +35,7 @@ func (b *BazelJSONBuilder) fileQuery(filename string) string {
 		fp, _ := filepath.Rel(b.bazel.WorkspaceRoot(), filename)
 		filename = fp
 	}
-	return fmt.Sprintf(`kind("go_library", same_pkg_direct_rdeps("%s"))`, filename)
+	return fmt.Sprintf(`kind("go_library|go_test", same_pkg_direct_rdeps("%s"))`, filename)
 }
 
 func (b *BazelJSONBuilder) packageQuery(importPath string) string {

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -48,19 +48,23 @@ func (b *BazelJSONBuilder) packageQuery(importPath string) string {
 func (b *BazelJSONBuilder) queryFromRequests(requests ...string) string {
 	ret := make([]string, 0, len(requests))
 	for _, request := range requests {
+		result := ""
 		if request == "." || request == "./..." {
 			if bazelQueryScope != "" {
-				ret = append(ret, fmt.Sprintf(`kind("go_library", %s)`, bazelQueryScope))
+				result = fmt.Sprintf(`kind("go_library", %s)`, bazelQueryScope)
 			} else {
-				ret = append(ret, fmt.Sprintf(RulesGoStdlibLabel))
+				result = fmt.Sprintf(RulesGoStdlibLabel)
 			}
 		} else if request == "builtin" || request == "std" {
-			ret = append(ret, fmt.Sprintf(RulesGoStdlibLabel))
+			result = fmt.Sprintf(RulesGoStdlibLabel)
 		} else if strings.HasPrefix(request, "file=") {
 			f := strings.TrimPrefix(request, "file=")
-			ret = append(ret, b.fileQuery(f))
+			result = b.fileQuery(f)
 		} else if bazelQueryScope != "" {
-			ret = append(ret, b.packageQuery(request))
+			result = b.packageQuery(request)
+		}
+		if result != "" {
+			ret = append(ret, result)
 		}
 	}
 	if len(ret) == 0 {

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -40,7 +40,7 @@ func (b *BazelJSONBuilder) fileQuery(filename string) string {
 
 func (b *BazelJSONBuilder) packageQuery(importPath string) string {
 	if strings.HasSuffix(importPath, "/...") {
-		importPath = strings.TrimSuffix(importPath, "/...") + "(/.+)?$"
+		importPath = fmt.Sprintf(`^%s(/.+)?$`, strings.TrimSuffix(importPath, "/..."))
 	}
 	return fmt.Sprintf(`kind("go_library", attr(importpath, "%s", deps(%s)))`, importPath, bazelQueryScope)
 }

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -42,7 +42,7 @@ func (b *BazelJSONBuilder) fileQuery(filename string) string {
 }
 
 func (b *BazelJSONBuilder) packageQuery(importPath string) string {
-	return fmt.Sprintf(`some(kind("go_library", attr(importpath, "%s", //...)))`, importPath)
+	return fmt.Sprintf(`some(kind("go_library", attr(importpath, "%s", %s)))`, importPath, bazelQueryScope)
 }
 
 func (b *BazelJSONBuilder) queryFromRequests(requests ...string) string {

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -40,7 +40,7 @@ func (b *BazelJSONBuilder) fileQuery(filename string) string {
 
 func (b *BazelJSONBuilder) packageQuery(importPath string) string {
 	if strings.HasSuffix(importPath, "/...") {
-		importPath = strings.TrimSuffix(importPath, "/...") + "/.*"
+		importPath = strings.TrimSuffix(importPath, "/...") + "(/.+)?$"
 	}
 	return fmt.Sprintf(`kind("go_library", attr(importpath, "%s", deps(%s)))`, importPath, bazelQueryScope)
 }

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -105,7 +105,11 @@ func (b *BazelJSONBuilder) query(ctx context.Context, query string) ([]string, e
 func (b *BazelJSONBuilder) Build(ctx context.Context, mode LoadMode) ([]string, error) {
 	labels, err := b.query(ctx, b.queryFromRequests(b.requests...))
 	if err != nil {
-		return nil, fmt.Errorf("unable to query: %w", err)
+		return nil, fmt.Errorf("query failed: %w", err)
+	}
+
+	if len(labels) == 0 {
+		return nil, fmt.Errorf("found no labels matching the requests")
 	}
 
 	buildArgs := concatStringsArrays([]string{

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -35,14 +35,14 @@ func (b *BazelJSONBuilder) fileQuery(filename string) string {
 		fp, _ := filepath.Rel(b.bazel.WorkspaceRoot(), filename)
 		filename = fp
 	}
-	return fmt.Sprintf(`some(kind("go_library", same_pkg_direct_rdeps("%s")))`, filename)
+	return fmt.Sprintf(`kind("go_library", same_pkg_direct_rdeps("%s"))`, filename)
 }
 
 func (b *BazelJSONBuilder) packageQuery(importPath string) string {
 	if strings.HasSuffix(importPath, "/...") {
 		importPath = strings.TrimSuffix(importPath, "/...") + "/.*"
 	}
-	return fmt.Sprintf(`some(kind("go_library", attr(importpath, "%s", deps(%s))))`, importPath, bazelQueryScope)
+	return fmt.Sprintf(`kind("go_library", attr(importpath, "%s", deps(%s)))`, importPath, bazelQueryScope)
 }
 
 func (b *BazelJSONBuilder) queryFromRequests(requests ...string) string {

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -79,8 +79,6 @@ func (b *BazelJSONBuilder) query(ctx context.Context, query string) ([]string, e
 	queryArgs := concatStringsArrays(bazelFlags, bazelQueryFlags, []string{
 		"--ui_event_filters=-info,-stderr",
 		"--noshow_progress",
-		// Use Sky Query
-		"--universe_scope=//...",
 		"--order_output=no",
 		"--output=label",
 		"--nodep_deps",

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -42,7 +42,7 @@ func (b *BazelJSONBuilder) fileQuery(filename string) string {
 }
 
 func (b *BazelJSONBuilder) packageQuery(importPath string) string {
-	return fmt.Sprintf(`some(kind("go_library", attr(importpath, "%s", %s)))`, importPath, bazelQueryScope)
+	return fmt.Sprintf(`some(kind("go_library", attr(importpath, "%s", deps(%s))))`, importPath, bazelQueryScope)
 }
 
 func (b *BazelJSONBuilder) queryFromRequests(requests ...string) string {

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -130,6 +130,7 @@ func (b *BazelJSONBuilder) PathResolver() PathResolverFunc {
 	return func(p string) string {
 		p = strings.Replace(p, "__BAZEL_EXECROOT__", b.bazel.ExecutionRoot(), 1)
 		p = strings.Replace(p, "__BAZEL_WORKSPACE__", b.bazel.WorkspaceRoot(), 1)
+		p = strings.Replace(p, "__BAZEL_OUTPUT_BASE__", b.bazel.OutputBase(), 1)
 		return p
 	}
 }

--- a/go/tools/gopackagesdriver/build_context.go
+++ b/go/tools/gopackagesdriver/build_context.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"go/build"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var buildContext = makeBuildContext()
+
+func makeBuildContext() *build.Context {
+	bctx := &build.Context{
+		GOOS:        getenvDefault("GOOS", build.Default.GOOS),
+		GOARCH:      getenvDefault("GOARCH", build.Default.GOARCH),
+		GOROOT:      getenvDefault("GOROOT", build.Default.GOROOT),
+		GOPATH:      getenvDefault("GOPATH", build.Default.GOPATH),
+		BuildTags:   strings.Split(getenvDefault("GOTAGS", ""), ","),
+		ReleaseTags: build.Default.ReleaseTags[:],
+	}
+	if v, ok := os.LookupEnv("CGO_ENABLED"); ok {
+		bctx.CgoEnabled = v == "1"
+	} else {
+		bctx.CgoEnabled = build.Default.CgoEnabled
+	}
+	return bctx
+}
+
+func filterSourceFilesForTags(files []string) []string {
+	ret := make([]string, 0, len(files))
+	for _, f := range files {
+		dir, filename := filepath.Split(f)
+		if match, _ := buildContext.MatchFile(dir, filename); match {
+			ret = append(ret, f)
+		}
+	}
+	return ret
+}

--- a/go/tools/gopackagesdriver/driver_request.go
+++ b/go/tools/gopackagesdriver/driver_request.go
@@ -65,7 +65,7 @@ const (
 )
 
 // From https://github.com/golang/tools/blob/v0.1.0/go/packages/external.go#L32
-// Most fields are disabled since there are no needs for them
+// Most fields are disabled since there is no need for them
 type DriverRequest struct {
 	Mode LoadMode `json:"mode"`
 	// Env specifies the environment the underlying build system should be run in.

--- a/go/tools/gopackagesdriver/flatpackage.go
+++ b/go/tools/gopackagesdriver/flatpackage.go
@@ -65,8 +65,10 @@ type FlatPackage struct {
 	Standard        bool                `json:",omitempty"`
 }
 
-type PackageFunc func(pkg *FlatPackage)
-type PathResolverFunc func(path string) string
+type (
+	PackageFunc      func(pkg *FlatPackage)
+	PathResolverFunc func(path string) string
+)
 
 func resolvePathsInPlace(prf PathResolverFunc, paths []string) {
 	for i, path := range paths {

--- a/go/tools/gopackagesdriver/flatpackage.go
+++ b/go/tools/gopackagesdriver/flatpackage.go
@@ -102,6 +102,13 @@ func (fp *FlatPackage) ResolvePaths(prf PathResolverFunc) error {
 	return nil
 }
 
+// FilterFilesForBuildTags filters the source files given the current build
+// tags.
+func (fp *FlatPackage) FilterFilesForBuildTags() {
+	fp.GoFiles = filterSourceFilesForTags(fp.GoFiles)
+	fp.CompiledGoFiles = filterSourceFilesForTags(fp.CompiledGoFiles)
+}
+
 func (fp *FlatPackage) IsStdlib() bool {
 	return fp.Standard
 }

--- a/go/tools/gopackagesdriver/main.go
+++ b/go/tools/gopackagesdriver/main.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"go/types"
 	"os"
-	"os/signal"
 	"strings"
 )
 
@@ -67,28 +66,6 @@ var (
 	}
 )
 
-func getenvDefault(key, defaultValue string) string {
-	if v, ok := os.LookupEnv(key); ok {
-		return v
-	}
-	return defaultValue
-}
-
-func signalContext(parentCtx context.Context, signals ...os.Signal) (ctx context.Context, stop context.CancelFunc) {
-	ctx, cancel := context.WithCancel(parentCtx)
-	ch := make(chan os.Signal, 1)
-	go func() {
-		select {
-		case <-ch:
-			cancel()
-		case <-ctx.Done():
-		}
-	}()
-	signal.Notify(ch, signals...)
-
-	return ctx, cancel
-}
-
 func run() (*driverResponse, error) {
 	ctx, cancel := signalContext(context.Background(), os.Interrupt)
 	defer cancel()
@@ -120,7 +97,6 @@ func run() (*driverResponse, error) {
 		return emptyResponse, fmt.Errorf("unable to load JSON files: %w", err)
 	}
 
-	// return driver.AllPackagesResponse(), nil
 	return driver.Match(queries...), nil
 }
 

--- a/go/tools/gopackagesdriver/main.go
+++ b/go/tools/gopackagesdriver/main.go
@@ -107,6 +107,9 @@ func main() {
 	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v", err)
+		// gopls will check the packages driver exit code, and if there is an
+		// error, it will fall back to go list. Obviously we don't want that,
+		// so force a 0 exit code.
 		os.Exit(0)
 	}
 }

--- a/go/tools/gopackagesdriver/main.go
+++ b/go/tools/gopackagesdriver/main.go
@@ -56,7 +56,7 @@ var (
 	bazelBin              = getenvDefault("GOPACKAGESDRIVER_BAZEL", "bazel")
 	bazelFlags            = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_FLAGS"))
 	bazelQueryFlags       = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_QUERY_FLAGS"))
-	bazelQueryScope       = getenvDefault("GOPACKAGESDRIVER_BAZEL_QUERY_SCOPE", "//...")
+	bazelQueryScope       = getenvDefault("GOPACKAGESDRIVER_BAZEL_QUERY_SCOPE", "")
 	bazelBuildFlags       = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_BUILD_FLAGS"))
 	workspaceRoot         = os.Getenv("BUILD_WORKSPACE_DIRECTORY")
 	emptyResponse         = &driverResponse{
@@ -93,6 +93,8 @@ func run() (*driverResponse, error) {
 	ctx, cancel := signalContext(context.Background(), os.Interrupt)
 	defer cancel()
 
+	queries := os.Args[1:]
+
 	request, err := ReadDriverRequest(os.Stdin)
 	if err != nil {
 		return emptyResponse, fmt.Errorf("unable to read request: %w", err)
@@ -103,7 +105,7 @@ func run() (*driverResponse, error) {
 		return emptyResponse, fmt.Errorf("unable to create bazel instance: %w", err)
 	}
 
-	bazelJsonBuilder, err := NewBazelJSONBuilder(bazel, os.Args[1:]...)
+	bazelJsonBuilder, err := NewBazelJSONBuilder(bazel, queries...)
 	if err != nil {
 		return emptyResponse, fmt.Errorf("unable to build JSON files: %w", err)
 	}
@@ -118,7 +120,8 @@ func run() (*driverResponse, error) {
 		return emptyResponse, fmt.Errorf("unable to load JSON files: %w", err)
 	}
 
-	return driver.Match("./..."), nil
+	// return driver.AllPackagesResponse(), nil
+	return driver.Match(queries...), nil
 }
 
 func main() {

--- a/go/tools/gopackagesdriver/main.go
+++ b/go/tools/gopackagesdriver/main.go
@@ -56,6 +56,7 @@ var (
 	bazelBin              = getenvDefault("GOPACKAGESDRIVER_BAZEL", "bazel")
 	bazelFlags            = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_FLAGS"))
 	bazelQueryFlags       = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_QUERY_FLAGS"))
+	bazelQueryScope       = getenvDefault("GOPACKAGESDRIVER_BAZEL_QUERY_SCOPE", "//...")
 	bazelBuildFlags       = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_BUILD_FLAGS"))
 	workspaceRoot         = os.Getenv("BUILD_WORKSPACE_DIRECTORY")
 	emptyResponse         = &driverResponse{

--- a/go/tools/gopackagesdriver/packageregistry.go
+++ b/go/tools/gopackagesdriver/packageregistry.go
@@ -84,34 +84,37 @@ func (pr *PackageRegistry) walk(acc map[string]*FlatPackage, root string) {
 
 func (pr *PackageRegistry) Match(patterns ...string) ([]string, []*FlatPackage) {
 	roots := map[string]struct{}{}
-	wildcard := false
 
 	for _, pattern := range patterns {
-		if strings.HasPrefix(pattern, "file=") {
-			f := strings.TrimPrefix(pattern, "file=")
+		if pattern == "." || pattern == "./..." {
+			for _, pkg := range pr.packagesByImportPath {
+				if strings.HasPrefix(pkg.ID, "//") {
+					roots[pkg.ID] = struct{}{}
+				}
+			}
+		} else if strings.HasSuffix(pattern, "/...") {
+			pkgPrefix := strings.TrimSuffix(pattern, "/...")
+			for _, pkg := range pr.packagesByImportPath {
+				if strings.HasPrefix(pkg.PkgPath, pkgPrefix) {
+					roots[pkg.ID] = struct{}{}
+				}
+			}
+		} else if pattern == "builtin" || pattern == "std" {
+			for _, pkg := range pr.packagesByImportPath {
+				if pkg.Standard {
+					roots[pkg.ID] = struct{}{}
+				}
+			}
+		} else if strings.HasPrefix(pattern, "file=") {
+			f := ensureAbsolutePathFromWorkspace(strings.TrimPrefix(pattern, "file="))
 			if pkg, ok := pr.packagesByFile[f]; ok {
 				roots[pkg.ID] = struct{}{}
 			}
-		} else if pattern == "." || pattern == "./..." {
-			wildcard = true
 		} else {
 			if pkg, ok := pr.packagesByImportPath[pattern]; ok {
 				roots[pkg.ID] = struct{}{}
 			}
 		}
-	}
-
-	if wildcard {
-		retPkgs := make([]*FlatPackage, 0, len(pr.packagesByImportPath))
-		retRoots := make([]string, 0, len(pr.packagesByImportPath))
-		for _, pkg := range pr.packagesByImportPath {
-			if strings.HasPrefix(pkg.ID, "//") {
-				retRoots = append(retRoots, pkg.ID)
-				roots[pkg.ID] = struct{}{}
-			}
-			retPkgs = append(retPkgs, pkg)
-		}
-		return retRoots, retPkgs
 	}
 
 	walkedPackages := map[string]*FlatPackage{}

--- a/go/tools/gopackagesdriver/packageregistry.go
+++ b/go/tools/gopackagesdriver/packageregistry.go
@@ -56,6 +56,10 @@ func (pr *PackageRegistry) Remove(pkgs ...*FlatPackage) *PackageRegistry {
 func (pr *PackageRegistry) ResolvePaths(prf PathResolverFunc) error {
 	for _, pkg := range pr.packagesByImportPath {
 		pkg.ResolvePaths(prf)
+		pkg.FilterFilesForBuildTags()
+		for _, f := range pkg.CompiledGoFiles {
+			pr.packagesByFile[f] = pkg
+		}
 		for _, f := range pkg.CompiledGoFiles {
 			pr.packagesByFile[f] = pkg
 		}

--- a/go/tools/gopackagesdriver/packageregistry.go
+++ b/go/tools/gopackagesdriver/packageregistry.go
@@ -95,7 +95,7 @@ func (pr *PackageRegistry) Match(patterns ...string) ([]string, []*FlatPackage) 
 		} else if strings.HasSuffix(pattern, "/...") {
 			pkgPrefix := strings.TrimSuffix(pattern, "/...")
 			for _, pkg := range pr.packagesByImportPath {
-				if strings.HasPrefix(pkg.PkgPath, pkgPrefix) {
+				if pkgPrefix == pkg.PkgPath || strings.HasPrefix(pkg.PkgPath, pkgPrefix+"/") {
 					roots[pkg.ID] = struct{}{}
 				}
 			}

--- a/go/tools/gopackagesdriver/utils.go
+++ b/go/tools/gopackagesdriver/utils.go
@@ -1,0 +1,23 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+func concatStringsArrays(values ...[]string) []string {
+	ret := []string{}
+	for _, v := range values {
+		ret = append(ret, v...)
+	}
+	return ret
+}

--- a/go/tools/gopackagesdriver/utils.go
+++ b/go/tools/gopackagesdriver/utils.go
@@ -14,10 +14,19 @@
 
 package main
 
+import "path/filepath"
+
 func concatStringsArrays(values ...[]string) []string {
 	ret := []string{}
 	for _, v := range values {
 		ret = append(ret, v...)
 	}
 	return ret
+}
+
+func ensureAbsolutePathFromWorkspace(path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(workspaceRoot, path)
 }

--- a/tools/gopackagesdriver.sh
+++ b/tools/gopackagesdriver.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+export GOPACKAGESDRIVER_RULES_GO_REPOSITORY_NAME=
+exec bazel run --tool_tag=gopackagesdriver -- //go/tools/gopackagesdriver "${@}"


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This PR introduces automatic target detection so that no user input
is required after the `GOPACKAGESDRIVER` setup. This effectively
deprecates the following environment variables:
- `GOPACKAGESDRIVER_BAZEL_TARGETS`
- `GOPACKAGESDRIVER_BAZEL_QUERY`
- `GOPACKAGESDRIVER_BAZEL_TAG_FILTERS`

It works as follows:
- for `importpath` queries, it will `bazel query` a matching `go_library`
    matching it
- for `file=` queries, it will try to find the matching `go_library` in the
    same package
- since it supports multiple queries at the same time, it will `union` those
    queries and query that

Once the `go_library` targets are found, it will try to build them directly,
which should dramatically speed up compilation times, at the loss of transition
support (which wasn't used as much as I thought it would be).

I may reintroduce it in the future via a user-defined flag (to only build the
part of the graph that needs building).

In any case, toolchain or platforms can be switched with the following
environment variables it configuration transitions are needed:
- `GOPACKAGESDRIVER_BAZEL_FLAGS` which will be passed to `bazel` invocations
- `GOPACKAGESDRIVER_BAZEL_QUERY_FLAGS` which will be passed to `bazel query`
    invocations
- `GOPACKAGESDRIVER_BAZEL_QUERY_SCOPE` which specifies the scope for `importpath` queries (since `gopls` only issues `file=` queries, so **use if you know what you're doing!**)
- `GOPACKAGESDRIVER_BAZEL_BUILD_FLAGS` which will be passed to `bazel build`
    invocations

Finally, the driver will not fail in case of a build failure, and even so
uses `--keep_going` and will return whatever packages that did build.

**Which issues(s) does this PR fix?**

It should fix most of the issues from #2858.

**Other notes for review**
I have added a `.vscode` folder for folks who work on `rules_go` with it so that `gopls` now works there too!