### PR TITLE
gopackagesdriver: Descend into go_proto_compiler's deps

### DIFF
--- a/go/tools/gopackagesdriver/aspect.bzl
+++ b/go/tools/gopackagesdriver/aspect.bzl
@@ -24,6 +24,16 @@ load(
 
 GoPkgInfo = provider()
 
+DEPS_ATTRS = [
+    "deps",
+    "embed",
+]
+
+PROTO_COMPILER_ATTRS = [
+    "compiler",
+    "compilers",
+]
+
 def _is_file_external(f):
     return f.owner.workspace_root != ""
 
@@ -67,8 +77,8 @@ def _go_pkg_info_aspect_impl(target, ctx):
     transitive_export_files = []
     transitive_compiled_go_files = []
 
-    for attr in ["deps", "embed"]:
-        for dep in getattr(ctx.rule.attr, attr, []):
+    for attr in DEPS_ATTRS + PROTO_COMPILER_ATTRS:
+        for dep in getattr(ctx.rule.attr, attr, []) or []:
             if GoPkgInfo in dep:
                 pkg_info = dep[GoPkgInfo]
                 transitive_json_files.append(pkg_info.pkg_json_files)
@@ -133,7 +143,7 @@ def _go_pkg_info_aspect_impl(target, ctx):
 
 go_pkg_info_aspect = aspect(
     implementation = _go_pkg_info_aspect_impl,
-    attr_aspects = ["embed", "deps"],
+    attr_aspects = DEPS_ATTRS + PROTO_COMPILER_ATTRS,
     attrs = {
         "_go_stdlib": attr.label(
             default = "//:stdlib",


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This lets the aspect generate .pkg.json files for well-known type
targets such as `@org_golang_google_protobuf//types/known/wrapperspb`.

**Which issues(s) does this PR fix?**

Fixes #3239 
