### PR TITLE
Fix Setup instructions in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -216,6 +216,7 @@ fetch rules_go and its dependencies. Bazel will download a recent supported
 Go toolchain and register it for use.
 
 .. code:: bzl
+
     load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
     http_archive(


### PR DESCRIPTION
A [recent change](https://github.com/bazelbuild/rules_go/commit/77eb360c510ece6ab1e2e069bc1764bbc6d7097d?short_path=7b3ed02#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168f) inadvertently hid the WORKSPACE setup instructions, by removing the leading blank line in the code block.

**What type of PR is this?**
Documentation

**What does this PR do? Why is it needed?**
To fix the setup docs.

**Which issues(s) does this PR fix?**
 N/A

**Other notes for review**
I'd suggest viewing the rendered diff.