### PR TITLE
Remove dependencie with bazelbuild/rules_cc

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -10,12 +10,10 @@ tasks:
   ubuntu2004:
     # enable some unflipped incompatible flags on this platform to ensure we don't regress.
     build_flags:
-    - "--incompatible_load_cc_rules_from_bzl"
     - "--incompatible_load_proto_rules_from_bzl"
     - "--incompatible_restrict_string_escapes"
     - "--incompatible_enable_cc_toolchain_resolution"
     test_flags:
-    - "--incompatible_load_cc_rules_from_bzl"
     - "--incompatible_load_proto_rules_from_bzl"
     - "--incompatible_restrict_string_escapes"
     - "--incompatible_enable_cc_toolchain_resolution"

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -130,21 +130,6 @@ def go_rules_dependencies(is_rules_go = False):
         patch_args = ["-p1"],
     )
 
-    # Needed for additional targets declared around binaries with c-archive
-    # and c-shared link modes.
-    # releaser:upgrade-dep bazelbuild rules_cc
-    _maybe(
-        http_archive,
-        name = "rules_cc",
-        # main, as of 2021-06-30
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/daf6ace7cfeacd6a83e9ff2ed659f416537b6c74.zip",
-            "https://github.com/bazelbuild/rules_cc/archive/daf6ace7cfeacd6a83e9ff2ed659f416537b6c74.zip",
-        ],
-        sha256 = "b295cad8c5899e371dde175079c0a2cdc0151f5127acc92366a8c986beb95c76",
-        strip_prefix = "rules_cc-daf6ace7cfeacd6a83e9ff2ed659f416537b6c74",
-    )
-
     # Proto dependencies
     # These are limited as much as possible. In most cases, users need to
     # declare these on their own (probably via go_repository rules generated

--- a/go/private/rules/BUILD.bazel
+++ b/go/private/rules/BUILD.bazel
@@ -30,7 +30,6 @@ bzl_library(
     name = "cgo",
     srcs = ["cgo.bzl"],
     visibility = ["//go:__subpackages__"],
-    # Don't list dependency on @rules_cc//cc:defs
     deps = [
         "@io_bazel_rules_go//go/private:common",
         "@io_bazel_rules_go//go/private:mode",

--- a/tests/core/c_linkmodes/BUILD.bazel
+++ b/tests/core/c_linkmodes/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
 go_binary(
     name = "adder_archive",

--- a/tests/core/cgo/BUILD.bazel
+++ b/tests/core/cgo/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_import", "cc_library")
 
 go_test(
     name = "opts_test",

--- a/tests/core/cgo/objc/BUILD.bazel
+++ b/tests/core/cgo/objc/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("@rules_cc//cc:defs.bzl", "objc_library")
 
 go_test(
     name = "objc_test",

--- a/tests/legacy/cgo_select/BUILD.bazel
+++ b/tests/legacy/cgo_select/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("@rules_cc//cc:defs.bzl", "cc_library")
 
 go_library(
     name = "go_default_library",

--- a/tests/legacy/examples/cgo/cc_dependency/BUILD.bazel
+++ b/tests/legacy/examples/cgo/cc_dependency/BUILD.bazel
@@ -1,5 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_import", "cc_library")
-
 config_setting(
     name = "darwin",
     values = {"cpu": "darwin"},

--- a/tests/legacy/transitive_data/BUILD.bazel
+++ b/tests/legacy/transitive_data/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
-load("@rules_cc//cc:defs.bzl", "cc_library")
 
 go_test(
     name = "go_default_test",

--- a/windows.rst
+++ b/windows.rst
@@ -66,18 +66,8 @@ Create a workspace with a simple ``cc_binary`` target.
 .. code::
 
     -- WORKSPACE --
-    load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-
-    git_repository(
-        name = "rules_cc",
-        commit = "7e650b11fe6d49f70f2ca7a1c4cb8bcc4a1fe239",
-        remote = "https://github.com/bazelbuild/rules_cc",
-        shallow_since = "1578064657 -0800",
-    )
 
     -- BUILD.bazel --
-    load("@rules_cc//cc:defs.bzl", "cc_binary")
-
     cc_binary(
         name = "hello",
         srcs = ["hello.c"],


### PR DESCRIPTION
Long time ago Bazel was saying that cc_binary, cc_library, cc_test and the other cc_* rules should be imported from rules_cc.
However rules_cc was always saying that there is no need to use them yet.
After several discussions it was clarified that migration to bazelbuild/rules_cc was put on hold and there is not need to the users that they start using it.
One of the reasons why a person would not want to use rules_cc right now is because there is no release and there is no notion of what is a good commit:
bazelbuild/rules_cc#91
bazelbuild/rules_cc#68

The fact that rules_go depends on rules_cc forces any rules_go user to use rules_cc. Considering that rules_docker depends on rules_go, any rules_docker user is also forced to depend on rules_cc.

More information about the discussions:
bazelbuild/rules_cc#86
bazelbuild/rules_cc#92
bazelbuild/buildtools#923
bazelbuild/buildtools#952

Fixes https://github.com/bazelbuild/rules_go/issues/2949