### PR TITLE
Getting architecture from JRE

### DIFF
--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -258,53 +258,15 @@ def _sdk_build_file(ctx, platform, version):
     )
 
 def _detect_host_platform(ctx):
-    if ctx.os.name == "linux":
-        goos, goarch = "linux", "amd64"
-        res = ctx.execute(["uname", "-p"])
-        if res.return_code == 0:
-            uname = res.stdout.strip()
-            if uname == "s390x":
-                goarch = "s390x"
-            elif uname == "i686":
-                goarch = "386"
-
-        # uname -p is not working on Aarch64 boards
-        # or for ppc64le on some distros
-        res = ctx.execute(["uname", "-m"])
-        if res.return_code == 0:
-            uname = res.stdout.strip()
-            if uname == "aarch64":
-                goarch = "arm64"
-            elif uname == "armv6l":
-                goarch = "arm"
-            elif uname == "armv7l":
-                goarch = "arm"
-            elif uname == "ppc64le":
-                goarch = "ppc64le"
-
-        # Default to amd64 when uname doesn't return a known value.
-
-    elif ctx.os.name == "mac os x":
-        goos, goarch = "darwin", "amd64"
-
-        res = ctx.execute(["uname", "-m"])
-        if res.return_code == 0:
-            uname = res.stdout.strip()
-            if uname == "arm64":
-                goarch = "arm64"
-
-        # Default to amd64 when uname doesn't return a known value.
-
-    elif ctx.os.name.startswith("windows"):
+    goos = ctx.os.name
+    if goos == "mac os x":
+        goos = "darwin"
+    elif goos.startswith("windows"):
         goos = "windows"
-        if ctx.os.environ.get("PROCESSOR_ARCHITECTURE") == "ARM64" or ctx.os.environ.get("PROCESSOR_ARCHITEW6432") == "ARM64":
-            goarch = "arm64"
-        else:
-            goarch = "amd64"
-    elif ctx.os.name == "freebsd":
-        goos, goarch = "freebsd", "amd64"
-    else:
-        fail("Unsupported operating system: " + ctx.os.name)
+
+    goarch = ctx.os.arch
+    if goarch == "aarch64":
+        goarch = "arm64"
 
     return goos, goarch
 

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -267,6 +267,8 @@ def _detect_host_platform(ctx):
     goarch = ctx.os.arch
     if goarch == "aarch64":
         goarch = "arm64"
+    elif goarch == "x86_64":
+        goarch = "amd64"
 
     return goos, goarch
 


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
This PR makes rules_go gets the host architecture repository_ctx, which in turn get it from JVM. This is because Bazel determines default host platform from its JVM https://github.com/bazelbuild/bazel/blob/a380a157f658cc392f66f86b6aba340c461dc408/src/main/java/com/google/devtools/build/lib/bazel/repository/LocalConfigPlatformFunction.java#L63 and https://github.com/bazelbuild/bazel/blob/577cfbc8a2b0841cd67a918febe9e3c5fcb3882e/src/main/java/com/google/devtools/build/lib/util/CPU.java#L56

If rules_go determines the host platform by calling `uname`, we may run into an interesting situation when users accidentally runs an ARM64 version of Bazel binary, with comes with ARM64 JVM, in a terminal with Rosetta translation:

* rules_go downloads an AMD64 version of Go SDK, because uname returns "amd64"
* Bazel tries to find a Go toolchain for ARM64, because JVM tells Bazel that it's running in ARM64

Leading to:

```
no matching toolchains found for types @io_bazel_rules_go//go:toolchain
```

**Which issues(s) does this PR fix?**

Fixes #3086

**Other notes for review**
Linux and Windows shouldn't have this problem, but getting arch from repository_ctx is much simpler than their current implementation. So I change all of them together. I don't have access to all these OS/Arch combination to verify. So I just optimistically assume that they would work. We can always override the arch names as needed in the future.
