### PR TITLE
Export support files needed for using Go's WebAssembly (WASM) output.

### DIFF
--- a/go/private/BUILD.sdk.bazel
+++ b/go/private/BUILD.sdk.bazel
@@ -74,6 +74,9 @@ filegroup(
 )
 
 exports_files(
-    ["lib/time/zoneinfo.zip"],
+    glob([
+        "lib/time/zoneinfo.zip",
+        "misc/wasm/**",
+    ]),
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Export support files needed for using Go's WebAssembly (WASM) output.  In particular, misc/wasm/wasm_exec.js contains glue code for making use of WASM output within Javascript.

**Which issues(s) does this PR fix?**

No issue filed. Per contribution guidelines, this looked too minor to file an issue. Please let me know if an issue should be filed.

**Other notes for review**

Without this change, my project (https://github.com/google/chrome-ssh-agent) needs to apply a patch as part of importing the rules_go repository.  This seems general-purpose enough that it should be applied in rules_go itself.