### PR TITLE
bzlmod: Set up automated BCR releases

### DIFF
--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,0 +1,1 @@
+fixedReleaser: fmeum

--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,12 @@
+{
+  "homepage": "https://github.com/bazelbuild/rules_go",
+  "maintainers": [
+    {
+      "email": "fabian@meumertzhe.im",
+      "github": "fmeum",
+      "name": "Fabian Meumertzheim"
+    }
+  ],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,31 @@
+matrix:
+  platform:
+    - centos7
+    - debian10
+    - ubuntu2004
+    - macos
+    - windows
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    build_targets:
+      - '@rules_go//go/tools/bzltestutil/...'
+bcr_test_module:
+  module_path: tests/bcr
+  matrix:
+    platform:
+      - centos7
+      - debian10
+      - ubuntu2004
+      - macos
+      - windows
+  tasks:
+    run_test_module:
+      name: Run test module
+      platform: ${{ platform }}
+      build_targets:
+        - //...
+        - '@go_sdk//...'
+      test_targets:
+        - //...

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,4 @@
+{
+  "integrity": "",
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.zip"
+}


### PR DESCRIPTION
This uses the https://github.com/bazel-contrib/publish-to-bcr app.
