### PR TITLE
Support generated embedsrcs

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -219,7 +219,9 @@ def _library_to_source(go, attr, library, coverage_instrumented):
     attr_srcs = [f for t in getattr(attr, "srcs", []) for f in as_iterable(t.files)]
     generated_srcs = getattr(library, "srcs", [])
     srcs = attr_srcs + generated_srcs
-    embedsrcs = [f for t in getattr(attr, "embedsrcs", []) for f in as_iterable(t.files)]
+    attr_embedsrcs = [f for t in getattr(attr, "embedsrcs", []) for f in as_iterable(t.files)]
+    generated_embedsrcs = getattr(library, "embedsrcs", [])
+    embedsrcs = attr_embedsrcs + generated_embedsrcs
     source = {
         "library": library,
         "mode": go.mode,


### PR DESCRIPTION
Just like for srcs, rules_go should support generated embedsrcs.

I'm currently running into a situation in which I've generated embed files, but I cannot pass them into `go.new_library` (because those get ignored) or into the attrs for `library_to_source` -- because `library_to_source` attr.embedsrcs is expected to be of type list of Target, and when you generate them, you generate a list of File. There isn't really a way to generate the targets, which is why `srcs` does the same thing of allowing `go.new_library` to specify a list of File and library_to_source attrs to specify targets and combines the two. This extends that to `embedsrcs`.