### PR TITLE
Append path into trimpath if option already exists

### DIFF
--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -277,14 +277,14 @@ func compileArchive(
 			return err
 		}
 
-		gcFlags = append(gcFlags, "-trimpath="+srcDir)
+		gcFlags = append(gcFlags, createTrimPath(gcFlags, srcDir))
 	} else {
 		if cgoExportHPath != "" {
 			if err := ioutil.WriteFile(cgoExportHPath, nil, 0666); err != nil {
 				return err
 			}
 		}
-		gcFlags = append(gcFlags, "-trimpath=.")
+		gcFlags = append(gcFlags, createTrimPath(gcFlags, "."))
 	}
 
 	// Check that the filtered sources don't import anything outside of
@@ -511,6 +511,15 @@ func runNogo(ctx context.Context, workDir string, nogoPath string, srcs []string
 	return nil
 }
 
+func createTrimPath(gcFlags []string, path string) string {
+	for _, flag := range gcFlags {
+		if strings.HasPrefix(flag, "-trimpath=") {
+			return flag + ":" + path
+		}
+	}
+
+	return "-trimpath=" + path
+}
 func sanitizePathForIdentifier(path string) string {
 	return strings.Map(func(r rune) rune {
 		if 'A' <= r && r <= 'Z' ||


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Appends paths to `trimpath` as opposed to overriding potential used-defined flags.

**Which issues(s) does this PR fix?**

User defined `trimpath` through `gc_goopts` are being overriden since a second `-trimpath` is being set. This change appends the path using `:` which has been supported by go for a while (see https://go-review.googlesource.com/c/go/+/173344/)