### PR TITLE
Fix broken bzl_library build graph

### DIFF
--- a/go/private/BUILD.bazel
+++ b/go/private/BUILD.bazel
@@ -56,6 +56,7 @@ bzl_library(
         ":mode",
         ":providers",
         "//go/platform:apple",
+        "//go/private/rules:transition",
         "@bazel_skylib//lib:paths",
         "@bazel_skylib//rules:common_settings",
         "@bazel_tools//tools/build_defs/cc:action_names.bzl",


### PR DESCRIPTION
**What type of PR is this?**
- Bug fix

**What does this PR do? Why is it needed?**
Currently, `//go/private:context` is missing a dep on `//go/private/rules:transition`, which is necessary in order to load `@io_bazel_stardoc//stardoc:stardoc.bzl`. This will be used in a subsequent PR for adding targets to generate Stardoc output.