### PR TITLE
Removing interfaces attribute from gomock source mode

### DIFF
--- a/extras/gomock.bzl
+++ b/extras/gomock.bzl
@@ -111,11 +111,6 @@ _gomock_source = rule(
             doc = "The new Go file to emit the generated mocks into",
             mandatory = True,
         ),
-        "interfaces": attr.string_list(
-            allow_empty = False,
-            doc = "Ignored. If `source` is not set, this would be the list of Go interfaces to generate mocks for.",
-            mandatory = True,
-        ),
         "aux_files": attr.label_keyed_string_dict(
             default = {},
             doc = "A map from auxilliary Go source files to their packages.",

--- a/tests/extras/gomock/BUILD.bazel
+++ b/tests/extras/gomock/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
 gomock(
     name = "mocks",
     out = "client_mock.go",
-    interfaces = ["Client"],
     library = ":client",
     package = "client",
     source = "client.go",


### PR DESCRIPTION
**What type of PR is this?**
Bug fix


**What does this PR do? Why is it needed?**
mockgen doesn't need a list of interface when in source mode. `gomock` rule should not require that either. Removing the  interfaces attribute from gomock source mode.

**Other notes for review**
Alternatively, we can keep the attribute and make it non-mandatory, like https://github.com/jmhodges/bazel_gomock/pull/56.
