### PR TITLE
Fix linker error if go_library with cgo references unresolved symbol

### DIFF
--- a/go/tools/builders/cgo2.go
+++ b/go/tools/builders/cgo2.go
@@ -197,7 +197,30 @@ func cgo2(goenv *env, goSrcs, cgoSrcs, cSrcs, cxxSrcs, objcSrcs, objcxxSrcs, sSr
 	args = append([]string{cc, "-o", mainBin, mainObj}, cObjs...)
 	args = append(args, combinedLdFlags...)
 	if err := goenv.runCommand(args); err != nil {
-		return "", nil, nil, err
+		// If linking the binary for cgo fails, this is usually because the
+		// object files reference external symbols that can't be resolved yet.
+		// Since the binary is only produced to have its symbols read by the cgo
+		// command, there is no harm in trying to build it allowing unresolved
+		// symbols - the real link that happens at the end will fail if they
+		// rightfully can't be resolved.
+		var allowUnresolvedSymbolsLdFlag string
+		switch os.Getenv("GOOS") {
+		case "windows":
+			// MinGW's linker doesn't seem to support --unresolved-symbols
+			// and MSVC isn't supported at all.
+			return "", nil, nil, err
+		case "darwin", "ios":
+			allowUnresolvedSymbolsLdFlag = "-Wl,-undefined,dynamic_lookup"
+		default:
+			allowUnresolvedSymbolsLdFlag = "-Wl,--unresolved-symbols=ignore-all"
+		}
+		if err2 := goenv.runCommand(append(args, allowUnresolvedSymbolsLdFlag)); err2 != nil {
+			// Return the original error if we can't link the binary with the
+			// additional linker flags as they may simply be incorrect for the
+			// particular compiler/linker pair and would obscure the true reason
+			// for the failure of the original command.
+			return "", nil, nil, err
+		}
 	}
 
 	cgoImportsGo := filepath.Join(workDir, "_cgo_imports.go")

--- a/tests/core/cgo/BUILD.bazel
+++ b/tests/core/cgo/BUILD.bazel
@@ -414,3 +414,23 @@ go_bazel_test(
     name = "external_includes_test",
     srcs = ["external_includes_test.go"],
 )
+
+go_library(
+    name = "use_external_symbol",
+    srcs = ["use_external_symbol.go"],
+    cgo = True,
+    importpath = "github.com/bazelbuild/rules_go/tests/core/cgo/use_external_symbol",
+    tags = ["manual"],
+)
+
+go_binary(
+    name = "provide_external_symbol",
+    srcs = ["provide_external_symbol.go"],
+    cgo = True,
+    target_compatible_with = select({
+        "@platforms//os:osx": [],
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    deps = [":use_external_symbol"],
+)

--- a/tests/core/cgo/provide_external_symbol.go
+++ b/tests/core/cgo/provide_external_symbol.go
@@ -1,0 +1,12 @@
+package main
+
+import "C"
+
+import "github.com/bazelbuild/rules_go/tests/core/cgo/use_external_symbol"
+
+//export external_symbol
+func external_symbol() {}
+
+func main() {
+	use_external_symbol.UseExternalSymbol()
+}

--- a/tests/core/cgo/use_external_symbol.go
+++ b/tests/core/cgo/use_external_symbol.go
@@ -1,0 +1,10 @@
+package use_external_symbol
+
+/*
+void external_symbol();
+*/
+import "C"
+
+func UseExternalSymbol() {
+	C.external_symbol()
+}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix


**What does this PR do? Why is it needed?**

Fix linker error if go_library with cgo references unresolved symbol
Before this commit, if a go_library referenced an unresolved C symbol,
the build would fail with an error about an undefined symbol since
compilepkg.go tries to link all object files into an executable to be
consumed by cgo's -dynimport argument.

Since this library is never used for any purpose other than having its
symbols parsed by the cgo command, retry with additional linker flags
intended to make the linker ignore unresolved symbols. If they remain
missing in the real link step, they will still be reported as unresolved
there.

Fixes https://github.com/golang/go/issues/25832 for rules_go.