### PR TITLE
go_path: support go:embed of generated files

### DIFF
--- a/go/private/tools/path.bzl
+++ b/go/private/tools/path.bzl
@@ -83,7 +83,8 @@ def _go_path_impl(ctx):
         for f in pkg.embedsrcs:
             if src_dir == None:
                 fail("cannot relativize {}: src_dir is unset".format(f.path))
-            dst = pkg.dir + "/" + paths.relativize(f.path, src_dir)
+            embedpath = paths.relativize(f.path, f.root.path)
+            dst = pkg.dir + "/" + paths.relativize(embedpath, src_dir)
             _add_manifest_entry(manifest_entries, manifest_entry_map, inputs, f, dst)
     if ctx.attr.include_pkg:
         for pkg in pkg_map.values():

--- a/tests/core/go_path/BUILD.bazel
+++ b/tests/core/go_path/BUILD.bazel
@@ -19,6 +19,15 @@ test_suite(name = "go_path")
 ) for mode in ("archive", "copy", "link")]
 
 go_path(
+    name = "transition_path",
+    testonly = True,
+    data = ["extra.txt"],
+    include_pkg = True,
+    mode = "copy",
+    deps = ["//tests/core/go_path/cmd/bin:pie"],
+)
+
+go_path(
     name = "nodata_path",
     testonly = True,
     data = ["extra.txt"],
@@ -49,6 +58,7 @@ go_test(
         ":archive_path",
         ":copy_path",
         ":link_path",
+        ":transition_path",
         ":nodata_path",
         ":notransitive_path",
     ],

--- a/tests/core/go_path/cmd/bin/BUILD.bazel
+++ b/tests/core/go_path/cmd/bin/BUILD.bazel
@@ -9,6 +9,17 @@ go_binary(
 )
 
 go_binary(
+    name = "pie",
+    srcs = ["bin.go"],
+    importpath = "example.com/repo/cmd/bin",
+    visibility = ["//visibility:public"],
+    linkmode="pie",
+    deps = [
+        "//tests/core/go_path/pkg/lib:go_default_library"
+    ]
+)
+
+go_binary(
     name = "cross",
     srcs = ["bin.go"],
     goarch = "arm",

--- a/tests/core/go_path/cmd/bin/BUILD.bazel
+++ b/tests/core/go_path/cmd/bin/BUILD.bazel
@@ -13,7 +13,7 @@ go_binary(
     srcs = ["bin.go"],
     importpath = "example.com/repo/cmd/bin",
     visibility = ["//visibility:public"],
-    linkmode="pie",
+    linkmode = "pie",
     deps = [
         "//tests/core/go_path/pkg/lib:go_default_library"
     ]

--- a/tests/core/go_path/pkg/lib/BUILD.bazel
+++ b/tests/core/go_path/pkg/lib/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 
 go_library(
     name = "go_default_library",
@@ -10,11 +11,18 @@ go_library(
     ],
     embedsrcs = [
         "embedded_src.txt",
+        "renamed_embedded_src.txt",
         "template/index.html.tmpl",
     ],
     importpath = "example.com/repo/pkg/lib",
     visibility = ["//visibility:public"],
     deps = [":transitive_lib"],
+)
+
+copy_file(
+    name = "rename_embedded_src.txt",
+    src = ":embedded_src.txt",
+    out = "renamed_embedded_src.txt",
 )
 
 go_test(

--- a/tests/core/go_path/pkg/lib/lib.go
+++ b/tests/core/go_path/pkg/lib/lib.go
@@ -8,5 +8,8 @@ import (
 //go:embed embedded_src.txt
 var embeddedSource string
 
+//go:embed renamed_embedded_src.txt
+var renamedEmbeddedSource string
+
 //go:embed template/index.html.tmpl
 var indexTmpl string


### PR DESCRIPTION
When embedded files are generated, relativize fails because the file path starts with the output directory. Without the change in path.bzl, the test case fails as follows:

Error in fail: Path 'bazel-out/darwin-fastbuild/bin/tests/core/go_path/pkg/lib/renamed_embedded_src.txt' is not beneath 'tests/core/go_path/pkg/lib'

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**Which issues(s) does this PR fix?**

Fixes #3284

**Other notes for review**
