### PR TITLE
Add command line copts/cxxopts to Cgo compile flags

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -578,7 +578,7 @@ def _cgo_context_data_impl(ctx):
             feature_configuration = feature_configuration,
             action_name = C_COMPILE_ACTION_NAME,
             variables = c_compile_variables,
-        ),
+        ) + ctx.fragments.cpp.copts + ctx.fragments.cpp.conlyopts,
         _COMPILER_OPTIONS_BLACKLIST,
     )
     env.update(cc_common.get_environment_variables(
@@ -596,7 +596,7 @@ def _cgo_context_data_impl(ctx):
             feature_configuration = feature_configuration,
             action_name = CPP_COMPILE_ACTION_NAME,
             variables = cxx_compile_variables,
-        ),
+        ) + ctx.fragments.cpp.copts + ctx.fragments.cpp.cxxopts,
         _COMPILER_OPTIONS_BLACKLIST,
     )
     env.update(cc_common.get_environment_variables(


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This PR is very similar to https://github.com/bazelbuild/rules_go/pull/2926. The cgo flag logic doesn't include --copts, --cxxopts, or --conlyopts. These flags are not part of the cc toolchain logic and are only added later.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
