### PR TITLE
Use output dir for empty packages to be hermetic

### DIFF
--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -178,7 +178,12 @@ func compileArchive(
 	defer cleanup()
 
 	if len(srcs.goSrcs) == 0 {
-		emptyPath := filepath.Join(workDir, "_empty.go")
+		// We need to run the compiler to create a valid archive, even if there's
+		// nothing in it. GoPack will complain if we try to add assembly or cgo
+		// objects.
+		// _empty.go needs to be in a deterministic location (not tmpdir) in order
+		// to ensure deterministic output
+		emptyPath := filepath.Join(filepath.Dir(outPath), "_empty.go")
 		if err := ioutil.WriteFile(emptyPath, []byte("package empty\n"), 0666); err != nil {
 			return err
 		}

--- a/tests/integration/reproducibility/reproducibility_test.go
+++ b/tests/integration/reproducibility/reproducibility_test.go
@@ -35,7 +35,13 @@ func TestMain(m *testing.M) {
 	bazel_testing.TestMain(m, bazel_testing.Args{
 		Main: `
 -- BUILD.bazel --
-load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+	name = "empty_lib",
+	srcs = [],
+	importpath = "empty_lib",
+)
 
 go_binary(
     name = "hello",


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Some packages are not deterministic, rather they have different content hashes when rebuilt. This occurs when rules_go creates an `_empty.go` file to satisfy the compiler. In those cases, the empty file is created in the OS temp dir, which changes across compiler invocations. The path of this file changes the content hash of the resulting package, thus breaking caches and downstream builds. 

This PR changes the location of this tmp file to the output path of the package, such that it is the same output path across compiler invocations. 

Reproduction steps: 

```sh
bazel build //tests/core/go_library:empty 
md5 bazel-bin/tests/core/go_library/empty.a

rm -f  bazel-bin/tests/core/go_library/empty.a

bazel build //tests/core/go_library:empty 
md5 bazel-bin/tests/core/go_library/empty.a
```


**Other notes for review**

I noted a broad use of tmpdir or workdir within rules_go, and this issue may be prevalent in other conditions. If determinism is a priority, perhaps an audit of tmp dir uses may be warranted.

~~It would be useful to have a test that validations reproducibility of this kind, but I'm not aware of a good way to structure that type of test.~~ Reproducibility test has been added 
