### PR TITLE
Use param files with go-protoc

### DIFF
--- a/go/tools/builders/asm.go
+++ b/go/tools/builders/asm.go
@@ -30,7 +30,7 @@ import (
 // Go rules as an action.
 func asm(args []string) error {
 	// Parse arguments.
-	args, err := expandParamsFiles(args)
+	args, _, err := expandParamsFiles(args)
 	if err != nil {
 		return err
 	}

--- a/go/tools/builders/builder.go
+++ b/go/tools/builders/builder.go
@@ -28,7 +28,7 @@ func main() {
 	log.SetFlags(0)
 	log.SetPrefix("builder: ")
 
-	args, err := expandParamsFiles(os.Args[1:])
+	args, _, err := expandParamsFiles(os.Args[1:])
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/go/tools/builders/compile.go
+++ b/go/tools/builders/compile.go
@@ -29,7 +29,7 @@ import (
 
 func compile(args []string) error {
 	// Parse arguments.
-	args, err := expandParamsFiles(args)
+	args, _, err := expandParamsFiles(args)
 	if err != nil {
 		return err
 	}

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -33,7 +33,7 @@ import (
 
 func compilePkg(args []string) error {
 	// Parse arguments.
-	args, err := expandParamsFiles(args)
+	args, _, err := expandParamsFiles(args)
 	if err != nil {
 		return err
 	}

--- a/go/tools/builders/cover.go
+++ b/go/tools/builders/cover.go
@@ -28,7 +28,7 @@ import (
 // cover transforms a source file with "go tool cover". It is invoked by the
 // Go rules as an action.
 func cover(args []string) error {
-	args, err := expandParamsFiles(args)
+	args, _, err := expandParamsFiles(args)
 	if err != nil {
 		return err
 	}

--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -176,7 +176,9 @@ func runAndLogCommand(cmd *exec.Cmd, verbose bool) error {
 // expandParamsFiles looks for arguments in args of the form
 // "-param=filename". When it finds these arguments it reads the file "filename"
 // and replaces the argument with its content.
-func expandParamsFiles(args []string) ([]string, error) {
+// It returns the expanded arguments as well as a bool that is true if any param
+// files have been passed.
+func expandParamsFiles(args []string) ([]string, bool, error) {
 	var paramsIndices []int
 	for i, arg := range args {
 		if strings.HasPrefix(arg, "-param=") {
@@ -184,7 +186,7 @@ func expandParamsFiles(args []string) ([]string, error) {
 		}
 	}
 	if len(paramsIndices) == 0 {
-		return args, nil
+		return args, false, nil
 	}
 	var expandedArgs []string
 	last := 0
@@ -195,12 +197,12 @@ func expandParamsFiles(args []string) ([]string, error) {
 		fileName := args[pi][len("-param="):]
 		fileArgs, err := readParamsFile(fileName)
 		if err != nil {
-			return nil, err
+			return nil, true, err
 		}
 		expandedArgs = append(expandedArgs, fileArgs...)
 	}
 	expandedArgs = append(expandedArgs, args[last:]...)
-	return expandedArgs, nil
+	return expandedArgs, true, nil
 }
 
 // readParamsFiles parses a Bazel params file in "shell" format. The file

--- a/go/tools/builders/generate_test_main.go
+++ b/go/tools/builders/generate_test_main.go
@@ -228,7 +228,7 @@ func main() {
 
 func genTestMain(args []string) error {
 	// Prepare our flags
-	args, err := expandParamsFiles(args)
+	args, _, err := expandParamsFiles(args)
 	if err != nil {
 		return err
 	}

--- a/go/tools/builders/info.go
+++ b/go/tools/builders/info.go
@@ -24,7 +24,7 @@ import (
 )
 
 func run(args []string) error {
-	args, err := expandParamsFiles(args)
+	args, _, err := expandParamsFiles(args)
 	if err != nil {
 		return err
 	}

--- a/go/tools/builders/link.go
+++ b/go/tools/builders/link.go
@@ -32,7 +32,7 @@ import (
 
 func link(args []string) error {
 	// Parse arguments.
-	args, err := expandParamsFiles(args)
+	args, _, err := expandParamsFiles(args)
 	if err != nil {
 		return err
 	}

--- a/go/tools/builders/nogo_main.go
+++ b/go/tools/builders/nogo_main.go
@@ -62,7 +62,7 @@ func main() {
 // run returns an error if there is a problem loading the package or if any
 // analysis fails.
 func run(args []string) error {
-	args, err := expandParamsFiles(args)
+	args, _, err := expandParamsFiles(args)
 	if err != nil {
 		return fmt.Errorf("error reading paramfiles: %v", err)
 	}

--- a/go/tools/builders/pack.go
+++ b/go/tools/builders/pack.go
@@ -38,7 +38,7 @@ import (
 // handle them, and ar may not be available (cpp.ar_executable is libtool
 // on darwin).
 func pack(args []string) error {
-	args, err := expandParamsFiles(args)
+	args, _, err := expandParamsFiles(args)
 	if err != nil {
 		return err
 	}

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -112,6 +112,7 @@ def go_proto_compile(go, compiler, protos, imports, importpath):
     args.add_all(go_srcs, before_each = "-expected")
     args.add_all(imports, before_each = "-import")
     args.add_all(proto_paths.keys())
+    args.use_param_file("-param=%s")
     go.actions.run(
         inputs = depset(
             direct = [


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Makes the `GoProtocGen` action use parameter files if the argument list gets too long.

**Which issues(s) does this PR fix?**

Fixes #3188

**Other notes for review**

Tested manually by temporarily setting `use_always = True` and running the tests. 