### PR TITLE
Remove legacy proto code for Bazel < 0.21

### DIFF
--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -143,21 +143,6 @@ def proto_path(src, proto):
     Returns:
         An import path string.
     """
-    if not hasattr(proto, "proto_source_root"):
-        # Legacy path. Remove when Bazel minimum version >= 0.21.0.
-        path = src.path
-        root = src.root.path
-        ws = src.owner.workspace_root
-        if path.startswith(root):
-            path = path[len(root):]
-        if path.startswith("/"):
-            path = path[1:]
-        if path.startswith(ws):
-            path = path[len(ws):]
-        if path.startswith("/"):
-            path = path[1:]
-        return path
-
     if proto.proto_source_root == ".":
         # true if proto sources were generated
         prefix = src.root.path + "/"


### PR DESCRIPTION
Hey wonderful Bazel Go folks,

I was browsing the codebase and noticed both that the minimum Bazel version for rules_go is 4.2.1 (in the release notes) and also saw a section of code saying it should be deleted when Bazel minimum version >= 0.21.0. So I figured I should toss up a PR doing just that!

Looks like @jayconrod wrote the code originally. Tagging him in case he wants to weigh in with context. Maybe there's more dead code that should be deleted. But it looks like he might be busy and hasn't committed in a while, so I'd propose that we probably shouldn't wait synchronously on his reply.

Thanks for reading!
Chris
(ex-Googler)