### PR TITLE
enable windows/arm64 go build with bazel

### DIFF
--- a/go/private/platforms.bzl
+++ b/go/private/platforms.bzl
@@ -83,6 +83,7 @@ GOOS_GOARCH = (
     ("windows", "386"),
     ("windows", "amd64"),
     ("windows", "arm"),
+    ("windows", "arm64"),
 )
 
 RACE_GOOS_GOARCH = {
@@ -135,6 +136,7 @@ CGO_GOOS_GOARCH = {
     ("solaris", "amd64"): None,
     ("windows", "386"): None,
     ("windows", "amd64"): None,
+    ("windows", "arm64"): None,
 }
 
 def _generate_constraints(names, bazel_constraints):

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -237,12 +237,6 @@ def _sdk_build_file(ctx, platform):
         },
     )
 
-def _get_env_var(ctx, name, default = ""):
-    if name in ctx.os.environ:
-        return ctx.os.environ[name]
-    else:
-        return default
-
 def _detect_host_platform(ctx):
     if ctx.os.name == "linux":
         goos, goarch = "linux", "amd64"
@@ -282,11 +276,11 @@ def _detect_host_platform(ctx):
         # Default to amd64 when uname doesn't return a known value.
 
     elif ctx.os.name.startswith("windows"):
-        goos, goarch = "windows", "amd64"
-        if _get_env_var(ctx, "PROCESSOR_ARCHITECTURE") == "ARM64":
+        goos = "windows"
+        if ctx.os.environ.get("PROCESSOR_ARCHITECTURE") == "ARM64" or ctx.os.environ.get("PROCESSOR_ARCHITEW6432") == "ARM64":
             goarch = "arm64"
-        elif _get_env_var(ctx, "PROCESSOR_ARCHITEW6432") == "ARM64":
-            goarch = "arm64"
+        else:
+            goarch = "amd64"
     elif ctx.os.name == "freebsd":
         goos, goarch = "freebsd", "amd64"
     else:

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -237,6 +237,12 @@ def _sdk_build_file(ctx, platform):
         },
     )
 
+def _get_env_var(ctx, name, default=""):
+    if name in ctx.os.environ:
+        return ctx.os.environ[name]
+    else:
+        return default
+
 def _detect_host_platform(ctx):
     if ctx.os.name == "linux":
         goos, goarch = "linux", "amd64"
@@ -276,11 +282,9 @@ def _detect_host_platform(ctx):
         # Default to amd64 when uname doesn't return a known value.
 
     elif ctx.os.name.startswith("windows"):
-        if "PROCESSOR_ARCHITECTURE" in ctx.os.environ and \
-            ctx.os.environ["PROCESSOR_ARCHITECTURE"] == "ARM64":
+        if _get_env_var(ctx, "PROCESSOR_ARCHITECTURE") == "ARM64":
             goarch = "arm64"
-        elif "PROCESSOR_ARCHITEW6432" in ctx.os.environ and \
-            ctx.os.environ["PROCESSOR_ARCHITEW6432"] == "ARM64":
+        elif _get_env_var(ctx, "PROCESSOR_ARCHITEW6432") == "ARM64":
             goarch = "arm64"
         else:
             goarch = "amd64"

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -282,13 +282,11 @@ def _detect_host_platform(ctx):
         # Default to amd64 when uname doesn't return a known value.
 
     elif ctx.os.name.startswith("windows"):
+        goos, goarch = "windows", "amd64"
         if _get_env_var(ctx, "PROCESSOR_ARCHITECTURE") == "ARM64":
             goarch = "arm64"
         elif _get_env_var(ctx, "PROCESSOR_ARCHITEW6432") == "ARM64":
             goarch = "arm64"
-        else:
-            goarch = "amd64"
-        goos = "windows"
     elif ctx.os.name == "freebsd":
         goos, goarch = "freebsd", "amd64"
     else:

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -276,7 +276,15 @@ def _detect_host_platform(ctx):
         # Default to amd64 when uname doesn't return a known value.
 
     elif ctx.os.name.startswith("windows"):
-        goos, goarch = "windows", "amd64"
+        if "PROCESSOR_ARCHITECTURE" in ctx.os.environ and \
+            ctx.os.environ["PROCESSOR_ARCHITECTURE"] == "ARM64":
+            goarch = "arm64"
+        elif "PROCESSOR_ARCHITEW6432" in ctx.os.environ and \
+            ctx.os.environ["PROCESSOR_ARCHITEW6432"] == "ARM64":
+            goarch = "arm64"
+        else:
+            goarch = "amd64"
+        goos = "windows"
     elif ctx.os.name == "freebsd":
         goos, goarch = "freebsd", "amd64"
     else:

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -237,7 +237,7 @@ def _sdk_build_file(ctx, platform):
         },
     )
 
-def _get_env_var(ctx, name, default=""):
+def _get_env_var(ctx, name, default = ""):
     if name in ctx.os.environ:
         return ctx.os.environ[name]
     else:

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -237,12 +237,6 @@ def _sdk_build_file(ctx, platform):
         },
     )
 
-def _get_env_var(ctx, name, default = ""):
-    if name in ctx.os.environ:
-        return ctx.os.environ[name]
-    else:
-        return default
-
 def _detect_host_platform(ctx):
     if ctx.os.name == "linux":
         goos, goarch = "linux", "amd64"
@@ -282,11 +276,11 @@ def _detect_host_platform(ctx):
         # Default to amd64 when uname doesn't return a known value.
 
     elif ctx.os.name.startswith("windows"):
-        goos, goarch = "windows", "amd64"
-        if _get_env_var(ctx, "PROCESSOR_ARCHITECTURE") == "ARM64":
+        goos = "windows"
+        if ctx.os.arch == "aarch64":
             goarch = "arm64"
-        elif _get_env_var(ctx, "PROCESSOR_ARCHITEW6432") == "ARM64":
-            goarch = "arm64"
+        else:
+            goarch = "amd64"
     elif ctx.os.name == "freebsd":
         goos, goarch = "freebsd", "amd64"
     else:

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -237,6 +237,12 @@ def _sdk_build_file(ctx, platform):
         },
     )
 
+def _get_env_var(ctx, name, default = ""):
+    if name in ctx.os.environ:
+        return ctx.os.environ[name]
+    else:
+        return default
+
 def _detect_host_platform(ctx):
     if ctx.os.name == "linux":
         goos, goarch = "linux", "amd64"
@@ -276,11 +282,11 @@ def _detect_host_platform(ctx):
         # Default to amd64 when uname doesn't return a known value.
 
     elif ctx.os.name.startswith("windows"):
-        goos = "windows"
-        if ctx.os.arch == "aarch64":
+        goos, goarch = "windows", "amd64"
+        if _get_env_var(ctx, "PROCESSOR_ARCHITECTURE") == "ARM64":
             goarch = "arm64"
-        else:
-            goarch = "amd64"
+        elif _get_env_var(ctx, "PROCESSOR_ARCHITEW6432") == "ARM64":
+            goarch = "arm64"
     elif ctx.os.name == "freebsd":
         goos, goarch = "freebsd", "amd64"
     else:


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

> Enable windows/arm64 go build with Bazel

**Other notes for review**

Go for windows/arm64 is available from version 17. This patch adds the missing pieces to build go programs with bazel.