### PR TITLE
Resolves #3081: add `analyzer_flags` to nogo config

### DIFF
--- a/go/nogo.rst
+++ b/go/nogo.rst
@@ -197,7 +197,7 @@ contain the following key-value pairs:
 +----------------------------+---------------------------------------------------------------------+
 | ``"analyzer_flags"``       | :type:`dictionary, string to string`                                |
 +----------------------------+---------------------------------------------------------------------+
-| Passes on a set of flags as defined by the Go ``flags`` package to the analyzer via the          |
+| Passes on a set of flags as defined by the Go ``flag`` package to the analyzer via the           |
 | ``analysis.Analyzer.Flags`` field. Its keys are the flag names *without* a ``-`` prefix, and its |
 | values are the flag values. nogo will exit with an error upon receiving flags not recognized by  |
 | the analyzer or upon receiving ill-formatted flag values as defined by the corresponding         |

--- a/go/nogo.rst
+++ b/go/nogo.rst
@@ -195,6 +195,14 @@ contain the following key-value pairs:
 | in both ``only_files`` and ``exclude_files``, the analyzer will not emit diagnostics for that    |
 | file.                                                                                            |
 +----------------------------+---------------------------------------------------------------------+
+| ``"analyzer_flags"``       | :type:`dictionary, string to string`                                |
++----------------------------+---------------------------------------------------------------------+
+| Passes on a set of flags as defined by the Go ``flags`` package to the analyzer via the          |
+| ``analysis.Analyzer.Flags`` field. Its keys are the flag names *without* a ``-`` prefix, and its |
+| values are the flag values. nogo will exit with an error upon receiving flags not recognized by  |
+| the analyzer or upon receiving ill-formatted flag values as defined by the corresponding         |
+| ``flag.Value`` specified by the analyzer.                                                        |
++----------------------------+---------------------------------------------------------------------+
 
 Example
 ^^^^^^^
@@ -202,6 +210,8 @@ Example
 The following configuration file configures the analyzers named ``importunsafe``
 and ``unsafedom``. Since the ``loopclosure`` analyzer is not explicitly
 configured, it will emit diagnostics for all Go files built by Bazel.
+``unsafedom`` will receive a flag equivalent to ``-block-unescaped-html=false``
+on a command line driver.
 
 .. code:: json
 
@@ -218,7 +228,10 @@ configured, it will emit diagnostics for all Go files built by Bazel.
         },
         "exclude_files": {
           "src/(third_party|vendor)/.*": "enforce DOM safety requirements only on first-party code"
-        }
+        },
+        "analyzer_flags": {
+            "block-unescaped-html": "false",
+        },
       }
     }
 

--- a/go/tools/builders/generate_nogo_main.go
+++ b/go/tools/builders/generate_nogo_main.go
@@ -54,6 +54,13 @@ var analyzers = []*analysis.Analyzer{
 var configs = map[string]config{
 {{- range $name, $config := .Configs}}
 	{{printf "%q" $name}}: config{
+		{{- if $config.AnalyzerFlags }}
+		analyzerFlags: map[string]string {
+			{{- range $flagKey, $flagValue := $config.AnalyzerFlags}}
+			{{printf "%q: %q" $flagKey $flagValue}},
+			{{- end}}
+		},
+		{{- end -}}
 		{{- if $config.OnlyFiles}}
 		onlyFiles: []*regexp.Regexp{
 			{{- range $path, $comment := $config.OnlyFiles}}
@@ -171,8 +178,9 @@ func buildConfig(path string) (Configs, error) {
 		}
 		configs[name] = Config{
 			// Description is currently unused.
-			OnlyFiles:    config.OnlyFiles,
-			ExcludeFiles: config.ExcludeFiles,
+			OnlyFiles:     config.OnlyFiles,
+			ExcludeFiles:  config.ExcludeFiles,
+			AnalyzerFlags: config.AnalyzerFlags,
 		}
 	}
 	return configs, nil
@@ -181,7 +189,8 @@ func buildConfig(path string) (Configs, error) {
 type Configs map[string]Config
 
 type Config struct {
-	Description  string
-	OnlyFiles    map[string]string `json:"only_files"`
-	ExcludeFiles map[string]string `json:"exclude_files"`
+	Description   string
+	OnlyFiles     map[string]string `json:"only_files"`
+	ExcludeFiles  map[string]string `json:"exclude_files"`
+	AnalyzerFlags map[string]string `json:"analyzer_flags"`
 }

--- a/go/tools/builders/nogo_main.go
+++ b/go/tools/builders/nogo_main.go
@@ -174,16 +174,16 @@ func checkPackage(analyzers []*analysis.Analyzer, packagePath string, packageFil
 	for _, a := range analyzers {
 		if cfg, ok := configs[a.Name]; ok {
 			for flagKey, flagVal := range cfg.analyzerFlags {
-				if err := a.Flags.Set(flagKey, flagVal); err != nil {
-					if strings.HasPrefix(flagKey, "-") {
-						return "", nil, fmt.Errorf(
-							"%s: flag should not begin with '-': %s", a.Name, flagKey)
-					}
-					if flag := a.Flags.Lookup(flagKey); flag == nil {
-						return "", nil, fmt.Errorf("%s: unrecognized flag: %s", a.Name, flagKey)
-					}
+				if strings.HasPrefix(flagKey, "-") {
 					return "", nil, fmt.Errorf(
-						"%s: invalid value for flag: %s=%s", a.Name, flagKey, flagVal)
+						"%s: flag should not begin with '-': %s", a.Name, flagKey)
+				}
+				if flag := a.Flags.Lookup(flagKey); flag == nil {
+					return "", nil, fmt.Errorf("%s: unrecognized flag: %s", a.Name, flagKey)
+				}
+				if err := a.Flags.Set(flagKey, flagVal); err != nil {
+					return "", nil, fmt.Errorf(
+						"%s: invalid value for flag: %s=%s: %w", a.Name, flagKey, flagVal, err)
 				}
 			}
 		}

--- a/go/tools/builders/nogo_main.go
+++ b/go/tools/builders/nogo_main.go
@@ -172,6 +172,11 @@ func checkPackage(analyzers []*analysis.Analyzer, packagePath string, packageFil
 
 	roots := make([]*action, 0, len(analyzers))
 	for _, a := range analyzers {
+		if cfg, ok := configs[a.Name]; ok {
+			for flagKey, flagVal := range cfg.analyzerFlags {
+				a.Flags.Set(flagKey, flagVal)
+			}
+		}
 		roots = append(roots, visit(a))
 	}
 
@@ -457,6 +462,9 @@ type config struct {
 	// excludeFiles is a list of regular expressions that match files that an
 	// analyzer will not emit diagnostics for.
 	excludeFiles []*regexp.Regexp
+
+	// analyzerFlags is a map of
+	analyzerFlags map[string]string
 }
 
 // importer is an implementation of go/types.Importer that imports type

--- a/tests/core/nogo/custom/custom_test.go
+++ b/tests/core/nogo/custom/custom_test.go
@@ -39,7 +39,6 @@ nogo(
         ":foofuncname",
         ":importfmt",
         ":visibility",
-        ":flagger",
     ],
     # config = "",
     visibility = ["//visibility:public"],
@@ -68,16 +67,6 @@ go_library(
     deps = [
         "@org_golang_x_tools//go/analysis",
         "@org_golang_x_tools//go/ast/inspector",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-go_library(
-    name = "flagger",
-    srcs = ["flagger.go"],
-    importpath = "flaggeranalyzer",
-    deps = [
-        "@org_golang_x_tools//go/analysis",
     ],
     visibility = ["//visibility:public"],
 )
@@ -291,48 +280,6 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	return nil, nil
 }
 
--- flagger.go --
-// flagger crashes when three flags are set in the config or else it no-ops
-package flagger
-
-import (
-        "errors"
-        "fmt"
-
-        "golang.org/x/tools/go/analysis"
-)
-
-var (
-        boolSwitch   bool
-        stringSwitch string
-        intSwitch    int
-)
-
-var Analyzer = &analysis.Analyzer{
-        Name: "flagger",
-        Run:  run,
-        Doc:  "Dummy analyzer that requires some flags to be set true in order to pass",
-}
-
-func init() {
-        Analyzer.Flags.BoolVar(&boolSwitch, "bool-switch", false, "Bool must be set to true to run")
-        Analyzer.Flags.StringVar(&stringSwitch, "string-switch", "no", "String must be set to \"yes\" to run")
-        Analyzer.Flags.IntVar(&intSwitch, "int-switch", 0, "Int must be set to 1 to run")
-}
-
-func run(pass *analysis.Pass) (interface{}, error) {
-        if !boolSwitch {
-                return nil, nil
-        }
-        if stringSwitch != "yes" {
-                return nil, nil
-        }
-        if intSwitch != 1 {
-                return nil, nil
-        }
-        return nil, errors.New("all switches were set -> fail")
-}
-
 -- config.json --
 {
   "importfmt": {
@@ -346,36 +293,6 @@ func run(pass *analysis.Pass) (interface{}, error) {
   "visibility": {
     "exclude_files": {
       "has_.*\\.go": "special exception to visibility rules"
-    }
-  }
-}
-
--- flagger_config.json --
-{
-  "importfmt": {
-    "only_files": {
-      "no_errors\\.go": ""
-    }
-  },
-  "foofuncname": {
-    "only_files": {
-      "no_errors\\.go": ""
-    }
-  },
-  "flagger": {
-    "description": "this will crash on the specified file",
-    "only_files": {
-      "has_errors\\.go": ""
-    },
-    "analyzer_flags": {
-        "bool-switch": "true",
-        "int-switch": "1",
-        "string-switch": "yes"
-    }
-  },
-  "visibility": {
-    "only_files": {
-      "no_errors\\.go": ""
     }
   }
 }
@@ -510,12 +427,6 @@ func Test(t *testing.T) {
 				// note the cross platform regex :)
 				`.*[\\/]cgo[\\/]examplepkg[\\/]pure_src_with_err_calling_native.go:.*function must not be named Foo \(foofuncname\)`,
 			},
-		}, {
-			desc:        "config_flags_triggering_error",
-			target:      "//:has_errors",
-			wantSuccess: false,
-			config:      "flagger_config.json",
-			includes:    []string{"all switches were set -> fail"},
 		}, {
 			desc:        "no_errors",
 			target:      "//:no_errors",

--- a/tests/core/nogo/custom/flags/BUILD.bazel
+++ b/tests/core/nogo/custom/flags/BUILD.bazel
@@ -1,0 +1,6 @@
+load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
+
+go_bazel_test(
+    name = "flags_test",
+    srcs = ["flags_test.go"],
+)

--- a/tests/core/nogo/custom/flags/README.rst
+++ b/tests/core/nogo/custom/flags/README.rst
@@ -1,0 +1,16 @@
+Custom nogo analyzers
+=====================
+
+.. _nogo: /go/nogo.rst
+.. _go_library: /docs/go/core/rules.md#_go_library
+
+Tests to ensure that custom `nogo`_ analyzers run and detect errors.
+
+.. contents::
+
+custom_test
+-----------
+Verifies that custom analyzers print errors and fail a `go_library`_ build when
+a configuration file is not provided, and that analyzers with the same package
+name do not conflict. Also checks that custom analyzers can be configured to
+apply only to certain file paths using a custom configuration file.

--- a/tests/core/nogo/custom/flags/README.rst
+++ b/tests/core/nogo/custom/flags/README.rst
@@ -4,13 +4,16 @@ Custom nogo analyzers
 .. _nogo: /go/nogo.rst
 .. _go_library: /docs/go/core/rules.md#_go_library
 
-Tests to ensure that custom `nogo`_ analyzers run and detect errors.
+Tests to ensure that custom `nogo`_ analyzers that consume flags can be
+supplied those flags via nono config.
 
 .. contents::
 
 custom_test
 -----------
-Verifies that custom analyzers print errors and fail a `go_library`_ build when
-a configuration file is not provided, and that analyzers with the same package
-name do not conflict. Also checks that custom analyzers can be configured to
-apply only to certain file paths using a custom configuration file.
+Verifies that a simple custom analyzer's behavior can be modified by setting
+its analyzer flags in the nogo driver, and that these flags can be provided to
+the driver via the nogo config `analyzer_flags` field. Also checks that
+invalid flags as defined by the `flag` package cause the driver to immediately
+return an error.
+

--- a/tests/core/nogo/custom/flags/README.rst
+++ b/tests/core/nogo/custom/flags/README.rst
@@ -1,4 +1,4 @@
-Custom nogo analyzers
+Custom nogo analyzer flags
 =====================
 
 .. _nogo: /go/nogo.rst
@@ -9,7 +9,7 @@ supplied those flags via nono config.
 
 .. contents::
 
-custom_test
+flags_test
 -----------
 Verifies that a simple custom analyzer's behavior can be modified by setting
 its analyzer flags in the nogo driver, and that these flags can be provided to

--- a/tests/core/nogo/custom/flags/flags_test.go
+++ b/tests/core/nogo/custom/flags/flags_test.go
@@ -1,0 +1,262 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flags_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"regexp"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+const origConfig = `# config = "",`
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Nogo: "@//:nogo",
+		Main: `
+-- BUILD.bazel --
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "nogo")
+
+nogo(
+    name = "nogo",
+    deps = [
+        ":flagger",
+    ],
+    # config = "",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "flagger",
+    srcs = ["flagger.go"],
+    importpath = "flaggeranalyzer",
+    deps = [
+        "@org_golang_x_tools//go/analysis",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "some_file",
+    srcs = ["some_file.go"],
+    importpath = "somefile",
+    deps = [":dep"],
+)
+
+go_library(
+    name = "dep",
+    srcs = ["dep.go"],
+    importpath = "dep",
+)
+
+-- flagger.go --
+// flagger crashes when three flags are set in the config or else it no-ops
+package flagger
+
+import (
+        "errors"
+
+        "golang.org/x/tools/go/analysis"
+)
+
+var (
+        boolSwitch   bool
+        stringSwitch string
+        intSwitch    int
+)
+
+var Analyzer = &analysis.Analyzer{
+        Name: "flagger",
+        Run:  run,
+        Doc:  "Dummy analyzer that crashes when all its flags are set correctly",
+}
+
+func init() {
+        Analyzer.Flags.BoolVar(&boolSwitch, "bool-switch", false, "Bool must be set to true to run")
+        Analyzer.Flags.StringVar(&stringSwitch, "string-switch", "no", "String must be set to \"yes\" to run")
+        Analyzer.Flags.IntVar(&intSwitch, "int-switch", 0, "Int must be set to 1 to run")
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+        if !boolSwitch {
+                return nil, nil
+        }
+        if stringSwitch != "yes" {
+                return nil, nil
+        }
+        if intSwitch != 1 {
+                return nil, nil
+        }
+        return nil, errors.New("all switches were set -> fail")
+}
+
+-- all_flags_set.json --
+{
+  "flagger": {
+    "description": "this will crash on every file",
+    "analyzer_flags": {
+        "bool-switch": "true",
+        "int-switch": "1",
+        "string-switch": "yes"
+    }
+  }
+}
+
+-- two_flags_set.json --
+{
+  "flagger": {
+    "description": "this will succeed on every file",
+    "analyzer_flags": {
+        "bool-switch": "true",
+        "int-switch": "1"
+    }
+  }
+}
+
+-- invalid_int.json --
+{
+  "flagger": {
+    "description": "this will crash immediately due to an invalid int flag",
+    "analyzer_flags": {
+        "int-switch": "one",
+        "string-switch": "yes"
+    }
+  }
+}
+
+-- nonexistent_flag.json --
+{
+  "flagger": {
+    "description": "this will crash immediately due to a nonexistent flag",
+    "analyzer_flags": {
+        "int-switch": "1",
+        "bool-switch": "true",
+        "string-switch": "yes",
+        "description": "This is a good analyzer"
+    }
+  }
+}
+
+-- hyphenated_flag.json --
+{
+  "flagger": {
+    "description": "this will crash immediately due to a hyphenated flag",
+    "analyzer_flags": {
+      "-int-switch": "1"
+    }
+  }
+}
+
+-- some_file.go --
+// package somefile contains a file and has a dep
+package somefile
+
+import "dep"
+
+func Baz() int {
+	dep.D()
+	return 1
+}
+
+-- dep.go --
+package dep
+
+func D() {
+}
+
+`,
+	})
+}
+
+func Test(t *testing.T) {
+	for _, test := range []struct {
+		desc, config       string
+		wantSuccess        bool
+		includes, excludes []string
+	}{
+		{
+			desc:        "config_flags_triggering_error",
+			wantSuccess: false,
+			config:      "all_flags_set.json",
+			includes:    []string{"all switches were set -> fail"},
+		}, {
+			desc:        "config_flags_triggering_success",
+			wantSuccess: true,
+			config:      "two_flags_set.json",
+		}, {
+			desc:        "invalid_int_triggering_error",
+			wantSuccess: false,
+			config:      "invalid_int.json",
+			includes:    []string{"flagger: invalid value for flag: int-switch=one"},
+		}, {
+			desc:        "nonexistent_flag_triggering_error",
+			wantSuccess: false,
+			config:      "nonexistent_flag.json",
+			includes:    []string{"flagger: unrecognized flag: description"},
+		}, {
+			desc:        "hyphenated_flag_triggering_error",
+			wantSuccess: false,
+			config:      "hyphenated_flag.json",
+			includes:    []string{"flagger: flag should not begin with '-': -int-switch"},
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			if test.config != "" {
+				customConfig := fmt.Sprintf("config = %q,", test.config)
+				if err := replaceInFile("BUILD.bazel", origConfig, customConfig); err != nil {
+					t.Fatal(err)
+				}
+				defer replaceInFile("BUILD.bazel", customConfig, origConfig)
+			}
+
+			cmd := bazel_testing.BazelCmd("build", "//:some_file")
+			stderr := &bytes.Buffer{}
+			cmd.Stderr = stderr
+			if err := cmd.Run(); err == nil && !test.wantSuccess {
+				t.Fatal("unexpected success")
+			} else if err != nil && test.wantSuccess {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			for _, pattern := range test.includes {
+				if matched, err := regexp.Match(pattern, stderr.Bytes()); err != nil {
+					t.Fatal(err)
+				} else if !matched {
+					t.Errorf("got output:\n %s\n which does not contain pattern: %s", string(stderr.Bytes()), pattern)
+				}
+			}
+			for _, pattern := range test.excludes {
+				if matched, err := regexp.Match(pattern, stderr.Bytes()); err != nil {
+					t.Fatal(err)
+				} else if matched {
+					t.Errorf("output contained pattern: %s", pattern)
+				}
+			}
+		})
+	}
+}
+
+func replaceInFile(path, old, new string) error {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	data = bytes.ReplaceAll(data, []byte(old), []byte(new))
+	return ioutil.WriteFile(path, data, 0666)
+}


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

Allow nogo config to specify flags to be passed to each analyzer via `analyzer_flags`. The ability to provide flags to each
analyzer is something not currently supported by the driver, which makes it more troublesome to use configurable 
analyzers in a Bazel Go project.

**Which issues(s) does this PR fix?**

#3081 

**Other notes for review**

Being able to pass in a list of CLI arguments might add greater flexibility, but given the restrictive nature of Go's `FlagSet`
API, it is unlikely that any analyzers in the wild will support positional arguments and the like.