### PR TITLE
gopackagesdriver: move non-Go files to OtherFiles (Fixes #3326)

### DIFF
--- a/go/tools/gopackagesdriver/aspect.bzl
+++ b/go/tools/gopackagesdriver/aspect.bzl
@@ -52,15 +52,15 @@ def _go_archive_to_pkg(archive):
         ExportFile = _file_path(archive.data.export_file),
         GoFiles = [
             _file_path(src)
-            for src in archive.data.orig_srcs if not src.path.endswith(".s")
+            for src in archive.data.orig_srcs if src.path.endswith(".go")
         ],
         CompiledGoFiles = [
             _file_path(src)
-            for src in archive.data.srcs if not src.path.endswith(".s")
+            for src in archive.data.srcs if src.path.endswith(".go")
         ],
-        SFiles = [
+        OtherFiles = [
             _file_path(src)
-            for src in archive.data.orig_srcs if src.path.endswith(".s")
+            for src in archive.data.orig_srcs if not src.path.endswith(".go")
         ]
     )
 

--- a/go/tools/gopackagesdriver/flatpackage.go
+++ b/go/tools/gopackagesdriver/flatpackage.go
@@ -59,7 +59,6 @@ type FlatPackage struct {
 	Errors          []FlatPackagesError `json:",omitempty"`
 	GoFiles         []string            `json:",omitempty"`
 	CompiledGoFiles []string            `json:",omitempty"`
-	SFiles          []string            `json:",omitempty"`
 	OtherFiles      []string            `json:",omitempty"`
 	ExportFile      string              `json:",omitempty"`
 	Imports         map[string]string   `json:",omitempty"`
@@ -98,7 +97,6 @@ func WalkFlatPackagesFromJSON(jsonFile string, onPkg PackageFunc) error {
 func (fp *FlatPackage) ResolvePaths(prf PathResolverFunc) error {
 	resolvePathsInPlace(prf, fp.CompiledGoFiles)
 	resolvePathsInPlace(prf, fp.GoFiles)
-	resolvePathsInPlace(prf, fp.SFiles)
 	resolvePathsInPlace(prf, fp.OtherFiles)
 	fp.ExportFile = prf(fp.ExportFile)
 	return nil


### PR DESCRIPTION
Previously only ".s" assembly files were separated. There are other non-Go file types that could exist in a pkg dir so this handles them all and stores them in the OtherFiles package field as defined in
https://github.com/golang/tools/blob/91311ab3b8fbb39d8d1df146082b6313ec6e2d55/go/packages/packages.go#L314.

An example output snippet with the new logic against https://github.com/hybridgroup/gocv (trimmed for readability):

```
"GoFiles":
[
    "/<usr>/.cache/bazel/_bazel_russomichael/0961bbf0241ac3833db3822167eb7327/external/io_gocv_x_gocv/calib3d.go",
    ...
    "/<usr>/.cache/bazel/_bazel_russomichael/0961bbf0241ac3833db3822167eb7327/external/io_gocv_x_gocv/videoio_string.go"
],
"CompiledGoFiles":
[
    "/<usr>/.cache/bazel/_bazel_russomichael/0961bbf0241ac3833db3822167eb7327/external/io_gocv_x_gocv/calib3d.go",
    ...
    "/<usr>/.cache/bazel/_bazel_russomichael/0961bbf0241ac3833db3822167eb7327/external/io_gocv_x_gocv/videoio_string.go"
],
"OtherFiles":
[
    "/<usr>/.cache/bazel/_bazel_russomichael/0961bbf0241ac3833db3822167eb7327/external/io_gocv_x_gocv/asyncarray.h",
    "/<usr>/.cache/bazel/_bazel_russomichael/0961bbf0241ac3833db3822167eb7327/external/io_gocv_x_gocv/calib3d.cpp",
    "/<usr>/.cache/bazel/_bazel_russomichael/0961bbf0241ac3833db3822167eb7327/external/io_gocv_x_gocv/calib3d.h",
    ...
    "/<usr>/.cache/bazel/_bazel_russomichael/0961bbf0241ac3833db3822167eb7327/external/io_gocv_x_gocv/videoio.h"
],
```

**What type of PR is this?**

Bug fix


**What does this PR do? Why is it needed?**

When non-Go files are listed as Go files, it can break other tools such as the gopls language server. See https://github.com/golang/go/issues/56208.

**Which issues(s) does this PR fix?**

Fixes #3326

**Other notes for review**
