### PR TITLE
Trim absolute paths in files generated by cgo

### DIFF
--- a/tests/core/cgo/BUILD.bazel
+++ b/tests/core/cgo/BUILD.bazel
@@ -220,6 +220,7 @@ cc_binary(
 go_test(
     name = "cc_libs_test",
     srcs = [
+        "cc_libs_common.go",
         "cc_libs_darwin_test.go",
         "cc_libs_linux_test.go",
     ],

--- a/tests/core/cgo/cc_libs_common.go
+++ b/tests/core/cgo/cc_libs_common.go
@@ -1,0 +1,34 @@
+package cc_libs_test
+
+import (
+	"bytes"
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+	"io/ioutil"
+	"testing"
+)
+
+// A distinctive substring contained in every absolute path pointing into the
+// Bazel cache.
+const execPathIndicator = "/execroot/io_bazel_rules_go"
+
+func verifyNoCachePaths(t *testing.T, shortPath string) {
+	binPath, err := bazel.Runfile(shortPath)
+	if err != nil {
+		t.Error(err)
+	}
+	binBytes, err := ioutil.ReadFile(binPath)
+	if err != nil {
+		t.Error(err)
+	}
+	if pos := bytes.Index(binBytes, []byte(execPathIndicator)); pos != -1 {
+		begin := pos - 150
+		if begin < 0 {
+			begin = 0
+		}
+		end := pos + 150
+		if end > len(binBytes) {
+			end = len(binBytes)
+		}
+		t.Errorf("%s leaks an absolute path:\n%q", shortPath, binBytes[begin:end])
+	}
+}

--- a/tests/core/cgo/cc_libs_darwin_test.go
+++ b/tests/core/cgo/cc_libs_darwin_test.go
@@ -64,6 +64,8 @@ func TestBinaries(t *testing.T) {
 					t.Errorf("wanted dependency on library %q", wantLib)
 				}
 			}
+
+			verifyNoCachePaths(t, test.shortPath)
 		})
 	}
 }

--- a/tests/core/cgo/cc_libs_linux_test.go
+++ b/tests/core/cgo/cc_libs_linux_test.go
@@ -61,6 +61,8 @@ func TestBinaries(t *testing.T) {
 					t.Errorf("wanted dependency on library %q", wantLib)
 				}
 			}
+
+			verifyNoCachePaths(t, test.shortPath)
 		})
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The cgo command generates .c files that contain //line comments
referencing source files by absolute paths into the Bazel cache. As the
contents of these comments end up in the symbol table of the resulting
c-archive, this makes Bazel-built CGo binaries non-reproducible.

This is fixed by passing the -trimpath argument to cgo to trim the
Bazel execroot prefix from these paths.

**Which issues(s) does this PR fix?**

Fixes #3010
