### PR TITLE
Make go_test() with embedsrcs work

### DIFF
--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -76,6 +76,7 @@ def _go_test_impl(ctx):
     )
     external_source = go.library_to_source(go, struct(
         srcs = [struct(files = go_srcs)],
+        embedsrcs = [struct(files = internal_source.embedsrcs)],
         deps = internal_archive.direct + [internal_archive],
         x_defs = ctx.attr.x_defs,
     ), external_library, ctx.coverage_instrumented())

--- a/tests/core/go_library/BUILD.bazel
+++ b/tests/core/go_library/BUILD.bazel
@@ -140,3 +140,9 @@ go_bazel_test(
     size = "medium",
     srcs = ["embedsrcs_error_test.go"],
 )
+
+go_test(
+    name = "embedsrcs_simple_test",
+    srcs = ["embedsrcs_simple_test.go"],
+    embedsrcs = ["embedsrcs_static/no"],
+)

--- a/tests/core/go_library/embedsrcs_simple_test.go
+++ b/tests/core/go_library/embedsrcs_simple_test.go
@@ -1,0 +1,6 @@
+package embedsrcs_simple_test
+
+import _ "embed"
+
+//go:embed embedsrcs_static/no
+var no []byte


### PR DESCRIPTION
Even though there already is testing coverage for go_test() with
embedsrcs using generated files and such, I can't seem to get one of the
most trivial cases to work. The file to be embedded doesn't get placed
in the sandbox during GoCompilePkg.

This change addresses this by explicitly copying the embedsrcs from the
internal source to the external, which seems to make things work
properly.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

It fixes go_test() with embedsrcs. It's needed, because I want to use that feature.

**Which issues(s) does this PR fix?**

I couldn't find any existing issues.

**Other notes for review**
