### PR TITLE
cover: use CamelCase for coverage variable

### DIFF
--- a/go/private/actions/cover.bzl
+++ b/go/private/actions/cover.bzl
@@ -26,6 +26,15 @@ def _sanitize(s):
     """Replaces /, -, and . with _."""
     return s.replace("/", "_").replace("-", "_").replace(".", "_")
 
+# convert string from snake_case to CamelCase
+def _snake_to_camel(s):
+    words = s.split("_")
+    out = ""
+    for w in words:
+        out += w[:1].upper()
+        out += w[1:].lower()
+    return out
+
 def emit_cover(go, source):
     """See go/toolchains.rst#cover for full documentation."""
 
@@ -44,7 +53,8 @@ def emit_cover(go, source):
         _, pkgpath = effective_importpath_pkgpath(source.library)
         srcname = pkgpath + "/" + orig.basename if pkgpath else orig.path
 
-        cover_var = "Cover_%s_%s" % (_sanitize(pkgpath), _sanitize(src.basename[:-3]))
+        snake_cover_var = "Cover_%s_%s" % (_sanitize(pkgpath), _sanitize(src.basename[:-3]))
+        cover_var = _snake_to_camel(snake_cover_var)
         out = go.declare_file(go, path = "Cover_%s" % _sanitize(src.basename[:-3]), ext = ".cover.go")
         covered_src_map.pop(src, None)
         covered_src_map[out] = orig

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -250,7 +250,8 @@ func compileArchive(
 			if ext := filepath.Ext(stem); ext != "" {
 				stem = stem[:len(stem)-len(ext)]
 			}
-			coverVar := fmt.Sprintf("Cover_%s_%d_%s", sanitizePathForIdentifier(importPath), i, sanitizePathForIdentifier(stem))
+			snakeCoverVar := fmt.Sprintf("Cover_%s_%d_%s", sanitizePathForIdentifier(importPath), i, sanitizePathForIdentifier(stem))
+			coverVar := snakeToCamel(snakeCoverVar)
 			coverSrc := filepath.Join(workDir, fmt.Sprintf("cover_%d.go", i))
 			if err := instrumentForCoverage(goenv, origSrc, srcName, coverVar, coverMode, coverSrc); err != nil {
 				return err
@@ -521,4 +522,16 @@ func sanitizePathForIdentifier(path string) string {
 		}
 		return '_'
 	}, path)
+}
+
+// snakeToCamel converts a snake_case string to CamelCase string
+func snakeToCamel(s string) string {
+	words := strings.Split(s, "_")
+
+	result := ""
+	for _, w := range words {
+		result += strings.ToUpper(w[:1]) + strings.ToLower(w[1:])
+	}
+
+	return result
 }


### PR DESCRIPTION
During the invocation of 'bazel coverage', rules_go will rewrite the
source files using 'go tool cover -var <cover var name> ...' so that the
variable can be extracted for coverage statistic later. For more
information on this, review the relevant Official Go Team's blog post (1).

rules_go currently injecting a variable using `Cover_snake_case` which
is natural to starlark and python, however this will strip up some
golang static analyzer for not following the `CamelCase` variable naming
convention. In particular, if the generated source for coverage is run
against `staticcheck`'s ST1003 installed as part of `nogo`, it will
fail.

Apply snake_case to CamelCase conversion on all coverage variables.

(1): https://go.dev/blog/cover

**What type of PR is this?**

> Uncomment one line below and remove others.
>
Bug fix
> Feature
> Documentation
> Other

**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

Fixes #2982

**Other notes for review**

I think the code in `go/private/actions/cover.bzl` code path is almost(?) irrelevant right now as updating that starlark files does not reflect much on how coverage is being collected. But I still want to provide a fix there just for completeness sake, just in case somebody else started to rely on the starlark code path one day.