### PR TITLE
Let go_binary's executable bit depend on `linkmode`

### DIFF
--- a/go/private/mode.bzl
+++ b/go/private/mode.bzl
@@ -28,6 +28,9 @@ LINKMODE_C_ARCHIVE = "c-archive"
 
 LINKMODES = [LINKMODE_NORMAL, LINKMODE_PLUGIN, LINKMODE_C_SHARED, LINKMODE_C_ARCHIVE, LINKMODE_PIE]
 
+# All link modes that produce executables to be run with bazel run.
+LINKMODES_EXECUTABLE = [LINKMODE_NORMAL, LINKMODE_PIE]
+
 def mode_string(mode):
     result = [mode.goos, mode.goarch]
     if mode.static:

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -372,7 +372,6 @@ _go_binary_kwargs = {
         ),
         "_go_context_data": attr.label(default = "//:go_context_data"),
     },
-    "executable": True,
     "toolchains": ["@io_bazel_rules_go//go:toolchain"],
     "doc": """This builds an executable from a set of source files,
     which must all be in the `main` package. You can run the binary with
@@ -387,8 +386,9 @@ _go_binary_kwargs = {
     """,
 }
 
-go_binary = rule(**_go_binary_kwargs)
-go_transition_binary = go_transition_rule(**_go_binary_kwargs)
+go_binary = rule(executable = True, **_go_binary_kwargs)
+go_transition_binary = go_transition_rule(executable = True, **_go_binary_kwargs)
+go_non_executable_transition_binary = go_transition_rule(executable = False, **_go_binary_kwargs)
 
 def _go_tool_binary_impl(ctx):
     sdk = ctx.attr.sdk[GoSDK]

--- a/tests/core/go_binary/BUILD.bazel
+++ b/tests/core/go_binary/BUILD.bazel
@@ -176,3 +176,8 @@ go_binary(
     name = "prefix",
     embed = ["//tests/core/go_binary/prefix"],
 )
+
+go_bazel_test(
+    name = "non_executable_test",
+    srcs = ["non_executable_test.go"],
+)

--- a/tests/core/go_binary/non_executable_test.go
+++ b/tests/core/go_binary/non_executable_test.go
@@ -1,0 +1,51 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package non_executable_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: `
+-- src/BUILD.bazel --
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+
+go_binary(
+    name = "archive",
+    srcs = ["archive.go"],
+    linkmode = "c-archive",
+)
+-- src/archive.go --
+package main
+
+func main() {}
+`,
+	})
+}
+
+func TestNonExecutableGoBinary(t *testing.T) {
+	if err := bazel_testing.RunBazel("build", "//src:archive"); err != nil {
+		t.Fatal(err)
+	}
+	err := bazel_testing.RunBazel("run", "//src:archive")
+	if err == nil || !strings.Contains(err.Error(), "ERROR: Cannot run target //src:archive: Not executable") {
+		t.Errorf("Expected bazel run to fail due to //src:archive not being executable")
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

If a go_binary's `linkmode` is neither `normal` nor `pie`, the resulting
file can't be executed. In this case, `executable` should be set to
`False` on the go_binary rule so that Bazel doesn't create a runfiles
tree for the targets and does not include e.g. a resulting static
library in the runfiles of dependants.
