### PR TITLE
.bazelci/presubmit.yml: remove old flag

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -11,11 +11,9 @@ tasks:
     # enable some unflipped incompatible flags on this platform to ensure we don't regress.
     build_flags:
     - "--incompatible_load_proto_rules_from_bzl"
-    - "--incompatible_restrict_string_escapes"
     - "--incompatible_enable_cc_toolchain_resolution"
     test_flags:
     - "--incompatible_load_proto_rules_from_bzl"
-    - "--incompatible_restrict_string_escapes"
     - "--incompatible_enable_cc_toolchain_resolution"
     build_targets:
     - "//..."


### PR DESCRIPTION
The --incompatible_restrict_string_escapes flag was flipped to true in
Bazel 4.0 and it has just been removed from HEAD. To keep rules_go
tested against HEAD, we must remove the flag.

Fixes #3002

