### PR TITLE
Avoid calling go_path rule in source mode

### DIFF
--- a/extras/gomock.bzl
+++ b/extras/gomock.bzl
@@ -19,12 +19,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_context")
-load("@io_bazel_rules_go//go/private:providers.bzl", "GoLibrary")
+# The rules in this files are still under development. Breaking changes are planned.
+# DO NOT USE IT.
+
+load("//go/private:context.bzl", "go_context")
+load("//go/private/rules:wrappers.bzl", go_binary = "go_binary_macro")
+load("//go/private:providers.bzl", "GoLibrary")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 
 _MOCKGEN_TOOL = "@com_github_golang_mock//mockgen"
-_MOCKGEN_MODEL_LIB = "@com_github_golang_mock//mockgen/model:go_default_library"
+_MOCKGEN_MODEL_LIB = "@com_github_golang_mock//mockgen/model"
 
 def _gomock_source_impl(ctx):
     go_ctx = go_context(ctx)

--- a/extras/gomock.bzl
+++ b/extras/gomock.bzl
@@ -19,33 +19,49 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_context", "go_path")
-load("@io_bazel_rules_go//go/private:providers.bzl", "GoLibrary", "GoPath")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_context")
+load("@io_bazel_rules_go//go/private:providers.bzl", "GoLibrary")
+load("@bazel_skylib//lib:paths.bzl", "paths")
 
 _MOCKGEN_TOOL = "@com_github_golang_mock//mockgen"
 _MOCKGEN_MODEL_LIB = "@com_github_golang_mock//mockgen/model:go_default_library"
 
 def _gomock_source_impl(ctx):
     go_ctx = go_context(ctx)
-    gopath = "$(pwd)/" + ctx.bin_dir.path + "/" + ctx.attr.gopath_dep[GoPath].gopath
 
+    # create GOPATH and copy source into GOPATH
+    source_relative_path = paths.join("src", ctx.attr.library[GoLibrary].importmap, ctx.file.source.basename)
+    source = ctx.actions.declare_file(paths.join("gopath", source_relative_path))
+    # trim the relative path of source to get GOPATH
+    gopath = source.path[:-len(source_relative_path)]
+    ctx.actions.run_shell(
+        outputs=[source],
+        inputs=[ctx.file.source],
+        command = "mkdir -p {0} && cp -L {1} {0}".format(source.dirname, ctx.file.source.path),
+    )
     # passed in source needs to be in gopath to not trigger module mode
-    args = ["-source", gopath + "/src/" + ctx.attr.library[GoLibrary].importmap + "/" + ctx.file.source.basename]
+    args = ["-source", source.path]
 
     args, needed_files = _handle_shared_args(ctx, args)
 
     if len(ctx.attr.aux_files) > 0:
         aux_files = []
-        for pkg, files in ctx.attr.aux_files.items():
-            for f in files:
-                mapped_f = gopath + "/src/" + ctx.attr.library[GoLibrary].importmap + "/" + f
-                aux_files.append("{0}={1}".format(pkg, mapped_f))
+        for target, pkg in ctx.attr.aux_files.items():
+            f = target.files.to_list()[0]
+            aux = ctx.actions.declare_file(paths.join(gopath, "src", pkg, f.basename))
+            ctx.actions.run_shell(
+                outputs=[aux],
+                inputs=[f],
+                command = "mkdir -p {0} && cp -L {1} {0}".format(aux.dirname, f.path)
+            )
+            aux_files.append("{0}={1}".format(pkg, aux.path))
+            needed_files.append(f)
         args += ["-aux_files", ",".join(aux_files)]
 
     inputs = (
-        ctx.attr.gopath_dep.files.to_list() + needed_files +
+        needed_files +
         go_ctx.sdk.headers + go_ctx.sdk.srcs + go_ctx.sdk.tools
-    ) + [ctx.file.source]
+    ) + [source]
 
     # We can use the go binary from the stdlib for most of the environment
     # variables, but our GOPATH is specific to the library target we were given.
@@ -57,14 +73,9 @@ def _gomock_source_impl(ctx):
             go_ctx.go,
         ],
         command = """
-           source <($PWD/{godir}/go env) &&
-           export PATH=$GOROOT/bin:$PWD/{godir}:$PATH &&
-           export GOPATH={gopath} &&
-           mkdir -p .gocache &&
-           export GOCACHE=$PWD/.gocache &&
-           {cmd} {args} > {out}
+            export GOPATH=$(pwd)/{gopath} &&
+            {cmd} {args} > {out}
         """.format(
-            godir = go_ctx.go.path[:-1 - len(go_ctx.go.basename)],
             gopath = gopath,
             cmd = "$(pwd)/" + ctx.file.mockgen_tool.path,
             args = " ".join(args),
@@ -72,7 +83,8 @@ def _gomock_source_impl(ctx):
             mnemonic = "GoMockSourceGen",
         ),
         env = {
-            "GO111MODULE": "off",  # explicitly relying on passed in go_path to not download modules while doing codegen
+            # GOCACHE is required starting in Go 1.12
+            "GOCACHE": "./.gocache",
         },
     )
 
@@ -98,9 +110,10 @@ _gomock_source = rule(
             doc = "Ignored. If `source` is not set, this would be the list of Go interfaces to generate mocks for.",
             mandatory = True,
         ),
-        "aux_files": attr.string_list_dict(
+        "aux_files": attr.label_keyed_string_dict(
             default = {},
-            doc = "A map from packages to auxilliary Go source files to load for those packages.",
+            doc = "A map from auxilliary Go source files to their packages.",
+            allow_files = True,
         ),
         "package": attr.string(
             doc = "The name of the package the generated mocks should be in. If not specified, uses mockgen's default.",
@@ -118,11 +131,6 @@ _gomock_source = rule(
         "copyright_file": attr.label(
             doc = "Optional file containing copyright to prepend to the generated contents.",
             allow_single_file = True,
-            mandatory = False,
-        ),
-        "gopath_dep": attr.label(
-            doc = "The go_path label to use to create the GOPATH for the given library. Will be set correctly by the gomock macro, so you don't need to set it.",
-            providers = [GoPath],
             mandatory = False,
         ),
         "mockgen_tool": attr.label(
@@ -146,15 +154,9 @@ def gomock(name, library, out, **kwargs):
         mockgen_tool = kwargs["mockgen_tool"]
 
     if kwargs.get("source", None):
-        gopath_name = name + "_gomock_gopath"
-        go_path(
-            name = gopath_name,
-            deps = [library, mockgen_tool],
-        )
         _gomock_source(
             name = name,
             library = library,
-            gopath_dep = gopath_name,
             out = out,
             **kwargs
         )

--- a/extras/gomock.bzl
+++ b/extras/gomock.bzl
@@ -32,13 +32,15 @@ def _gomock_source_impl(ctx):
     # create GOPATH and copy source into GOPATH
     source_relative_path = paths.join("src", ctx.attr.library[GoLibrary].importmap, ctx.file.source.basename)
     source = ctx.actions.declare_file(paths.join("gopath", source_relative_path))
+
     # trim the relative path of source to get GOPATH
     gopath = source.path[:-len(source_relative_path)]
     ctx.actions.run_shell(
-        outputs=[source],
-        inputs=[ctx.file.source],
+        outputs = [source],
+        inputs = [ctx.file.source],
         command = "mkdir -p {0} && cp -L {1} {0}".format(source.dirname, ctx.file.source.path),
     )
+
     # passed in source needs to be in gopath to not trigger module mode
     args = ["-source", source.path]
 
@@ -50,9 +52,9 @@ def _gomock_source_impl(ctx):
             f = target.files.to_list()[0]
             aux = ctx.actions.declare_file(paths.join(gopath, "src", pkg, f.basename))
             ctx.actions.run_shell(
-                outputs=[aux],
-                inputs=[f],
-                command = "mkdir -p {0} && cp -L {1} {0}".format(aux.dirname, f.path)
+                outputs = [aux],
+                inputs = [f],
+                command = "mkdir -p {0} && cp -L {1} {0}".format(aux.dirname, f.path),
             )
             aux_files.append("{0}={1}".format(pkg, aux.path))
             needed_files.append(f)

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -59,6 +59,10 @@ load(
     _go_embed_data = "go_embed_data",
 )
 load(
+    "//extras:gomock.bzl",
+    _gomock = "gomock",
+)
+load(
     "//go/private/tools:path.bzl",
     _go_path = "go_path",
 )
@@ -121,6 +125,7 @@ RULES_GO_VERSION = "0.31.0"
 declare_toolchains = _declare_toolchains
 go_context = _go_context
 go_embed_data = _go_embed_data
+gomock = _gomock
 go_sdk = _go_sdk
 go_tool_library = _go_tool_library
 go_toolchain = _go_toolchain

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -260,6 +260,24 @@ def go_rules_dependencies():
         patch_args = ["-E", "-p1"],
     )
 
+    # releaser:upgrade-dep golang mock
+    _maybe(
+        http_archive,
+        name = "com_github_golang_mock",
+        # v1.6.0, latest as of 2022-04-16
+        urls = [
+            "https://mirror.bazel.build/github.com/golang/mock/archive/v1.6.0.zip",
+            "https://github.com/golang/mock/archive/v1.6.0.zip",
+        ],
+        patches = [
+            # releaser:patch-cmd gazelle -repo_root . -go_prefix github.com/golang/mock
+            Label("//third_party:com_github_golang_mock-gazelle.patch"),
+        ],
+        patch_args = ["-p1"],
+        sha256 = "604d9ab25b07d60c1b8ba6d3ea2e66873138edeed2e561c5358de804ea421a0e",
+        strip_prefix = "mock-1.6.0",
+    )
+
     # This may be overridden by go_register_toolchains, but it's not mandatory
     # for users to call that function (they may declare their own @go_sdk and
     # register their own toolchains).

--- a/tests/core/gomock/BUILD.bazel
+++ b/tests/core/gomock/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test", "gomock")
+
+go_library(
+    name = "client",
+    srcs = [
+        "client.go",
+    ],
+    importpath = "uber.com/client",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@go_googleapis//google/bytestream:bytestream_go_proto",
+        "@org_golang_google_grpc//:grpc",
+    ],
+)
+
+gomock(
+    name = "mocks",
+    out = "client_mock.go",
+    interfaces = ["Client"],
+    library = ":client",
+    package = "client",
+    source = "client.go",
+)
+
+go_test(
+    name = "client_test",
+    srcs = [
+        "client_mock.go",
+        "client_test.go",
+    ],
+    embed = [":client"],
+    deps = ["@com_github_golang_mock//gomock"],
+)

--- a/tests/core/gomock/BUILD.bazel
+++ b/tests/core/gomock/BUILD.bazel
@@ -5,7 +5,7 @@ go_library(
     srcs = [
         "client.go",
     ],
-    importpath = "uber.com/client",
+    importpath = "github.com/bazelbuild/rules_go/gomock/client",
     visibility = ["//visibility:public"],
     deps = [
         "@go_googleapis//google/bytestream:bytestream_go_proto",

--- a/tests/core/gomock/client.go
+++ b/tests/core/gomock/client.go
@@ -1,0 +1,10 @@
+package client
+
+import (
+	"google.golang.org/genproto/googleapis/bytestream"
+	"google.golang.org/grpc"
+)
+
+type Client interface {
+	Connect(grpc.ClientConnInterface) *bytestream.ByteStreamClient
+}

--- a/tests/core/gomock/client_test.go
+++ b/tests/core/gomock/client_test.go
@@ -1,0 +1,3 @@
+package client
+
+var _ Client = (*MockClient)(nil)

--- a/third_party/com_github_golang_mock-gazelle.patch
+++ b/third_party/com_github_golang_mock-gazelle.patch
@@ -1,0 +1,822 @@
+diff -urN a/gomock/BUILD.bazel b/gomock/BUILD.bazel
+--- a/gomock/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/gomock/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,29 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "gomock",
++    srcs = [
++        "call.go",
++        "callset.go",
++        "controller.go",
++        "matchers.go",
++    ],
++    importpath = "github.com/golang/mock/gomock",
++    visibility = ["//visibility:public"],
++)
++
++go_test(
++    name = "gomock_test",
++    srcs = [
++        "call_test.go",
++        "callset_test.go",
++        "controller_113_test.go",
++        "controller_114_test.go",
++        "controller_test.go",
++        "example_test.go",
++        "matchers_test.go",
++        "mock_test.go",
++    ],
++    embed = [":gomock"],
++    deps = ["//gomock/internal/mock_gomock"],
++)
+diff -urN a/gomock/internal/mock_gomock/BUILD.bazel b/gomock/internal/mock_gomock/BUILD.bazel
+--- a/gomock/internal/mock_gomock/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/gomock/internal/mock_gomock/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,9 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "mock_gomock",
++    srcs = ["mock_matcher.go"],
++    importpath = "github.com/golang/mock/gomock/internal/mock_gomock",
++    visibility = ["//gomock:__subpackages__"],
++    deps = ["//gomock"],
++)
+diff -urN a/mockgen/BUILD.bazel b/mockgen/BUILD.bazel
+--- a/mockgen/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,35 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
++
++go_library(
++    name = "mockgen_lib",
++    srcs = [
++        "mockgen.go",
++        "parse.go",
++        "reflect.go",
++        "version.1.11.go",
++        "version.1.12.go",
++    ],
++    importpath = "github.com/golang/mock/mockgen",
++    visibility = ["//visibility:private"],
++    deps = [
++        "//mockgen/model",
++        "@org_golang_x_mod//modfile:go_default_library",
++        "@org_golang_x_tools//imports:go_default_library",
++    ],
++)
++
++go_binary(
++    name = "mockgen",
++    embed = [":mockgen_lib"],
++    visibility = ["//visibility:public"],
++)
++
++go_test(
++    name = "mockgen_test",
++    srcs = [
++        "mockgen_test.go",
++        "parse_test.go",
++    ],
++    embed = [":mockgen_lib"],
++    deps = ["//mockgen/model"],
++)
+diff -urN a/mockgen/internal/tests/aux_imports_embedded_interface/BUILD.bazel b/mockgen/internal/tests/aux_imports_embedded_interface/BUILD.bazel
+--- a/mockgen/internal/tests/aux_imports_embedded_interface/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/aux_imports_embedded_interface/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,22 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "aux_imports_embedded_interface",
++    srcs = [
++        "bugreport.go",
++        "bugreport_mock.go",
++    ],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/aux_imports_embedded_interface",
++    visibility = ["//mockgen:__subpackages__"],
++    deps = [
++        "//gomock",
++        "//mockgen/internal/tests/aux_imports_embedded_interface/faux",
++    ],
++)
++
++go_test(
++    name = "aux_imports_embedded_interface_test",
++    srcs = ["bugreport_test.go"],
++    embed = [":aux_imports_embedded_interface"],
++    deps = ["//gomock"],
++)
+diff -urN a/mockgen/internal/tests/aux_imports_embedded_interface/faux/BUILD.bazel b/mockgen/internal/tests/aux_imports_embedded_interface/faux/BUILD.bazel
+--- a/mockgen/internal/tests/aux_imports_embedded_interface/faux/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/aux_imports_embedded_interface/faux/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "faux",
++    srcs = ["faux.go"],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/aux_imports_embedded_interface/faux",
++    visibility = ["//mockgen:__subpackages__"],
++)
+diff -urN a/mockgen/internal/tests/const_array_length/BUILD.bazel b/mockgen/internal/tests/const_array_length/BUILD.bazel
+--- a/mockgen/internal/tests/const_array_length/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/const_array_length/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "const_array_length",
++    srcs = [
++        "input.go",
++        "mock.go",
++    ],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/const_array_length",
++    visibility = ["//mockgen:__subpackages__"],
++    deps = ["//gomock"],
++)
+diff -urN a/mockgen/internal/tests/copyright_file/BUILD.bazel b/mockgen/internal/tests/copyright_file/BUILD.bazel
+--- a/mockgen/internal/tests/copyright_file/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/copyright_file/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "copyright_file",
++    srcs = [
++        "input.go",
++        "mock.go",
++    ],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/copyright_file",
++    visibility = ["//mockgen:__subpackages__"],
++    deps = ["//gomock"],
++)
+diff -urN a/mockgen/internal/tests/custom_package_name/client/v1/BUILD.bazel b/mockgen/internal/tests/custom_package_name/client/v1/BUILD.bazel
+--- a/mockgen/internal/tests/custom_package_name/client/v1/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/custom_package_name/client/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "client",
++    srcs = ["client.go"],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/custom_package_name/client/v1",
++    visibility = ["//mockgen:__subpackages__"],
++)
+diff -urN a/mockgen/internal/tests/custom_package_name/greeter/BUILD.bazel b/mockgen/internal/tests/custom_package_name/greeter/BUILD.bazel
+--- a/mockgen/internal/tests/custom_package_name/greeter/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/custom_package_name/greeter/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,25 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "greeter",
++    srcs = ["greeter.go"],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/custom_package_name/greeter",
++    visibility = ["//mockgen:__subpackages__"],
++    deps = [
++        "//mockgen/internal/tests/custom_package_name/client/v1:client",
++        "//mockgen/internal/tests/custom_package_name/validator",
++    ],
++)
++
++go_test(
++    name = "greeter_test",
++    srcs = [
++        "greeter_mock_test.go",
++        "greeter_test.go",
++    ],
++    embed = [":greeter"],
++    deps = [
++        "//gomock",
++        "//mockgen/internal/tests/custom_package_name/client/v1:client",
++    ],
++)
+diff -urN a/mockgen/internal/tests/custom_package_name/validator/BUILD.bazel b/mockgen/internal/tests/custom_package_name/validator/BUILD.bazel
+--- a/mockgen/internal/tests/custom_package_name/validator/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/custom_package_name/validator/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "validator",
++    srcs = ["validate.go"],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/custom_package_name/validator",
++    visibility = ["//mockgen:__subpackages__"],
++)
+diff -urN a/mockgen/internal/tests/dot_imports/BUILD.bazel b/mockgen/internal/tests/dot_imports/BUILD.bazel
+--- a/mockgen/internal/tests/dot_imports/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/dot_imports/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "dot_imports",
++    srcs = [
++        "input.go",
++        "mock.go",
++    ],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/dot_imports",
++    visibility = ["//mockgen:__subpackages__"],
++    deps = ["//gomock"],
++)
+diff -urN a/mockgen/internal/tests/empty_interface/BUILD.bazel b/mockgen/internal/tests/empty_interface/BUILD.bazel
+--- a/mockgen/internal/tests/empty_interface/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/empty_interface/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "empty_interface",
++    srcs = [
++        "input.go",
++        "mock.go",
++    ],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/empty_interface",
++    visibility = ["//mockgen:__subpackages__"],
++    deps = ["//gomock"],
++)
+diff -urN a/mockgen/internal/tests/extra_import/BUILD.bazel b/mockgen/internal/tests/extra_import/BUILD.bazel
+--- a/mockgen/internal/tests/extra_import/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/extra_import/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "extra_import",
++    srcs = [
++        "import.go",
++        "mock.go",
++    ],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/extra_import",
++    visibility = ["//mockgen:__subpackages__"],
++    deps = ["//gomock"],
++)
+diff -urN a/mockgen/internal/tests/generated_identifier_conflict/BUILD.bazel b/mockgen/internal/tests/generated_identifier_conflict/BUILD.bazel
+--- a/mockgen/internal/tests/generated_identifier_conflict/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/generated_identifier_conflict/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "generated_identifier_conflict",
++    srcs = [
++        "bugreport.go",
++        "bugreport_mock.go",
++    ],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/generated_identifier_conflict",
++    visibility = ["//mockgen:__subpackages__"],
++    deps = ["//gomock"],
++)
++
++go_test(
++    name = "generated_identifier_conflict_test",
++    srcs = ["bugreport_test.go"],
++    embed = [":generated_identifier_conflict"],
++    deps = ["//gomock"],
++)
+diff -urN a/mockgen/internal/tests/import_embedded_interface/BUILD.bazel b/mockgen/internal/tests/import_embedded_interface/BUILD.bazel
+--- a/mockgen/internal/tests/import_embedded_interface/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/import_embedded_interface/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,29 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "import_embedded_interface",
++    srcs = [
++        "bugreport.go",
++        "bugreport_mock.go",
++        "net.go",
++        "net_mock.go",
++    ],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/import_embedded_interface",
++    visibility = ["//mockgen:__subpackages__"],
++    deps = [
++        "//gomock",
++        "//mockgen/internal/tests/import_embedded_interface/ersatz",
++        "//mockgen/internal/tests/import_embedded_interface/faux",
++        "//mockgen/internal/tests/import_embedded_interface/other/ersatz",
++    ],
++)
++
++go_test(
++    name = "import_embedded_interface_test",
++    srcs = [
++        "bugreport_test.go",
++        "net_test.go",
++    ],
++    embed = [":import_embedded_interface"],
++    deps = ["//gomock"],
++)
+diff -urN a/mockgen/internal/tests/import_embedded_interface/ersatz/BUILD.bazel b/mockgen/internal/tests/import_embedded_interface/ersatz/BUILD.bazel
+--- a/mockgen/internal/tests/import_embedded_interface/ersatz/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/import_embedded_interface/ersatz/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "ersatz",
++    srcs = ["ersatz.go"],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/import_embedded_interface/ersatz",
++    visibility = ["//mockgen:__subpackages__"],
++)
+diff -urN a/mockgen/internal/tests/import_embedded_interface/faux/BUILD.bazel b/mockgen/internal/tests/import_embedded_interface/faux/BUILD.bazel
+--- a/mockgen/internal/tests/import_embedded_interface/faux/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/import_embedded_interface/faux/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,15 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "faux",
++    srcs = [
++        "conflict.go",
++        "faux.go",
++    ],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/import_embedded_interface/faux",
++    visibility = ["//mockgen:__subpackages__"],
++    deps = [
++        "//mockgen/internal/tests/import_embedded_interface/other/ersatz",
++        "//mockgen/internal/tests/import_embedded_interface/other/log",
++    ],
++)
+diff -urN a/mockgen/internal/tests/import_embedded_interface/other/ersatz/BUILD.bazel b/mockgen/internal/tests/import_embedded_interface/other/ersatz/BUILD.bazel
+--- a/mockgen/internal/tests/import_embedded_interface/other/ersatz/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/import_embedded_interface/other/ersatz/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "ersatz",
++    srcs = ["ersatz.go"],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/import_embedded_interface/other/ersatz",
++    visibility = ["//mockgen:__subpackages__"],
++)
+diff -urN a/mockgen/internal/tests/import_embedded_interface/other/log/BUILD.bazel b/mockgen/internal/tests/import_embedded_interface/other/log/BUILD.bazel
+--- a/mockgen/internal/tests/import_embedded_interface/other/log/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/import_embedded_interface/other/log/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "log",
++    srcs = ["log.go"],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/import_embedded_interface/other/log",
++    visibility = ["//mockgen:__subpackages__"],
++)
+diff -urN a/mockgen/internal/tests/import_source/BUILD.bazel b/mockgen/internal/tests/import_source/BUILD.bazel
+--- a/mockgen/internal/tests/import_source/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/import_source/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "import_source",
++    srcs = ["source_mock.go"],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/import_source",
++    visibility = ["//mockgen:__subpackages__"],
++    deps = [
++        "//gomock",
++        "//mockgen/internal/tests/import_source/definition",
++    ],
++)
+diff -urN a/mockgen/internal/tests/import_source/definition/BUILD.bazel b/mockgen/internal/tests/import_source/definition/BUILD.bazel
+--- a/mockgen/internal/tests/import_source/definition/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/import_source/definition/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "definition",
++    srcs = [
++        "source.go",
++        "source_mock.go",
++    ],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/import_source/definition",
++    visibility = ["//mockgen:__subpackages__"],
++    deps = ["//gomock"],
++)
+diff -urN a/mockgen/internal/tests/internal_pkg/BUILD.bazel b/mockgen/internal/tests/internal_pkg/BUILD.bazel
+--- a/mockgen/internal/tests/internal_pkg/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/internal_pkg/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "internal_pkg",
++    srcs = ["generate.go"],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/internal_pkg",
++    visibility = ["//mockgen:__subpackages__"],
++)
+diff -urN a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/BUILD.bazel b/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/BUILD.bazel
+--- a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "pkg",
++    srcs = ["input.go"],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/internal_pkg/subdir/internal/pkg",
++    visibility = ["//mockgen:__subpackages__"],
++)
+diff -urN a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/reflect_output/BUILD.bazel b/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/reflect_output/BUILD.bazel
+--- a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/reflect_output/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/reflect_output/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "reflect_output",
++    srcs = ["mock.go"],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/reflect_output",
++    visibility = ["//mockgen:__subpackages__"],
++    deps = [
++        "//gomock",
++        "//mockgen/internal/tests/internal_pkg/subdir/internal/pkg",
++    ],
++)
+diff -urN a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/source_output/BUILD.bazel b/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/source_output/BUILD.bazel
+--- a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/source_output/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/source_output/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "source_output",
++    srcs = ["mock.go"],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/source_output",
++    visibility = ["//mockgen:__subpackages__"],
++    deps = [
++        "//gomock",
++        "//mockgen/internal/tests/internal_pkg/subdir/internal/pkg",
++    ],
++)
+diff -urN a/mockgen/internal/tests/missing_import/output/BUILD.bazel b/mockgen/internal/tests/missing_import/output/BUILD.bazel
+--- a/mockgen/internal/tests/missing_import/output/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/missing_import/output/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "output",
++    srcs = ["source_mock.go"],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/missing_import/output",
++    visibility = ["//mockgen:__subpackages__"],
++    deps = [
++        "//gomock",
++        "//mockgen/internal/tests/missing_import/source",
++    ],
++)
+diff -urN a/mockgen/internal/tests/missing_import/source/BUILD.bazel b/mockgen/internal/tests/missing_import/source/BUILD.bazel
+--- a/mockgen/internal/tests/missing_import/source/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/missing_import/source/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "source",
++    srcs = ["source.go"],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/missing_import/source",
++    visibility = ["//mockgen:__subpackages__"],
++)
+diff -urN a/mockgen/internal/tests/mock_in_test_package/BUILD.bazel b/mockgen/internal/tests/mock_in_test_package/BUILD.bazel
+--- a/mockgen/internal/tests/mock_in_test_package/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/mock_in_test_package/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,17 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "mock_in_test_package",
++    srcs = ["user.go"],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/mock_in_test_package",
++    visibility = ["//mockgen:__subpackages__"],
++)
++
++go_test(
++    name = "mock_in_test_package_test",
++    srcs = ["mock_test.go"],
++    deps = [
++        ":mock_in_test_package",
++        "//gomock",
++    ],
++)
+diff -urN a/mockgen/internal/tests/overlapping_methods/BUILD.bazel b/mockgen/internal/tests/overlapping_methods/BUILD.bazel
+--- a/mockgen/internal/tests/overlapping_methods/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/overlapping_methods/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,20 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "overlapping_methods",
++    srcs = [
++        "interfaces.go",
++        "mock.go",
++        "overlap.go",
++    ],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/overlapping_methods",
++    visibility = ["//mockgen:__subpackages__"],
++    deps = ["//gomock"],
++)
++
++go_test(
++    name = "overlapping_methods_test",
++    srcs = ["overlap_test.go"],
++    embed = [":overlapping_methods"],
++    deps = ["//gomock"],
++)
+diff -urN a/mockgen/internal/tests/panicing_test/BUILD.bazel b/mockgen/internal/tests/panicing_test/BUILD.bazel
+--- a/mockgen/internal/tests/panicing_test/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/panicing_test/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,15 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "panicing_test",
++    srcs = ["panic.go"],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/panicing_test",
++    visibility = ["//mockgen:__subpackages__"],
++)
++
++go_test(
++    name = "panicing_test_test",
++    srcs = ["mock_test.go"],
++    embed = [":panicing_test"],
++    deps = ["//gomock"],
++)
+diff -urN a/mockgen/internal/tests/parenthesized_parameter_type/BUILD.bazel b/mockgen/internal/tests/parenthesized_parameter_type/BUILD.bazel
+--- a/mockgen/internal/tests/parenthesized_parameter_type/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/parenthesized_parameter_type/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "parenthesized_parameter_type",
++    srcs = [
++        "input.go",
++        "mock.go",
++    ],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/parenthesized_parameter_type",
++    visibility = ["//mockgen:__subpackages__"],
++    deps = ["//gomock"],
++)
+diff -urN a/mockgen/internal/tests/performance/big_interface/BUILD.bazel b/mockgen/internal/tests/performance/big_interface/BUILD.bazel
+--- a/mockgen/internal/tests/performance/big_interface/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/performance/big_interface/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "big_interface",
++    srcs = ["big_interface.go"],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/performance/big_interface",
++    visibility = ["//mockgen:__subpackages__"],
++)
+diff -urN a/mockgen/internal/tests/self_package/BUILD.bazel b/mockgen/internal/tests/self_package/BUILD.bazel
+--- a/mockgen/internal/tests/self_package/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/self_package/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "self_package",
++    srcs = [
++        "mock.go",
++        "types.go",
++    ],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/self_package",
++    visibility = ["//mockgen:__subpackages__"],
++    deps = ["//gomock"],
++)
+diff -urN a/mockgen/internal/tests/test_package/BUILD.bazel b/mockgen/internal/tests/test_package/BUILD.bazel
+--- a/mockgen/internal/tests/test_package/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/test_package/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,17 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "test_package",
++    srcs = ["foo.go"],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/test_package",
++    visibility = ["//mockgen:__subpackages__"],
++)
++
++go_test(
++    name = "test_package_test",
++    srcs = [
++        "mock_test.go",
++        "user_test.go",
++    ],
++    deps = ["//gomock"],
++)
+diff -urN a/mockgen/internal/tests/unexported_method/BUILD.bazel b/mockgen/internal/tests/unexported_method/BUILD.bazel
+--- a/mockgen/internal/tests/unexported_method/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/unexported_method/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "unexported_method",
++    srcs = [
++        "bugreport.go",
++        "bugreport_mock.go",
++    ],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/unexported_method",
++    visibility = ["//mockgen:__subpackages__"],
++    deps = ["//gomock"],
++)
++
++go_test(
++    name = "unexported_method_test",
++    srcs = ["bugreport_test.go"],
++    embed = [":unexported_method"],
++    deps = ["//gomock"],
++)
+diff -urN a/mockgen/internal/tests/vendor_dep/BUILD.bazel b/mockgen/internal/tests/vendor_dep/BUILD.bazel
+--- a/mockgen/internal/tests/vendor_dep/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/vendor_dep/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,16 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "vendor_dep",
++    srcs = [
++        "doc.go",
++        "mock.go",
++        "vendor_dep.go",
++    ],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/vendor_dep",
++    visibility = ["//mockgen:__subpackages__"],
++    deps = [
++        "//gomock",
++        "@org_golang_x_tools//present:go_default_library",
++    ],
++)
+diff -urN a/mockgen/internal/tests/vendor_dep/source_mock_package/BUILD.bazel b/mockgen/internal/tests/vendor_dep/source_mock_package/BUILD.bazel
+--- a/mockgen/internal/tests/vendor_dep/source_mock_package/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/vendor_dep/source_mock_package/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "source_mock_package",
++    srcs = ["mock.go"],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/vendor_dep/source_mock_package",
++    visibility = ["//mockgen:__subpackages__"],
++    deps = [
++        "//gomock",
++        "@org_golang_x_tools//present:go_default_library",
++    ],
++)
+diff -urN a/mockgen/internal/tests/vendor_pkg/BUILD.bazel b/mockgen/internal/tests/vendor_pkg/BUILD.bazel
+--- a/mockgen/internal/tests/vendor_pkg/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/internal/tests/vendor_pkg/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "vendor_pkg",
++    srcs = [
++        "doc.go",
++        "mock.go",
++    ],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/vendor_pkg",
++    visibility = ["//mockgen:__subpackages__"],
++    deps = ["//gomock"],
++)
+diff -urN a/mockgen/model/BUILD.bazel b/mockgen/model/BUILD.bazel
+--- a/mockgen/model/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/mockgen/model/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,14 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "model",
++    srcs = ["model.go"],
++    importpath = "github.com/golang/mock/mockgen/model",
++    visibility = ["//visibility:public"],
++)
++
++go_test(
++    name = "model_test",
++    srcs = ["model_test.go"],
++    embed = [":model"],
++)
+diff -urN a/sample/BUILD.bazel b/sample/BUILD.bazel
+--- a/sample/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/sample/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,30 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "sample",
++    srcs = ["user.go"],
++    importpath = "github.com/golang/mock/sample",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//sample/imp1",
++        "//sample/imp2",
++        "//sample/imp3",
++        "//sample/imp4",
++    ],
++)
++
++go_test(
++    name = "sample_test",
++    srcs = [
++        "mock_user_test.go",
++        "user_test.go",
++    ],
++    deps = [
++        ":sample",
++        "//gomock",
++        "//sample/imp1",
++        "//sample/imp2",
++        "//sample/imp3",
++        "//sample/imp4",
++    ],
++)
+diff -urN a/sample/concurrent/BUILD.bazel b/sample/concurrent/BUILD.bazel
+--- a/sample/concurrent/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/sample/concurrent/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,18 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "concurrent",
++    srcs = ["concurrent.go"],
++    importpath = "github.com/golang/mock/sample/concurrent",
++    visibility = ["//visibility:public"],
++)
++
++go_test(
++    name = "concurrent_test",
++    srcs = ["concurrent_test.go"],
++    embed = [":concurrent"],
++    deps = [
++        "//gomock",
++        "//sample/concurrent/mock",
++    ],
++)
+diff -urN a/sample/concurrent/mock/BUILD.bazel b/sample/concurrent/mock/BUILD.bazel
+--- a/sample/concurrent/mock/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/sample/concurrent/mock/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,9 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "mock",
++    srcs = ["concurrent_mock.go"],
++    importpath = "github.com/golang/mock/sample/concurrent/mock",
++    visibility = ["//visibility:public"],
++    deps = ["//gomock"],
++)
+diff -urN a/sample/imp1/BUILD.bazel b/sample/imp1/BUILD.bazel
+--- a/sample/imp1/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/sample/imp1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "imp1",
++    srcs = ["imp1.go"],
++    importpath = "github.com/golang/mock/sample/imp1",
++    visibility = ["//visibility:public"],
++)
+diff -urN a/sample/imp2/BUILD.bazel b/sample/imp2/BUILD.bazel
+--- a/sample/imp2/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/sample/imp2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "imp2",
++    srcs = ["imp2.go"],
++    importpath = "github.com/golang/mock/sample/imp2",
++    visibility = ["//visibility:public"],
++)
+diff -urN a/sample/imp3/BUILD.bazel b/sample/imp3/BUILD.bazel
+--- a/sample/imp3/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/sample/imp3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "imp3",
++    srcs = ["imp3.go"],
++    importpath = "github.com/golang/mock/sample/imp3",
++    visibility = ["//visibility:public"],
++)
+diff -urN a/sample/imp4/BUILD.bazel b/sample/imp4/BUILD.bazel
+--- a/sample/imp4/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/sample/imp4/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "imp4",
++    srcs = ["imp4.go"],
++    importpath = "github.com/golang/mock/sample/imp4",
++    visibility = ["//visibility:public"],
++)


### PR DESCRIPTION
**What type of PR is this?**
Performance optimization. This is also a breaking change from original `gomock` rule implementation, because it changes the types of `aux_files` attribute.

**What does this PR do? Why is it needed?**
Running mockgen in source mode does not require all its dependencies in GOPATH. It only need the source file and some aux files. We can copy them to form a GOPATH structure without calling `go_path` rule. 

Before this patch:
```
Critical path (1.199 s):
       Time Percentage   Description
    0.46 ms    0.04%   action 'Writing file mocks_gomock_gopath~manifest'
     250 ms   20.86%   action 'GoPath mocks_gomock_gopath'
     949 ms   79.10%   action 'Action mocks.go'
```
After this patch:

```
Critical path (891 ms):
       Time Percentage   Description
    24.1 ms    2.70%   action 'Action gopath/src/uber.com/gomock/client.go'
     867 ms   97.30%   action 'Action mocks.go'
```

The experiment can be reproduced in the following workspace:

1. create a workspace with the following files:
```
-- BUILD.bazel --
load("@io_bazel_rules_go//go:def.bzl", "go_library")
load("@io_bazel_rules_go//extras:gomock.bzl", "gomock")
load("@bazel_gazelle//:def.bzl", "gazelle")

# gazelle:prefix uber.com/gomock
gazelle(name = "gazelle")

gazelle(
    name = "gazelle-update-repos",
    args = [
        "-from_file=go.mod",
        "-prune",
    ],
    command = "update-repos",
)

go_library(
    name = "client",
    srcs = ["client.go"],
    importpath = "uber.com/gomock",
    visibility = ["//visibility:public"],
    deps = [
        "@go_googleapis//google/bytestream:bytestream_go_proto",
        "@org_golang_google_grpc//:go_default_library",
    ],
)

# gazelle:exclude mocks.go
gomock(
    name = "mocks",
    out = "mocks.go",
    library = ":client",
    package = "gomock",
    source = "client.go",
    interfaces = ["Client"],
)
-- client.go --
package gomock

import (
	_ "github.com/mattn/go-sqlite3"
	_ "google.golang.org/genproto/googleapis/bytestream"
	_ "google.golang.org/grpc"
)

type Client interface {
}
-- go.mod --
module uber.com/gomock

go 1.18

require (
	github.com/mattn/go-sqlite3 v1.14.12
	google.golang.org/genproto v0.0.0-20220414192740-2d67ff6cf2b4
	google.golang.org/grpc v1.45.0
)

require (
	github.com/golang/protobuf v1.5.2 // indirect
	github.com/google/go-cmp v0.5.7 // indirect
	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f // indirect
	golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8 // indirect
	golang.org/x/text v0.3.7 // indirect
	google.golang.org/protobuf v1.28.0 // indirect
)
-- WORKSPACE --
load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

http_archive(
    name = "io_bazel_rules_go",
    sha256 = "6c3bc93b2f14db41c2ef53388700fb95cbf7005b7c94e98f5d8bca0748110062",
    strip_prefix = "rules_go-926c47abbb2dd059a4fcd3f810005167cc62ed1c",
    urls = [
        "https://github.com/bazelbuild/rules_go/archive/926c47abbb2dd059a4fcd3f810005167cc62ed1c.zip",
    ],
)

http_archive(
    name = "bazel_gazelle",
    sha256 = "de69a09dc70417580aabf20a28619bb3ef60d038470c7cf8442fafcf627c21cb",
    urls = [
        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
    ],
)

load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")

go_rules_dependencies()

go_register_toolchains(version = "1.18")

gazelle_dependencies()

http_archive(
    name = "com_google_protobuf",
    sha256 = "d0f5f605d0d656007ce6c8b5a82df3037e1d8fe8b121ed42e536f569dec16113",
    strip_prefix = "protobuf-3.14.0",
    urls = [
        "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v3.14.0.tar.gz",
        "https://github.com/protocolbuffers/protobuf/archive/v3.14.0.tar.gz",
    ],
)

load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")

protobuf_deps()

go_repository(
    name = "com_github_golang_mock",
    build_file_generation = "on",
    importpath = "github.com/golang/mock",
    sum = "h1:G5FRp8JnTd7RQH5kemVNlMeyXQAztQ3mOWV95KxsXH8=",
    version = "v1.1.1",
)
```
2. run `go mod tidy`
3. run `bazel run //:gazelle-update-repos`
4. run `bazel build --profile=/tmp/mocks.gz //:mocks`
5. run `bazel analyze-profile /tmp/mocks.gz`