### PR TITLE
go_test: Add env attribute

### DIFF
--- a/go/core.rst
+++ b/go/core.rst
@@ -492,6 +492,13 @@ Attributes
 | List of Go libraries this test imports directly.                                                 |
 | These may be go_library rules or compatible rules with the GoLibrary_ provider.                  |
 +----------------------------+-----------------------------+---------------------------------------+
+| :param:`env`               | :type:`string_dict`         | :value:`{}`                           |
++----------------------------+-----------------------------+---------------------------------------+
+| Environment variables to set for the test execution.                                             |
+| The values (but not keys) are subject to                                                         |
+| [location expansion](https://docs.bazel.build/versions/main/skylark/macros.html) but not full    |
+| [make variable expansion](https://docs.bazel.build/versions/main/be/make-variables.html).        |
++----------------------------+-----------------------------+---------------------------------------+
 | :param:`embed`             | :type:`label_list`          | :value:`[]`                           |
 +----------------------------+-----------------------------+---------------------------------------+
 | List of Go libraries whose sources should be compiled together with this                         |

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -154,6 +154,10 @@ def _go_test_impl(ctx):
         info_file = ctx.info_file,
     )
 
+    env = {}
+    for k, v in ctx.attr.env.items():
+        env[k] = ctx.expand_location(v, ctx.attr.data)
+
     # Bazel only looks for coverage data if the test target has an
     # InstrumentedFilesProvider. If the provider is found and at least one
     # source file is present, Bazel will set the COVERAGE_OUTPUT_FILE
@@ -175,6 +179,7 @@ def _go_test_impl(ctx):
             dependency_attributes = ["deps", "embed"],
             extensions = ["go"],
         ),
+        testing.TestEnvironment(env),
     ]
 
 _go_test_kwargs = {
@@ -185,6 +190,7 @@ _go_test_kwargs = {
         "deps": attr.label_list(providers = [GoLibrary]),
         "embed": attr.label_list(providers = [GoLibrary]),
         "embedsrcs": attr.label_list(allow_files = True),
+        "env": attr.string_dict(),
         "importpath": attr.string(),
         "gc_goopts": attr.string_list(),
         "gc_linkopts": attr.string_list(),

--- a/go/tools/bazel/bazel_test.go
+++ b/go/tools/bazel/bazel_test.go
@@ -255,7 +255,7 @@ func TestPythonManifest(t *testing.T) {
 		t.Errorf("failed to init runfiles: %v", runfiles.err)
 	}
 
-	entry, ok := runfiles.index["important.txt"]
+	entry, ok := runfiles.index.GetIgnoringWorkspace("important.txt")
 	if !ok {
 		t.Errorf("failed to locate runfile %s in index", "important.txt")
 	}

--- a/tests/core/go_test/BUILD.bazel
+++ b/tests/core/go_test/BUILD.bazel
@@ -213,3 +213,15 @@ go_test(
     name = "fuzz_test",
     srcs = ["fuzz_test.go"],
 )
+
+go_test(
+    name = "env_test",
+    srcs = ["env_test.go"],
+    data = ["@go_sdk//:lib/time/zoneinfo.zip"],
+    env = {
+        "ZONEINFO": "$(execpath @go_sdk//:lib/time/zoneinfo.zip)",
+    },
+    deps = [
+        "@io_bazel_rules_go//go/tools/bazel",
+    ],
+)

--- a/tests/core/go_test/env_test.go
+++ b/tests/core/go_test/env_test.go
@@ -1,0 +1,39 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env_test
+
+import (
+    "os"
+    "testing"
+
+    "github.com/bazelbuild/rules_go/go/tools/bazel"
+)
+
+func TestEnv(t *testing.T) {
+    v := os.Getenv("ZONEINFO")
+    if v == "" {
+        t.Fatalf("ZONEINFO env var was empty")
+    }
+
+    path, err := bazel.Runfile(v)
+    if err != nil {
+        t.Fatalf("Could not find runfile %v: %v", v, err)
+    }
+
+    if _, err := os.Stat(path); err != nil {
+        t.Fatalf("Could not find file at env var $ZONEINFO (value: %v) at path %v: %v", v, path, err)
+    }
+}
+


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This allows setting environment variables before static initialisers
run, and which reference expanded locations.

**Which issues(s) does this PR fix?**

Partially fixes #2921