### PR TITLE
Update URLs for archives

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -224,8 +224,8 @@ Go toolchain and register it for use.
         name = "io_bazel_rules_go",
         sha256 = "ab21448cef298740765f33a7f5acee0607203e4ea321219f2a4c85a6e0fb0a27",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.32.0/rules_go-v0.32.0.zip",
-            "https://github.com/bazelbuild/rules_go/releases/download/v0.32.0/rules_go-v0.32.0.zip",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/archive/refs/tags/v0.32.0.zip",
+            "https://github.com/bazelbuild/rules_go/archive/refs/tags/v0.32.0.zip",
         ],
     )
 
@@ -271,8 +271,8 @@ Add the ``bazel_gazelle`` repository and its dependencies to your
         name = "io_bazel_rules_go",
         sha256 = "ab21448cef298740765f33a7f5acee0607203e4ea321219f2a4c85a6e0fb0a27",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.32.0/rules_go-v0.32.0.zip",
-            "https://github.com/bazelbuild/rules_go/releases/download/v0.32.0/rules_go-v0.32.0.zip",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/archive/refs/tags/v0.32.0.zip",
+            "https://github.com/bazelbuild/rules_go/archive/refs/tags/v0.32.0.zip",
         ],
     )
 
@@ -397,8 +397,8 @@ automatically from a go.mod or Gopkg.lock file.
         name = "io_bazel_rules_go",
         sha256 = "ab21448cef298740765f33a7f5acee0607203e4ea321219f2a4c85a6e0fb0a27",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.32.0/rules_go-v0.32.0.zip",
-            "https://github.com/bazelbuild/rules_go/releases/download/v0.32.0/rules_go-v0.32.0.zip",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/archive/refs/tags/v0.32.0.zip",
+            "https://github.com/bazelbuild/rules_go/archive/refs/tags/v0.32.0.zip",
         ],
     )
 

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -138,7 +138,7 @@ def go_rules_dependencies():
         sha256 = "dc4339bd2011a230d81d5ec445361efeb78366f1d30a7757e8fbea3e7221080e",
         # v1.28.0, latest as of 2022-05-09
         urls = [
-            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf-go/archive/v1.28.0.zip",
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf-go/archive/refs/tags/v1.28.0.zip",
             "https://github.com/protocolbuffers/protobuf-go/archive/v1.28.0.zip",
         ],
         strip_prefix = "protobuf-go-1.28.0",

--- a/go/tools/releaser/upgradedep.go
+++ b/go/tools/releaser/upgradedep.go
@@ -348,7 +348,7 @@ func upgradeDepDecl(ctx context.Context, gh *githubClient, workDir, name string,
 			}
 		}
 		if ghURL == "" {
-			ghURL = fmt.Sprintf("https://github.com/%s/%s/archive/%s.zip", orgName, repoName, *highestTag.Name)
+			ghURL = fmt.Sprintf("https://github.com/%s/%s/archive/refs/tags/%s.zip", orgName, repoName, *highestTag.Name)
 			stripPrefix = repoName + "-" + strings.TrimPrefix(*highestTag.Name, "v")
 		}
 		urlComment = fmt.Sprintf("%s, latest as of %s", *highestTag.Name, date)


### PR DESCRIPTION
Update URLs to archives to reflect their location on mirror.bazel.build (https://github.com/bazelbuild/bazel/issues/15480), as well as the releaser tool that generate the URLs.