### PR TITLE
compilepkg: fix paths in compile errors

### DIFF
--- a/go/tools/builders/cgo2.go
+++ b/go/tools/builders/cgo2.go
@@ -204,14 +204,19 @@ func cgo2(goenv *env, goSrcs, cgoSrcs, cSrcs, cxxSrcs, objcSrcs, objcxxSrcs, sSr
 
 	// Copy regular Go source files into the work directory so that we can
 	// use -trimpath=workDir.
-	goBases, err := gatherSrcs(workDir, goSrcs)
+	subDir := filepath.Join(workDir, packagePath)
+	err = os.MkdirAll(subDir, 0755)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	goBases, err := gatherSrcs(subDir, goSrcs)
 	if err != nil {
 		return "", nil, nil, err
 	}
 
 	allGoSrcs = make([]string, len(goSrcs)+len(genGoSrcs))
 	for i := range goSrcs {
-		allGoSrcs[i] = filepath.Join(workDir, goBases[i])
+		allGoSrcs[i] = filepath.Join(subDir, goBases[i])
 	}
 	copy(allGoSrcs[len(goSrcs):], genGoSrcs)
 	return workDir, allGoSrcs, cObjs, nil

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -284,7 +284,16 @@ func compileArchive(
 				return err
 			}
 		}
-		gcFlags = append(gcFlags, "-trimpath=.")
+		subDir := filepath.Join(workDir, packagePath)
+		err := os.MkdirAll(subDir, 0755)
+		if err != nil {
+			return err
+		}
+		goBases, err := gatherSrcs(subDir, goSrcs)
+		for i, base := range goBases {
+			goSrcs[i] = filepath.Join(subDir, base)
+		}
+		gcFlags = append(gcFlags, "-trimpath="+workDir)
 	}
 
 	// Check that the filtered sources don't import anything outside of

--- a/go/tools/builders/generate_test_main.go
+++ b/go/tools/builders/generate_test_main.go
@@ -159,6 +159,12 @@ func testsInShard() []testing.InternalTest {
 }
 
 func main() {
+	// NOTE(ricky): Bazel sets the TEST_TMPDIR env variable, but Cockroach
+	// tests generally consult TMPDIR.
+	err := os.Setenv("TMPDIR", os.Getenv("TEST_TMPDIR"))
+	if err != nil {
+		panic(err)
+	}
 	if bzltestutil.ShouldWrap() {
 		err := bzltestutil.Wrap("{{.Pkgname}}")
 		if xerr, ok := err.(*exec.ExitError); ok {

--- a/go/tools/builders/generate_test_main.go
+++ b/go/tools/builders/generate_test_main.go
@@ -162,6 +162,7 @@ func main() {
 	if bzltestutil.ShouldWrap() {
 		err := bzltestutil.Wrap("{{.Pkgname}}")
 		if xerr, ok := err.(*exec.ExitError); ok {
+			log.Printf("Test %v exited with error code %v", os.Getenv("TEST_TARGET"), xerr.ExitCode())
 			os.Exit(xerr.ExitCode())
 		} else if err != nil {
 			log.Print(err)

--- a/go/tools/builders/link.go
+++ b/go/tools/builders/link.go
@@ -30,7 +30,21 @@ import (
 	"strings"
 )
 
+// NOTE(ricky): The go executable freaks out if the PATH contains relative
+// paths. Unfortunately, that happens normally as part of the Bazel build
+// process when using custom toolchains. As a result, we munge all the paths in
+// PATH to be absolute.
+// https://github.com/golang/go/commit/953d1feca9b21af075ad5fc8a3dad096d3ccc3a0
+func mungePath() {
+	var newPaths []string
+	for _, path := range strings.Split(os.Getenv("PATH"), string(os.PathListSeparator)) {
+		newPaths = append(newPaths, abs(path))
+	}
+	os.Setenv("PATH", strings.Join(newPaths, string(os.PathListSeparator)))
+}
+
 func link(args []string) error {
+	mungePath()
 	// Parse arguments.
 	args, err := expandParamsFiles(args)
 	if err != nil {

--- a/go/tools/bzltestutil/wrap.go
+++ b/go/tools/bzltestutil/wrap.go
@@ -85,6 +85,11 @@ func Wrap(pkg string) error {
 			return fmt.Errorf("error while generating testreport: %s", werr)
 		}
 	}
+	if out, ok := os.LookupEnv("GO_TEST_JSON_OUTPUT_FILE"); ok {
+		if err := ioutil.WriteFile(out, jsonBuffer.Bytes(), 0664); err != nil {
+			return fmt.Errorf("error writing test json: %s", err)
+		}
+	}
 	return err
 }
 


### PR DESCRIPTION
A previous change (18a0557abfe2e1029fa12e35a46e846eb2564292) resulted
in full paths being shown when there are compile errors. The paths
are in a temporary directory and they can be problematic with tools
that interpret the build output (e.g. vim's `:make`).

This change fixes this by switching the current working directory
before calling out to `compile`.

For example - before:
```
/tmp/rules_go_work-3549239678/github.com/cockroachdb/cockroach/pkg/sql/scan.go:91:20: undefined: descpbx
```
After:
```
github.com/cockroachdb/cockroach/pkg/sql/scan.go:91:20: undefined: descpbx
```