### PR TITLE
Reset Go settings for protoc dependencies

### DIFF
--- a/go/private/rules/nogo.bzl
+++ b/go/private/rules/nogo.bzl
@@ -25,7 +25,7 @@ load(
 )
 load(
     "//go/private/rules:transition.bzl",
-    "go_exec_reset_transition",
+    "go_tool_transition",
 )
 
 def _nogo_impl(ctx):
@@ -103,7 +103,7 @@ _nogo = rule(
         ),
     },
     toolchains = ["@io_bazel_rules_go//go:toolchain"],
-    cfg = go_exec_reset_transition,
+    cfg = go_tool_transition,
 )
 
 def nogo(name, visibility = None, **kwargs):

--- a/go/private/rules/nogo.bzl
+++ b/go/private/rules/nogo.bzl
@@ -25,7 +25,7 @@ load(
 )
 load(
     "//go/private/rules:transition.bzl",
-    "go_reset_transition",
+    "go_exec_reset_transition",
 )
 
 def _nogo_impl(ctx):
@@ -103,7 +103,7 @@ _nogo = rule(
         ),
     },
     toolchains = ["@io_bazel_rules_go//go:toolchain"],
-    cfg = go_reset_transition,
+    cfg = go_exec_reset_transition,
 )
 
 def nogo(name, visibility = None, **kwargs):

--- a/go/private/rules/transition.bzl
+++ b/go/private/rules/transition.bzl
@@ -221,7 +221,7 @@ go_transition = transition(
     ]],
 )
 
-_reset_transition_dict = {
+_common_reset_transition_dict = {
     "@io_bazel_rules_go//go/config:static": False,
     "@io_bazel_rules_go//go/config:msan": False,
     "@io_bazel_rules_go//go/config:race": False,
@@ -230,17 +230,22 @@ _reset_transition_dict = {
     "@io_bazel_rules_go//go/config:debug": False,
     "@io_bazel_rules_go//go/config:linkmode": LINKMODE_NORMAL,
     "@io_bazel_rules_go//go/config:tags": [],
-    "@io_bazel_rules_go//go/private:bootstrap_nogo": True,
 }
+
+_reset_transition_dict = dict(_common_reset_transition_dict, **{
+    "@io_bazel_rules_go//go/private:bootstrap_nogo": True,
+})
 
 _reset_transition_keys = sorted([filter_transition_label(label) for label in _reset_transition_dict.keys()])
 
-def _go_reset_transition_impl(settings, attr):
-    """Sets Go settings to default values so tools can be built safely.
+def _go_exec_reset_transition_impl(settings, attr):
+    """Sets most Go settings to default values (use for external Go tools).
 
-    go_reset_transition sets all of the //go/config settings to their default
-    values. This is used for tool binaries like nogo. Tool binaries shouldn't
-    depend on the link mode or tags of the target configuration. This transition
+    go_exec_reset_transition sets all of the //go/config settings to their
+    default values and disables nogo. This is used for Go tool binaries like
+    nogo itself. Tool binaries shouldn't depend on the link mode or tags of the
+    target configuration and neither the tools nor the code they potentially
+    generate should be subject to nogo's static analysis. This transition
     doesn't change the platform (goos, goarch), but tool binaries should also
     have `cfg = "exec"` so tool binaries should be built for the execution
     platform.
@@ -250,15 +255,44 @@ def _go_reset_transition_impl(settings, attr):
         settings[filter_transition_label(label)] = value
     return settings
 
-go_reset_transition = transition(
-    implementation = _go_reset_transition_impl,
+go_exec_reset_transition = transition(
+    implementation = _go_exec_reset_transition_impl,
     inputs = _reset_transition_keys,
     outputs = _reset_transition_keys,
 )
 
-def _go_reset_target_impl(ctx):
+_non_go_exec_reset_transition_dict = dict(_common_reset_transition_dict, **{
+    "@io_bazel_rules_go//go/private:bootstrap_nogo": False,
+})
+
+_non_go_exec_reset_transition_keys = sorted([filter_transition_label(label) for label in _non_go_exec_reset_transition_dict.keys()])
+
+def _go_non_go_exec_reset_tool_transition_impl(settings, attr):
+    """Sets all Go settings to default values (use for external non-Go tools).
+
+    go_non_go_exec_reset_transition sets all of the //go/config settings as well
+    as the nogo settings to their default values. This is used for all tools that
+    are not themselves targets created from rules_go rules and thus do not read
+    these settings. Resetting all of them to defaults prevents unnecessary
+    configuration changes for these targets that could cause rebuilds.
+
+    Examples: This transition is applied to attributes referening proto_library
+    targets or protoc directly.
+    """
+    settings = dict(settings)
+    for label, value in _non_go_exec_reset_transition_dict.items():
+        settings[filter_transition_label(label)] = value
+    return settings
+
+go_non_go_exec_reset_tool_transition = transition(
+    implementation = _go_non_go_exec_reset_tool_transition_impl,
+    inputs = _non_go_exec_reset_transition_keys,
+    outputs = _non_go_exec_reset_transition_keys,
+)
+
+def _go_exec_reset_target_impl(ctx):
     t = ctx.attr.dep[0]  # [0] seems to be necessary with the transition
-    providers = [t[p] for p in [GoLibrary, GoSource, GoArchive]]
+    providers = [t[p] for p in [GoLibrary, GoSource, GoArchive] if p in t]
 
     # We can't pass DefaultInfo through as-is, since Bazel forbids executable
     # if it's a file declared in a different target. To emulate that, symlink
@@ -290,25 +324,49 @@ def _go_reset_target_impl(ctx):
     )
     return providers
 
-go_reset_target = rule(
-    implementation = _go_reset_target_impl,
+go_exec_reset_target = rule(
+    implementation = _go_exec_reset_target_impl,
     attrs = {
         "dep": attr.label(
             mandatory = True,
-            cfg = go_reset_transition,
+            cfg = go_exec_reset_transition,
         ),
-        "_whitelist_function_transition": attr.label(
-            default = "@bazel_tools//tools/whitelists/function_transition_whitelist",
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),
     },
-    doc = """Forwards providers from a target and applies go_reset_transition.
+    doc = """Forwards providers from a target and applies go_exec_reset_transition.
 
-go_reset_target depends on a single target, built using go_reset_transition.
+go_exec_reset_target depends on a single target, built using go_exec_reset_transition.
 It forwards Go providers and DefaultInfo.
 
 This is used to work around a problem with building tools: tools should be
 built with 'cfg = "exec"' so they work on the execution platform, but we also
-need to apply go_reset_transition, so for example, a tool isn't built as a
+need to apply go_exec_reset_transition, so for example, a tool isn't built as a
+shared library with race instrumentation. This acts as an intermediately rule
+so we can apply both transitions.
+""",
+)
+
+go_non_go_exec_reset_target = rule(
+    implementation = _go_exec_reset_target_impl,
+    attrs = {
+        "dep": attr.label(
+            mandatory = True,
+            cfg = go_non_go_exec_reset_tool_transition,
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+    doc = """Forwards providers from a target and applies go_exec_reset_transition.
+
+go_exec_reset_target depends on a single target, built using go_exec_reset_transition.
+It forwards Go providers and DefaultInfo.
+
+This is used to work around a problem with building tools: tools should be
+built with 'cfg = "exec"' so they work on the execution platform, but we also
+need to apply go_exec_reset_transition, so for example, a tool isn't built as a
 shared library with race instrumentation. This acts as an intermediately rule
 so we can apply both transitions.
 """,

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//go:def.bzl", "go_binary", "go_source", "go_test")
-load("//go/private/rules:transition.bzl", "go_reset_target")
+load("//go/private/rules:transition.bzl", "go_exec_reset_target")
 
 go_test(
     name = "filter_test",
@@ -93,7 +93,7 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-go_reset_target(
+go_exec_reset_target(
     name = "go_path",
     dep = ":go_path-bin",
     visibility = ["//visibility:public"],
@@ -127,7 +127,7 @@ go_binary(
     visibility = ["//visibility:private"],
 )
 
-go_reset_target(
+go_exec_reset_target(
     name = "go-protoc",
     dep = ":go-protoc-bin",
     visibility = ["//visibility:public"],

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//go:def.bzl", "go_binary", "go_source", "go_test")
-load("//go/private/rules:transition.bzl", "go_exec_reset_target")
+load("//go/private/rules:transition.bzl", "go_reset_target")
 
 go_test(
     name = "filter_test",
@@ -93,7 +93,7 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-go_exec_reset_target(
+go_reset_target(
     name = "go_path",
     dep = ":go_path-bin",
     visibility = ["//visibility:public"],
@@ -127,7 +127,7 @@ go_binary(
     visibility = ["//visibility:private"],
 )
 
-go_exec_reset_target(
+go_reset_target(
     name = "go-protoc",
     dep = ":go-protoc-bin",
     visibility = ["//visibility:public"],

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -5,7 +5,7 @@ load(
 )
 load(
     "//go/private/rules:transition.bzl",
-    "go_non_go_exec_reset_target",
+    "non_go_reset_target",
 )
 load(
     "//proto/wkt:well_known_types.bzl",
@@ -116,8 +116,8 @@ go_proto_compiler(
     ] + WELL_KNOWN_TYPE_RULES.values(),
 )
 
-go_non_go_exec_reset_target(
-    name = "protoc_reset_target_",
+non_go_reset_target(
+    name = "protoc",
     dep = "@com_google_protobuf//:protoc",
     visibility = ["//visibility:public"],
 )

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -4,6 +4,10 @@ load(
     "go_proto_compiler",
 )
 load(
+    "//go/private/rules:transition.bzl",
+    "go_non_go_exec_reset_target",
+)
+load(
     "//proto/wkt:well_known_types.bzl",
     "GOGO_WELL_KNOWN_TYPE_REMAPS",
     "PROTO_RUNTIME_DEPS",
@@ -110,6 +114,12 @@ go_proto_compiler(
         "@org_golang_google_grpc//status:go_default_library",
         "@org_golang_x_net//context:go_default_library",
     ] + WELL_KNOWN_TYPE_RULES.values(),
+)
+
+go_non_go_exec_reset_target(
+    name = "protoc_reset_target_",
+    dep = "@com_google_protobuf//:protoc",
+    visibility = ["//visibility:public"],
 )
 
 filegroup(

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -23,7 +23,7 @@ load(
 )
 load(
     "//go/private/rules:transition.bzl",
-    "go_exec_reset_target",
+    "go_reset_target",
 )
 
 GoProtoCompiler = provider(
@@ -200,7 +200,7 @@ _go_proto_compiler = rule(
         "_protoc": attr.label(
             executable = True,
             cfg = "exec",
-            default = "//proto:protoc_reset_target_",
+            default = "//proto:protoc",
         ),
         "_go_context_data": attr.label(
             default = "//:go_context_data",
@@ -212,7 +212,7 @@ _go_proto_compiler = rule(
 def go_proto_compiler(name, **kwargs):
     plugin = kwargs.pop("plugin", "@com_github_golang_protobuf//protoc-gen-go")
     reset_plugin_name = name + "_reset_plugin_"
-    go_exec_reset_target(
+    go_reset_target(
         name = reset_plugin_name,
         dep = plugin,
         visibility = ["//visibility:private"],

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -23,7 +23,7 @@ load(
 )
 load(
     "//go/private/rules:transition.bzl",
-    "go_reset_target",
+    "go_exec_reset_target",
 )
 
 GoProtoCompiler = provider(
@@ -200,7 +200,7 @@ _go_proto_compiler = rule(
         "_protoc": attr.label(
             executable = True,
             cfg = "exec",
-            default = "@com_google_protobuf//:protoc",
+            default = "//proto:protoc_reset_target_",
         ),
         "_go_context_data": attr.label(
             default = "//:go_context_data",
@@ -212,7 +212,7 @@ _go_proto_compiler = rule(
 def go_proto_compiler(name, **kwargs):
     plugin = kwargs.pop("plugin", "@com_github_golang_protobuf//protoc-gen-go")
     reset_plugin_name = name + "_reset_plugin_"
-    go_reset_target(
+    go_exec_reset_target(
         name = reset_plugin_name,
         dep = plugin,
         visibility = ["//visibility:private"],

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -19,6 +19,10 @@ load(
     "go_context",
 )
 load(
+    "@bazel_skylib//lib:types.bzl",
+    "types",
+)
+load(
     "//proto:compiler.bzl",
     "GoProtoCompiler",
     "proto_path",
@@ -26,6 +30,10 @@ load(
 load(
     "//go/private:providers.bzl",
     "INFERRED_PATH",
+)
+load(
+    "//go/private/rules:transition.bzl",
+    "go_non_go_exec_reset_tool_transition",
 )
 load(
     "@rules_proto//proto:defs.bzl",
@@ -37,8 +45,9 @@ GoProtoImports = provider()
 def get_imports(attr):
     proto_deps = []
 
-    if hasattr(attr, "proto") and attr.proto and ProtoInfo in attr.proto:
-        proto_deps = [attr.proto]
+    # ctx.attr.proto is a one-element array since there is a Starlark transition attached to it.
+    if hasattr(attr, "proto") and attr.proto and types.is_list(attr.proto) and ProtoInfo in attr.proto[0]:
+        proto_deps = [attr.proto[0]]
     elif hasattr(attr, "protos"):
         proto_deps = [d for d in attr.protos if ProtoInfo in d]
     else:
@@ -92,7 +101,9 @@ def _go_proto_library_impl(ctx):
         #TODO: print("DEPRECATED: proto attribute on {}, use protos instead".format(ctx.label))
         if ctx.attr.protos:
             fail("Either proto or protos (non-empty) argument must be specified, but not both")
-        proto_deps = [ctx.attr.proto]
+
+        # ctx.attr.proto is a one-element array since there is a Starlark transition attached to it.
+        proto_deps = [ctx.attr.proto[0]]
     else:
         if not ctx.attr.protos:
             fail("Either proto or protos (non-empty) argument must be specified")
@@ -137,8 +148,12 @@ def _go_proto_library_impl(ctx):
 go_proto_library = rule(
     implementation = _go_proto_library_impl,
     attrs = {
-        "proto": attr.label(providers = [ProtoInfo]),
+        "proto": attr.label(
+            cfg = go_non_go_exec_reset_tool_transition,
+            providers = [ProtoInfo],
+        ),
         "protos": attr.label_list(
+            cfg = go_non_go_exec_reset_tool_transition,
             providers = [ProtoInfo],
             default = [],
         ),
@@ -158,6 +173,9 @@ go_proto_library = rule(
         ),
         "_go_context_data": attr.label(
             default = "//:go_context_data",
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),
     },
     toolchains = ["@io_bazel_rules_go//go:toolchain"],

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -33,7 +33,7 @@ load(
 )
 load(
     "//go/private/rules:transition.bzl",
-    "go_non_go_exec_reset_tool_transition",
+    "non_go_tool_transition",
 )
 load(
     "@rules_proto//proto:defs.bzl",
@@ -149,11 +149,11 @@ go_proto_library = rule(
     implementation = _go_proto_library_impl,
     attrs = {
         "proto": attr.label(
-            cfg = go_non_go_exec_reset_tool_transition,
+            cfg = non_go_tool_transition,
             providers = [ProtoInfo],
         ),
         "protos": attr.label_list(
-            cfg = go_non_go_exec_reset_tool_transition,
+            cfg = non_go_tool_transition,
             providers = [ProtoInfo],
             default = [],
         ),

--- a/tests/core/transition/BUILD.bazel
+++ b/tests/core/transition/BUILD.bazel
@@ -5,3 +5,9 @@ go_bazel_test(
     size = "medium",
     srcs = ["cmdline_test.go"],
 )
+
+go_bazel_test(
+    name = "hermeticity_test",
+    size = "medium",
+    srcs = ["hermeticity_test.go"],
+)

--- a/tests/core/transition/hermeticity_test.go
+++ b/tests/core/transition/hermeticity_test.go
@@ -111,6 +111,7 @@ func assertDependsCleanlyOnWithFlags(t *testing.T, targetA, targetB string, flag
 	out, err := bazel_testing.BazelOutput(append(
 		[]string{
 			"cquery",
+			"--transitions=full",
 			query,
 		},
 		flags...,

--- a/tests/core/transition/hermeticity_test.go
+++ b/tests/core/transition/hermeticity_test.go
@@ -1,0 +1,175 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hermeticity_test
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: `
+-- BUILD.bazel --
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "foo_proto",
+    srcs = ["foo.proto"],
+)
+
+go_proto_library(
+    name = "foo_go_proto",
+    importpath = "github.com/bazelbuild/rules_go/tests/core/transition/foo",
+    proto = ":foo_proto",
+)
+-- foo.proto --
+syntax = "proto3";
+
+package tests.core.transition.foo;
+option go_package = "github.com/bazelbuild/rules_go/tests/core/transition/foo";
+
+message Foo {
+  int64 value = 1;
+}
+`,
+		WorkspaceSuffix: `
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "com_google_protobuf",
+    sha256 = "a79d19dcdf9139fa4b81206e318e33d245c4c9da1ffed21c87288ed4380426f9",
+    strip_prefix = "protobuf-3.11.4",
+    # latest, as of 2020-02-21
+    urls = [
+        "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v3.11.4.tar.gz",
+        "https://github.com/protocolbuffers/protobuf/archive/v3.11.4.tar.gz",
+    ],
+)
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
+http_archive(
+    name = "rules_proto",
+    sha256 = "4d421d51f9ecfe9bf96ab23b55c6f2b809cbaf0eea24952683e397decfbd0dd0",
+    strip_prefix = "rules_proto-f6b8d89b90a7956f6782a4a3609b2f0eee3ce965",
+    # master, as of 2020-01-06
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/f6b8d89b90a7956f6782a4a3609b2f0eee3ce965.tar.gz",
+        "https://github.com/bazelbuild/rules_proto/archive/f6b8d89b90a7956f6782a4a3609b2f0eee3ce965.tar.gz",
+    ],
+)
+`,
+	})
+}
+
+func TestGoProtoLibraryToolAttrsAreReset(t *testing.T) {
+	assertDependsCleanlyOn(t, "//:foo_go_proto", "@com_google_protobuf//:protoc")
+}
+
+func assertDependsCleanlyOn(t *testing.T, targetA, targetB string) {
+	assertDependsCleanlyOnWithFlags(
+		t,
+		targetA,
+		targetB,
+		"--@io_bazel_rules_go//go/config:static",
+		"--@io_bazel_rules_go//go/config:msan",
+		"--@io_bazel_rules_go//go/config:race",
+		"--@io_bazel_rules_go//go/config:debug",
+		"--@io_bazel_rules_go//go/config:linkmode=c-archive",
+		"--@io_bazel_rules_go//go/config:tags=fake_tag",
+	)
+	assertDependsCleanlyOnWithFlags(
+		t,
+		targetA,
+		targetB,
+		"--@io_bazel_rules_go//go/config:pure",
+	)
+}
+
+func assertDependsCleanlyOnWithFlags(t *testing.T, targetA, targetB string, flags ...string) {
+	query := fmt.Sprintf("deps(%s) intersect %s", targetA, targetB)
+	out, err := bazel_testing.BazelOutput(append(
+		[]string{
+			"cquery",
+			query,
+		},
+		flags...,
+	)...,
+	)
+	if err != nil {
+		t.Fatalf("bazel cquery '%s': %v", query, err)
+	}
+	cqueryOut := string(bytes.TrimSpace(out))
+	configHashes := extractConfigHashes(t, cqueryOut)
+	if len(configHashes) != 1 {
+		t.Fatalf(
+			"%s depends on %s in multiple configs with these differences in rules_go options: %s",
+			targetA,
+			targetB,
+			strings.Join(getGoOptions(t, configHashes...), "\n"),
+		)
+	}
+	goOptions := getGoOptions(t, configHashes[0])
+	if len(goOptions) != 0 {
+		t.Fatalf(
+			"%s depends on %s in a config with rules_go options: %s",
+			targetA,
+			targetB,
+			strings.Join(goOptions, "\n"),
+		)
+	}
+}
+
+func extractConfigHashes(t *testing.T, cqueryOut string) []string {
+	lines := strings.Split(cqueryOut, "\n")
+	var hashes []string
+	for _, line := range lines {
+		openingParens := strings.Index(line, "(")
+		closingParens := strings.Index(line, ")")
+		if openingParens == -1 || closingParens <= openingParens {
+			t.Fatalf("failed to find config hash in cquery out line: %s", line)
+		}
+		hashes = append(hashes, line[openingParens+1:closingParens])
+	}
+	return hashes
+}
+
+func getGoOptions(t *testing.T, hashes ...string) []string {
+	out, err := bazel_testing.BazelOutput(append([]string{"config"}, hashes...)...)
+	if err != nil {
+		t.Fatalf("bazel config %s: %v", strings.Join(hashes, " "), err)
+	}
+	lines := strings.Split(string(bytes.TrimSpace(out)), "\n")
+	differingGoOptions := make([]string, 0)
+	for _, line := range lines {
+		// Lines with configuration options are indented
+		if !strings.HasPrefix(line, "  ") {
+			continue
+		}
+		optionAndValue := strings.TrimLeft(line, " ")
+		if strings.HasPrefix(optionAndValue, "@io_bazel_rules_go//") {
+			differingGoOptions = append(differingGoOptions, optionAndValue)
+		}
+	}
+	return differingGoOptions
+}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Reduces the number of essentially distinct configurations in which `protoc` as a dependency of `go_proto_library` is analyzed. 

Note that this may not (yet) result in a significant reduction of *rebuilds* since Bazel is not particular friendly to reset transitions at the moment: It encodes some information about the path of transitions taken into the build configuration, which e.g. prevents transitions from ever returning to the top-level target configuration. But this will be solved by https://github.com/bazelbuild/bazel/issues/14023, which is very actively being worked on. In the meantime, this change should at least not regress the current behavior further.

**Which issues(s) does this PR fix?**

Fixes a part of #2999.

**Other notes for review**

@robfig If you think that this PR is useful, I would also look into a follow-up that resets the non-Go attrs, e.g. `data` and `embedsrcs`, of rules such as `go_library` to their values before `go_transition`. Ideally, `rules_go` settings set by transitions would only ever propagate to rules that provide a Go provider. Since this requires memoizing the state of settings before a transition, this will be a bit more complicated, which is why I would like to get your feedback on this simpler case first.
