### PR TITLE
Disable //tests/core/cgo:race_test on Windows

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -273,6 +273,7 @@ tasks:
     - "-//tests/core/cgo:dylib_test"
     - "-//tests/core/cgo:generated_dylib_client"
     - "-//tests/core/cgo:generated_dylib_test"
+    - "-//tests/core/cgo:race_test" # fails on Windows due to upstream bug, see issue #2911
     - "-//tests/core/cgo:versioned_dylib_client"
     - "-//tests/core/cgo:versioned_dylib_test"
     - "-//tests/core/cgo:generated_versioned_dylib_client"


### PR DESCRIPTION
What type of PR is this?

Other: Bazel CI configuration change.

What does this PR do? Why is it needed?

Disables a test that fails on Windows due to an unfixed upstream bug in Go. See https://buildkite.com/bazel/rules-go-golang/builds/3158#c8bfc9aa-f9e7-4c3e-9b47-1332ab952b76

Which issues(s) does this PR fix?

Fixes #2911.

Other notes for review
