### PR TITLE
Fix failing open hermeticity test

### DIFF
--- a/tests/core/transition/hermeticity_test.go
+++ b/tests/core/transition/hermeticity_test.go
@@ -277,7 +277,7 @@ type bazelConfigOutput struct {
 	Fragments []struct {
 		Name    string            `json:"name"`
 		Options map[string]string `json:"options"`
-	} `json:"fragments"`
+	} `json:"fragmentOptions"`
 }
 
 type bazelCqueryOutput struct {


### PR DESCRIPTION
Due to an incorrect JSON field name used in a test helper, the test
did not fail when a target is built in two configurations that differ
in rules_go settings.