### PR TITLE
Allow gomock to take Bazel common attributes

### DIFF
--- a/docs/go/extras/extras.md
+++ b/docs/go/extras/extras.md
@@ -77,7 +77,7 @@ go_embed_data_dependencies()
 
 <pre>
 gomock(<a href="#gomock-name">name</a>, <a href="#gomock-library">library</a>, <a href="#gomock-out">out</a>, <a href="#gomock-source">source</a>, <a href="#gomock-interfaces">interfaces</a>, <a href="#gomock-package">package</a>, <a href="#gomock-self_package">self_package</a>, <a href="#gomock-aux_files">aux_files</a>, <a href="#gomock-mockgen_tool">mockgen_tool</a>,
-       <a href="#gomock-imports">imports</a>, <a href="#gomock-copyright_file">copyright_file</a>, <a href="#gomock-mock_names">mock_names</a>)
+       <a href="#gomock-imports">imports</a>, <a href="#gomock-copyright_file">copyright_file</a>, <a href="#gomock-mock_names">mock_names</a>, <a href="#gomock-kwargs">kwargs</a>)
 </pre>
 
 Calls [mockgen](https://github.com/golang/mock) to generates a Go file containing mocks from the given library.
@@ -102,5 +102,6 @@ If `source` is given, the mocks are generated in source mode; otherwise in refle
 | <a id="gomock-imports"></a>imports |  dictionary of name-path pairs of explicit imports to use. See [mockgen's -imports](https://github.com/golang/mock#flags) for more information.   |  <code>{}</code> |
 | <a id="gomock-copyright_file"></a>copyright_file |  optional file containing copyright to prepend to the generated contents. See [mockgen's -copyright_file](https://github.com/golang/mock#flags) for more information.   |  <code>None</code> |
 | <a id="gomock-mock_names"></a>mock_names |  dictionary of interface name to mock name pairs to change the output names of the mock objects. Mock names default to 'Mock' prepended to the name of the interface. See [mockgen's -mock_names](https://github.com/golang/mock#flags) for more information.   |  <code>{}</code> |
+| <a id="gomock-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
 
 

--- a/extras/gomock.bzl
+++ b/extras/gomock.bzl
@@ -150,7 +150,7 @@ _gomock_source = rule(
     toolchains = [GO_TOOLCHAIN],
 )
 
-def gomock(name, library, out, source = None, interfaces = [], aux_files = {}, **kwargs):
+def gomock(name, library, out, source = None, interfaces = [], package = "", self_package = "", aux_files = {}, mockgen_tool = _MOCKGEN_TOOL, imports = {}, copyright_file = None, mock_names = {}, **kwargs):
     """Calls [mockgen](https://github.com/golang/mock) to generates a Go file containing mocks from the given library.
 
     If `source` is given, the mocks are generated in source mode; otherwise in reflective mode.
@@ -168,6 +168,7 @@ def gomock(name, library, out, source = None, interfaces = [], aux_files = {}, *
         imports: dictionary of name-path pairs of explicit imports to use. See [mockgen's -imports](https://github.com/golang/mock#flags) for more information.
         copyright_file: optional file containing copyright to prepend to the generated contents. See [mockgen's -copyright_file](https://github.com/golang/mock#flags) for more information.
         mock_names: dictionary of interface name to mock name pairs to change the output names of the mock objects. Mock names default to 'Mock' prepended to the name of the interface. See [mockgen's -mock_names](https://github.com/golang/mock#flags) for more information.
+        kwargs: common attributes](https://bazel.build/reference/be/common-definitions#common-attributes) to all Bazel rules.
     """
     if source:
         _gomock_source(
@@ -175,8 +176,14 @@ def gomock(name, library, out, source = None, interfaces = [], aux_files = {}, *
             library = library,
             out = out,
             source = source,
+            package = package,
+            self_package = self_package,
             aux_files = aux_files,
-            **kwargs
+            mockgen_tool = mockgen_tool,
+            imports = imports,
+            copyright_file = copyright_file,
+            mock_names = mock_names,
+            **kwargs,
         )
     else:
         _gomock_reflect(
@@ -184,7 +191,13 @@ def gomock(name, library, out, source = None, interfaces = [], aux_files = {}, *
             library = library,
             out = out,
             interfaces = interfaces,
-            **kwargs
+            package = package,
+            self_package = self_package,
+            mockgen_tool = mockgen_tool,
+            imports = imports,
+            copyright_file = copyright_file,
+            mock_names = mock_names,
+            **kwargs,
         )
 
 def _gomock_reflect(name, library, out, mockgen_tool, **kwargs):

--- a/extras/gomock.bzl
+++ b/extras/gomock.bzl
@@ -150,7 +150,7 @@ _gomock_source = rule(
     toolchains = [GO_TOOLCHAIN],
 )
 
-def gomock(name, library, out, source = None, interfaces = [], package = "", self_package = "", aux_files = {}, mockgen_tool = _MOCKGEN_TOOL, imports = {}, copyright_file = None, mock_names = {}):
+def gomock(name, library, out, source = None, interfaces = [], aux_files = {}, **kwargs):
     """Calls [mockgen](https://github.com/golang/mock) to generates a Go file containing mocks from the given library.
 
     If `source` is given, the mocks are generated in source mode; otherwise in reflective mode.
@@ -175,13 +175,8 @@ def gomock(name, library, out, source = None, interfaces = [], package = "", sel
             library = library,
             out = out,
             source = source,
-            package = package,
-            self_package = self_package,
             aux_files = aux_files,
-            mockgen_tool = mockgen_tool,
-            imports = imports,
-            copyright_file = copyright_file,
-            mock_names = mock_names,
+            **kwargs
         )
     else:
         _gomock_reflect(
@@ -189,12 +184,7 @@ def gomock(name, library, out, source = None, interfaces = [], package = "", sel
             library = library,
             out = out,
             interfaces = interfaces,
-            package = package,
-            self_package = self_package,
-            mockgen_tool = mockgen_tool,
-            imports = imports,
-            copyright_file = copyright_file,
-            mock_names = mock_names,
+            **kwargs
         )
 
 def _gomock_reflect(name, library, out, mockgen_tool, **kwargs):

--- a/extras/gomock.bzl
+++ b/extras/gomock.bzl
@@ -183,7 +183,7 @@ def gomock(name, library, out, source = None, interfaces = [], package = "", sel
             imports = imports,
             copyright_file = copyright_file,
             mock_names = mock_names,
-            **kwargs,
+            **kwargs
         )
     else:
         _gomock_reflect(
@@ -197,7 +197,7 @@ def gomock(name, library, out, source = None, interfaces = [], package = "", sel
             imports = imports,
             copyright_file = copyright_file,
             mock_names = mock_names,
-            **kwargs,
+            **kwargs
         )
 
 def _gomock_reflect(name, library, out, mockgen_tool, **kwargs):

--- a/tests/extras/gomock/BUILD.bazel
+++ b/tests/extras/gomock/BUILD.bazel
@@ -19,6 +19,7 @@ gomock(
     library = ":client",
     package = "client",
     source = "client.go",
+    visibility = ["//visibility:public"],
 )
 
 go_test(


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
Add a `kwargs` to gomock so it can take common attributes such as `visibility`
