### PR TITLE
sdk: symlink everything under lib/ when using local SDK

### DIFF
--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -219,7 +219,7 @@ def _remote_sdk(ctx, urls, strip_prefix, sha256):
         )
 
 def _local_sdk(ctx, path):
-    for entry in ["src", "pkg", "bin"]:
+    for entry in ["src", "pkg", "bin", "lib"]:
         ctx.symlink(path + "/" + entry, entry)
 
 def _sdk_build_file(ctx, platform):


### PR DESCRIPTION
We rely on the packaged zoneinfo zip in CRDB, found under
lib/time/zoneinfo.zip. When using the remote SDK macro, we untar the
entire archive into the sandbox. When pointing to a local SDK however,
we previously ignored everything under lib. It feels reasonable to also
symlink lib/ into the sandbox given they have valid symbols to build
against.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

See commit message.

**Which issues(s) does this PR fix?**

No filed issue.

**Other notes for review**
