### PR TITLE
Do not print to stderr if cgo linking succeeds after retry

### DIFF
--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -141,12 +141,12 @@ func (e *env) runCommand(args []string) error {
 	return err
 }
 
-// runCommandToFile executes a subprocess and writes the output to the given
-// writer.
-func (e *env) runCommandToFile(w io.Writer, args []string) error {
+// runCommandToFile executes a subprocess and writes stdout/stderr to the given
+// writers.
+func (e *env) runCommandToFile(out, err io.Writer, args []string) error {
 	cmd := exec.Command(args[0], args[1:]...)
-	cmd.Stdout = w
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = out
+	cmd.Stderr = err
 	return runAndLogCommand(cmd, e.verbose)
 }
 

--- a/go/tools/builders/info.go
+++ b/go/tools/builders/info.go
@@ -48,10 +48,10 @@ func run(args []string) error {
 		}
 		defer f.Close()
 	}
-	if err := goenv.runCommandToFile(f, goenv.goCmd("version")); err != nil {
+	if err := goenv.runCommandToFile(f, os.Stderr, goenv.goCmd("version")); err != nil {
 		return err
 	}
-	if err := goenv.runCommandToFile(f, goenv.goCmd("env")); err != nil {
+	if err := goenv.runCommandToFile(f, os.Stderr, goenv.goCmd("env")); err != nil {
 		return err
 	}
 	return nil

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -223,7 +223,7 @@ func stdliblist(args []string) error {
 	defer jsonFile.Close()
 
 	jsonData := &bytes.Buffer{}
-	if err := goenv.runCommandToFile(jsonData, listArgs); err != nil {
+	if err := goenv.runCommandToFile(jsonData, os.Stderr, listArgs); err != nil {
 		return err
 	}
 	encoder := json.NewEncoder(jsonFile)


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The rety logic introduced by 6ab73ec5b still emitted the stderr of the
failing compiler execution before the retry. Now, this output is cached
and only emitted if the retry also fails.

