### PR TITLE
Fix gopackagesdriver for Go 1.18 by replicating stdlib

### DIFF
--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -158,18 +158,21 @@ func stdliblist(args []string) error {
 		return err
 	}
 
+	execRoot := abs(".")
+	if err := replicate(os.Getenv("GOROOT"), execRoot, replicatePaths("src", "pkg/tool", "pkg/include")); err != nil {
+		return err
+	}
+
 	// Ensure paths are absolute.
 	absPaths := []string{}
 	for _, path := range filepath.SplitList(os.Getenv("PATH")) {
 		absPaths = append(absPaths, abs(path))
 	}
 	os.Setenv("PATH", strings.Join(absPaths, string(os.PathListSeparator)))
-	os.Setenv("GOROOT", abs(os.Getenv("GOROOT")))
+	os.Setenv("GOROOT", execRoot)
 	// Make sure we have an absolute path to the C compiler.
 	// TODO(#1357): also take absolute paths of includes and other paths in flags.
 	os.Setenv("CC", abs(os.Getenv("CC")))
-
-	execRoot := abs(".")
 
 	cachePath := abs(*out + ".gocache")
 	defer os.RemoveAll(cachePath)

--- a/tests/core/stdlib/stdlib_files.bzl
+++ b/tests/core/stdlib/stdlib_files.bzl
@@ -27,10 +27,11 @@ pure_transition = transition(
 def _stdlib_files_impl(ctx):
     # When a transition is used, ctx.attr._stdlib is a list of Target instead
     # of a Target. Possibly a bug?
-    libs = ctx.attr._stdlib[0][GoStdLib].libs
+    stdlib = ctx.attr._stdlib[0][GoStdLib]
+    libs = stdlib.libs
     runfiles = ctx.runfiles(files = libs)
     return [DefaultInfo(
-        files = depset(libs),
+        files = depset(libs + [stdlib._list_json]),
         runfiles = runfiles,
     )]
 


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The gopackagesdriver relies on the "stdliblist" action provided by rules_go.
The stdliblist action fails on Go 1.18 with the following error:

```
external/go_sdk/src/crypto/elliptic/p256_asm.go:24:12: pattern p256_asm_table.bin: cannot embed irregular file p256_asm_table.bin
```

We see this failure because Bazel builds a symlink tree of the GOROOT to run
`go list` with. However, since [CL 380475][1], the Go standard library uses
`go:embed` to embed a file in `crypto/elliptic`, but `go:embed` does not
support symlinks.

[1]: https://go.dev/cl/380475

Fix this by having stdliblist copy the relevant portions of the GOROOT to
run `go list` with. This matches [what the stdlib action does][2].

[2]: https://github.com/bazelbuild/rules_go/blob/e9a7054ff11a520e3b8aceb76a3ba44bb8da4c94/go/tools/builders/stdlib.go#L54-L57

**Which issues(s) does this PR fix?**

Fixes #3080

**Other notes for review**

I've updated the existing stdlib test to also depend on the output of
stdliblist, and verified that that fails with Go 1.18rc1 without this change.
