### PR TITLE
Add `go_default_library` alias for gomock targets

### DIFF
--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -264,13 +264,13 @@ def go_rules_dependencies():
     _maybe(
         http_archive,
         name = "com_github_golang_mock",
-        # v1.6.0, latest as of 2022-05-09
+        # v1.6.0, latest as of 2022-05-13
         urls = [
             "https://mirror.bazel.build/github.com/golang/mock/archive/v1.6.0.zip",
             "https://github.com/golang/mock/archive/v1.6.0.zip",
         ],
         patches = [
-            # releaser:patch-cmd gazelle -repo_root . -go_prefix github.com/golang/mock
+            # releaser:patch-cmd gazelle -repo_root . -go_prefix github.com/golang/mock -go_naming_convention import_alias
             Label("//third_party:com_github_golang_mock-gazelle.patch"),
         ],
         patch_args = ["-p1"],

--- a/third_party/com_github_golang_mock-gazelle.patch
+++ b/third_party/com_github_golang_mock-gazelle.patch
@@ -1,7 +1,7 @@
 diff -urN a/gomock/BUILD.bazel b/gomock/BUILD.bazel
---- a/gomock/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/gomock/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/gomock/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -13,6 +13,12 @@ diff -urN a/gomock/BUILD.bazel b/gomock/BUILD.bazel
 +        "matchers.go",
 +    ],
 +    importpath = "github.com/golang/mock/gomock",
++    visibility = ["//visibility:public"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":gomock",
 +    visibility = ["//visibility:public"],
 +)
 +
@@ -32,9 +38,9 @@ diff -urN a/gomock/BUILD.bazel b/gomock/BUILD.bazel
 +    deps = ["//gomock/internal/mock_gomock"],
 +)
 diff -urN a/gomock/internal/mock_gomock/BUILD.bazel b/gomock/internal/mock_gomock/BUILD.bazel
---- a/gomock/internal/mock_gomock/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/gomock/internal/mock_gomock/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/gomock/internal/mock_gomock/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,9 @@
+@@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -44,8 +50,14 @@ diff -urN a/gomock/internal/mock_gomock/BUILD.bazel b/gomock/internal/mock_gomoc
 +    visibility = ["//gomock:__subpackages__"],
 +    deps = ["//gomock"],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":mock_gomock",
++    visibility = ["//gomock:__subpackages__"],
++)
 diff -urN a/mockgen/BUILD.bazel b/mockgen/BUILD.bazel
---- a/mockgen/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
@@ -84,9 +96,9 @@ diff -urN a/mockgen/BUILD.bazel b/mockgen/BUILD.bazel
 +    deps = ["//mockgen/model"],
 +)
 diff -urN a/mockgen/internal/tests/aux_imports_embedded_interface/BUILD.bazel b/mockgen/internal/tests/aux_imports_embedded_interface/BUILD.bazel
---- a/mockgen/internal/tests/aux_imports_embedded_interface/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/aux_imports_embedded_interface/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/aux_imports_embedded_interface/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,22 @@
+@@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -103,6 +115,12 @@ diff -urN a/mockgen/internal/tests/aux_imports_embedded_interface/BUILD.bazel b/
 +    ],
 +)
 +
++alias(
++    name = "go_default_library",
++    actual = ":aux_imports_embedded_interface",
++    visibility = ["//mockgen:__subpackages__"],
++)
++
 +go_test(
 +    name = "aux_imports_embedded_interface_test",
 +    srcs = ["bugreport_test.go"],
@@ -110,9 +128,9 @@ diff -urN a/mockgen/internal/tests/aux_imports_embedded_interface/BUILD.bazel b/
 +    deps = ["//gomock"],
 +)
 diff -urN a/mockgen/internal/tests/aux_imports_embedded_interface/faux/BUILD.bazel b/mockgen/internal/tests/aux_imports_embedded_interface/faux/BUILD.bazel
---- a/mockgen/internal/tests/aux_imports_embedded_interface/faux/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/aux_imports_embedded_interface/faux/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/aux_imports_embedded_interface/faux/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,8 @@
+@@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -121,10 +139,16 @@ diff -urN a/mockgen/internal/tests/aux_imports_embedded_interface/faux/BUILD.baz
 +    importpath = "github.com/golang/mock/mockgen/internal/tests/aux_imports_embedded_interface/faux",
 +    visibility = ["//mockgen:__subpackages__"],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":faux",
++    visibility = ["//mockgen:__subpackages__"],
++)
 diff -urN a/mockgen/internal/tests/const_array_length/BUILD.bazel b/mockgen/internal/tests/const_array_length/BUILD.bazel
---- a/mockgen/internal/tests/const_array_length/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/const_array_length/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/const_array_length/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -137,10 +161,16 @@ diff -urN a/mockgen/internal/tests/const_array_length/BUILD.bazel b/mockgen/inte
 +    visibility = ["//mockgen:__subpackages__"],
 +    deps = ["//gomock"],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":const_array_length",
++    visibility = ["//mockgen:__subpackages__"],
++)
 diff -urN a/mockgen/internal/tests/copyright_file/BUILD.bazel b/mockgen/internal/tests/copyright_file/BUILD.bazel
---- a/mockgen/internal/tests/copyright_file/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/copyright_file/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/copyright_file/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -153,10 +183,16 @@ diff -urN a/mockgen/internal/tests/copyright_file/BUILD.bazel b/mockgen/internal
 +    visibility = ["//mockgen:__subpackages__"],
 +    deps = ["//gomock"],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":copyright_file",
++    visibility = ["//mockgen:__subpackages__"],
++)
 diff -urN a/mockgen/internal/tests/custom_package_name/client/v1/BUILD.bazel b/mockgen/internal/tests/custom_package_name/client/v1/BUILD.bazel
---- a/mockgen/internal/tests/custom_package_name/client/v1/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/custom_package_name/client/v1/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/custom_package_name/client/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,8 @@
+@@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -165,10 +201,16 @@ diff -urN a/mockgen/internal/tests/custom_package_name/client/v1/BUILD.bazel b/m
 +    importpath = "github.com/golang/mock/mockgen/internal/tests/custom_package_name/client/v1",
 +    visibility = ["//mockgen:__subpackages__"],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":client",
++    visibility = ["//mockgen:__subpackages__"],
++)
 diff -urN a/mockgen/internal/tests/custom_package_name/greeter/BUILD.bazel b/mockgen/internal/tests/custom_package_name/greeter/BUILD.bazel
---- a/mockgen/internal/tests/custom_package_name/greeter/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/custom_package_name/greeter/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/custom_package_name/greeter/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,25 @@
+@@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -180,6 +222,12 @@ diff -urN a/mockgen/internal/tests/custom_package_name/greeter/BUILD.bazel b/moc
 +        "//mockgen/internal/tests/custom_package_name/client/v1:client",
 +        "//mockgen/internal/tests/custom_package_name/validator",
 +    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":greeter",
++    visibility = ["//mockgen:__subpackages__"],
 +)
 +
 +go_test(
@@ -195,9 +243,9 @@ diff -urN a/mockgen/internal/tests/custom_package_name/greeter/BUILD.bazel b/moc
 +    ],
 +)
 diff -urN a/mockgen/internal/tests/custom_package_name/validator/BUILD.bazel b/mockgen/internal/tests/custom_package_name/validator/BUILD.bazel
---- a/mockgen/internal/tests/custom_package_name/validator/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/custom_package_name/validator/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/custom_package_name/validator/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,8 @@
+@@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -206,10 +254,16 @@ diff -urN a/mockgen/internal/tests/custom_package_name/validator/BUILD.bazel b/m
 +    importpath = "github.com/golang/mock/mockgen/internal/tests/custom_package_name/validator",
 +    visibility = ["//mockgen:__subpackages__"],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":validator",
++    visibility = ["//mockgen:__subpackages__"],
++)
 diff -urN a/mockgen/internal/tests/dot_imports/BUILD.bazel b/mockgen/internal/tests/dot_imports/BUILD.bazel
---- a/mockgen/internal/tests/dot_imports/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/dot_imports/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/dot_imports/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -222,10 +276,16 @@ diff -urN a/mockgen/internal/tests/dot_imports/BUILD.bazel b/mockgen/internal/te
 +    visibility = ["//mockgen:__subpackages__"],
 +    deps = ["//gomock"],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":dot_imports",
++    visibility = ["//mockgen:__subpackages__"],
++)
 diff -urN a/mockgen/internal/tests/empty_interface/BUILD.bazel b/mockgen/internal/tests/empty_interface/BUILD.bazel
---- a/mockgen/internal/tests/empty_interface/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/empty_interface/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/empty_interface/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -238,10 +298,16 @@ diff -urN a/mockgen/internal/tests/empty_interface/BUILD.bazel b/mockgen/interna
 +    visibility = ["//mockgen:__subpackages__"],
 +    deps = ["//gomock"],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":empty_interface",
++    visibility = ["//mockgen:__subpackages__"],
++)
 diff -urN a/mockgen/internal/tests/extra_import/BUILD.bazel b/mockgen/internal/tests/extra_import/BUILD.bazel
---- a/mockgen/internal/tests/extra_import/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/extra_import/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/extra_import/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -254,10 +320,16 @@ diff -urN a/mockgen/internal/tests/extra_import/BUILD.bazel b/mockgen/internal/t
 +    visibility = ["//mockgen:__subpackages__"],
 +    deps = ["//gomock"],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":extra_import",
++    visibility = ["//mockgen:__subpackages__"],
++)
 diff -urN a/mockgen/internal/tests/generated_identifier_conflict/BUILD.bazel b/mockgen/internal/tests/generated_identifier_conflict/BUILD.bazel
---- a/mockgen/internal/tests/generated_identifier_conflict/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/generated_identifier_conflict/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/generated_identifier_conflict/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -271,6 +343,12 @@ diff -urN a/mockgen/internal/tests/generated_identifier_conflict/BUILD.bazel b/m
 +    deps = ["//gomock"],
 +)
 +
++alias(
++    name = "go_default_library",
++    actual = ":generated_identifier_conflict",
++    visibility = ["//mockgen:__subpackages__"],
++)
++
 +go_test(
 +    name = "generated_identifier_conflict_test",
 +    srcs = ["bugreport_test.go"],
@@ -278,9 +356,9 @@ diff -urN a/mockgen/internal/tests/generated_identifier_conflict/BUILD.bazel b/m
 +    deps = ["//gomock"],
 +)
 diff -urN a/mockgen/internal/tests/import_embedded_interface/BUILD.bazel b/mockgen/internal/tests/import_embedded_interface/BUILD.bazel
---- a/mockgen/internal/tests/import_embedded_interface/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/import_embedded_interface/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/import_embedded_interface/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -301,6 +379,12 @@ diff -urN a/mockgen/internal/tests/import_embedded_interface/BUILD.bazel b/mockg
 +    ],
 +)
 +
++alias(
++    name = "go_default_library",
++    actual = ":import_embedded_interface",
++    visibility = ["//mockgen:__subpackages__"],
++)
++
 +go_test(
 +    name = "import_embedded_interface_test",
 +    srcs = [
@@ -311,9 +395,9 @@ diff -urN a/mockgen/internal/tests/import_embedded_interface/BUILD.bazel b/mockg
 +    deps = ["//gomock"],
 +)
 diff -urN a/mockgen/internal/tests/import_embedded_interface/ersatz/BUILD.bazel b/mockgen/internal/tests/import_embedded_interface/ersatz/BUILD.bazel
---- a/mockgen/internal/tests/import_embedded_interface/ersatz/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/import_embedded_interface/ersatz/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/import_embedded_interface/ersatz/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,8 @@
+@@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -322,10 +406,16 @@ diff -urN a/mockgen/internal/tests/import_embedded_interface/ersatz/BUILD.bazel 
 +    importpath = "github.com/golang/mock/mockgen/internal/tests/import_embedded_interface/ersatz",
 +    visibility = ["//mockgen:__subpackages__"],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":ersatz",
++    visibility = ["//mockgen:__subpackages__"],
++)
 diff -urN a/mockgen/internal/tests/import_embedded_interface/faux/BUILD.bazel b/mockgen/internal/tests/import_embedded_interface/faux/BUILD.bazel
---- a/mockgen/internal/tests/import_embedded_interface/faux/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/import_embedded_interface/faux/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/import_embedded_interface/faux/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -341,10 +431,16 @@ diff -urN a/mockgen/internal/tests/import_embedded_interface/faux/BUILD.bazel b/
 +        "//mockgen/internal/tests/import_embedded_interface/other/log",
 +    ],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":faux",
++    visibility = ["//mockgen:__subpackages__"],
++)
 diff -urN a/mockgen/internal/tests/import_embedded_interface/other/ersatz/BUILD.bazel b/mockgen/internal/tests/import_embedded_interface/other/ersatz/BUILD.bazel
---- a/mockgen/internal/tests/import_embedded_interface/other/ersatz/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/import_embedded_interface/other/ersatz/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/import_embedded_interface/other/ersatz/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,8 @@
+@@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -353,10 +449,16 @@ diff -urN a/mockgen/internal/tests/import_embedded_interface/other/ersatz/BUILD.
 +    importpath = "github.com/golang/mock/mockgen/internal/tests/import_embedded_interface/other/ersatz",
 +    visibility = ["//mockgen:__subpackages__"],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":ersatz",
++    visibility = ["//mockgen:__subpackages__"],
++)
 diff -urN a/mockgen/internal/tests/import_embedded_interface/other/log/BUILD.bazel b/mockgen/internal/tests/import_embedded_interface/other/log/BUILD.bazel
---- a/mockgen/internal/tests/import_embedded_interface/other/log/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/import_embedded_interface/other/log/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/import_embedded_interface/other/log/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,8 @@
+@@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -365,10 +467,16 @@ diff -urN a/mockgen/internal/tests/import_embedded_interface/other/log/BUILD.baz
 +    importpath = "github.com/golang/mock/mockgen/internal/tests/import_embedded_interface/other/log",
 +    visibility = ["//mockgen:__subpackages__"],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":log",
++    visibility = ["//mockgen:__subpackages__"],
++)
 diff -urN a/mockgen/internal/tests/import_source/BUILD.bazel b/mockgen/internal/tests/import_source/BUILD.bazel
---- a/mockgen/internal/tests/import_source/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/import_source/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/import_source/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -381,10 +489,16 @@ diff -urN a/mockgen/internal/tests/import_source/BUILD.bazel b/mockgen/internal/
 +        "//mockgen/internal/tests/import_source/definition",
 +    ],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":import_source",
++    visibility = ["//mockgen:__subpackages__"],
++)
 diff -urN a/mockgen/internal/tests/import_source/definition/BUILD.bazel b/mockgen/internal/tests/import_source/definition/BUILD.bazel
---- a/mockgen/internal/tests/import_source/definition/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/import_source/definition/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/import_source/definition/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -397,10 +511,16 @@ diff -urN a/mockgen/internal/tests/import_source/definition/BUILD.bazel b/mockge
 +    visibility = ["//mockgen:__subpackages__"],
 +    deps = ["//gomock"],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":definition",
++    visibility = ["//mockgen:__subpackages__"],
++)
 diff -urN a/mockgen/internal/tests/internal_pkg/BUILD.bazel b/mockgen/internal/tests/internal_pkg/BUILD.bazel
---- a/mockgen/internal/tests/internal_pkg/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/internal_pkg/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/internal_pkg/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,8 @@
+@@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -409,10 +529,16 @@ diff -urN a/mockgen/internal/tests/internal_pkg/BUILD.bazel b/mockgen/internal/t
 +    importpath = "github.com/golang/mock/mockgen/internal/tests/internal_pkg",
 +    visibility = ["//mockgen:__subpackages__"],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":internal_pkg",
++    visibility = ["//mockgen:__subpackages__"],
++)
 diff -urN a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/BUILD.bazel b/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/BUILD.bazel
---- a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,8 @@
+@@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -421,10 +547,16 @@ diff -urN a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/BUILD.bazel 
 +    importpath = "github.com/golang/mock/mockgen/internal/tests/internal_pkg/subdir/internal/pkg",
 +    visibility = ["//mockgen:__subpackages__"],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":pkg",
++    visibility = ["//mockgen:__subpackages__"],
++)
 diff -urN a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/reflect_output/BUILD.bazel b/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/reflect_output/BUILD.bazel
---- a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/reflect_output/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/reflect_output/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/reflect_output/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -437,10 +569,16 @@ diff -urN a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/reflect_outp
 +        "//mockgen/internal/tests/internal_pkg/subdir/internal/pkg",
 +    ],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":reflect_output",
++    visibility = ["//mockgen:__subpackages__"],
++)
 diff -urN a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/source_output/BUILD.bazel b/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/source_output/BUILD.bazel
---- a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/source_output/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/source_output/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/source_output/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -453,10 +591,16 @@ diff -urN a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/source_outpu
 +        "//mockgen/internal/tests/internal_pkg/subdir/internal/pkg",
 +    ],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":source_output",
++    visibility = ["//mockgen:__subpackages__"],
++)
 diff -urN a/mockgen/internal/tests/missing_import/output/BUILD.bazel b/mockgen/internal/tests/missing_import/output/BUILD.bazel
---- a/mockgen/internal/tests/missing_import/output/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/missing_import/output/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/missing_import/output/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -469,10 +613,16 @@ diff -urN a/mockgen/internal/tests/missing_import/output/BUILD.bazel b/mockgen/i
 +        "//mockgen/internal/tests/missing_import/source",
 +    ],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":output",
++    visibility = ["//mockgen:__subpackages__"],
++)
 diff -urN a/mockgen/internal/tests/missing_import/source/BUILD.bazel b/mockgen/internal/tests/missing_import/source/BUILD.bazel
---- a/mockgen/internal/tests/missing_import/source/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/missing_import/source/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/missing_import/source/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,8 @@
+@@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -481,16 +631,28 @@ diff -urN a/mockgen/internal/tests/missing_import/source/BUILD.bazel b/mockgen/i
 +    importpath = "github.com/golang/mock/mockgen/internal/tests/missing_import/source",
 +    visibility = ["//mockgen:__subpackages__"],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":source",
++    visibility = ["//mockgen:__subpackages__"],
++)
 diff -urN a/mockgen/internal/tests/mock_in_test_package/BUILD.bazel b/mockgen/internal/tests/mock_in_test_package/BUILD.bazel
---- a/mockgen/internal/tests/mock_in_test_package/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/mock_in_test_package/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/mock_in_test_package/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
 +    name = "mock_in_test_package",
 +    srcs = ["user.go"],
 +    importpath = "github.com/golang/mock/mockgen/internal/tests/mock_in_test_package",
++    visibility = ["//mockgen:__subpackages__"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":mock_in_test_package",
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 +
@@ -503,9 +665,9 @@ diff -urN a/mockgen/internal/tests/mock_in_test_package/BUILD.bazel b/mockgen/in
 +    ],
 +)
 diff -urN a/mockgen/internal/tests/overlapping_methods/BUILD.bazel b/mockgen/internal/tests/overlapping_methods/BUILD.bazel
---- a/mockgen/internal/tests/overlapping_methods/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/overlapping_methods/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/overlapping_methods/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,20 @@
+@@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -520,6 +682,12 @@ diff -urN a/mockgen/internal/tests/overlapping_methods/BUILD.bazel b/mockgen/int
 +    deps = ["//gomock"],
 +)
 +
++alias(
++    name = "go_default_library",
++    actual = ":overlapping_methods",
++    visibility = ["//mockgen:__subpackages__"],
++)
++
 +go_test(
 +    name = "overlapping_methods_test",
 +    srcs = ["overlap_test.go"],
@@ -527,15 +695,21 @@ diff -urN a/mockgen/internal/tests/overlapping_methods/BUILD.bazel b/mockgen/int
 +    deps = ["//gomock"],
 +)
 diff -urN a/mockgen/internal/tests/panicing_test/BUILD.bazel b/mockgen/internal/tests/panicing_test/BUILD.bazel
---- a/mockgen/internal/tests/panicing_test/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/panicing_test/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/panicing_test/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
 +    name = "panicing_test",
 +    srcs = ["panic.go"],
 +    importpath = "github.com/golang/mock/mockgen/internal/tests/panicing_test",
++    visibility = ["//mockgen:__subpackages__"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":panicing_test",
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 +
@@ -546,9 +720,9 @@ diff -urN a/mockgen/internal/tests/panicing_test/BUILD.bazel b/mockgen/internal/
 +    deps = ["//gomock"],
 +)
 diff -urN a/mockgen/internal/tests/parenthesized_parameter_type/BUILD.bazel b/mockgen/internal/tests/parenthesized_parameter_type/BUILD.bazel
---- a/mockgen/internal/tests/parenthesized_parameter_type/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/parenthesized_parameter_type/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/parenthesized_parameter_type/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -561,10 +735,16 @@ diff -urN a/mockgen/internal/tests/parenthesized_parameter_type/BUILD.bazel b/mo
 +    visibility = ["//mockgen:__subpackages__"],
 +    deps = ["//gomock"],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":parenthesized_parameter_type",
++    visibility = ["//mockgen:__subpackages__"],
++)
 diff -urN a/mockgen/internal/tests/performance/big_interface/BUILD.bazel b/mockgen/internal/tests/performance/big_interface/BUILD.bazel
---- a/mockgen/internal/tests/performance/big_interface/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/performance/big_interface/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/performance/big_interface/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,8 @@
+@@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -573,10 +753,16 @@ diff -urN a/mockgen/internal/tests/performance/big_interface/BUILD.bazel b/mockg
 +    importpath = "github.com/golang/mock/mockgen/internal/tests/performance/big_interface",
 +    visibility = ["//mockgen:__subpackages__"],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":big_interface",
++    visibility = ["//mockgen:__subpackages__"],
++)
 diff -urN a/mockgen/internal/tests/self_package/BUILD.bazel b/mockgen/internal/tests/self_package/BUILD.bazel
---- a/mockgen/internal/tests/self_package/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/self_package/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/self_package/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -589,16 +775,28 @@ diff -urN a/mockgen/internal/tests/self_package/BUILD.bazel b/mockgen/internal/t
 +    visibility = ["//mockgen:__subpackages__"],
 +    deps = ["//gomock"],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":self_package",
++    visibility = ["//mockgen:__subpackages__"],
++)
 diff -urN a/mockgen/internal/tests/test_package/BUILD.bazel b/mockgen/internal/tests/test_package/BUILD.bazel
---- a/mockgen/internal/tests/test_package/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/test_package/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/test_package/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
 +    name = "test_package",
 +    srcs = ["foo.go"],
 +    importpath = "github.com/golang/mock/mockgen/internal/tests/test_package",
++    visibility = ["//mockgen:__subpackages__"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":test_package",
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 +
@@ -611,9 +809,9 @@ diff -urN a/mockgen/internal/tests/test_package/BUILD.bazel b/mockgen/internal/t
 +    deps = ["//gomock"],
 +)
 diff -urN a/mockgen/internal/tests/unexported_method/BUILD.bazel b/mockgen/internal/tests/unexported_method/BUILD.bazel
---- a/mockgen/internal/tests/unexported_method/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/unexported_method/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/unexported_method/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -627,6 +825,12 @@ diff -urN a/mockgen/internal/tests/unexported_method/BUILD.bazel b/mockgen/inter
 +    deps = ["//gomock"],
 +)
 +
++alias(
++    name = "go_default_library",
++    actual = ":unexported_method",
++    visibility = ["//mockgen:__subpackages__"],
++)
++
 +go_test(
 +    name = "unexported_method_test",
 +    srcs = ["bugreport_test.go"],
@@ -634,9 +838,9 @@ diff -urN a/mockgen/internal/tests/unexported_method/BUILD.bazel b/mockgen/inter
 +    deps = ["//gomock"],
 +)
 diff -urN a/mockgen/internal/tests/vendor_dep/BUILD.bazel b/mockgen/internal/tests/vendor_dep/BUILD.bazel
---- a/mockgen/internal/tests/vendor_dep/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/vendor_dep/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/vendor_dep/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,16 @@
+@@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -653,10 +857,16 @@ diff -urN a/mockgen/internal/tests/vendor_dep/BUILD.bazel b/mockgen/internal/tes
 +        "@org_golang_x_tools//present:go_default_library",
 +    ],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":vendor_dep",
++    visibility = ["//mockgen:__subpackages__"],
++)
 diff -urN a/mockgen/internal/tests/vendor_dep/source_mock_package/BUILD.bazel b/mockgen/internal/tests/vendor_dep/source_mock_package/BUILD.bazel
---- a/mockgen/internal/tests/vendor_dep/source_mock_package/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/vendor_dep/source_mock_package/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/vendor_dep/source_mock_package/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -669,10 +879,16 @@ diff -urN a/mockgen/internal/tests/vendor_dep/source_mock_package/BUILD.bazel b/
 +        "@org_golang_x_tools//present:go_default_library",
 +    ],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":source_mock_package",
++    visibility = ["//mockgen:__subpackages__"],
++)
 diff -urN a/mockgen/internal/tests/vendor_pkg/BUILD.bazel b/mockgen/internal/tests/vendor_pkg/BUILD.bazel
---- a/mockgen/internal/tests/vendor_pkg/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/internal/tests/vendor_pkg/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/internal/tests/vendor_pkg/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -685,10 +901,16 @@ diff -urN a/mockgen/internal/tests/vendor_pkg/BUILD.bazel b/mockgen/internal/tes
 +    visibility = ["//mockgen:__subpackages__"],
 +    deps = ["//gomock"],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":vendor_pkg",
++    visibility = ["//mockgen:__subpackages__"],
++)
 diff -urN a/mockgen/model/BUILD.bazel b/mockgen/model/BUILD.bazel
---- a/mockgen/model/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/mockgen/model/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/mockgen/model/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,14 @@
+@@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -698,15 +920,21 @@ diff -urN a/mockgen/model/BUILD.bazel b/mockgen/model/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 +
++alias(
++    name = "go_default_library",
++    actual = ":model",
++    visibility = ["//visibility:public"],
++)
++
 +go_test(
 +    name = "model_test",
 +    srcs = ["model_test.go"],
 +    embed = [":model"],
 +)
 diff -urN a/sample/BUILD.bazel b/sample/BUILD.bazel
---- a/sample/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/sample/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/sample/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,30 @@
+@@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -720,6 +948,12 @@ diff -urN a/sample/BUILD.bazel b/sample/BUILD.bazel
 +        "//sample/imp3",
 +        "//sample/imp4",
 +    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":sample",
++    visibility = ["//visibility:public"],
 +)
 +
 +go_test(
@@ -738,15 +972,21 @@ diff -urN a/sample/BUILD.bazel b/sample/BUILD.bazel
 +    ],
 +)
 diff -urN a/sample/concurrent/BUILD.bazel b/sample/concurrent/BUILD.bazel
---- a/sample/concurrent/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/sample/concurrent/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/sample/concurrent/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,18 @@
+@@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
 +    name = "concurrent",
 +    srcs = ["concurrent.go"],
 +    importpath = "github.com/golang/mock/sample/concurrent",
++    visibility = ["//visibility:public"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":concurrent",
 +    visibility = ["//visibility:public"],
 +)
 +
@@ -760,9 +1000,9 @@ diff -urN a/sample/concurrent/BUILD.bazel b/sample/concurrent/BUILD.bazel
 +    ],
 +)
 diff -urN a/sample/concurrent/mock/BUILD.bazel b/sample/concurrent/mock/BUILD.bazel
---- a/sample/concurrent/mock/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/sample/concurrent/mock/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/sample/concurrent/mock/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,9 @@
+@@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -772,10 +1012,16 @@ diff -urN a/sample/concurrent/mock/BUILD.bazel b/sample/concurrent/mock/BUILD.ba
 +    visibility = ["//visibility:public"],
 +    deps = ["//gomock"],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":mock",
++    visibility = ["//visibility:public"],
++)
 diff -urN a/sample/imp1/BUILD.bazel b/sample/imp1/BUILD.bazel
---- a/sample/imp1/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/sample/imp1/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/sample/imp1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,8 @@
+@@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -784,10 +1030,16 @@ diff -urN a/sample/imp1/BUILD.bazel b/sample/imp1/BUILD.bazel
 +    importpath = "github.com/golang/mock/sample/imp1",
 +    visibility = ["//visibility:public"],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":imp1",
++    visibility = ["//visibility:public"],
++)
 diff -urN a/sample/imp2/BUILD.bazel b/sample/imp2/BUILD.bazel
---- a/sample/imp2/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/sample/imp2/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/sample/imp2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,8 @@
+@@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -796,10 +1048,16 @@ diff -urN a/sample/imp2/BUILD.bazel b/sample/imp2/BUILD.bazel
 +    importpath = "github.com/golang/mock/sample/imp2",
 +    visibility = ["//visibility:public"],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":imp2",
++    visibility = ["//visibility:public"],
++)
 diff -urN a/sample/imp3/BUILD.bazel b/sample/imp3/BUILD.bazel
---- a/sample/imp3/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/sample/imp3/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/sample/imp3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,8 @@
+@@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -808,15 +1066,27 @@ diff -urN a/sample/imp3/BUILD.bazel b/sample/imp3/BUILD.bazel
 +    importpath = "github.com/golang/mock/sample/imp3",
 +    visibility = ["//visibility:public"],
 +)
++
++alias(
++    name = "go_default_library",
++    actual = ":imp3",
++    visibility = ["//visibility:public"],
++)
 diff -urN a/sample/imp4/BUILD.bazel b/sample/imp4/BUILD.bazel
---- a/sample/imp4/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
+--- a/sample/imp4/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
 +++ b/sample/imp4/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,8 @@
+@@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
 +    name = "imp4",
 +    srcs = ["imp4.go"],
 +    importpath = "github.com/golang/mock/sample/imp4",
++    visibility = ["//visibility:public"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":imp4",
 +    visibility = ["//visibility:public"],
 +)


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Sets `go_naming_convention` to `import_alias` for gomock, as per the other
Go dependencies. This means users with `go_naming_convention` set to
`go_default_library` do not have to make adjustments to
Gazelle generated files or override the dependency.

**Which issues(s) does this PR fix?**

Fixes #3154

**Other notes for review**

N/A