### PR TITLE
Accepting multiple platform SDKs in go_wrap_sdk

### DIFF
--- a/go/toolchains.rst
+++ b/go/toolchains.rst
@@ -355,11 +355,17 @@ rule.
 | A unique name for this SDK. This should almost always be :value:`go_sdk` if you want the SDK     |
 | to be used by toolchains.                                                                        |
 +--------------------------------+-----------------------------+-----------------------------------+
-| :param:`root_file`             | :type:`label`               | |mandatory|                       |
+| :param:`root_file`             | :type:`label`               | :value:`None`                     |
 +--------------------------------+-----------------------------+-----------------------------------+
 | A Bazel label referencing a file in the root directory of the SDK. Used to                       |
-| determine the GOROOT for the SDK.                                                                |
+| determine the GOROOT for the SDK. This attribute and `root_files` cannot be both provided.       |
 +--------------------------------+-----------------------------+-----------------------------------+
+| :param:`root_files`            | :type:`string_dict`         | :value:`None`                     |
++--------------------------------+-----------------------------+-----------------------------------+
+| A set of mappings from the host platform to a Bazel label referencing a file in the SDK's root   |
+| directory. This attribute and `root_file` cannot be both provided.                               |
++--------------------------------+-----------------------------+-----------------------------------+
+
 
 **Example:**
 


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
`go_wrap_sdk`'s `root_file` only accepts one Go SDK. This pull requests adds a new `root_files` attribute to accept multiple Go SDKs for multiplatform support similar to `go_download_sdk`
