### PR TITLE
Add first class support for GOOS=ios

### DIFF
--- a/go/platform/apple.bzl
+++ b/go/platform/apple.bzl
@@ -29,7 +29,7 @@ _PLATFORMS = {
 def _apple_version_min(ctx, platform, platform_type):
     xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
     min_os = str(xcode_config.minimum_os_for_platform_type(platform_type))
-    return "-m" + platform.name_in_plist.lower() + "-version-min=" + min_os
+    return "-m{}-version-min={}".format(platform.name_in_plist.lower(), min_os)
 
 def _apple_env(ctx, platform):
     xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
@@ -40,8 +40,6 @@ def apple_ensure_options(ctx, env, tags, compiler_option_lists, linker_option_li
     platform, platform_type = _PLATFORMS.get(target_gnu_system_name, (None, None))
     if not platform:
         return
-    if platform_type == apple_common.platform_type.ios:
-        tags.append("ios")  # needed for stdlib building
     env.update(_apple_env(ctx, platform))
     min_version = _apple_version_min(ctx, platform, platform_type)
     for compiler_options in compiler_option_lists:

--- a/go/platform/list.bzl
+++ b/go/platform/list.bzl
@@ -54,25 +54,6 @@ def declare_config_settings():
             ],
         )
 
-    # Additional settings for ios. Unfortunately, we cannot have a "darwin"
-    # setting that covers both operating systems, so "darwin" here means macOS.
-    # The "darwin" build tag will be true for both during execution; this only
-    # matters when evaluating select expressions.
-    native.config_setting(
-        name = "ios",
-        constraint_values = [
-            "@platforms//os:ios",
-        ],
-    )
-    for goarch in ("arm", "arm64", "386", "amd64"):
-        native.config_setting(
-            name = "ios_" + goarch,
-            constraint_values = [
-                "@platforms//os:ios",
-                "@io_bazel_rules_go//go/toolchain:" + goarch,
-            ],
-        )
-
     # Setting that determines whether cgo is enabled.
     # This is experimental and may be changed or removed when we migrate
     # to build settings.

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -108,7 +108,7 @@ def emit_link(
         tool_args.add("-pluginpath", archive.data.importpath)
 
     # TODO: Rework when https://github.com/bazelbuild/bazel/pull/12304 is mainstream
-    if go.mode.link == LINKMODE_C_SHARED and go.mode.goos == "darwin":
+    if go.mode.link == LINKMODE_C_SHARED and (go.mode.goos in ["darwin", "ios"]):
         extldflags.extend([
             "-install_name",
             rpath.install_name(executable),

--- a/go/private/mode.bzl
+++ b/go/private/mode.bzl
@@ -127,8 +127,8 @@ def mode_tags_equivalent(l, r):
 
 # Ported from https://github.com/golang/go/blob/master/src/cmd/go/internal/work/init.go#L76
 _LINK_C_ARCHIVE_PLATFORMS = {
-    "darwin/arm": None,
     "darwin/arm64": None,
+    "ios/arm64": None,
 }
 
 _LINK_C_ARCHIVE_GOOS = {
@@ -140,18 +140,11 @@ _LINK_C_ARCHIVE_GOOS = {
     "solaris": None,
 }
 
-_LINK_C_SHARED_PLATFORMS = {
-    "linux/amd64": None,
-    "linux/arm": None,
-    "linux/arm64": None,
-    "linux/386": None,
-    "linux/ppc64le": None,
-    "linux/s390x": None,
-    "android/amd64": None,
-    "android/arm": None,
-    "android/arm64": None,
-    "android/386": None,
-}
+_LINK_C_SHARED_GOOS = [
+    "android",
+    "freebsd",
+    "linux",
+]
 
 _LINK_PLUGIN_PLATFORMS = {
     "linux/amd64": None,
@@ -166,6 +159,8 @@ _LINK_PLUGIN_PLATFORMS = {
     "android/386": None,
     "darwin/amd64": None,
     "darwin/arm64": None,
+    "ios/arm": None,
+    "ios/arm64": None,
 }
 
 _LINK_PIE_PLATFORMS = {
@@ -191,7 +186,7 @@ def link_mode_args(mode):
             mode.goos in _LINK_C_ARCHIVE_GOOS and platform != "linux/ppc64"):
             args.append("-shared")
     elif mode.link == LINKMODE_C_SHARED:
-        if platform in _LINK_C_SHARED_PLATFORMS:
+        if mode.goos in _LINK_C_SHARED_GOOS:
             args.append("-shared")
     elif mode.link == LINKMODE_PLUGIN:
         if platform in _LINK_PLUGIN_PLATFORMS:
@@ -218,7 +213,7 @@ def extld_from_cc_toolchain(go):
     elif go.mode.link in (LINKMODE_SHARED, LINKMODE_PLUGIN, LINKMODE_C_SHARED, LINKMODE_PIE):
         return ["-extld", go.cgo_tools.ld_dynamic_lib_path]
     elif go.mode.link == LINKMODE_C_ARCHIVE:
-        if go.mode.goos == "darwin":
+        if go.mode.goos in ["darwin", "ios"]:
             # TODO(jayconrod): on macOS, set -extar. At this time, wrapped_ar is
             # a bash script without a shebang line, so we can't execute it. We
             # use /usr/bin/ar (the default) instead.

--- a/go/private/platforms.bzl
+++ b/go/private/platforms.bzl
@@ -20,6 +20,7 @@ BAZEL_GOOS_CONSTRAINTS = {
     "android": "@platforms//os:android",
     "darwin": "@platforms//os:osx",
     "freebsd": "@platforms//os:freebsd",
+    "ios": "@platforms//os:ios",
     "linux": "@platforms//os:linux",
     "windows": "@platforms//os:windows",
 }
@@ -49,6 +50,8 @@ GOOS_GOARCH = (
     ("freebsd", "arm"),
     ("freebsd", "arm64"),
     ("illumos", "amd64"),
+    ("ios", "amd64"),
+    ("ios", "arm64"),
     ("js", "wasm"),
     ("linux", "386"),
     ("linux", "amd64"),
@@ -107,6 +110,8 @@ CGO_GOOS_GOARCH = {
     ("freebsd", "amd64"): None,
     ("freebsd", "arm"): None,
     ("illumos", "amd64"): None,
+    ("ios", "amd64"): None,
+    ("ios", "arm64"): None,
     ("linux", "386"): None,
     ("linux", "amd64"): None,
     ("linux", "arm"): None,
@@ -166,26 +171,6 @@ def _generate_platforms():
                 constraints = constraints + ["@io_bazel_rules_go//go/toolchain:cgo_on"] + mingw,
                 cgo = True,
             ))
-
-    for goarch in ("arm", "arm64", "386", "amd64"):
-        constraints = [
-            "@platforms//os:ios",
-            GOARCH_CONSTRAINTS[goarch],
-        ]
-        platforms.append(struct(
-            name = "ios_" + goarch,
-            goos = "darwin",
-            goarch = goarch,
-            constraints = constraints + ["@io_bazel_rules_go//go/toolchain:cgo_off"],
-            cgo = False,
-        ))
-        platforms.append(struct(
-            name = "ios_" + goarch + "_cgo",
-            goos = "darwin",
-            goarch = goarch,
-            constraints = constraints + ["@io_bazel_rules_go//go/toolchain:cgo_on"],
-            cgo = True,
-        ))
 
     return platforms
 

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -129,6 +129,7 @@ def _go_binary_impl(ctx):
         cc_import_kwargs = {
             "linkopts": {
                 "darwin": [],
+                "ios": [],
                 "windows": ["-mthreads"],
             }.get(go.mode.goos, ["-pthread"]),
         }

--- a/go/tools/builders/cgo2.go
+++ b/go/tools/builders/cgo2.go
@@ -284,7 +284,7 @@ func defaultCFlags(workDir string) []string {
 	}
 	goos, goarch := os.Getenv("GOOS"), os.Getenv("GOARCH")
 	switch {
-	case goos == "darwin":
+	case goos == "darwin" || goos == "ios":
 		return flags
 	case goos == "windows" && goarch == "amd64":
 		return append(flags, "-mthreads")
@@ -298,7 +298,7 @@ func defaultLdFlags() []string {
 	switch {
 	case goos == "android":
 		return []string{"-llog", "-ldl"}
-	case goos == "darwin":
+	case goos == "darwin" || goos == "ios":
 		return nil
 	case goos == "windows" && goarch == "amd64":
 		return []string{"-mthreads"}

--- a/go/tools/builders/link.go
+++ b/go/tools/builders/link.go
@@ -67,7 +67,7 @@ func link(args []string) error {
 	// os.Open on Windows converts absolute paths to some other path format with
 	// longer length limits. Absolute paths do not work on macOS for .dylib
 	// outputs because they get baked in as the "install path".
-	if runtime.GOOS != "darwin" {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "ios" {
 		*outFile = abs(*outFile)
 	}
 	*main = abs(*main)


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Add first class support for `GOOS=ios`.

Up until now, `ios` was supported as `darwin_arm64` by Go. `GOOS=ios`
support was added in Go 1.16 [1].

1. https://golang.org/doc/go1.16
