### PR TITLE
Add support for `go_binary` to gopackagesdriver.

### DIFF
--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -35,7 +35,7 @@ func (b *BazelJSONBuilder) fileQuery(filename string) string {
 		fp, _ := filepath.Rel(b.bazel.WorkspaceRoot(), filename)
 		filename = fp
 	}
-	return fmt.Sprintf(`kind("go_library|go_test", same_pkg_direct_rdeps("%s"))`, filename)
+	return fmt.Sprintf(`kind("go_library|go_test|go_binary", same_pkg_direct_rdeps("%s"))`, filename)
 }
 
 func (b *BazelJSONBuilder) packageQuery(importPath string) string {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
This PR adds `go_binary` as a supported rule type, fixing a bug preventing features like autocomplete from working when using gopackagesdriver.

**Which issues(s) does this PR fix?**

Fixes #3270

**Other notes for review**
As discussed in #3270, The current implementation of `bazel_json_builder`
does not handle `go_binary` build rules. This means that when
`gopackagesdriver` attempts to be used on a file that is apart of a
`go_binary`, no build target is produced as the output of `bazel query`.
This prevents downstream utilities (`gopls`) from being able to provide
functionality such as autocompletion support.

I didn't see any tests to update, but let me know if I missed something and I'm happy to make changes.