### PR TITLE
Officially deprecate `go_embed_data`

### DIFF
--- a/extras/embed_data.bzl
+++ b/extras/embed_data.bzl
@@ -34,6 +34,8 @@ go_embed_data_dependencies()
 """
 
 def _go_embed_data_impl(ctx):
+    print("Embedding is now better handled by using rules_go's built in https://github.com/bazelbuild/rules_go/blob/master/docs/go/core/embedding.md functionality. The `bindata` rule is deprecated and will be removed in rules_go version 0.35.")
+
     go = go_context(ctx)
     if ctx.attr.src and ctx.attr.srcs:
         fail("%s: src and srcs attributes cannot both be specified" % ctx.label)


### PR DESCRIPTION
rules_go has had a built in way to handle embedded for a while. Let's deprecate the non-standard way.