### PR TITLE
compilepkg: fix race when run without sandbox

### DIFF
--- a/go/private/actions/compilepkg.bzl
+++ b/go/private/actions/compilepkg.bzl
@@ -99,9 +99,10 @@ def emit_compilepkg(
         args.add("-cover_format", go.cover_format)
         args.add_all(cover, before_each = "-cover")
     args.add_all(archives, before_each = "-arc", map_each = _archive)
-    args.add("-label_name", go.label.name)
     if importpath:
         args.add("-importpath", importpath)
+    else:
+        args.add("-importpath", go.label.name)
     if importmap:
         args.add("-p", importmap)
     args.add("-package_list", go.package_list)

--- a/go/private/actions/compilepkg.bzl
+++ b/go/private/actions/compilepkg.bzl
@@ -99,6 +99,7 @@ def emit_compilepkg(
         args.add("-cover_format", go.cover_format)
         args.add_all(cover, before_each = "-cover")
     args.add_all(archives, before_each = "-arc", map_each = _archive)
+    args.add("-label_name", go.label.name)
     if importpath:
         args.add("-importpath", importpath)
     if importmap:

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -194,11 +194,11 @@ func compileArchive(
 		// otherwise platforms without sandbox support may race to create/remove
 		// the file during parallel compilation.
 		emptyDir := filepath.Join(filepath.Dir(outPath), sanitizePathForIdentifier(importPath))
-		err := os.Mkdir(emptyDir, 0700)
-		if err != nil {
-			return err
+		if err := os.Mkdir(emptyDir, 0700); err != nil {
+			return fmt.Errorf("could not create directory for _empty.go: %v", err)
 		}
 		defer os.RemoveAll(emptyDir)
+
 		emptyPath := filepath.Join(emptyDir, "_empty.go")
 		if err := os.WriteFile(emptyPath, []byte("package empty\n"), 0666); err != nil {
 			return err

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -42,7 +42,7 @@ func compilePkg(args []string) error {
 	goenv := envFlags(fs)
 	var unfilteredSrcs, coverSrcs, embedSrcs, embedLookupDirs, embedRoots multiFlag
 	var deps archiveMultiFlag
-	var importPath, packagePath, nogoPath, packageListPath, coverMode string
+	var labelName, importPath, packagePath, nogoPath, packageListPath, coverMode string
 	var outPath, outFactsPath, cgoExportHPath string
 	var testFilter string
 	var gcFlags, asmFlags, cppFlags, cFlags, cxxFlags, objcFlags, objcxxFlags, ldFlags quoteMultiFlag
@@ -63,6 +63,7 @@ func compilePkg(args []string) error {
 	fs.Var(&objcFlags, "objcflags", "Objective-C compiler flags")
 	fs.Var(&objcxxFlags, "objcxxflags", "Objective-C++ compiler flags")
 	fs.Var(&ldFlags, "ldflags", "C linker flags")
+	fs.StringVar(&labelName, "label_name", "", "The label's name")
 	fs.StringVar(&nogoPath, "nogo", "", "The nogo binary. If unset, nogo will not be run.")
 	fs.StringVar(&packageListPath, "package_list", "", "The file containing the list of standard library packages")
 	fs.StringVar(&coverMode, "cover_mode", "", "The coverage mode to use. Empty if coverage instrumentation should not be added.")
@@ -123,6 +124,7 @@ func compilePkg(args []string) error {
 
 	return compileArchive(
 		goenv,
+		labelName,
 		importPath,
 		packagePath,
 		srcs,
@@ -152,6 +154,7 @@ func compilePkg(args []string) error {
 
 func compileArchive(
 	goenv *env,
+	labelName string,
 	importPath string,
 	packagePath string,
 	srcs archiveSrcs,
@@ -193,7 +196,7 @@ func compileArchive(
 		// to ensure deterministic output. The location also needs to be unique
 		// otherwise platforms without sandbox support may race to create/remove
 		// the file during parallel compilation.
-		emptyDir := filepath.Join(filepath.Dir(outPath), sanitizePathForIdentifier(importPath))
+		emptyDir := filepath.Join(filepath.Dir(outPath), labelName)
 		err := os.Mkdir(emptyDir, 0700)
 		if err != nil {
 			return err

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -42,7 +42,7 @@ func compilePkg(args []string) error {
 	goenv := envFlags(fs)
 	var unfilteredSrcs, coverSrcs, embedSrcs, embedLookupDirs, embedRoots multiFlag
 	var deps archiveMultiFlag
-	var labelName, importPath, packagePath, nogoPath, packageListPath, coverMode string
+	var importPath, packagePath, nogoPath, packageListPath, coverMode string
 	var outPath, outFactsPath, cgoExportHPath string
 	var testFilter string
 	var gcFlags, asmFlags, cppFlags, cFlags, cxxFlags, objcFlags, objcxxFlags, ldFlags quoteMultiFlag
@@ -63,7 +63,6 @@ func compilePkg(args []string) error {
 	fs.Var(&objcFlags, "objcflags", "Objective-C compiler flags")
 	fs.Var(&objcxxFlags, "objcxxflags", "Objective-C++ compiler flags")
 	fs.Var(&ldFlags, "ldflags", "C linker flags")
-	fs.StringVar(&labelName, "label_name", "", "The label's name")
 	fs.StringVar(&nogoPath, "nogo", "", "The nogo binary. If unset, nogo will not be run.")
 	fs.StringVar(&packageListPath, "package_list", "", "The file containing the list of standard library packages")
 	fs.StringVar(&coverMode, "cover_mode", "", "The coverage mode to use. Empty if coverage instrumentation should not be added.")
@@ -124,7 +123,6 @@ func compilePkg(args []string) error {
 
 	return compileArchive(
 		goenv,
-		labelName,
 		importPath,
 		packagePath,
 		srcs,
@@ -154,7 +152,6 @@ func compilePkg(args []string) error {
 
 func compileArchive(
 	goenv *env,
-	labelName string,
 	importPath string,
 	packagePath string,
 	srcs archiveSrcs,
@@ -196,7 +193,7 @@ func compileArchive(
 		// to ensure deterministic output. The location also needs to be unique
 		// otherwise platforms without sandbox support may race to create/remove
 		// the file during parallel compilation.
-		emptyDir := filepath.Join(filepath.Dir(outPath), labelName)
+		emptyDir := filepath.Join(filepath.Dir(outPath), sanitizePathForIdentifier(importPath))
 		err := os.Mkdir(emptyDir, 0700)
 		if err != nil {
 			return err

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -176,8 +176,8 @@ func compileArchive(
 	outPath string,
 	outXPath string,
 	cgoExportHPath string,
-	coverFormat string) error {
-
+	coverFormat string,
+) error {
 	workDir, cleanup, err := goenv.workDir()
 	if err != nil {
 		return err
@@ -188,19 +188,29 @@ func compileArchive(
 		// We need to run the compiler to create a valid archive, even if there's
 		// nothing in it. GoPack will complain if we try to add assembly or cgo
 		// objects.
+		//
 		// _empty.go needs to be in a deterministic location (not tmpdir) in order
-		// to ensure deterministic output
-		emptyPath := filepath.Join(filepath.Dir(outPath), "_empty.go")
+		// to ensure deterministic output. The location also needs to be unique
+		// otherwise platforms without sandbox support may race to create/remove
+		// the file during parallel compilation.
+		emptyDir := filepath.Join(filepath.Dir(outPath), sanitizePathForIdentifier(importPath))
+		err := os.Mkdir(emptyDir, 0700)
+		if err != nil {
+			return err
+		}
+		defer os.RemoveAll(emptyDir)
+		emptyPath := filepath.Join(emptyDir, "_empty.go")
 		if err := os.WriteFile(emptyPath, []byte("package empty\n"), 0666); err != nil {
 			return err
 		}
+		defer os.Remove(emptyPath)
+
 		srcs.goSrcs = append(srcs.goSrcs, fileInfo{
 			filename: emptyPath,
 			ext:      goExt,
 			matched:  true,
 			pkg:      "empty",
 		})
-		defer os.Remove(emptyPath)
 	}
 	packageName := srcs.goSrcs[0].pkg
 	var goSrcs, cgoSrcs []string
@@ -416,8 +426,8 @@ func compileArchive(
 	// Compile the .s files.
 	if len(srcs.sSrcs) > 0 {
 		includeSet := map[string]struct{}{
-			filepath.Join(os.Getenv("GOROOT"), "pkg", "include"): struct{}{},
-			workDir: struct{}{},
+			filepath.Join(os.Getenv("GOROOT"), "pkg", "include"): {},
+			workDir: {},
 		}
 		for _, hdr := range srcs.hSrcs {
 			includeSet[filepath.Dir(hdr.filename)] = struct{}{}

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -203,7 +203,6 @@ func compileArchive(
 		if err := os.WriteFile(emptyPath, []byte("package empty\n"), 0666); err != nil {
 			return err
 		}
-		defer os.Remove(emptyPath)
 
 		srcs.goSrcs = append(srcs.goSrcs, fileInfo{
 			filename: emptyPath,

--- a/tests/core/go_test/BUILD.bazel
+++ b/tests/core/go_test/BUILD.bazel
@@ -195,6 +195,27 @@ go_library(
     deps = [":indirect_import_lib"],
 )
 
+[
+    go_library(
+        name = "same_package_{}".format(i),
+        srcs = ["same_package.go"],
+        importpath = "github.com/bazelbuild/rules_go/tests/core/go_test/same_package_{}".format(i),
+        x_defs = {
+            "name": "{}".format(i),
+        },
+    )
+    for i in range(1, 80)
+]
+
+[
+    go_test(
+        name = "same_package_{}_test".format(i),
+        srcs = ["same_package_test.go"],
+        embed = [":same_package_{}".format(i)],
+    )
+    for i in range(1, 80)
+]
+
 go_bazel_test(
     name = "testmain_without_exit_test",
     srcs = ["testmain_without_exit_test.go"],

--- a/tests/core/go_test/BUILD.bazel
+++ b/tests/core/go_test/BUILD.bazel
@@ -196,22 +196,9 @@ go_library(
 )
 
 [
-    go_library(
-        name = "same_package_{}".format(i),
-        srcs = ["same_package.go"],
-        importpath = "github.com/bazelbuild/rules_go/tests/core/go_test/same_package_{}".format(i),
-        x_defs = {
-            "name": "{}".format(i),
-        },
-    )
-    for i in range(1, 80)
-]
-
-[
     go_test(
         name = "same_package_{}_test".format(i),
         srcs = ["same_package_test.go"],
-        embed = [":same_package_{}".format(i)],
     )
     for i in range(1, 80)
 ]

--- a/tests/core/go_test/BUILD.bazel
+++ b/tests/core/go_test/BUILD.bazel
@@ -216,6 +216,11 @@ go_library(
     for i in range(1, 80)
 ]
 
+test_suite(
+    name = "same_package_test",
+    tests = ["same_package_{}_test".format(i) for i in range(1, 80)],
+)
+
 go_bazel_test(
     name = "testmain_without_exit_test",
     srcs = ["testmain_without_exit_test.go"],

--- a/tests/core/go_test/same_package.go
+++ b/tests/core/go_test/same_package.go
@@ -1,3 +1,0 @@
-package same_package
-
-var name string

--- a/tests/core/go_test/same_package.go
+++ b/tests/core/go_test/same_package.go
@@ -1,0 +1,3 @@
+package same_package
+
+var name string

--- a/tests/core/go_test/same_package_test.go
+++ b/tests/core/go_test/same_package_test.go
@@ -1,0 +1,11 @@
+package same_package
+
+import (
+	"testing"
+)
+
+func OkTest(t *testing.T) {
+	if name == "" {
+		t.Errorf("expected name to be non empty")
+	}
+}

--- a/tests/core/go_test/same_package_test.go
+++ b/tests/core/go_test/same_package_test.go
@@ -4,8 +4,4 @@ import (
 	"testing"
 )
 
-func OkTest(t *testing.T) {
-	if name == "" {
-		t.Errorf("expected name to be non empty")
-	}
-}
+func OkTest(t *testing.T) {}


### PR DESCRIPTION
compilepkg: fix race when run without sandbox

On platforms without sandbox execution support such as Windows, multiple
go_test targets declared in the same package would cause a race condition.

```
[
    go_library(
        name = "same_package_{}".format(i),
        srcs = ["same_package.go"],
        importpath = "github.com/bazelbuild/rules_go/tests/core/go_test/same_package_{}".format(i),
        x_defs = {
            "name": "{}".format(i),
        },
    )
    for i in range(1, 80)
]

[
    go_test(
        name = "same_package_{}_test".format(i),
        srcs = ["same_package_test.go"],
        embed = [":same_package_{}".format(i)],
    )
    for i in range(1, 80)
]
```

For each of go_test targets, there would be internal archive and
external archive that needs to compile from source files.  However, due
to testfilter, external archive would end up without any Go source and
thus compilepkg needs to generate a dummy source file `_empty.go` to
trick 'go tool compile'.

This `_empty.go` file is generated in the output path of the Bazel
package thus multiple go_test targets in the same package would generate
this file using the same path.  On a sandbox supported platform,
this is not a problem as the full path is prefixed with the sandbox root
dir.  However, without sandbox, the full path is the same for each
go_test's external archive compilation, leading to a race condition
where multiple compilations running in parallel would compete to
create/delete the same file.

Fix this by using the unique importPath to create a directory to store
the _empty.go file.  This would effectively give each go_test compilation
it's own _empty.go file in non-sandbox environment.

Worth to note that in current solution, we still have yet to solve
problem when 'importPath' is not provided. For example, in a setup like
this where `go_library` does not exist, `importPath` will be blank and
thus causes similar issues on non-sandbox platforms.

```
[
    go_test(
        name = "same_package_{}_test".format(i),
        srcs = ["same_package_test.go"],
    )
    for i in range(1, 80)
]
```

Although this is a valid use case, we recommend avoid setting up tests
this way. Instead, you could setup a single go_test target with multiple
shards to achieve similar result:

```
go_test(
    name = "same_package_{}_test".format(i),
    srcs = ["same_package_test.go"],
    shard_count = 80,
)
```

For more information, please review Bazel Test Sharding documentation(1)

(1): https://docs.bazel.build/versions/main/test-encyclopedia.html#test-sharding

Fix #3144 