### PR TITLE
migrating to rbe_preconfig

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -54,21 +54,20 @@ llvm_toolchain(
 )
 
 http_archive(
-    name = "bazel_toolchains",
-    sha256 = "179ec02f809e86abf56356d8898c8bd74069f1bd7c56044050c2cd3d79d0e024",
-    strip_prefix = "bazel-toolchains-4.1.0",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/4.1.0/bazel-toolchains-4.1.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-toolchains/releases/download/4.1.0/bazel-toolchains-4.1.0.tar.gz",
-    ],
+    name = "bazelci_rules",
+    sha256 = "eca21884e6f66a88c358e580fd67a6b148d30ab57b1680f62a96c00f9bc6a07e",
+    strip_prefix = "bazelci_rules-1.0.0",
+    url = "https://github.com/bazelbuild/continuous-integration/releases/download/rules-1.0.0/bazelci_rules-1.0.0.tar.gz",
 )
 
-load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
+load("@bazelci_rules//:rbe_repo.bzl", "rbe_preconfig")
 
-# Creates toolchain configuration for remote execution with BuildKite CI
-# for rbe_ubuntu1604
-rbe_autoconfig(
+# Creates a default toolchain config for RBE.
+# Use this as is if you are using the rbe_ubuntu16_04 container,
+# otherwise refer to RBE docs.
+rbe_preconfig(
     name = "buildkite_config",
+    toolchain = "ubuntu1804-bazel-java11",
 )
 
 # Needed for tests and tools


### PR DESCRIPTION
**What type of PR is this?**
 Other

**What does this PR do? Why is it needed?**
We had a flag flip to enforce the use of constraints values from @platforms. `rules_go` still uses the older `bazel_toolchains` that links to RBE which caused the failure when the flag is flipped.
Please see https://github.com/bazelbuild/continuous-integration/issues/1404

