### PR TITLE
Officially deprecate bindata

### DIFF
--- a/extras/bindata.bzl
+++ b/extras/bindata.bzl
@@ -20,6 +20,8 @@ load(
 )
 
 def _bindata_impl(ctx):
+    print("Embedding is now better handled by using rules_go's built in https://github.com/bazelbuild/rules_go/blob/master/docs/go/core/embedding.md functionality. The `bindata` rule is deprecated and will be removed in rules_go version 0.35.")
+    
     go = go_context(ctx)
     out = go.declare_file(go, ext = ".go")
     arguments = ctx.actions.args()

--- a/extras/bindata.bzl
+++ b/extras/bindata.bzl
@@ -20,7 +20,10 @@ load(
 )
 
 def _bindata_impl(ctx):
-    print("Embedding is now better handled by using rules_go's built in https://github.com/bazelbuild/rules_go/blob/master/docs/go/core/embedding.md functionality. The `bindata` rule is deprecated and will be removed in rules_go version 0.35.")
+    print("""\Embedding is now better handled by using rules_go's built in
+https://github.com/bazelbuild/rules_go/blob/master/docs/go/core/embedding.md
+functionality. The `bindata` rule is deprecated and will be removed in
+rules_go version 0.35.""")
     
     go = go_context(ctx)
     out = go.declare_file(go, ext = ".go")

--- a/extras/bindata.bzl
+++ b/extras/bindata.bzl
@@ -20,10 +20,7 @@ load(
 )
 
 def _bindata_impl(ctx):
-    print("""Embedding is now better handled by using rules_go's built in
-https://github.com/bazelbuild/rules_go/blob/master/docs/go/core/embedding.md
-functionality. The `bindata` rule is deprecated and will be removed in
-rules_go version 0.35.""")
+    print("Embedding is now better handled by using rules_go's built in https://github.com/bazelbuild/rules_go/blob/master/docs/go/core/embedding.md functionality. The `bindata` rule is deprecated and will be removed in rules_go version 0.35.")
     
     go = go_context(ctx)
     out = go.declare_file(go, ext = ".go")

--- a/extras/bindata.bzl
+++ b/extras/bindata.bzl
@@ -20,7 +20,7 @@ load(
 )
 
 def _bindata_impl(ctx):
-    print("""\Embedding is now better handled by using rules_go's built in
+    print("""Embedding is now better handled by using rules_go's built in
 https://github.com/bazelbuild/rules_go/blob/master/docs/go/core/embedding.md
 functionality. The `bindata` rule is deprecated and will be removed in
 rules_go version 0.35.""")


### PR DESCRIPTION
rules_go has had a built in way to handle embedded for a while. Let's deprecate the non-standard way.