### PR TITLE
Add supplimental check for M1

### DIFF
--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -272,6 +272,10 @@ def _detect_host_platform(ctx):
             uname = res.stdout.strip()
             if uname == "arm64":
                 goarch = "arm64"
+            else:
+                res_sysctl = ctx.execute(["sysctl", "-n", "sysctl.proc_translated"])
+                if res_sysctl.return_code == 0 and res_sysctl.stdout.strip() == "1":
+                    goarch = "arm64"
 
         # Default to amd64 when uname doesn't return a known value.
 


### PR DESCRIPTION
"uname -m" will return "x86_64" if the root process is running through
  Rosetta. In this case we want to add the sysctl check to make sure.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
> Bug fix

**What does this PR do? Why is it needed?**
This PR is to fix the error "no matching toolchains found for types @io_bazel_rules_go//go:toolchain" on M1 MBPs, when there are x86_64 processes bootstrapping bazel builds.


**Which issues(s) does this PR fix?**

Fixes #3086

**Other notes for review**
