### PR TITLE
Fix //tests/legacy/examples/cgo:cgo_lib_test on M1 Macs

### DIFF
--- a/tests/legacy/examples/cgo/cc_dependency/BUILD.bazel
+++ b/tests/legacy/examples/cgo/cc_dependency/BUILD.bazel
@@ -1,8 +1,3 @@
-config_setting(
-    name = "darwin",
-    values = {"cpu": "darwin"},
-)
-
 cc_library(
     name = "version",
     srcs = ["cxx_version.cc"],
@@ -12,7 +7,7 @@ cc_library(
     # TODO(yugui) Support darwin too and remove this workaround.
     # See also comments in cxx_version.cc.
     deps = select({
-        ":darwin": [],
+        "@platforms//os:macos": [],
         "//conditions:default": [":c_version_import"],
     }),
 )


### PR DESCRIPTION
The CPU config setting didn't match for M1 Macs, which are darwin_arm64.
Instead, use a more modern @platforms condition for the special casing.

We should ultimately fix the underlying issue with linking on macOS
instead.
