### PR TITLE
gopackagesdriver: separates "s" files in pkg info

### DIFF
--- a/go/tools/gopackagesdriver/aspect.bzl
+++ b/go/tools/gopackagesdriver/aspect.bzl
@@ -42,12 +42,16 @@ def _go_archive_to_pkg(archive):
         ExportFile = _file_path(archive.data.export_file),
         GoFiles = [
             _file_path(src)
-            for src in archive.data.orig_srcs
+            for src in archive.data.orig_srcs if not src.path.endswith(".s")
         ],
         CompiledGoFiles = [
             _file_path(src)
-            for src in archive.data.srcs
+            for src in archive.data.srcs if not src.path.endswith(".s")
         ],
+        SFiles = [
+            _file_path(src)
+            for src in archive.data.orig_srcs if src.path.endswith(".s")
+        ]
     )
 
 def _make_pkg_json(ctx, archive, pkg_info):

--- a/go/tools/gopackagesdriver/flatpackage.go
+++ b/go/tools/gopackagesdriver/flatpackage.go
@@ -59,6 +59,7 @@ type FlatPackage struct {
 	Errors          []FlatPackagesError `json:",omitempty"`
 	GoFiles         []string            `json:",omitempty"`
 	CompiledGoFiles []string            `json:",omitempty"`
+	SFiles          []string            `json:",omitempty"`
 	OtherFiles      []string            `json:",omitempty"`
 	ExportFile      string              `json:",omitempty"`
 	Imports         map[string]string   `json:",omitempty"`
@@ -97,6 +98,7 @@ func WalkFlatPackagesFromJSON(jsonFile string, onPkg PackageFunc) error {
 func (fp *FlatPackage) ResolvePaths(prf PathResolverFunc) error {
 	resolvePathsInPlace(prf, fp.CompiledGoFiles)
 	resolvePathsInPlace(prf, fp.GoFiles)
+	resolvePathsInPlace(prf, fp.SFiles)
 	resolvePathsInPlace(prf, fp.OtherFiles)
 	fp.ExportFile = prf(fp.ExportFile)
 	return nil


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

We kept running into weird issues with the gopackagesdriver tool because
it would often run into "cannot parse non-Go file", and point to a .s
file. After some digging I decided to compare the output of the driver
vs the output for `go list -json` (continue reading for full
comparison). As it turns out, the driver includes all srcs in both the
`GoFiles` and `CompiledGoFiles` pkg info output. However ".s" files
have their own section (because they're not Go files) in the regular go
list JSON output. This commit modifies the aspect to account for that.

Somewhat (trimmed for readability) full output for the package
github.com/dgraph-io/ristretto/z:

```jsonc
// go list -json github.com/dgraph-io/ristretto/z
{
	"GoFiles": [
		"allocator.go",
		"bbloom.go",
		"btree.go",
		"buffer.go",
		"calloc.go",
		"calloc_64bit.go",
		"calloc_nojemalloc.go",
		"file.go",
		"file_default.go",
		"flags.go",
		"histogram.go",
		"mmap.go",
		"mmap_darwin.go",
		"rtutil.go",
		"z.go"
	],
	"SFiles": [
		"rtutil.s"
	],
    // CompileGoFiles not is not here
}
```

```jsonc
// from the driver
{
	"GoFiles": [
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/allocator.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/bbloom.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/btree.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/buffer.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/calloc.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/calloc_64bit.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/calloc_nojemalloc.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/file.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/file_default.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/flags.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/histogram.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/mmap.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/mmap_darwin.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/rtutil.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/rtutil.s",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/z.go"
	],
	"CompiledGoFiles": [
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/allocator.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/bbloom.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/btree.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/buffer.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/calloc.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/calloc_64bit.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/calloc_nojemalloc.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/file.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/file_default.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/flags.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/histogram.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/mmap.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/mmap_darwin.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/rtutil.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/rtutil.s",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/z.go"
	],
}
```

```jsonc
// driver after this change
{
	"ID": "@com_github_dgraph_io_ristretto//z:z",
	"Name": "z",
	"PkgPath": "github.com/dgraph-io/ristretto/z",
	"GoFiles": [
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/allocator.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/bbloom.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/btree.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/buffer.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/calloc.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/calloc_64bit.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/calloc_nojemalloc.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/file.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/file_default.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/flags.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/histogram.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/mmap.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/mmap_darwin.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/rtutil.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/z.go"
	],
	"CompiledGoFiles": [
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/allocator.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/bbloom.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/btree.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/buffer.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/calloc.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/calloc_64bit.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/calloc_nojemalloc.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/file.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/file_default.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/flags.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/histogram.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/mmap.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/mmap_darwin.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/rtutil.go",
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/z.go"
	],
	"SFiles": [
		"/private/var/tmp/_bazel_ricard.sole/b0012d46b327274ba1a89c748dd78c0b/external/com_github_dgraph_io_ristretto/z/rtutil.s"
	],
}
```