### PR TITLE
[protoc] use @filename approach if options are long

### DIFF
--- a/go/tools/builders/protoc.go
+++ b/go/tools/builders/protoc.go
@@ -83,8 +83,19 @@ func run(args []string) error {
 		// This is required to work with long paths on Windows.
 		*plugin = "\\\\?\\" + abs(*plugin)
 	}
+
+	outArg := fmt.Sprintf("--%v_out=%v:%v", pluginName, strings.Join(options, ","), tmpDir)
+	if len(outArg) > 100000 {
+		argsFile := filepath.Join(tmpDir, "longargs.params")
+		err := os.WriteFile(argsFile, []byte(outArg), 0644)
+		if err != nil {
+			return fmt.Errorf("error creating file for long args: %v", err)
+		}
+		outArg = "@" + argsFile
+	}
+
 	protoc_args := []string{
-		fmt.Sprintf("--%v_out=%v:%v", pluginName, strings.Join(options, ","), tmpDir),
+		outArg,
 		"--plugin", fmt.Sprintf("%v=%v", strings.TrimSuffix(pluginBase, ".exe"), *plugin),
 		"--descriptor_set_in", strings.Join(descriptors, string(os.PathListSeparator)),
 	}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

For proto's with several dependencies, protoc fails with "argument list too long". Use `@<filename>` approach only if options are too long.

**Which issues(s) does this PR fix?**

Fixes #3188

**Other notes for review**
Use `@<filename>` only if options are long. Otherwise, file IO can cause significant build time increase.

The limit of 100k is, kind of, arbitrary; based on what worked on Linux & macOS. Any help with identifying a better limit is welcome.