### PR TITLE
Remove references to go_transition_test

### DIFF
--- a/go/tools/gopackagesdriver/aspect.bzl
+++ b/go/tools/gopackagesdriver/aspect.bzl
@@ -90,7 +90,7 @@ def _go_pkg_info_aspect_impl(target, ctx):
         pkg = _go_archive_to_pkg(archive)
         pkg_json_files.append(_make_pkg_json(ctx, archive, pkg))
 
-        if ctx.rule.kind in ["go_test", "go_transition_test"]:
+        if ctx.rule.kind == "go_test":
             for dep_archive in archive.direct:
                 # find the archive containing the test sources
                 if archive.data.label == dep_archive.data.label:

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -35,7 +35,7 @@ func (b *BazelJSONBuilder) fileQuery(filename string) string {
 		fp, _ := filepath.Rel(b.bazel.WorkspaceRoot(), filename)
 		filename = fp
 	}
-	return fmt.Sprintf(`kind("go_library|go_test|go_transition_test", same_pkg_direct_rdeps("%s"))`, filename)
+	return fmt.Sprintf(`kind("go_library|go_test", same_pkg_direct_rdeps("%s"))`, filename)
 }
 
 func (b *BazelJSONBuilder) packageQuery(importPath string) string {


### PR DESCRIPTION
This partially revert #3160, because #3116 removed `go_transition_test`.

@JamyDev @fmeum Please review.