### PR TITLE
Include go_transition_test in bazel aspect

### DIFF
--- a/go/tools/gopackagesdriver/aspect.bzl
+++ b/go/tools/gopackagesdriver/aspect.bzl
@@ -86,7 +86,7 @@ def _go_pkg_info_aspect_impl(target, ctx):
         pkg = _go_archive_to_pkg(archive)
         pkg_json_files.append(_make_pkg_json(ctx, archive, pkg))
 
-        if ctx.rule.kind == "go_test":
+        if ctx.rule.kind in ["go_test", "go_transition_test"]:
             for dep_archive in archive.direct:
                 # find the archive containing the test sources
                 if archive.data.label == dep_archive.data.label:

--- a/go/tools/gopackagesdriver/bazel.go
+++ b/go/tools/gopackagesdriver/bazel.go
@@ -138,15 +138,13 @@ func (b *Bazel) Query(ctx context.Context, args ...string) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("bazel query failed: %w", err)
 	}
-	return strings.Split(strings.TrimSpace(output), "\n"), nil
-}
 
-func (b *Bazel) QueryLabels(ctx context.Context, args ...string) ([]string, error) {
-	output, err := b.run(ctx, "query", args...)
-	if err != nil {
-		return nil, fmt.Errorf("bazel query failed: %w", err)
+	trimmedOutput := strings.TrimSpace(output)
+	if len(trimmedOutput) == 0 {
+		return nil, nil
 	}
-	return strings.Split(strings.TrimSpace(output), "\n"), nil
+
+	return strings.Split(trimmedOutput, "\n"), nil
 }
 
 func (b *Bazel) WorkspaceRoot() string {

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -35,7 +35,7 @@ func (b *BazelJSONBuilder) fileQuery(filename string) string {
 		fp, _ := filepath.Rel(b.bazel.WorkspaceRoot(), filename)
 		filename = fp
 	}
-	return fmt.Sprintf(`kind("go_library|go_test", same_pkg_direct_rdeps("%s"))`, filename)
+	return fmt.Sprintf(`kind("go_library|go_test|go_transition_test", same_pkg_direct_rdeps("%s"))`, filename)
 }
 
 func (b *BazelJSONBuilder) packageQuery(importPath string) string {


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**

Also look for `go_transition_test`, not just `go_test` targets when generating dependency file info for test targets.

Also cleanup duplicate function in JSON builder (it was unused as far as I could tell).


**Which issues(s) does this PR fix?**

Fixes #3015, to my knowledge (I have been using this patch locally for quite some time as a fix for it).

See https://github.com/bazelbuild/rules_go/issues/3015#issuecomment-1004988375

**Other notes for review**
