### PR TITLE
Consider volatile and stable status files separately

### DIFF
--- a/docs/go/core/defines_and_stamping.md
+++ b/docs/go/core/defines_and_stamping.md
@@ -65,8 +65,11 @@ by spaces, one per line. For example:
 echo STABLE_GIT_COMMIT $(git rev-parse HEAD)
 ```
 
-***Note:*** keys that start with `STABLE_` will trigger a re-link when they change.
-Other keys will NOT trigger a re-link.
+***Note:*** stamping with keys that bazel designates as "stable" will trigger a
+re-link when any stable key changes. Currently, in bazel, stable keys are
+`BUILD_EMBED_LABEL`, `BUILD_USER`, `BUILD_HOST` and keys whose names start with
+`STABLE_`. Stamping only with keys that are not stable keys will not trigger a
+relink.
 
 You can reference these in `x_defs` using curly braces.
 

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -15,6 +15,7 @@
 load(
     "//go/private:common.bzl",
     "as_set",
+    "count_group_matches",
     "has_shared_lib_extension",
 )
 load(
@@ -136,16 +137,27 @@ def emit_link(
     extldflags.extend(cgo_rpaths)
 
     # Process x_defs, and record whether stamping is used.
-    stamp_x_defs = False
+    stamp_x_defs_volatile = False
+    stamp_x_defs_stable = False
     for k, v in archive.x_defs.items():
-        if go.stamp and v.find("{") != -1 and v.find("}") != -1:
-            stamp_x_defs = True
         builder_args.add("-X", "%s=%s" % (k, v))
+        if go.stamp:
+            stable_vars_count = (count_group_matches(v, "{STABLE_", "}") +
+                                 v.count("{BUILD_EMBED_LABEL}") +
+                                 v.count("{BUILD_USER}") +
+                                 v.count("{BUILD_HOST}"))
+            if stable_vars_count > 0:
+                stamp_x_defs_stable = True
+            if count_group_matches(v, "{", "}") != stable_vars_count:
+                stamp_x_defs_volatile = True
 
     # Stamping support
     stamp_inputs = []
-    if stamp_x_defs:
-        stamp_inputs = [info_file, version_file]
+    if stamp_x_defs_stable:
+        stamp_inputs.append(info_file)
+    if stamp_x_defs_volatile:
+        stamp_inputs.append(version_file)
+    if stamp_inputs:
         builder_args.add_all(stamp_inputs, before_each = "-stamp")
 
     builder_args.add("-o", executable)

--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -240,3 +240,30 @@ def as_set(v):
     if type(v) == "tuple":
         return depset(v)
     fail("as_tuple failed on {}".format(v))
+
+def count_group_matches(v, prefix, suffix):
+    """Counts reluctant substring matches between prefix and suffix.
+
+    Equivalent to the number of regular expression matches "prefix.+?suffix"
+    in the string v.
+    """
+
+    count = 0
+    idx = 0
+    for i in range(0, len(v)):
+        if idx > i:
+            continue
+
+        idx = v.find(prefix, idx)
+        if idx == -1:
+            break
+
+        # If there is another prefix before the next suffix, the previous prefix is discarded.
+        # This is OK; it does not affect our count.
+        idx = v.find(suffix, idx)
+        if idx == -1:
+            break
+
+        count = count + 1
+
+    return count

--- a/tests/core/starlark/common_tests.bzl
+++ b/tests/core/starlark/common_tests.bzl
@@ -1,5 +1,5 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load("//go/private:common.bzl", "has_shared_lib_extension")
+load("//go/private:common.bzl", "count_group_matches", "has_shared_lib_extension")
 
 def _versioned_shared_libraries_test(ctx):
     env = unittest.begin(ctx)
@@ -30,9 +30,24 @@ def _versioned_shared_libraries_test(ctx):
 
 versioned_shared_libraries_test = unittest.make(_versioned_shared_libraries_test)
 
+def _count_group_matches_test(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(env, 1, count_group_matches("{foo_status}", "{foo_", "}"))
+    asserts.equals(env, 1, count_group_matches("{foo_status} {status}", "{foo_", "}"))
+    asserts.equals(env, 0, count_group_matches("{foo_status}", "{bar_", "}"))
+    asserts.equals(env, 1, count_group_matches("{foo_status}", "{", "}"))
+    asserts.equals(env, 2, count_group_matches("{foo} {bar}", "{", "}"))
+    asserts.equals(env, 2, count_group_matches("{foo{bar} {baz}", "{", "}"))
+
+    return unittest.end(env)
+
+count_group_matches_test = unittest.make(_count_group_matches_test)
+
 def common_test_suite():
     """Creates the test targets and test suite for common.bzl tests."""
     unittest.suite(
         "common_tests",
         versioned_shared_libraries_test,
+        count_group_matches_test,
     )


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

The PR improves local cache hit rate for workspaces that generate stable status variables but may stamp some targets with only volatile status variables.

**Which issues(s) does this PR fix?**

Fixes #3078

**Other notes for review**

I follow this strategy also in [rules_r](https://github.com/grailbio/rules_r/blob/9df1e588b20004ba4001563ce0490b87edd51624/R/internal/build.bzl#L296).