### PR TITLE
Add dependency to rules_proto in MODULE.bazel.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,6 +11,7 @@ print("WARNING: The rules_go Bazel module is still highly experimental and subje
 
 bazel_dep(name = "bazel_skylib", version = "1.2.0")
 bazel_dep(name = "platforms", version = "0.0.4")
+bazel_dep(name = "rules_proto", version = "4.0.0")
 
 non_module_dependencies = use_extension("//go/private:extensions.bzl", "non_module_dependencies")
 use_repo(


### PR DESCRIPTION
rules_proto is being used here: https://github.com/bazelbuild/rules_go/blob/master/proto/def.bzl#L43, but it is not declared.

I'm getting an error when trying to use go_proto_library: `Unable to find package for @rules_proto//proto:defs.bzl: The repository '@rules_proto' could not be resolved: Repository '@rules_proto' is not visible from repository '@rules_go.0.33.0'.`

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix
> Feature
> Documentation
> Other

**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
