### PR TITLE
Allow per rule `nogo` customization

### DIFF
--- a/go/private/BUILD.bazel
+++ b/go/private/BUILD.bazel
@@ -165,7 +165,7 @@ bool_setting(
 # does not happen in rules_go and does not seem to be useful).
 bool_setting(
     name = "request_nogo",
-    build_setting_default = False,
+    build_setting_default = True,
     visibility = ["//visibility:public"],
 )
 

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -375,6 +375,8 @@ def go_context(ctx, attr = None):
         go_config_info = attr._go_config[GoConfigInfo]
     if hasattr(attr, "_stdlib"):
         stdlib = attr._stdlib[GoStdLib]
+    if getattr(attr, "nogo", None):
+        nogo = ctx.files.nogo[0] if ctx.files.nogo else None
 
     mode = get_mode(ctx, toolchain, cgo_context_info, go_config_info)
     tags = mode.tags

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -357,6 +357,13 @@ _go_binary_kwargs = {
             </ul>
             """,
         ),
+        "nogo": attr.label(
+            cfg = "exec",
+            doc = """
+            Custom nogo checker for rule.
+            Also you can completely disable nogo by using `@io_bazel_rules_go//:default_nogo` label.
+            """,
+        ),
         "_go_context_data": attr.label(default = "//:go_context_data"),
     },
     "executable": True,

--- a/go/private/rules/library.bzl
+++ b/go/private/rules/library.bzl
@@ -163,6 +163,13 @@ go_library = rule(
             Subject to ["Make variable"] substitution and [Bourne shell tokenization]. Only valid if `cgo = True`.
             """,
         ),
+        "nogo": attr.label(
+            cfg = "exec",
+            doc = """
+            Custom nogo checker for rule.
+            Also you can completely disable nogo by using `@io_bazel_rules_go//:default_nogo` label.
+            """,
+        ),
         "_go_context_data": attr.label(default = "//:go_context_data"),
     },
     toolchains = ["@io_bazel_rules_go//go:toolchain"],

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -392,6 +392,13 @@ _go_test_kwargs = {
             See [Cross compilation] for more information.
             """,
         ),
+        "nogo": attr.label(
+            cfg = "exec",
+            doc = """
+            Custom nogo checker for rule.
+            Also you can completely disable nogo by using `@io_bazel_rules_go//:default_nogo` label.
+            """,
+        ),
         "_go_context_data": attr.label(default = "//:go_context_data"),
         "_testmain_additional_deps": attr.label_list(
             providers = [GoLibrary],


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This PR allow customize `nogo` per rule.
In my case I use multiple `WORKSPACE` (one `WORKSPACE` per `go.mod`) and all .go-code (our and third party) became external.
So I can't simply split nogo configuration per our code and third party code with `exclude_files` attribute.
