### PR TITLE
Symlink "misc" into repository for local_sdk.

### DIFF
--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -228,7 +228,7 @@ def _remote_sdk(ctx, urls, strip_prefix, sha256):
         )
 
 def _local_sdk(ctx, path):
-    for entry in ["src", "pkg", "bin", "lib"]:
+    for entry in ["src", "pkg", "bin", "lib", "misc"]:
         ctx.symlink(path + "/" + entry, entry)
 
 def _sdk_build_file(ctx, platform, version, sdk_type = "remote"):


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Adds a symlink to the `misc` directory in the implementation for local SDKs, so that the wasm files can be picked up.

**Which issues(s) does this PR fix?**

Fixes #3312
