### PR TITLE
Always include debug symbols with -c dbg

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -107,7 +107,11 @@ cgo_context_data_proxy(
 # to depend on all build settings directly.
 go_config(
     name = "go_config",
-    debug = "//go/config:debug",
+    # Always include debug symbols with -c dbg.
+    debug = select({
+        "//go/private:is_compilation_mode_dbg": "//go/private:always_true",
+        "//conditions:default": "//go/config:debug",
+    }),
     gotags = "//go/config:tags",
     linkmode = "//go/config:linkmode",
     msan = "//go/config:msan",

--- a/go/modes.rst
+++ b/go/modes.rst
@@ -78,7 +78,7 @@ or using `Bazel configuration transitions`_.
 | :param:`debug`    | :type:`bool`        | :value:`false`                     |
 +-------------------+---------------------+------------------------------------+
 | Includes debugging information in compiled packages (using the ``-N`` and    |
-| ``-l`` flags).                                                               |
+| ``-l`` flags). This is always true with ``-c dbg``.                          |
 +-------------------+---------------------+------------------------------------+
 | :param:`gotags`   | :type:`string_list` | :value:`[]`                        |
 +-------------------+---------------------+------------------------------------+

--- a/go/private/BUILD.bazel
+++ b/go/private/BUILD.bazel
@@ -180,3 +180,18 @@ config_setting(
         ":request_nogo": "True",
     },
 )
+
+bool_setting(
+    name = "always_true",
+    build_setting_default = True,
+    visibility = ["//visibility:public"],
+)
+
+# Only used by //:go_config.
+config_setting(
+    name = "is_compilation_mode_dbg",
+    values = {
+        "compilation_mode": "dbg",
+    },
+    visibility = ["//:__pkg__"],
+)


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Previously, debugging a `go_test` target was only possible with an explicit `--@io_bazel_rules_go//go/config:debug`.

**Which issues(s) does this PR fix?**

Fixes https://github.com/bazelbuild/intellij/issues/2313, which I think is more of a `rules_go` issue.
