### PR TITLE
Trim transitioned Go settings on non-Go dependencies

### DIFF
--- a/go/private/rules/BUILD.bazel
+++ b/go/private/rules/BUILD.bazel
@@ -2,7 +2,7 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:common_settings.bzl", "string_setting")
 load(
     ":transition.bzl",
-    "POTENTIALLY_TRANSITIONED_SETTINGS",
+    "TRANSITIONED_GO_SETTING_KEYS",
 )
 
 exports_files(["library.bzl"])
@@ -13,7 +13,7 @@ exports_files(["library.bzl"])
         build_setting_default = "",
         visibility = ["//visibility:private"],
     )
-    for setting in POTENTIALLY_TRANSITIONED_SETTINGS
+    for setting in TRANSITIONED_GO_SETTING_KEYS
 ]
 
 filegroup(

--- a/go/private/rules/BUILD.bazel
+++ b/go/private/rules/BUILD.bazel
@@ -1,6 +1,20 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@bazel_skylib//rules:common_settings.bzl", "string_setting")
+load(
+    ":transition.bzl",
+    "POTENTIALLY_TRANSITIONED_SETTINGS",
+)
 
 exports_files(["library.bzl"])
+
+[
+    string_setting(
+        name = "original_" + setting.split(":")[1],
+        build_setting_default = "",
+        visibility = ["//visibility:private"],
+    )
+    for setting in POTENTIALLY_TRANSITIONED_SETTINGS
+]
 
 filegroup(
     name = "all_rules",

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -30,6 +30,7 @@ load(
 load(
     "//go/private/rules:transition.bzl",
     "go_transition_rule",
+    "non_go_transition",
 )
 load(
     "//go/private:mode.bzl",
@@ -173,6 +174,7 @@ _go_binary_kwargs = {
     "attrs": {
         "srcs": attr.label_list(
             allow_files = go_exts + asm_exts + cgo_exts,
+            cfg = non_go_transition,
             doc = """The list of Go source files that are compiled to create the package.
             Only `.go` and `.s` files are permitted, unless the `cgo`
             attribute is set, in which case,
@@ -183,6 +185,7 @@ _go_binary_kwargs = {
         ),
         "data": attr.label_list(
             allow_files = True,
+            cfg = non_go_transition,
             doc = """List of files needed by this rule at run-time. This may include data files
             needed or other programs that may be executed. The [bazel] package may be
             used to locate run files; they may appear in different places depending on the
@@ -210,6 +213,7 @@ _go_binary_kwargs = {
         ),
         "embedsrcs": attr.label_list(
             allow_files = True,
+            cfg = non_go_transition,
             doc = """The list of files that may be embedded into the compiled package using
             `//go:embed` directives. All files must be in the same logical directory
             or a subdirectory as source files. All source files containing `//go:embed`
@@ -262,6 +266,7 @@ _go_binary_kwargs = {
             """,
         ),
         "cdeps": attr.label_list(
+            cfg = non_go_transition,
             doc = """The list of other libraries that the c code depends on.
             This can be anything that would be allowed in [cc_library deps]
             Only valid if `cgo` = `True`.
@@ -371,6 +376,9 @@ _go_binary_kwargs = {
             """,
         ),
         "_go_context_data": attr.label(default = "//:go_context_data"),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
     },
     "executable": True,
     "toolchains": ["@io_bazel_rules_go//go:toolchain"],

--- a/go/private/rules/library.bzl
+++ b/go/private/rules/library.bzl
@@ -27,6 +27,10 @@ load(
     "GoLibrary",
     "INFERRED_PATH",
 )
+load(
+    "//go/private/rules:transition.bzl",
+    "non_go_transition",
+)
 
 def _go_library_impl(ctx):
     """Implements the go_library() rule."""
@@ -55,6 +59,7 @@ go_library = rule(
     attrs = {
         "data": attr.label_list(
             allow_files = True,
+            cfg = non_go_transition,
             doc = """
             List of files needed by this rule at run-time.
             This may include data files needed or other programs that may be executed.
@@ -64,6 +69,7 @@ go_library = rule(
         ),
         "srcs": attr.label_list(
             allow_files = go_exts + asm_exts + cgo_exts,
+            cfg = non_go_transition,
             doc = """
             The list of Go source files that are compiled to create the package.
             Only `.go` and `.s` files are permitted, unless the `cgo` attribute is set,
@@ -106,6 +112,7 @@ go_library = rule(
         ),
         "embedsrcs": attr.label_list(
             allow_files = True,
+            cfg = non_go_transition,
             doc = """
             The list of files that may be embedded into the compiled package using `//go:embed`
             directives. All files must be in the same logical directory or a subdirectory as source files.
@@ -133,6 +140,7 @@ go_library = rule(
             """,
         ),
         "cdeps": attr.label_list(
+            cfg = non_go_transition,
             doc = """
             List of other libraries that the c code depends on.
             This can be anything that would be allowed in [cc_library deps] Only valid if `cgo = True`.
@@ -164,6 +172,9 @@ go_library = rule(
             """,
         ),
         "_go_context_data": attr.label(default = "//:go_context_data"),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
     },
     toolchains = ["@io_bazel_rules_go//go:toolchain"],
     doc = """This builds a Go library from a set of source files that are all part of

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -40,6 +40,7 @@ load(
 load(
     "//go/private/rules:transition.bzl",
     "go_transition_rule",
+    "non_go_transition",
 )
 load(
     "//go/private:mode.bzl",
@@ -191,6 +192,7 @@ _go_test_kwargs = {
     "attrs": {
         "data": attr.label_list(
             allow_files = True,
+            cfg = non_go_transition,
             doc = """List of files needed by this rule at run-time. This may include data files
             needed or other programs that may be executed. The [bazel] package may be
             used to locate run files; they may appear in different places depending on the
@@ -200,6 +202,7 @@ _go_test_kwargs = {
         ),
         "srcs": attr.label_list(
             allow_files = go_exts + asm_exts + cgo_exts,
+            cfg = non_go_transition,
             doc = """The list of Go source files that are compiled to create the package.
             Only `.go` and `.s` files are permitted, unless the `cgo`
             attribute is set, in which case,
@@ -227,6 +230,7 @@ _go_test_kwargs = {
         ),
         "embedsrcs": attr.label_list(
             allow_files = True,
+            cfg = non_go_transition,
             doc = """The list of files that may be embedded into the compiled package using
             `//go:embed` directives. All files must be in the same logical directory
             or a subdirectory as source files. All source files containing `//go:embed`
@@ -299,6 +303,7 @@ _go_test_kwargs = {
             """,
         ),
         "cdeps": attr.label_list(
+            cfg = non_go_transition,
             doc = """The list of other libraries that the c code depends on.
             This can be anything that would be allowed in [cc_library deps]
             Only valid if `cgo` = `True`.
@@ -403,6 +408,9 @@ _go_test_kwargs = {
             executable = True,
             default = "//go/tools/builders:lcov_merger",
             cfg = "target",
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),
     },
     "executable": True,


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

By resetting Go-specific settings changed by go_transition to their previous values when crossing a non-deps dependency edge, e.g. srcs or data, dependencies through those edges are not affected by the change in Go settings. This has two advantages:

* Correctness: Previously, if a go_binary with `linkmode = "c-archive"`  used another go_binary to generate srcs, that go_binary would also be built as a c-archive and thus fail to run during the build. This was observed in https://github.com/bazelbuild/bazel/issues/14626.
* Performance: With the new Bazel flag `--experimental_output_directory_naming_scheme=diff_against_baseline`, transitions can return to the top-level configuration since the Starlark settings that were affected by a transition at some point during the build are no longer tracked explicitly in a setting, but computed as a configuration diff. Resetting the configuration for non-deps dependencies thus prevents redundant rebuilds of non-Go deps caused by changes in Go settings, achieving a version of "configuration trimming" for Go.

**Which issues(s) does this PR fix?**

Fixes #2999
Fixes #3120
Fixes https://github.com/bazelbuild/bazel/issues/14626

**Other notes for review**

This is based on https://github.com/bazelbuild/rules_go/pull/3005 and completes the work started there. #3005 can be reviewed and merged first if preferred.
