### PR TITLE
Correctly forward InstrumentedFilesInfo from dependencies

### DIFF
--- a/go/private/rules/library.bzl
+++ b/go/private/rules/library.bzl
@@ -52,6 +52,12 @@ def _go_library_impl(ctx):
         DefaultInfo(
             files = depset([archive.data.file]),
         ),
+        coverage_common.instrumented_files_info(
+            ctx,
+            source_attributes = ["srcs"],
+            dependency_attributes = ["data", "deps", "embed", "embedsrcs"],
+            extensions = ["go"],
+        ),
         OutputGroupInfo(
             cgo_exports = archive.cgo_exports,
             compilation_outputs = [archive.data.file],

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -181,7 +181,7 @@ def _go_test_impl(ctx):
         coverage_common.instrumented_files_info(
             ctx,
             source_attributes = ["srcs"],
-            dependency_attributes = ["deps", "embed"],
+            dependency_attributes = ["data", "deps", "embed", "embedsrcs"],
             extensions = ["go"],
         ),
         testing.TestEnvironment(env),


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix


**What does this PR do? Why is it needed?**

This is required with coverage_output_generator v2.6 used by Bazel@HEAD, which filters LCOV files to contain only those source mentioned in the provider.

**Which issues(s) does this PR fix?**

Fixes #3293
