### PR TITLE
Fix include paths for CGo deps in external repositories

### DIFF
--- a/tests/core/cgo/BUILD.bazel
+++ b/tests/core/cgo/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
 
 go_test(
     name = "opts_test",
@@ -407,4 +408,9 @@ cc_library(
     name = "split_import_c",
     srcs = ["split_import_c.c"],
     hdrs = ["split_import_c.h"],
+)
+
+go_bazel_test(
+    name = "external_includes_test",
+    srcs = ["external_includes_test.go"],
 )

--- a/tests/core/cgo/external_includes_test.go
+++ b/tests/core/cgo/external_includes_test.go
@@ -1,0 +1,85 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package external_includes_test
+
+import (
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: `
+-- other_repo/WORKSPACE --
+-- other_repo/cc/BUILD.bazel --
+cc_binary(
+    name = "main",
+    srcs = ["main.c"],
+    deps = ["//cgo"],
+)
+-- other_repo/cc/main.c --
+#include "cgo/cgo.h"
+
+int main() {}
+-- other_repo/cgo/BUILD.bazel --
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_binary(
+    name = "cgo",
+    embed = [":cgo_lib"],
+    importpath = "example.com/rules_go/cgo",
+    linkmode = "c-archive",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "cgo_lib",
+    srcs = ["cgo.go"],
+    cgo = True,
+    importpath = "example.com/rules_go/cgo",
+    visibility = ["//visibility:private"],
+)
+-- other_repo/cgo/cgo.go --
+package main
+
+import "C"
+
+//export HelloCgo
+func HelloCgo() {}
+
+func main() {}
+`,
+	WorkspaceSuffix: `
+local_repository(
+    name = "other_repo",
+    path = "other_repo",
+)
+`,
+	})
+}
+
+func TestExternalIncludes(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		if err := bazel_testing.RunBazel("build", "@other_repo//cc:main"); err != nil {
+			t.Fatalf("Did not expect error:\n%+v", err)
+		}
+	})
+	t.Run("experimental_sibling_repository_layout", func(t *testing.T) {
+		if err := bazel_testing.RunBazel("build", "--experimental_sibling_repository_layout", "@other_repo//cc:main"); err != nil {
+			t.Fatalf("Did not expect error:\n%+v", err)
+		}
+	})
+}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix 

**What does this PR do? Why is it needed?**

A CGo-generated header file from any repository, external or main, must
always be includeable via its path relative to its repository root.
Previously, this was not true for CGo targets in external repositories,
which required an additional `external/<repo name>/` prefix, thus
breaking references within the external repository.

**Which issues(s) does this PR fix?**

Fixes #3109

**Other notes for review**
