### PR TITLE
new_library: remove unused resolver

### DIFF
--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -54,9 +54,6 @@ load(
     "structs",
 )
 
-def _testmain_library_to_source(go, attr, source, merge):
-    source["deps"] = source["deps"] + [attr.library]
-
 def _go_test_impl(ctx):
     """go_test_impl implements go testing.
 

--- a/go/toolchains.rst
+++ b/go/toolchains.rst
@@ -940,7 +940,7 @@ resolver when it is invoked.
 |                                                                                                  |
 | .. code:: bzl                                                                                    |
 |                                                                                                  |
-|     def _testmain_library_to_source(go, attr, source, merge)                                     |
+|     def _stdlib_library_to_source(go, attr, source, merge)                                       |
 |                                                                                                  |
 | attr is the attributes of the rule being processed                                               |
 | source is the dictionary of GoSource fields being generated                                      |


### PR DESCRIPTION
`_testmain_library_to_source` was introduced in 1c4f6fd1 and last usage
of this resolver was in 56e5592c.

  ```
  > git log -S'_testmain_library_to_source' --oneline
  56e5592c Move the test library rule to be go_test internal actions (#1267)
  9031d58e Add GoContext (#1140)
  1c4f6fd1 Fix aspect based proto builds (#1131)
  ```

Let's remove the unused resolver and replace the documentation with the
resolver that is actually being used.
