### PR TITLE
Bumping minimal Bazel version to 5.1.0

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -2,7 +2,7 @@
 tasks:
   ubuntu1804_bazel400:
     platform: ubuntu1804
-    bazel: 4.2.1 # test minimum supported version of bazel
+    bazel: 5.1.0 # test minimum supported version of bazel
     shell_commands:
       - tests/core/cgo/generate_imported_dylib.sh
     build_targets:

--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -66,25 +66,12 @@ def emit_archive(go, source = None, _recompile_suffix = ""):
     runfiles = source.runfiles
     data_files = runfiles.files
 
-    # After bazel version 5.0.0, starlark introduced a new API called merge_all().
-    # There is a recommendation in the release notes to use merge_all() if we hit
-    # the depth limit because of using merge() in a loop; we saw some repositories
-    # hitting this issue after upgrading to 5.0.0. To keep it backward compatible,
-    # we will fall back to the old logic if the array doesn't have merge_all().
-    # TODO: remove this check after the MINIMUM_BAZEL_VERSION becomes >= 5.0.0
-    # https://blog.bazel.build/2022/01/19/bazel-5.0.html#starlark-build-language
-    if hasattr(runfiles, "merge_all"):
-        files = []
-        for a in direct:
-            files.append(a.runfiles)
-            if a.source.mode != go.mode:
-                fail("Archive mode does not match {} is {} expected {}".format(a.data.label, mode_string(a.source.mode), mode_string(go.mode)))
-        runfiles.merge_all(files)
-    else:
-        for a in direct:
-            runfiles = runfiles.merge(a.runfiles)
-            if a.source.mode != go.mode:
-                fail("Archive mode does not match {} is {} expected {}".format(a.data.label, mode_string(a.source.mode), mode_string(go.mode)))
+    files = []
+    for a in direct:
+        files.append(a.runfiles)
+        if a.source.mode != go.mode:
+            fail("Archive mode does not match {} is {} expected {}".format(a.data.label, mode_string(a.source.mode), mode_string(go.mode)))
+    runfiles.merge_all(files)
 
     importmap = "main" if source.library.is_main else source.library.importmap
     importpath, _ = effective_importpath_pkgpath(source.library)

--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -199,7 +199,7 @@ def get_versioned_shared_lib_extension(path):
     # something like 1.2.3, or so.1.2, or dylib.1.2, or foo.1.2
     return ""
 
-MINIMUM_BAZEL_VERSION = "4.2.1"
+MINIMUM_BAZEL_VERSION = "5.1.0"
 
 def as_list(v):
     """Returns a list, tuple, or depset as a list."""


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
Bumping minimal Bazel version to 5.1.0, so we can use `runfiles.merge_all` and `repository_os.arch`, which unblocks #3282

**Other notes for review**
Bazel 5.1.0 is already half a year old

cc @moisesvega 
