### PR TITLE
releaser: fix scrubbing timestamp from patch files

### DIFF
--- a/go/tools/releaser/upgradedep.go
+++ b/go/tools/releaser/upgradedep.go
@@ -544,15 +544,17 @@ func parseUpgradeDepDirective(call *bzl.CallExpr) (orgName, repoName string, err
 // that any year starting with "19" is a zero-valeud date.
 func sanitizePatch(patch []byte) []byte {
 	lines := bytes.Split(patch, []byte{'\n'})
-LineLoop:
+
 	for i, line := range lines {
-		if !bytes.HasPrefix(line, []byte("+++ ")) && !bytes.HasSuffix(line, []byte("--- ")) {
+		if !bytes.HasPrefix(line, []byte("+++ ")) && !bytes.HasPrefix(line, []byte("--- ")) {
 			continue
 		}
+
 		tab := bytes.LastIndexByte(line, '\t')
 		if tab < 0 || bytes.HasPrefix(line[tab+1:], []byte("19")) {
-			continue LineLoop
+			continue
 		}
+
 		lines[i] = append(line[:tab+1], []byte("2000-01-01 00:00:00.000000000 -0000")...)
 	}
 	return bytes.Join(lines, []byte{'\n'})


### PR DESCRIPTION
Make sure that we scrub the time zone correctly for the line started with `---` as well.

This should keep the release PR a lot smaller and easier to review.
See sample of current release PR in https://github.com/bazelbuild/rules_go/pull/3175#issuecomment-1147463053 where this problem occur.