### PR TITLE
Fix gopackagesdriver for Go 1.18 by replicating stdlib and add test for stdliblist.go

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -264,6 +264,7 @@ tasks:
     - "-@org_golang_x_text//language:language_test"
     - "-@org_golang_x_tools//cmd/splitdwarf/internal/macho:macho_test"
     - "-@test_chdir_remote//sub:go_default_test"
+    - "-//go/tools/builders:stdliblist_test" # fails on Windows due to #2491
     - "-//tests:buildifier_test" # requires bash
     - "-//tests/core/cgo:dylib_client"
     - "-//tests/core/cgo:dylib_test"

--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -52,8 +52,10 @@ def _should_use_sdk_stdlib(go):
             go.mode.link == LINKMODE_NORMAL)
 
 def _build_stdlib_list_json(go):
+    print("this is the go_sdk_path: %s\n" % go.sdk.root_file.dirname)
     out = go.declare_file(go, "stdlib.pkg.json")
     args = go.builder_args(go, "stdliblist")
+    args.add("-sdk", go.sdk.root_file.dirname)
     args.add("-out", out)
     go.actions.run(
         inputs = go.sdk_files,

--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -52,7 +52,6 @@ def _should_use_sdk_stdlib(go):
             go.mode.link == LINKMODE_NORMAL)
 
 def _build_stdlib_list_json(go):
-    print("this is the go_sdk_path: %s\n" % go.sdk.root_file.dirname)
     out = go.declare_file(go, "stdlib.pkg.json")
     args = go.builder_args(go, "stdliblist")
     args.add("-sdk", go.sdk.root_file.dirname)

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -34,7 +34,10 @@ go_test(
         "stdliblist_test.go",
     ],
     data = ["@go_sdk//:files"],
-    rundir = ".",
+    # -sdk in stdliblist needs to be a relative path, otherwise it breaks
+    # assumptions of cloning go_sdk, thus we need to set up the test in a
+    # way that go_sdk is under the directory where test is run.
+    rundir = "..",
     deps = ["//go/tools/bazel"],
 )
 

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -23,6 +23,19 @@ go_test(
     ],
 )
 
+go_test(
+    name = "stdliblist_test",
+    size = "small",
+    data = ["@go_sdk//:files"],
+    srcs = [
+        "stdliblist.go",
+        "stdliblist_test.go",
+        "env.go",
+        "flags.go",
+        "replicate.go",
+    ],
+)
+
 filegroup(
     name = "builder_srcs",
     srcs = [

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -34,10 +34,6 @@ go_test(
         "stdliblist_test.go",
     ],
     data = ["@go_sdk//:files"],
-    # -sdk in stdliblist needs to be a relative path, otherwise it breaks
-    # assumptions of cloning go_sdk, thus we need to set up the test in a
-    # way that go_sdk is under the directory where test is run.
-    rundir = "..",
     deps = ["//go/tools/bazel"],
 )
 

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -26,14 +26,14 @@ go_test(
 go_test(
     name = "stdliblist_test",
     size = "small",
-    data = ["@go_sdk//:files"],
     srcs = [
-        "stdliblist.go",
-        "stdliblist_test.go",
         "env.go",
         "flags.go",
         "replicate.go",
+        "stdliblist.go",
+        "stdliblist_test.go",
     ],
+    data = ["@go_sdk//:files"],
 )
 
 filegroup(

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -34,6 +34,8 @@ go_test(
         "stdliblist_test.go",
     ],
     data = ["@go_sdk//:files"],
+    rundir = ".",
+    deps = ["//go/tools/bazel"],
 )
 
 filegroup(

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -33,8 +33,8 @@ go_test(
         "stdliblist.go",
         "stdliblist_test.go",
     ],
-    rundir = ".",
     data = ["@go_sdk//:files"],
+    rundir = ".",
 )
 
 filegroup(

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -33,8 +33,8 @@ go_test(
         "stdliblist.go",
         "stdliblist_test.go",
     ],
+    rundir = ".",
     data = ["@go_sdk//:files"],
-    deps = ["//go/tools/bazel"],
 )
 
 filegroup(

--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -44,7 +44,7 @@ var (
 // See ./README.rst for more information about handling arguments and
 // environment variables.
 type env struct {
-	// cwd is the path to the working directory
+	// wd is the path to the working directory
 	wd string
 
 	// sdk is the path to the Go SDK, which contains tools for the host

--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -44,6 +44,9 @@ var (
 // See ./README.rst for more information about handling arguments and
 // environment variables.
 type env struct {
+	// cwd is the path to the working directory
+	wd string
+
 	// sdk is the path to the Go SDK, which contains tools for the host
 	// platform. This may be different than GOROOT.
 	sdk string
@@ -71,6 +74,7 @@ func envFlags(flags *flag.FlagSet) *env {
 	flags.StringVar(&env.installSuffix, "installsuffix", "", "Standard library under GOROOT/pkg")
 	flags.BoolVar(&env.verbose, "v", false, "Whether subprocess command lines should be printed")
 	flags.BoolVar(&env.shouldPreserveWorkDir, "work", false, "if true, the temporary work directory will be preserved")
+	flags.StringVar(&env.wd, "wd", ".", "working director default to dot")
 	return env
 }
 
@@ -121,6 +125,10 @@ func (e *env) goTool(tool string, args ...string) []string {
 // and additional arguments.
 func (e *env) goCmd(cmd string, args ...string) []string {
 	exe := filepath.Join(e.sdk, "bin", "go")
+	if len(e.wd) > 0 {
+		exe = filepath.Join(e.wd, exe)
+	}
+
 	if runtime.GOOS == "windows" {
 		exe += ".exe"
 	}

--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -44,9 +44,6 @@ var (
 // See ./README.rst for more information about handling arguments and
 // environment variables.
 type env struct {
-	// wd is the path to the working directory
-	wd string
-
 	// sdk is the path to the Go SDK, which contains tools for the host
 	// platform. This may be different than GOROOT.
 	sdk string
@@ -69,12 +66,11 @@ type env struct {
 // configured with those flags.
 func envFlags(flags *flag.FlagSet) *env {
 	env := &env{}
-	flags.StringVar(&env.sdk, "sdk", "", "Path to the Go SDK.")
+	flags.StringVar(&env.sdk, "sdk", "", "Relative path to the Go SDK.")
 	flags.Var(&tagFlag{}, "tags", "List of build tags considered true.")
 	flags.StringVar(&env.installSuffix, "installsuffix", "", "Standard library under GOROOT/pkg")
 	flags.BoolVar(&env.verbose, "v", false, "Whether subprocess command lines should be printed")
 	flags.BoolVar(&env.shouldPreserveWorkDir, "work", false, "if true, the temporary work directory will be preserved")
-	flags.StringVar(&env.wd, "wd", ".", "working director default to dot")
 	return env
 }
 
@@ -125,9 +121,6 @@ func (e *env) goTool(tool string, args ...string) []string {
 // and additional arguments.
 func (e *env) goCmd(cmd string, args ...string) []string {
 	exe := filepath.Join(e.sdk, "bin", "go")
-	if len(e.wd) > 0 {
-		exe = filepath.Join(e.wd, exe)
-	}
 
 	if runtime.GOOS == "windows" {
 		exe += ".exe"

--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -66,7 +66,7 @@ type env struct {
 // configured with those flags.
 func envFlags(flags *flag.FlagSet) *env {
 	env := &env{}
-	flags.StringVar(&env.sdk, "sdk", "", "Relative path to the Go SDK.")
+	flags.StringVar(&env.sdk, "sdk", "", "Path to the Go SDK.")
 	flags.Var(&tagFlag{}, "tags", "List of build tags considered true.")
 	flags.StringVar(&env.installSuffix, "installsuffix", "", "Standard library under GOROOT/pkg")
 	flags.BoolVar(&env.verbose, "v", false, "Whether subprocess command lines should be printed")
@@ -121,7 +121,6 @@ func (e *env) goTool(tool string, args ...string) []string {
 // and additional arguments.
 func (e *env) goCmd(cmd string, args ...string) []string {
 	exe := filepath.Join(e.sdk, "bin", "go")
-
 	if runtime.GOOS == "windows" {
 		exe += ".exe"
 	}

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -196,7 +196,7 @@ func stdliblist(args []string) error {
 	}
 	defer func() { cleanup() }()
 
-	newGoRoot := filepath.Join(cloneBase, "go_sdk")
+	newGoRoot := filepath.Join(cloneBase, "external/go_sdk")
 	err = cloneGoRoot(abs(goenv.sdk), abs(newGoRoot))
 	if err != nil {
 		return fmt.Errorf("failed to clone new go root %v", err)

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"go/build"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -190,11 +191,10 @@ func stdliblist(args []string) error {
 		return err
 	}
 
-	cloneBase, cleanup, err := goenv.workDir()
+	cloneBase, err := ioutil.TempDir(goenv.workDirPath, "stdlist-*")
 	if err != nil {
 		return err
 	}
-	defer func() { cleanup() }()
 
 	newGoRoot := filepath.Join(cloneBase, "external/go_sdk")
 	err = cloneGoRoot(abs(goenv.sdk), abs(newGoRoot))

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"go/build"
 	"os"
 	"path/filepath"
@@ -165,9 +166,6 @@ func flatPackageForStd(cloneBase string, pkg *goListPackage) *flatPackage {
 // under.
 func cloneGoRoot(execRoot, relativeGoroot, cloneBase string) (newGoRoot string, err error) {
 	goroot := filepath.Join(execRoot, relativeGoroot)
-	if err != nil {
-		return "", err
-	}
 	newGoRoot = filepath.Join(cloneBase, relativeGoroot)
 	if err := os.MkdirAll(newGoRoot, 01755); err != nil {
 		return "", err
@@ -197,13 +195,11 @@ func stdliblist(args []string) error {
 	if err != nil {
 		return err
 	}
-	defer func() {
-		cleanup()
-	}()
+	defer func() { cleanup() }()
 
 	cloneGoRoot, err := cloneGoRoot(goenv.wd, goenv.sdk, cloneBase)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to clone new go root %v", err)
 	}
 
 	// Ensure paths are absolute.

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -158,12 +158,12 @@ func flatPackageForStd(cloneBase string, pkg *goListPackage) *flatPackage {
 // To work around this, cloneGoRoot creates a copy of external/go_sdk into a new
 // cloneBase directory while retaining its path relative to the root directory.
 // So "$OUTPUT_BASE/external/go_sdk" becomes
-// tmp_directory/external/go_sdk", which will be set at GOROOT later.
+// {cloneBase}/external/go_sdk", which will be set at GOROOT later.
 // This ensures that file paths in the generated JSON are still valid.
 //
 // cloneGoRoot returns the new GOROOT we should run
 // under.
-func cloneGoRoot(execRoot, relativeGoroot string, cloneBase string) (newGoRoot string, err error) {
+func cloneGoRoot(execRoot, relativeGoroot, cloneBase string) (newGoRoot string, err error) {
 	goroot := filepath.Join(execRoot, relativeGoroot)
 	if err != nil {
 		return "", err

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -158,18 +158,21 @@ func stdliblist(args []string) error {
 		return err
 	}
 
+	execRoot := abs(".")
+	if err := replicate(os.Getenv("GOROOT"), execRoot, replicatePaths("src", "pkg/tool", "pkg/include")); err != nil {
+		return err
+	}
+
 	// Ensure paths are absolute.
 	absPaths := []string{}
 	for _, path := range filepath.SplitList(os.Getenv("PATH")) {
 		absPaths = append(absPaths, abs(path))
 	}
 	os.Setenv("PATH", strings.Join(absPaths, string(os.PathListSeparator)))
-	os.Setenv("GOROOT", abs(os.Getenv("GOROOT")))
+	os.Setenv("GOROOT", execRoot)
 	// Make sure we have an absolute path to the C compiler.
 	// TODO(#1357): also take absolute paths of includes and other paths in flags.
 	os.Setenv("CC", abs(os.Getenv("CC")))
-
-	execRoot := abs(".")
 
 	cachePath := abs(*out + ".gocache")
 	defer os.RemoveAll(cachePath)

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -156,14 +156,15 @@ func flatPackageForStd(cloneBase string, pkg *goListPackage) *flatPackage {
 // If we run "go list" with that GOROOT, this action will fail because those
 // go:embed directives will refuse to include the symlinks in the sandbox.
 //
-// To work around this, cloneGoRoot creates a copy of external/go_sdk into a new
-// cloneBase directory while retaining its path relative to the root directory.
+// To work around this, cloneGoRoot creates a copy of a subset of external/go_sdk
+// that is sufficient to call "go list" into a new cloneBase directory while
+// retaining its path relative to the root directory, e.g. "go list" needs to
+// call "compile", which needs "pkg/tool".
 // So "$OUTPUT_BASE/external/go_sdk" becomes
-// {cloneBase}/external/go_sdk", which will be set at GOROOT later.
-// This ensures that file paths in the generated JSON are still valid.
+// {cloneBase}/external/go_sdk", which will be set at GOROOT later. This ensures
+// that file paths in the generated JSON are still valid.
 //
-// cloneGoRoot returns the new GOROOT we should run
-// under.
+// cloneGoRoot returns the new GOROOT we should run under.
 func cloneGoRoot(execRoot, relativeGoroot, cloneBase string) (newGoRoot string, err error) {
 	goroot := filepath.Join(execRoot, relativeGoroot)
 	newGoRoot = filepath.Join(cloneBase, relativeGoroot)

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -196,7 +196,12 @@ func stdliblist(args []string) error {
 		return err
 	}
 
-	newGoRoot := filepath.Join(cloneBase, "external/go_sdk")
+	relGoSdk, err := filepath.Rel(".", goenv.sdk)
+	if err != nil {
+		return err
+	}
+
+	newGoRoot := filepath.Join(cloneBase, relGoSdk)
 	err = cloneGoRoot(abs(goenv.sdk), abs(newGoRoot))
 	if err != nil {
 		return fmt.Errorf("failed to clone new go root %v", err)

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"fmt"
 	"go/build"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -191,10 +190,11 @@ func stdliblist(args []string) error {
 		return err
 	}
 
-	cloneBase, err := ioutil.TempDir(goenv.workDirPath, "stdlist-*")
+	cloneBase, cleanup, err := goenv.workDir()
 	if err != nil {
 		return err
 	}
+	defer func() { cleanup() }()
 
 	relGoSdk, err := filepath.Rel(".", goenv.sdk)
 	if err != nil {

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -110,8 +110,8 @@ func stdlibPackageID(importPath string) string {
 	return "@io_bazel_rules_go//stdlib:" + importPath
 }
 
-// labelledPath replace the cloneBase with output base label
-func labelledPath(cloneBase, p string) string {
+// outputBasePath replace the cloneBase with output base label
+func outputBasePath(cloneBase, p string) string {
 	dir, _ := filepath.Rel(cloneBase, p)
 	return filepath.Join("__BAZEL_OUTPUT_BASE__", dir)
 }
@@ -120,7 +120,7 @@ func labelledPath(cloneBase, p string) string {
 //  paths with the label for all source files in a package
 func absoluteSourcesPaths(cloneBase, pkgDir string, srcs []string) []string {
 	ret := make([]string, 0, len(srcs))
-	pkgDir = labelledPath(cloneBase, pkgDir)
+	pkgDir = outputBasePath(cloneBase, pkgDir)
 	for _, src := range srcs {
 		ret = append(ret, filepath.Join(pkgDir, src))
 	}
@@ -135,7 +135,7 @@ func flatPackageForStd(cloneBase string, pkg *goListPackage) *flatPackage {
 		ID:              stdlibPackageID(pkg.ImportPath),
 		Name:            pkg.Name,
 		PkgPath:         pkg.ImportPath,
-		ExportFile:      labelledPath(cloneBase, pkg.Target),
+		ExportFile:      outputBasePath(cloneBase, pkg.Target),
 		Imports:         map[string]string{},
 		Standard:        pkg.Standard,
 		GoFiles:         goFiles,

--- a/go/tools/builders/stdliblist_test.go
+++ b/go/tools/builders/stdliblist_test.go
@@ -1,51 +1,50 @@
 package main
 
 import (
-	"bufio"
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
-	"os"
-	"strings"
-	"testing"
+    "bufio"
+    "encoding/json"
+    "fmt"
+    "io/ioutil"
+    "os"
+    "strings"
+    "testing"
 )
 
 func Test_stdliblist(t *testing.T) {
-	fmt.Println("cur:" + abs("."))
-	testDir := t.TempDir()
-	f, _ := ioutil.TempFile(testDir, "*")
+    testDir := t.TempDir()
+    f, _ := ioutil.TempFile(testDir, "*")
 
-	// test files are at TEST_SRCDIR, but this test is run at
-	// TEST_SRCDIR/TEST_WORKSPACE/...
-	// since -sdk is assumed to be a relative path to execRoot
-	// (go.sdk.root_file.dirname), thus setting wd to
-	// TEST_SRCDIR so that go_sdk is discoverable
-	test_args := []string{
-		fmt.Sprintf("-out=%s", f.Name()),
-		fmt.Sprintf("-sdk=%s", "go_sdk"),
-		fmt.Sprintf("-wd=%s", os.Getenv("TEST_SRCDIR")),
-	}
-	err := stdliblist(test_args)
-	if err != nil {
-		t.Errorf("calling stdliblist got err: %v", err)
-	}
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		var result flatPackage
-		jsonLineStr := scanner.Text()
-		if err := json.Unmarshal([]byte(jsonLineStr), &result); err != nil {
-			t.Errorf("cannot parse result line %s \n to goListPackage{}: %v\n", err)
-		}
-		if !strings.HasPrefix(result.ID, "@io_bazel_rules_go//stdlib") {
-			t.Errorf("ID should be prefixed with @io_bazel_rules_go//stdlib :%s", jsonLineStr)
-		}
-		if !strings.HasPrefix(result.ExportFile, "__BAZEL_OUTPUT_BASE__") {
-			t.Errorf("export file should be prefixed with __BAZEL_OUTPUT_BASE__ :%s", jsonLineStr)
-		}
-		for _, gofile := range result.GoFiles {
-			if !strings.HasPrefix(gofile, "__BAZEL_OUTPUT_BASE__/go_sdk") {
-				t.Errorf("All go files should be prefixed with __BAZEL_OUTPUT_BASE__/go_sdk :%s", jsonLineStr)
-			}
-		}
-	}
+    // test files are at TEST_SRCDIR, but this test is run at
+    // TEST_SRCDIR/TEST_WORKSPACE/...
+    // since -sdk is assumed to be a relative path to execRoot
+    // (go.sdk.root_file.dirname), thus setting wd to
+    // TEST_SRCDIR so that go_sdk is discoverable
+    test_args := []string{
+        fmt.Sprintf("-out=%s", f.Name()),
+        fmt.Sprintf("-sdk=%s", "go_sdk"),
+        fmt.Sprintf("-wd=%s", os.Getenv("TEST_SRCDIR")),
+    }
+    err := stdliblist(test_args)
+    if err != nil {
+        t.Errorf("calling stdliblist got err: %v", err)
+    }
+    scanner := bufio.NewScanner(f)
+    for scanner.Scan() {
+        var result flatPackage
+        jsonLineStr := scanner.Text()
+        if err := json.Unmarshal([]byte(jsonLineStr), &result); err != nil {
+            t.Errorf("cannot parse result line %s \n to goListPackage{}: %v\n", err)
+        }
+        if !strings.HasPrefix(result.ID, "@io_bazel_rules_go//stdlib") {
+            t.Errorf("ID should be prefixed with @io_bazel_rules_go//stdlib :%s", jsonLineStr)
+        }
+        if !strings.HasPrefix(result.ExportFile, "__BAZEL_OUTPUT_BASE__") {
+            t.Errorf("export file should be prefixed with __BAZEL_OUTPUT_BASE__ :%s", jsonLineStr)
+        }
+        for _, gofile := range result.GoFiles {
+            if !strings.HasPrefix(gofile, "__BAZEL_OUTPUT_BASE__/go_sdk") {
+                t.Errorf("All go files should be prefixed with __BAZEL_OUTPUT_BASE__/go_sdk :%s", jsonLineStr)
+            }
+        }
+    }
 }

--- a/go/tools/builders/stdliblist_test.go
+++ b/go/tools/builders/stdliblist_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"github.com/bazelbuild/rules_go/go/tools/bazel"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,17 +14,12 @@ func Test_stdliblist(t *testing.T) {
 	testDir := t.TempDir()
 	outJSON := filepath.Join(testDir, "out.json")
 
-	runFilePath, err := bazel.RunfilesPath()
-	if err != nil {
-		t.Errorf("cannot file runfile path %v", err)
-	}
 	test_args := []string{
 		fmt.Sprintf("-out=%s", outJSON),
-		fmt.Sprintf("-sdk=%s", abs(filepath.Join(filepath.Dir(runFilePath), "go_sdk"))),
+		fmt.Sprintf("-sdk=%s", "external/go_sdk"),
 	}
 
-	err = stdliblist(test_args)
-	if err != nil {
+	if err := stdliblist(test_args); err != nil {
 		t.Errorf("calling stdliblist got err: %v", err)
 	}
 	f, err := os.Open(outJSON)

--- a/go/tools/builders/stdliblist_test.go
+++ b/go/tools/builders/stdliblist_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+)
+
+func Test_stdliblist(t *testing.T) {
+	fmt.Println("cur:" + abs("."))
+	testDir := t.TempDir()
+	f, _ := ioutil.TempFile(testDir, "*")
+
+	// test files are at TEST_SRCDIR, but this test is run at
+	// TEST_SRCDIR/TEST_WORKSPACE/...
+	// since -sdk is assumed to be a relative path to execRoot
+	// (go.sdk.root_file.dirname), thus setting wd to
+	// TEST_SRCDIR so that go_sdk is discoverable
+	test_args := []string{
+		fmt.Sprintf("-out=%s", f.Name()),
+		fmt.Sprintf("-sdk=%s", "go_sdk"),
+		fmt.Sprintf("-wd=%s", os.Getenv("TEST_SRCDIR")),
+	}
+	err := stdliblist(test_args)
+	if err != nil {
+		t.Errorf("calling stdliblist got err: %v", err)
+	}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var result flatPackage
+		jsonLineStr := scanner.Text()
+		if err := json.Unmarshal([]byte(jsonLineStr), &result); err != nil {
+			t.Errorf("cannot parse result line %s \n to goListPackage{}: %v\n", err)
+		}
+		if !strings.HasPrefix(result.ID, "@io_bazel_rules_go//stdlib") {
+			t.Errorf("ID should be prefixed with @io_bazel_rules_go//stdlib :%s", jsonLineStr)
+		}
+		if !strings.HasPrefix(result.ExportFile, "__BAZEL_OUTPUT_BASE__") {
+			t.Errorf("export file should be prefixed with __BAZEL_OUTPUT_BASE__ :%s", jsonLineStr)
+		}
+		for _, gofile := range result.GoFiles {
+			if !strings.HasPrefix(gofile, "__BAZEL_OUTPUT_BASE__/go_sdk") {
+				t.Errorf("All go files should be prefixed with __BAZEL_OUTPUT_BASE__/go_sdk :%s", jsonLineStr)
+			}
+		}
+	}
+}

--- a/go/tools/builders/stdliblist_test.go
+++ b/go/tools/builders/stdliblist_test.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -14,7 +14,7 @@ import (
 
 func Test_stdliblist(t *testing.T) {
 	testDir := t.TempDir()
-	f, _ := ioutil.TempFile(testDir, "*")
+	outJSON := filepath.Join(testDir, "out.json")
 
 	// test files are at run file directory, but this test is run at
 	// {runfile directory}/bazel.TestWorkspace()
@@ -27,7 +27,7 @@ func Test_stdliblist(t *testing.T) {
 		t.Error("failed to find runfiles path")
 	}
 	test_args := []string{
-		fmt.Sprintf("-out=%s", f.Name()),
+		fmt.Sprintf("-out=%s", outJSON),
 		fmt.Sprintf("-sdk=%s", "go_sdk"),
 		fmt.Sprintf("-wd=%s", filepath.Dir(filepath.Clean(runFilesPath))),
 	}
@@ -36,6 +36,11 @@ func Test_stdliblist(t *testing.T) {
 	if err != nil {
 		t.Errorf("calling stdliblist got err: %v", err)
 	}
+	f, err := os.Open(outJSON)
+	if err != nil {
+		t.Errorf("cannot open output json: %v", err)
+	}
+	defer func() { _ = f.Close() }()
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		var result flatPackage

--- a/go/tools/builders/stdliblist_test.go
+++ b/go/tools/builders/stdliblist_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,16 +15,16 @@ func Test_stdliblist(t *testing.T) {
 	testDir := t.TempDir()
 	outJSON := filepath.Join(testDir, "out.json")
 
-	// test files are at {runfile directory}/go_sdk,
-	// this test is run at {runfile directory}/{workspace}/../
-	// thus go_sdk is the relative path to current working
-	// directory
+	runFilePath, err := bazel.RunfilesPath()
+	if err != nil {
+		t.Errorf("cannot file runfile path %v", err)
+	}
 	test_args := []string{
 		fmt.Sprintf("-out=%s", outJSON),
-		fmt.Sprintf("-sdk=%s", "go_sdk"),
+		fmt.Sprintf("-sdk=%s", abs(filepath.Join(filepath.Dir(runFilePath), "go_sdk"))),
 	}
 
-	err := stdliblist(test_args)
+	err = stdliblist(test_args)
 	if err != nil {
 		t.Errorf("calling stdliblist got err: %v", err)
 	}

--- a/go/tools/builders/stdliblist_test.go
+++ b/go/tools/builders/stdliblist_test.go
@@ -8,31 +8,22 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/bazelbuild/rules_go/go/tools/bazel"
 )
 
 func Test_stdliblist(t *testing.T) {
 	testDir := t.TempDir()
 	outJSON := filepath.Join(testDir, "out.json")
 
-	// test files are at run file directory, but this test is run at
-	// {runfile directory}/bazel.TestWorkspace()
-	// since -sdk is assumed to be a relative path to execRoot
-	// (go.sdk.root_file.dirname), thus setting wd to
-	// {runfile directory} so that go_sdk is discoverable
-	// {runfile directory} is the parent directory of bazel.RunfilesPath()
-	runFilesPath, err := bazel.RunfilesPath()
-	if err != nil {
-		t.Error("failed to find runfiles path")
-	}
+	// test files are at {runfile directory}/go_sdk,
+	// this test is run at {runfile directory}/{workspace}/../
+	// thus go_sdk is the relative path to current working
+	// directory
 	test_args := []string{
 		fmt.Sprintf("-out=%s", outJSON),
 		fmt.Sprintf("-sdk=%s", "go_sdk"),
-		fmt.Sprintf("-wd=%s", filepath.Dir(filepath.Clean(runFilesPath))),
 	}
 
-	err = stdliblist(test_args)
+	err := stdliblist(test_args)
 	if err != nil {
 		t.Errorf("calling stdliblist got err: %v", err)
 	}

--- a/go/tools/builders/stdliblist_test.go
+++ b/go/tools/builders/stdliblist_test.go
@@ -1,50 +1,58 @@
 package main
 
 import (
-    "bufio"
-    "encoding/json"
-    "fmt"
-    "io/ioutil"
-    "os"
-    "strings"
-    "testing"
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
 )
 
 func Test_stdliblist(t *testing.T) {
-    testDir := t.TempDir()
-    f, _ := ioutil.TempFile(testDir, "*")
+	testDir := t.TempDir()
+	f, _ := ioutil.TempFile(testDir, "*")
 
-    // test files are at TEST_SRCDIR, but this test is run at
-    // TEST_SRCDIR/TEST_WORKSPACE/...
-    // since -sdk is assumed to be a relative path to execRoot
-    // (go.sdk.root_file.dirname), thus setting wd to
-    // TEST_SRCDIR so that go_sdk is discoverable
-    test_args := []string{
-        fmt.Sprintf("-out=%s", f.Name()),
-        fmt.Sprintf("-sdk=%s", "go_sdk"),
-        fmt.Sprintf("-wd=%s", os.Getenv("TEST_SRCDIR")),
-    }
-    err := stdliblist(test_args)
-    if err != nil {
-        t.Errorf("calling stdliblist got err: %v", err)
-    }
-    scanner := bufio.NewScanner(f)
-    for scanner.Scan() {
-        var result flatPackage
-        jsonLineStr := scanner.Text()
-        if err := json.Unmarshal([]byte(jsonLineStr), &result); err != nil {
-            t.Errorf("cannot parse result line %s \n to goListPackage{}: %v\n", err)
-        }
-        if !strings.HasPrefix(result.ID, "@io_bazel_rules_go//stdlib") {
-            t.Errorf("ID should be prefixed with @io_bazel_rules_go//stdlib :%s", jsonLineStr)
-        }
-        if !strings.HasPrefix(result.ExportFile, "__BAZEL_OUTPUT_BASE__") {
-            t.Errorf("export file should be prefixed with __BAZEL_OUTPUT_BASE__ :%s", jsonLineStr)
-        }
-        for _, gofile := range result.GoFiles {
-            if !strings.HasPrefix(gofile, "__BAZEL_OUTPUT_BASE__/go_sdk") {
-                t.Errorf("All go files should be prefixed with __BAZEL_OUTPUT_BASE__/go_sdk :%s", jsonLineStr)
-            }
-        }
-    }
+	// test files are at run file directory, but this test is run at
+	// {runfile directory}/bazel.TestWorkspace()
+	// since -sdk is assumed to be a relative path to execRoot
+	// (go.sdk.root_file.dirname), thus setting wd to
+	// {runfile directory} so that go_sdk is discoverable
+	// {runfile directory} is the parent directory of bazel.RunfilesPath()
+	runFilesPath, err := bazel.RunfilesPath()
+	if err != nil {
+		t.Error("failed to find runfiles path")
+	}
+	test_args := []string{
+		fmt.Sprintf("-out=%s", f.Name()),
+		fmt.Sprintf("-sdk=%s", "go_sdk"),
+		fmt.Sprintf("-wd=%s", filepath.Dir(filepath.Clean(runFilesPath))),
+	}
+
+	err = stdliblist(test_args)
+	if err != nil {
+		t.Errorf("calling stdliblist got err: %v", err)
+	}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var result flatPackage
+		jsonLineStr := scanner.Text()
+		if err := json.Unmarshal([]byte(jsonLineStr), &result); err != nil {
+			t.Errorf("cannot parse result line %s \n to goListPackage{}: %v\n", err)
+		}
+		if !strings.HasPrefix(result.ID, "@io_bazel_rules_go//stdlib") {
+			t.Errorf("ID should be prefixed with @io_bazel_rules_go//stdlib :%s", jsonLineStr)
+		}
+		if !strings.HasPrefix(result.ExportFile, "__BAZEL_OUTPUT_BASE__") {
+			t.Errorf("export file should be prefixed with __BAZEL_OUTPUT_BASE__ :%s", jsonLineStr)
+		}
+		for _, gofile := range result.GoFiles {
+			if !strings.HasPrefix(gofile, "__BAZEL_OUTPUT_BASE__/go_sdk") {
+				t.Errorf("All go files should be prefixed with __BAZEL_OUTPUT_BASE__/go_sdk :%s", jsonLineStr)
+			}
+		}
+	}
 }

--- a/go/tools/builders/stdliblist_test.go
+++ b/go/tools/builders/stdliblist_test.go
@@ -47,7 +47,7 @@ func Test_stdliblist(t *testing.T) {
 			t.Errorf("export file should be prefixed with __BAZEL_OUTPUT_BASE__ :%s", jsonLineStr)
 		}
 		for _, gofile := range result.GoFiles {
-			if !strings.HasPrefix(gofile, "__BAZEL_OUTPUT_BASE__/go_sdk") {
+			if !strings.HasPrefix(gofile, "__BAZEL_OUTPUT_BASE__/external/go_sdk") {
 				t.Errorf("All go files should be prefixed with __BAZEL_OUTPUT_BASE__/go_sdk :%s", jsonLineStr)
 			}
 		}

--- a/tests/core/stdlib/stdlib_files.bzl
+++ b/tests/core/stdlib/stdlib_files.bzl
@@ -26,10 +26,11 @@ pure_transition = transition(
 def _stdlib_files_impl(ctx):
     # When a transition is used, ctx.attr._stdlib is a list of Target instead
     # of a Target. Possibly a bug?
-    libs = ctx.attr._stdlib[0][GoStdLib].libs
+    stdlib = ctx.attr._stdlib[0][GoStdLib]
+    libs = stdlib.libs
     runfiles = ctx.runfiles(files = libs)
     return [DefaultInfo(
-        files = depset(libs),
+        files = depset(libs + [stdlib._list_json]),
         runfiles = runfiles,
     )]
 


### PR DESCRIPTION
What type of PR is this?

This PR addresses comments for https://github.com/bazelbuild/rules_go/pull/3083

What does this PR do? Why is it needed?
It fixes go list invocations from bazel for go1.18, where std library uses go:embed
see https://github.com/bazelbuild/rules_go/pull/3083

Which issues(s) does this PR fix?

Fixes https://github.com/bazelbuild/rules_go/issues/3080

Other notes for review
updated the patch in our repo with this patch

verified that the targets that failed without the patch can build successfully
verified a rebuild of all our repo behaved as expected