### PR TITLE
runfiles: remove deprecated api

### DIFF
--- a/go/tools/bazel/bazel_test.go
+++ b/go/tools/bazel/bazel_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -96,7 +95,7 @@ func TestRunfilesPath(t *testing.T) {
 }
 
 func TestNewTmpDir(t *testing.T) {
-	//prefix := "new/temp/dir"
+	// prefix := "new/temp/dir"
 	prefix := "demodir"
 	tmpdir, err := NewTmpDir(prefix)
 	if err != nil {
@@ -124,101 +123,6 @@ func TestTestWorkspace(t *testing.T) {
 
 	if err != nil {
 		t.Errorf("Unable to get workspace with error %s", err)
-	}
-}
-
-func TestFindRunfiles(t *testing.T) {
-	testData := []struct {
-		name string
-
-		pathsToCreate []string
-		wantRunfiles  string
-		wantOk        bool
-	}{
-		{
-			"NoFiles",
-			[]string{},
-			"",
-			false,
-		},
-		{
-			"CurrentDirectory",
-			[]string{
-				"data-file",
-			},
-			".",
-			true,
-		},
-		{
-			"BazelBinNoConfigurationInPath",
-			[]string{
-				"bazel-bin/some/package/bin.runfiles/project/",
-				"bazel-bin/some/package/bin.runfiles/project/data-file",
-				"data-file", // bazel-bin should be preferred.
-			},
-			"bazel-bin/some/package/bin.runfiles/project",
-			true,
-		},
-		{
-			"BazelBinConfigurationInPath",
-			[]string{
-				"bazel-bin/some/package/amd64/bin.runfiles/project/",
-				"bazel-bin/some/package/arm64/bin.runfiles/project/",
-				"bazel-bin/some/package/arm64/bin.runfiles/project/data-file",
-				"bazel-bin/some/package/powerpc/bin.runfiles/project/",
-				"data-file", // bazel-bin should be preferred.
-			},
-			"bazel-bin/some/package/arm64/bin.runfiles/project",
-			true,
-		},
-	}
-	for _, d := range testData {
-		t.Run(d.name, func(t *testing.T) {
-			cleanup, err := makeAndEnterTempdir()
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer cleanup()
-
-			if err := createPaths(d.pathsToCreate); err != nil {
-				t.Fatal(err)
-			}
-
-			runfiles, ok := findRunfiles("project", "some/package", "bin", "data-file")
-			if filepath.Clean(runfiles) != filepath.Clean(d.wantRunfiles) || ok != d.wantOk {
-				t.Errorf("Got %s, %v; want %s, %v", runfiles, ok, d.wantRunfiles, d.wantOk)
-			}
-		})
-	}
-}
-
-func TestEnterRunfiles(t *testing.T) {
-	cleanup, err := makeAndEnterTempdir()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cleanup()
-
-	pathsToCreate := []string{
-		"bazel-bin/some/package/bin.runfiles/project/",
-		"bazel-bin/some/package/bin.runfiles/project/data-file",
-	}
-	if err := createPaths(pathsToCreate); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := EnterRunfiles("project", "some/package", "bin", "data-file"); err != nil {
-		t.Fatalf("Cannot enter runfiles tree: %v", err)
-	}
-	// The cleanup routine returned by makeAndEnterTempdir restores the working directory from
-	// the beginning of the test, so we don't have to worry about it here.
-
-	if _, err := os.Lstat("data-file"); err != nil {
-		wd, err := os.Getwd()
-		if err != nil {
-			t.Errorf("failed to get current working directory: %v", err)
-		}
-		t.Errorf("data-file not found in current directory (%s); entered invalid runfiles tree?", wd)
 	}
 }
 
@@ -263,7 +167,6 @@ func TestPythonManifest(t *testing.T) {
 	if entry.Workspace != "__main__" {
 		t.Errorf("incorrect workspace for runfile. Expected: %s, actual %s", "__main__", entry.Workspace)
 	}
-
 }
 
 func TestSpliceDelimitedOSArgs(t *testing.T) {

--- a/go/tools/bazel/runfiles.go
+++ b/go/tools/bazel/runfiles.go
@@ -64,7 +64,7 @@ func Runfile(path string) (string, error) {
 				return path, nil
 			}
 		}
-    }
+	}
 
 	// Search the main workspace.
 	if runfiles.workspace != "" {
@@ -262,26 +262,6 @@ func RunfilesPath() (string, error) {
 	return filepath.Join(runfiles.dir, runfiles.workspace), nil
 }
 
-// EnterRunfiles locates the directory under which a built binary can find its data dependencies
-// using relative paths, and enters that directory.
-//
-// "workspace" indicates the name of the current project, "pkg" indicates the relative path to the
-// build package that contains the binary target, "binary" indicates the basename of the binary
-// searched for, and "cookie" indicates an arbitrary data file that we expect to find within the
-// runfiles tree.
-//
-// DEPRECATED: use RunfilesPath instead.
-func EnterRunfiles(workspace string, pkg string, binary string, cookie string) error {
-	runfiles, ok := findRunfiles(workspace, pkg, binary, cookie)
-	if !ok {
-		return fmt.Errorf("cannot find runfiles tree")
-	}
-	if err := os.Chdir(runfiles); err != nil {
-		return fmt.Errorf("cannot enter runfiles tree: %v", err)
-	}
-	return nil
-}
-
 var runfiles = struct {
 	once, listOnce sync.Once
 
@@ -308,13 +288,13 @@ var runfiles = struct {
 }{}
 
 type index struct {
-	indexWithWorkspace map[indexKey]*RunfileEntry
+	indexWithWorkspace     map[indexKey]*RunfileEntry
 	indexIgnoringWorksapce map[string]*RunfileEntry
 }
 
 func newIndex() index {
-	return index {
-		indexWithWorkspace: make(map[indexKey]*RunfileEntry),
+	return index{
+		indexWithWorkspace:     make(map[indexKey]*RunfileEntry),
 		indexIgnoringWorksapce: make(map[string]*RunfileEntry),
 	}
 }
@@ -455,38 +435,4 @@ func initRunfiles() {
 		}
 		sort.Strings(runfiles.workspaces)
 	}
-}
-
-// getCandidates returns the list of all possible "prefix/suffix" paths where there might be an
-// optional component in-between the two pieces.
-//
-// This function exists to cope with issues #1239 because we cannot tell where the built Go
-// binaries are located upfront.
-//
-// DEPRECATED: only used by EnterRunfiles.
-func getCandidates(prefix string, suffix string) []string {
-	candidates := []string{filepath.Join(prefix, suffix)}
-	if entries, err := ioutil.ReadDir(prefix); err == nil {
-		for _, entry := range entries {
-			candidate := filepath.Join(prefix, entry.Name(), suffix)
-			candidates = append(candidates, candidate)
-		}
-	}
-	return candidates
-}
-
-// findRunfiles locates the directory under which a built binary can find its data dependencies
-// using relative paths.
-//
-// DEPRECATED: only used by EnterRunfiles.
-func findRunfiles(workspace string, pkg string, binary string, cookie string) (string, bool) {
-	candidates := getCandidates(filepath.Join("bazel-bin", pkg), filepath.Join(binary+".runfiles", workspace))
-	candidates = append(candidates, ".")
-
-	for _, candidate := range candidates {
-		if _, err := os.Stat(filepath.Join(candidate, cookie)); err == nil {
-			return candidate, true
-		}
-	}
-	return "", false
 }


### PR DESCRIPTION
These API have been deprecated since
Jun 3 2019 with 4442d82a001f378d0605cbbca3fb529979a1c3a6.

It has been 3 years since then, let's clean up the deprecation.