### PR TITLE
Suppress goroot path in tool builds

### DIFF
--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -235,6 +235,7 @@ def _go_tool_binary_impl(ctx):
         arguments = [largs],
         inputs = sdk.libs + sdk.headers + sdk.tools + [cout],
         outputs = [out],
+        env = {"GOROOT_FINAL": "GOROOT"},  # Suppress go root paths to keep the output reproducible.
         mnemonic = "GoToolchainBinary",
     )
 


### PR DESCRIPTION
The goroot is encoded in the output binary, but the goroot is different
in different workspaces. As a result tool binaries (such as builder) are
not reproducible. Bazel will have cache misses for build involving
builder even if the resulting output from the build is reproducible.

Similar to go_binary builds, suppress the goroot path in go_tool_binary
output so that the result in reproducible.

**What type of PR is this?**
> Bug fix

**What does this PR do? Why is it needed?**
Like go_binary output, ensure go_tool_binary output is reproducible

**Which issues(s) does this PR fix?**

Fixes #2951

