### PR TITLE
go_test: add compatibility with fuzzing in Go 1.18+

### DIFF
--- a/tests/core/go_test/BUILD.bazel
+++ b/tests/core/go_test/BUILD.bazel
@@ -208,3 +208,8 @@ go_test(
     srcs = ["wrapped_test.go"],
     tags = ["manual"],
 )
+
+go_test(
+    name = "fuzz_test",
+    srcs = ["fuzz_test.go"],
+)

--- a/tests/core/go_test/README.rst
+++ b/tests/core/go_test/README.rst
@@ -111,3 +111,8 @@ wrapper_test
 
 Checks that a ``go_test`` can be executed by another test in a subdirectory.
 Verifies `#2749`_.
+
+fuzz_test
+---------
+
+Checks that a ``go_test`` with a fuzz target builds correctly.

--- a/tests/core/go_test/fuzz_test.go
+++ b/tests/core/go_test/fuzz_test.go
@@ -1,0 +1,29 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build go1.18
+// +build go1.18
+
+package fuzz_test
+
+import "testing"
+
+func Fuzz(f *testing.F) {
+	f.Add("seed")
+	f.Fuzz(func(t *testing.T, s string) {
+		if s != "seed" {
+			t.Fail()
+		}
+	})
+}


### PR DESCRIPTION
The GoTestGenTest action now produces testmain.go files compatible
with Go 1.18 and lower versions. In 1.18, the function
testing.MainStart accepts a new parameter, a list of fuzz targets. We
now find those targets and pass them in for Go 1.18 and higher.

Go 1.18 is still months away, and it's possible the API may change
before then. It's likely that FuzzTarget will be renamed. That should be a
minor change though. MainStart is carved out of the Go 1 compatibility
promise and is only meant to be called by code generated by 'go test',
which we're emulating here.

This change does not add full support for fuzzing. It is possible to
start the fuzzing engine by passing --test_arg=-test.fuzz=regexp
--test_arg=-test.fuzzcachedir=dir. However, if a crash is found,
there's nowhere for the fuzzing engine to write it.

For #2284
