### PR TITLE
Add support for --@io_bazel_rules_go//go/toolchain:sdk_version flag.

### DIFF
--- a/go/private/BUILD.sdk.bazel
+++ b/go/private/BUILD.sdk.bazel
@@ -1,6 +1,7 @@
 load("@{rules_go_repo_name}//go/private/rules:binary.bzl", "go_tool_binary")
 load("@{rules_go_repo_name}//go/private/rules:sdk.bzl", "package_list")
 load("@{rules_go_repo_name}//go:def.bzl", "declare_toolchains", "go_sdk")
+load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -58,10 +59,60 @@ package_list(
     root_file = "ROOT",
 )
 
+sdk_version_label = "@{rules_go_repo_name}//go/toolchain:sdk_version"
+
+config_setting(
+    name = "match_all_versions",
+    flag_values = {
+        sdk_version_label: "",
+    },
+)
+
+config_setting(
+    name = "match_major_version",
+    flag_values = {
+        sdk_version_label: "{major_version}",
+    },
+)
+
+config_setting(
+    name = "match_major_minor_version",
+    flag_values = {
+        sdk_version_label: "{major_version}.{minor_version}",
+    },
+)
+
+config_setting(
+    name = "match_patch_version",
+    flag_values = {
+        sdk_version_label: "{major_version}.{minor_version}.{patch_version}",
+    },
+)
+
+# If prerelease version is "", this will be the same as ":match_patch_version", but that's fine since we use match_any in config_setting_group.
+config_setting(
+    name = "match_prerelease_version",
+    flag_values = {
+        sdk_version_label: "{major_version}.{minor_version}.{patch_version}{prerelease_suffix}",
+    },
+)
+
+selects.config_setting_group(
+    name = "sdk_version_setting",
+    match_any = [
+        ":match_all_versions",
+        ":match_major_version",
+        ":match_major_minor_version",
+        ":match_patch_version",
+        ":match_prerelease_version",
+    ],
+)
+
 declare_toolchains(
     builder = ":builder",
     host = "{goos}_{goarch}",
     sdk = ":go_sdk",
+    sdk_version_setting = ":sdk_version_setting",
 )
 
 filegroup(

--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -92,7 +92,7 @@ go_toolchain = rule(
     provides = [platform_common.ToolchainInfo],
 )
 
-def declare_toolchains(host, sdk, builder):
+def declare_toolchains(host, sdk, builder, sdk_version_setting):
     """Declares go_toolchain and toolchain targets for each platform."""
 
     # keep in sync with generate_toolchain_names
@@ -139,5 +139,6 @@ def declare_toolchains(host, sdk, builder):
                 "@io_bazel_rules_go//go/toolchain:" + host_goarch,
             ],
             target_compatible_with = constraints,
+            target_settings = [sdk_version_setting],
             toolchain = ":" + impl_name,
         )

--- a/go/toolchain/BUILD.bazel
+++ b/go/toolchain/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load(
     ":toolchains.bzl",
     "declare_constraints",
@@ -7,6 +8,11 @@ load(
 package(default_visibility = ["//visibility:public"])
 
 declare_constraints()
+
+string_flag(
+    name = "sdk_version",
+    build_setting_default = "",
+)
 
 filegroup(
     name = "all_rules",

--- a/go/toolchains.rst
+++ b/go/toolchains.rst
@@ -67,6 +67,16 @@ SDKs are specific to a host platform (e.g., ``linux_amd64``) and a version of
 Go. They may target all platforms that Go supports. The Go SDK is naturally
 cross compiling.
 
+By default, all ``go_binary``, ``go_test``, etc. rules will use the first declared
+Go SDK. If you would like to build a target using a specific Go SDK version, first
+ensure that you have declared a Go SDK of that version using one of the above rules
+(`go_download_sdk`_, `go_host_sdk`_, `go_local_sdk`_, `go_wrap_sdk`_). Then you
+can specify the sdk version to build with when running a ``bazel build`` by passing
+the flag ``--@io_bazel_rules_go//go/toolchain:sdk_version="version"`` where
+``"version"`` is the SDK version you would like to build with, eg. ``"1.18.3"``.
+The SDK version can omit the patch, or include a prerelease part, eg. ``"1"``,
+``"1.18"``, ``"1.18.0"``, and ``"1.19.0beta1"`` are all valid values for ``sdk_version``.
+
 The toolchain
 ~~~~~~~~~~~~~
 

--- a/tests/bcr/bcr.patch
+++ b/tests/bcr/bcr.patch
@@ -33,7 +33,7 @@ index 9a364815..2eb6349d 100644
  
  def _go_toolchain_impl(ctx):
      sdk = ctx.attr.sdk[GoSDK]
-@@ -115,8 +115,8 @@ def declare_toolchains(host, sdk, builder):
+@@ -115,8 +115,8 @@ def declare_toolchains(host, sdk, builder, sdk_version_setting):
          impl_name = toolchain_name + "-impl"
  
          cgo_constraints = (
@@ -44,7 +44,7 @@ index 9a364815..2eb6349d 100644
          )
          constraints = [c for c in p.constraints if c not in cgo_constraints]
  
-@@ -135,8 +135,8 @@ def declare_toolchains(host, sdk, builder):
+@@ -135,8 +135,8 @@ def declare_toolchains(host, sdk, builder, sdk_version_setting):
              name = toolchain_name,
              toolchain_type = GO_TOOLCHAIN,
              exec_compatible_with = [
@@ -54,7 +54,7 @@ index 9a364815..2eb6349d 100644
 +                "@rules_go//go/toolchain:" + host_goarch,
              ],
              target_compatible_with = constraints,
-             toolchain = ":" + impl_name,
+             target_settings = [sdk_version_setting],
 diff --git a/go/private/nogo.bzl b/go/private/nogo.bzl
 index 1d3491bb..efb4594f 100644
 --- a/go/private/nogo.bzl
@@ -128,15 +128,15 @@ diff --git a/go/private/sdk.bzl b/go/private/sdk.bzl
 index ee53cb0b..768b174d 100644
 --- a/go/private/sdk.bzl
 +++ b/go/private/sdk.bzl
-@@ -237,7 +237,7 @@ def _sdk_build_file(ctx, platform):
+@@ -249,7 +249,7 @@ def _sdk_build_file(ctx, platform, version):
              "{goos}": goos,
              "{goarch}": goarch,
              "{exe}": ".exe" if goos == "windows" else "",
 -            "{rules_go_repo_name}": "io_bazel_rules_go",
 +            "{rules_go_repo_name}": "rules_go",
-         },
-     )
- 
+             "{major_version}": str(major),
+             "{minor_version}": str(minor),
+             "{patch_version}": str(patch),
 diff --git a/go/toolchain/toolchains.bzl b/go/toolchain/toolchains.bzl
 index b4e070cf..6a342da7 100644
 --- a/go/toolchain/toolchains.bzl


### PR DESCRIPTION

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
This PR adds a build flag `--@io_bazel_rules_go//go/toolchain:sdk_version`, that allows changing which go SDK version to use to build targets. Implementation details:
- Each go_sdk now has config_settings that specify different values of `sdk_version`. Eg. a `go1.17.3` SDK would declare a config_setting for `sdk_version="1"`, `sdk_version="1.17"`, `sdk_version="1.17.3"`, and `sdk_version=""`.
- Then each toolchain that is registered for an SDK will have a config_setting_group constraint that combines the above config_settings. In the example given above, the go1.17.3 SDK would have a toolchain that only gets selected if sdk_version is 1, 1.17, 1.17.3 or the empty string (default).
- If sdk_version flag is not specified, then all SDKs can be selected because of the inclusion of the empty string config_setting in the config_setting_group.


**Which issues(s) does this PR fix?**
Partially #3202 
Second diff coming to fully close that issue.


**Other notes for review**
See #3202 for more discussion about this feature.

Working with my employer on signing the CLA at the moment.

Signed-off-by: James Bartlett <jamesbartlett@pixielabs.ai>