### PR TITLE
Disable //tests/core/race:race_test on Windows

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -305,6 +305,7 @@ tasks:
     - "-//tests/core/go_test:data_test"
     - "-//tests/core/go_test:pwd_test"
     - "-//tests/core/nogo/coverage:coverage_test"
+    - "-//tests/core/race:race_test" # fails on Windows due to upstream bug, see issue #2911
     - "-//tests/core/stdlib:buildid_test"
     - "-//tests/examples/executable_name:executable_name"
     - "-//tests/integration/gazelle:gazelle_test" # exceeds command line length limit


### PR DESCRIPTION
**What type of PR is this?**

Other: Bazel CI configuration change.

**What does this PR do? Why is it needed?**

Disables a test that fails on Windows due to an unfixed upstream bug in Go.

**Which issues(s) does this PR fix?**

Fixes #2911.

**Other notes for review**
