### PR TITLE
Add platform contraints for GOAMD64

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -105,6 +105,13 @@ cgo_context_data_proxy(
 # to depend on all build settings directly.
 go_config(
     name = "go_config",
+    amd64 = select({
+        "//go/constraints/amd64:v2": "v2",
+        "//go/constraints/amd64:v3": "v3",
+        "//go/constraints/amd64:v4": "v4",
+        # The default is v1.
+        "//conditions:default": None,
+    }),
     cover_format = "//go/config:cover_format",
     # Always include debug symbols with -c dbg.
     debug = select({

--- a/go/BUILD.bazel
+++ b/go/BUILD.bazel
@@ -5,6 +5,7 @@ filegroup(
     testonly = True,
     srcs = glob(["**"]) + [
         "//go/config:all_files",
+        "//go/constraints/amd64:all_files",
         "//go/platform:all_files",
         "//go/toolchain:all_files",
         "//go/tools:all_files",

--- a/go/constraints/amd64/BUILD.bazel
+++ b/go/constraints/amd64/BUILD.bazel
@@ -1,0 +1,38 @@
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+# Represents the level of support for the particular microarchitecture of a
+# target platform based on the general amd64 architecture.
+# GOAMD64 is set based on the chosen constraint_value.
+# See https://github.com/golang/go/wiki/MinimumRequirements#amd64
+constraint_setting(
+    name = "amd64",
+)
+
+constraint_value(
+    name = "v1",
+    constraint_setting = ":amd64",
+)
+
+constraint_value(
+    name = "v2",
+    constraint_setting = ":amd64",
+)
+
+constraint_value(
+    name = "v3",
+    constraint_setting = ":amd64",
+)
+
+constraint_value(
+    name = "v4",
+    constraint_setting = ":amd64",
+)
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -432,6 +432,12 @@ def go_context(ctx, attr = None):
         # happen. See #2291 for more information.
         "GOPATH": "",
     }
+
+    # The level of support is determined by the platform constraints in
+    # //go/constraints/amd64.
+    # See https://github.com/golang/go/wiki/MinimumRequirements#amd64
+    if mode.amd64:
+        env["GOAMD64"] = mode.amd64
     if mode.pure:
         crosstool = []
         cgo_tools = None
@@ -814,6 +820,7 @@ def _go_config_impl(ctx):
         tags = ctx.attr.gotags[BuildSettingInfo].value,
         stamp = ctx.attr.stamp,
         cover_format = ctx.attr.cover_format[BuildSettingInfo].value,
+        amd64 = ctx.attr.amd64,
     )]
 
 go_config = rule(
@@ -856,6 +863,7 @@ go_config = rule(
             mandatory = True,
             providers = [BuildSettingInfo],
         ),
+        "amd64": attr.string(),
     },
     provides = [GoConfigInfo],
     doc = """Collects information about build settings in the current

--- a/go/private/mode.bzl
+++ b/go/private/mode.bzl
@@ -80,6 +80,7 @@ def get_mode(ctx, go_toolchain, cgo_context_info, go_config_info):
     debug = go_config_info.debug if go_config_info else False
     linkmode = go_config_info.linkmode if go_config_info else LINKMODE_NORMAL
     cover_format = go_config_info and go_config_info.cover_format
+    amd64 = go_config_info.amd64 if go_config_info else None
     goos = go_toolchain.default_goos if getattr(ctx.attr, "goos", "auto") == "auto" else ctx.attr.goos
     goarch = go_toolchain.default_goarch if getattr(ctx.attr, "goarch", "auto") == "auto" else ctx.attr.goarch
 
@@ -112,6 +113,7 @@ def get_mode(ctx, go_toolchain, cgo_context_info, go_config_info):
         goarch = goarch,
         tags = tags,
         cover_format = cover_format,
+        amd64 = amd64,
     )
 
 def installsuffix(mode):


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

The new constraints `//go/constraints/amd64:v1` to `v4` can be used to
mark a platform as supporting the corresponding level of `GOAMD64`.

To use the new feature, users would supply their own platform:

```starlark
platform(
    name = "amd64_with_avx",
    contraint_values = [
        "@platforms//os:linux",
        "@platforms//cpu:x86_64",
        "@io_bazel_rules_go//go/constraints/amd64:v3",
    ],
)
```

and then specify the platform with `--platforms`.

**Which issues(s) does this PR fix?**

Fixes #3248

**Other notes for review**
