### PR TITLE
Use top level VERSION file when it exists

### DIFF
--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -303,6 +303,14 @@ def _detect_sdk_platform(ctx, goroot):
     return platforms[0]
 
 def _detect_sdk_version(ctx, goroot):
+    version_file_path = goroot + "/VERSION"
+    if ctx.path(version_file_path).exists:
+        version_contents = ctx.read(version_file_path)
+        # VERSION file has version prefixed by go, eg. go1.18.3
+        return version_contents[2:]
+
+    # The top-level VERSION file does not exist in all Go SDK distributions, e.g. those shipped by Debian or Fedora.
+    # Falling back to running "go version"
     go_binary_path = goroot + "/bin/go"
     result = ctx.execute([go_binary_path, "version"])
     if result.return_code != 0:

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -306,6 +306,7 @@ def _detect_sdk_version(ctx, goroot):
     version_file_path = goroot + "/VERSION"
     if ctx.path(version_file_path).exists:
         version_contents = ctx.read(version_file_path)
+
         # VERSION file has version prefixed by go, eg. go1.18.3
         return version_contents[2:]
 


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
Instead of calling `go version` unconditionally, we can check the existence of the VERSION file first. It's more efficient.

**Other notes for review**
This is a follow-up for #3296. 
