### PR TITLE
Disable //tests/core/cgo:race_test on Mac

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -28,6 +28,7 @@ tasks:
     - "//..."
     test_targets:
     - "//..."
+    - "-//tests/core/race:race_test" # fails on Mac due to upstream bug, see issue #2911
   rbe_ubuntu1604:
     build_targets:
     - "//..."

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -28,7 +28,7 @@ tasks:
     - "//..."
     test_targets:
     - "//..."
-    - "-//tests/core/race:race_test" # fails on Mac due to upstream bug, see issue #2911
+    - "-//tests/core/cgo:race_test"  # fails on Mac due to upstream bug, see issue #2911
   rbe_ubuntu1604:
     build_targets:
     - "//..."


### PR DESCRIPTION
**What type of PR is this?**

Other: Bazel CI configuration change.

**What does this PR do? Why is it needed?**

Disables a test that fails on Mac due to an unfixed upstream bug in Go. See https://buildkite.com/bazel/rules-go-golang/builds/3158#c8bfc9aa-f9e7-4c3e-9b47-1332ab952b76

**Which issues(s) does this PR fix?**

Fixes #2911.

**Other notes for review**
