### PR TITLE
Make one label repository-absolute again

### DIFF
--- a/go/private/nogo.bzl
+++ b/go/private/nogo.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DEFAULT_NOGO = str(Label("//:default_nogo"))
+DEFAULT_NOGO = "@io_bazel_rules_go//:default_nogo"
 
 def _go_register_nogo_impl(ctx):
     ctx.template(


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Changing this particular label to the str(Label(...)) pattern does not
behave as expected (https://github.com/bazelbuild/bazel/issues/14590).
It is thus safer to revert back to the old form for now and instead rely
on patches in a future renaming of io_bazel_rules_go to rules_go for the
BCR.


**Which issues(s) does this PR fix?**

Work towards #3020.

**Other notes for review**
@achew22 would probably be in the best position to review as this is a follow-up to https://github.com/bazelbuild/rules_go/pull/3038.