### PR TITLE
Add output of bindata rule to runfiles

### DIFF
--- a/extras/bindata.bzl
+++ b/extras/bindata.bzl
@@ -55,6 +55,7 @@ def _bindata_impl(ctx):
     return [
         DefaultInfo(
             files = depset([out]),
+            runfiles = ctx.runfiles([out]),
         ),
     ]
 


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The DefaultInfo provided by the `bindata` rule doesn't put its output in runfiles.

A binary rule such as an `sh_binary` that adds on the output of `bindata` to its data would expect the output to be found at `$(rootpath :bindata_target)`.

For example,

```
sh_binary(
    name = "bin_target",
    srcs = ["script.sh"],
    data = [":bindata_target"],
    args = ["$(rootpath :bindata_target)"],
)
```

**Which issues(s) does this PR fix?**

None filed

**Other notes for review**
