### PR TITLE
Replace go_name_hack with a usage of Label

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -2,7 +2,7 @@
 tasks:
   ubuntu1804_bazel400:
     platform: ubuntu1804
-    bazel: 4.2.0 # test minimum supported version of bazel
+    bazel: 4.2.1 # test minimum supported version of bazel
     shell_commands:
       - tests/core/cgo/generate_imported_dylib.sh
     build_targets:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,7 +4,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
-go_rules_dependencies(is_rules_go = True)
+go_rules_dependencies()
 
 go_register_toolchains(version = "1.17")
 

--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -199,7 +199,7 @@ def get_versioned_shared_lib_extension(path):
     # something like 1.2.3, or so.1.2, or dylib.1.2, or foo.1.2
     return ""
 
-MINIMUM_BAZEL_VERSION = "4.2.0"
+MINIMUM_BAZEL_VERSION = "4.2.1"
 
 def as_list(v):
     """Returns a list, tuple, or depset as a list."""

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -20,7 +20,7 @@ load("//go/private:nogo.bzl", "DEFAULT_NOGO", "go_register_nogo")
 load("//proto:gogo.bzl", "gogo_special_proto")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-def go_rules_dependencies(is_rules_go = False):
+def go_rules_dependencies():
     """Declares workspaces the Go rules depend on. Workspaces that use
     rules_go should call this.
 
@@ -285,37 +285,6 @@ def go_rules_dependencies(is_rules_go = False):
         nogo = DEFAULT_NOGO,
     )
 
-    go_name_hack(
-        name = "io_bazel_rules_go_name_hack",
-        is_rules_go = is_rules_go,
-    )
-
 def _maybe(repo_rule, name, **kwargs):
     if name not in native.existing_rules():
         repo_rule(name = name, **kwargs)
-
-def _go_name_hack_impl(ctx):
-    build_content = """\
-load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-
-bzl_library(
-    name = "def",
-    srcs = ["def.bzl"],
-    visibility = ["//visibility:public"],
-)
-"""
-    ctx.file("BUILD.bazel", build_content)
-    content = "IS_RULES_GO = {}".format(ctx.attr.is_rules_go)
-    ctx.file("def.bzl", content)
-
-go_name_hack = repository_rule(
-    implementation = _go_name_hack_impl,
-    attrs = {
-        "is_rules_go": attr.bool(),
-    },
-    doc = """go_name_hack records whether the main workspace is rules_go.
-
-See documentation for _filter_transition_label in
-go/private/rules/transition.bzl.
-""",
-)

--- a/go/private/rules/BUILD.bazel
+++ b/go/private/rules/BUILD.bazel
@@ -119,7 +119,6 @@ bzl_library(
         "@io_bazel_rules_go//go/private:mode",
         "@io_bazel_rules_go//go/private:platforms",
         "@io_bazel_rules_go//go/private:providers",
-        "@io_bazel_rules_go_name_hack//:def",
     ],
 )
 


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

The Label constructor can be used to transform a label string such as @io_bazel_rules_go//foo:bar into the canonical label referencing this target from the repository in which it is called.

For example, `str(Label("@io_bazel_rules_go//foo:bar"))` returns `"@io_bazel_rules_go//foo:bar"` if rules_go is used as an external repository from another main workspace, but returns `"//foo:bar"` when rules_go is the main repository (e.g., when running the tests in the CI).

**Which issues(s) does this PR fix?**

It doesn't resolve a bug, but simplifies the rules_go repository setup. This simplification will be especially useful when converting `rules_go` to a Bazel module in the future.

**Other notes for review**
