### PR TITLE
Find embedsrcs built in different configurations

### DIFF
--- a/go/private/actions/compilepkg.bzl
+++ b/go/private/actions/compilepkg.bzl
@@ -30,6 +30,15 @@ def _archive(v):
         v.data.export_file.path if v.data.export_file else v.data.file.path,
     )
 
+def _embedroot_arg(src):
+    return src.root.path
+
+def _embedlookupdir_arg(src):
+    root_relative = src.dirname[len(src.root.path):]
+    if root_relative.startswith("/"):
+        root_relative = root_relative[len("/"):]
+    return root_relative
+
 def emit_compilepkg(
         go,
         sources = None,
@@ -66,6 +75,20 @@ def emit_compilepkg(
     args = go.builder_args(go, "compilepkg")
     args.add_all(sources, before_each = "-src")
     args.add_all(embedsrcs, before_each = "-embedsrc", expand_directories = False)
+    args.add_all(
+        sources + [out_lib] + embedsrcs,
+        map_each = _embedroot_arg,
+        before_each = "-embedroot",
+        uniquify = True,
+        expand_directories = False,
+    )
+    args.add_all(
+        sources + [out_lib],
+        map_each = _embedlookupdir_arg,
+        before_each = "-embedlookupdir",
+        uniquify = True,
+        expand_directories = False,
+    )
     if cover and go.coverdata:
         inputs.append(go.coverdata.data.export_file)
         args.add("-arc", _archive(go.coverdata))

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -40,7 +40,7 @@ func compilePkg(args []string) error {
 
 	fs := flag.NewFlagSet("GoCompilePkg", flag.ExitOnError)
 	goenv := envFlags(fs)
-	var unfilteredSrcs, coverSrcs, embedSrcs multiFlag
+	var unfilteredSrcs, coverSrcs, embedSrcs, embedLookupDirs, embedRoots multiFlag
 	var deps archiveMultiFlag
 	var importPath, packagePath, nogoPath, packageListPath, coverMode string
 	var outPath, outFactsPath, cgoExportHPath string
@@ -49,6 +49,8 @@ func compilePkg(args []string) error {
 	fs.Var(&unfilteredSrcs, "src", ".go, .c, .cc, .m, .mm, .s, or .S file to be filtered and compiled")
 	fs.Var(&coverSrcs, "cover", ".go file that should be instrumented for coverage (must also be a -src)")
 	fs.Var(&embedSrcs, "embedsrc", "file that may be compiled into the package with a //go:embed directive")
+	fs.Var(&embedLookupDirs, "embedlookupdir", "Root-relative paths to directories relative to which //go:embed directives are resolved")
+	fs.Var(&embedRoots, "embedroot", "Bazel output root under which a file passed via -embedsrc resides")
 	fs.Var(&deps, "arc", "Import path, package path, and file name of a direct dependency, separated by '='")
 	fs.StringVar(&importPath, "importpath", "", "The import path of the package being compiled. Not passed to the compiler, but may be displayed in debug data.")
 	fs.StringVar(&packagePath, "p", "", "The package path (importmap) of the package being compiled")
@@ -129,6 +131,8 @@ func compilePkg(args []string) error {
 		coverMode,
 		coverSrcs,
 		embedSrcs,
+		embedLookupDirs,
+		embedRoots,
 		cgoEnabled,
 		cc,
 		gcFlags,
@@ -155,6 +159,8 @@ func compileArchive(
 	coverMode string,
 	coverSrcs []string,
 	embedSrcs []string,
+	embedLookupDirs []string,
+	embedRoots []string,
 	cgoEnabled bool,
 	cc string,
 	gcFlags []string,
@@ -334,24 +340,24 @@ func compileArchive(
 	// Embed patterns are relative to any one of a list of root directories
 	// that may contain embeddable files. Source files containing embed patterns
 	// must be in one of these root directories so the pattern appears to be
-	// relative to the source file. Usually, there are two roots: the source
-	// directory, and the output directory (so that generated files are
-	// embeddable). There may be additional roots if sources are in multiple
-	// directories (like if there are are generated source files).
-	var srcDirs []string
-	srcDirs = append(srcDirs, filepath.Dir(outPath))
-	for _, src := range srcs.goSrcs {
-		srcDirs = append(srcDirs, filepath.Dir(src.filename))
-	}
-	sort.Strings(srcDirs) // group duplicates to uniq them below.
-	embedRootDirs := srcDirs[:1]
-	for _, dir := range srcDirs {
-		prev := embedRootDirs[len(embedRootDirs)-1]
-		if dir == prev || strings.HasPrefix(dir, prev+string(filepath.Separator)) {
-			// Skip duplicates.
-			continue
+	// relative to the source file. Due to transitions, source files can reside
+	// under Bazel roots different from both those of the go srcs and those of
+	// the compilation output. Thus, we have to consider all combinations of
+	// Bazel roots embedsrcs and root-relative paths of source files and the
+	// output binary.
+	var embedRootDirs []string
+	for _, root := range embedRoots {
+		for _, lookupDir := range embedLookupDirs {
+			embedRootDir := abs(filepath.Join(root, lookupDir))
+			// Since we are iterating over all combinations of roots and
+			// root-relative paths, some resulting paths may not exist and
+			// should be filtered out before being passed to buildEmbedcfgFile.
+			// Since Bazel uniquified both the roots and the root-relative
+			// paths, the combinations are automatically unique.
+			if _, err := os.Stat(embedRootDir); err == nil {
+				embedRootDirs = append(embedRootDirs, embedRootDir)
+			}
 		}
-		embedRootDirs = append(embedRootDirs, dir)
 	}
 	embedcfgPath, err := buildEmbedcfgFile(srcs.goSrcs, embedSrcs, embedRootDirs, workDir)
 	if err != nil {

--- a/tests/core/go_library/BUILD.bazel
+++ b/tests/core/go_library/BUILD.bazel
@@ -105,6 +105,7 @@ go_test(
         "embedsrcs_test.go",
     ],
     embedsrcs = [
+        ":embedsrcs_transitioned",
         ":embedsrcs_dynamic",
         "embedsrcs_test.go",
     ] + glob(["embedsrcs_static/**"]),
@@ -128,6 +129,14 @@ embedsrcs_files(
         "glob/f",
         "no",
     ],
+)
+
+go_binary(
+    name = "embedsrcs_transitioned",
+    srcs = ["empty_main.go"],
+    out = "embedsrcs_transitioned",
+    # Causes a transition on the incoming dependency edge.
+    race = "on",
 )
 
 go_binary(

--- a/tests/core/go_library/embedsrcs_test.go
+++ b/tests/core/go_library/embedsrcs_test.go
@@ -31,6 +31,9 @@ var static embed.FS
 //go:embed embedsrcs_dynamic/file embedsrcs_dynamic/dir embedsrcs_dynamic/glob/*
 var dynamic embed.FS
 
+//go:embed embedsrcs_transitioned
+var transitioned embed.FS
+
 //go:embed *
 var star embed.FS
 
@@ -85,6 +88,14 @@ func TestFiles(t *testing.T) {
 			},
 		},
 		{
+			desc: "transitioned",
+			fsys: transitioned,
+			want: []string{
+				".",
+				"embedsrcs_transitioned",
+			},
+		},
+		{
 			desc: "star",
 			fsys: star,
 			want: []string{
@@ -105,6 +116,7 @@ func TestFiles(t *testing.T) {
 				"embedsrcs_static/glob/f",
 				"embedsrcs_static/no",
 				"embedsrcs_test.go",
+				"embedsrcs_transitioned",
 			},
 		},
 	} {

--- a/tests/core/go_library/empty_main.go
+++ b/tests/core/go_library/empty_main.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Previously, embedsrcs under configuration roots different from that of
the Go target itself or its source files weren't found.

This is fixed by considering all combinations of roots of embedsrcs and
root-relative paths of source files and compilation outputs.

**Which issues(s) does this PR fix?**

Fixes #3114

**Other notes for review**

This blocks #3108, which causes the underlying bug to manifest itself in many simple situations.