### PR TITLE
Add initial bzlmod setup

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -23,6 +23,25 @@ tasks:
     - "//..."
     test_targets:
     - "//..."
+  ubuntu2004_bazel5_bzlmod:
+    platform: ubuntu2004
+    bazel: 5.0.0rc4
+    shell_commands:
+      - tests/core/cgo/generate_imported_dylib.sh
+    build_flags:
+      - "--experimental_enable_bzlmod"
+    test_flags:
+      - "--experimental_enable_bzlmod"
+    # Stardoc is currently broken with bzlmod since it is not repo mapping
+    # aware (https://github.com/bazelbuild/bazel/issues/14140).
+    build_targets:
+      - "--"
+      - "//..."
+      - "-//docs/..."
+    test_targets:
+      - "--"
+      - "//..."
+      - "-//docs/..."
   macos:
     shell_commands:
       - tests/core/cgo/generate_imported_dylib.sh

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "io_bazel_rules_go",
+    version = "0.29.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.1.1")
+bazel_dep(name = "platforms", version = "0.0.4")


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This commit uses MODULE.bazel to load all regular dependencies
that are already available in the Bazel Central Registry. The contents
of the WORKSPACE file will be used as a fallback, so dependencies can be
"modularized" incrementally.

Also adds a Bazel CI job to verify the module setup.

Note: Until all repositories in repositories.bzl are loaded from
MODULE.bazel, rules_go can only be used as the main module. The next
step thus consists of refactoring repositories.bzl such that it can be
used both as a WORKSPACE macro and a module extension.


**Which issues(s) does this PR fix?**

Work towards #3020 

**Other notes for review**
