### PR TITLE
Restore original paniconexit0 flag after calling lcovAtExitHook

### DIFF
--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -191,7 +191,7 @@ func compileArchive(
 		// _empty.go needs to be in a deterministic location (not tmpdir) in order
 		// to ensure deterministic output
 		emptyPath := filepath.Join(filepath.Dir(outPath), "_empty.go")
-		if err := ioutil.WriteFile(emptyPath, []byte("package empty\n"), 0666); err != nil {
+		if err := os.WriteFile(emptyPath, []byte("package empty\n"), 0666); err != nil {
 			return err
 		}
 		srcs.goSrcs = append(srcs.goSrcs, fileInfo{

--- a/go/tools/builders/generate_test_main.go
+++ b/go/tools/builders/generate_test_main.go
@@ -193,7 +193,7 @@ func main() {
 	}
 {{if eq .CoverFormat "lcov"}}
 	panicOnExit0Flag := flag.Lookup("test.paniconexit0").Value
-	testDeps.OriginalPanicOnExit, _ = strconv.ParseBool(panicOnExit0Flag.String())
+	testDeps.OriginalPanicOnExit = panicOnExit0Flag.(flag.Getter).Get().(bool)
 	// Setting this flag provides a way to run hooks right before testing.M.Run() returns.
 	panicOnExit0Flag.Set("true")
 {{end}}

--- a/go/tools/builders/generate_test_main.go
+++ b/go/tools/builders/generate_test_main.go
@@ -192,12 +192,10 @@ func main() {
 		flag.Lookup("test.failfast").Value.Set("true")
 	}
 {{if eq .CoverFormat "lcov"}}
-	panicOnExit0Flag := flag.Lookup("test.paniconexit0")
-	if panicOnExit0Flag != nil && panicOnExit0Flag.Value.String() != "false" {
-		testDeps.OriginalPanicOnExit = true
-	}
+	panicOnExit0Flag := flag.Lookup("test.paniconexit0").Value
+	testDeps.OriginalPanicOnExit, _ = strconv.ParseBool(panicOnExit0Flag.String())
 	// Setting this flag provides a way to run hooks right before testing.M.Run() returns.
-	panicOnExit0Flag.Value.Set("true")
+	panicOnExit0Flag.Set("true")
 {{end}}
 {{if ne .CoverMode ""}}
 	if len(coverdata.Counters) > 0 {

--- a/go/tools/builders/generate_test_main.go
+++ b/go/tools/builders/generate_test_main.go
@@ -191,14 +191,15 @@ func main() {
 	if failfast := os.Getenv("TESTBRIDGE_TEST_RUNNER_FAIL_FAST"); failfast != "" {
 		flag.Lookup("test.failfast").Value.Set("true")
 	}
-
-	// Setting this flag serves two purposes:
-	// 1. It attains parity with "go test", which enables this feature by default.
-	//    https://cs.opensource.google/go/go/+/refs/tags/go1.18.1:src/cmd/go/internal/test/test.go;l=1331-1337
-	// 2. It provides a way to run hooks right before testing.M.Run() returns.
-	flag.Lookup("test.paniconexit0").Value.Set("true")
-
-	{{if ne .CoverMode ""}}
+{{if eq .CoverFormat "lcov"}}
+	panicOnExit0Flag := flag.Lookup("test.paniconexit0")
+	if panicOnExit0Flag != nil && panicOnExit0Flag.Value.String() != "false" {
+		testDeps.OriginalPanicOnExit = true
+	}
+	// Setting this flag provides a way to run hooks right before testing.M.Run() returns.
+	panicOnExit0Flag.Value.Set("true")
+{{end}}
+{{if ne .CoverMode ""}}
 	if len(coverdata.Counters) > 0 {
 		testing.RegisterCover(testing.Cover{
 			Mode: "{{ .CoverMode }}",

--- a/go/tools/bzltestutil/lcov.go
+++ b/go/tools/bzltestutil/lcov.go
@@ -158,6 +158,7 @@ func emitLcovLines(lcov io.StringWriter, path string, lineCounts map[uint32]uint
 // major versions of Go.
 type LcovTestDeps struct {
 	testdeps.TestDeps
+	OriginalPanicOnExit bool
 }
 
 // SetPanicOnExit0 is called with true by m.Run() before running all tests,
@@ -171,7 +172,7 @@ func (ltd LcovTestDeps) SetPanicOnExit0(panicOnExit bool) {
 	if !panicOnExit {
 		lcovAtExitHook()
 	}
-	ltd.TestDeps.SetPanicOnExit0(panicOnExit)
+	ltd.TestDeps.SetPanicOnExit0(ltd.OriginalPanicOnExit)
 }
 
 func lcovAtExitHook() {


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
This PR adds a field `OriginalPanicOnExit` to `go/tools/bzltestutil. LcovTestDeps`, so it can restore the original paniconexit bit after calling `lcovAtExitHook()`. This allows testing Exec command using [this pattern](https://jamiethompson.me/posts/Unit-Testing-Exec-Command-In-Golang/).

