### PR TITLE
feat(pkg-drv): allow setting custom aspect and kinds

### DIFF
--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -30,16 +30,15 @@ const (
 	RulesGoStdlibLabel = "@io_bazel_rules_go//:stdlib"
 )
 
+var _defaultKinds = []string{"go_library", "go_test", "go_binary"}
+
 func (b *BazelJSONBuilder) fileQuery(filename string) string {
 	if filepath.IsAbs(filename) {
 		fp, _ := filepath.Rel(b.bazel.WorkspaceRoot(), filename)
 		filename = fp
 	}
-	addtlKinds := ""
-	if len(additionalKinds) > 0 {
-		addtlKinds = "|" + strings.Join(additionalKinds, "|")
-	}
-	return fmt.Sprintf(`kind("go_library|go_test|go_binary%s", same_pkg_direct_rdeps("%s"))`, addtlKinds, filename)
+	kinds := append(_defaultKinds, additionalKinds...)
+	return fmt.Sprintf(`kind("%s", same_pkg_direct_rdeps("%s"))`, strings.Join(kinds, "|"), filename)
 }
 
 func (b *BazelJSONBuilder) packageQuery(importPath string) string {

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -35,7 +35,11 @@ func (b *BazelJSONBuilder) fileQuery(filename string) string {
 		fp, _ := filepath.Rel(b.bazel.WorkspaceRoot(), filename)
 		filename = fp
 	}
-	return fmt.Sprintf(`kind("go_library|go_test|go_binary", same_pkg_direct_rdeps("%s"))`, filename)
+	addtlKinds := ""
+	if len(additionalKinds) > 0 {
+		addtlKinds = "|" + strings.Join(additionalKinds, "|")
+	}
+	return fmt.Sprintf(`kind("go_library|go_test|go_binary%s", same_pkg_direct_rdeps("%s"))`, addtlKinds, filename)
 }
 
 func (b *BazelJSONBuilder) packageQuery(importPath string) string {
@@ -120,7 +124,7 @@ func (b *BazelJSONBuilder) Build(ctx context.Context, mode LoadMode) ([]string, 
 		"--experimental_convenience_symlinks=ignore",
 		"--ui_event_filters=-info,-stderr",
 		"--noshow_progress",
-		"--aspects=" + rulesGoRepositoryName + "//go/tools/gopackagesdriver:aspect.bzl%go_pkg_info_aspect",
+		"--aspects=" + customAspect,
 		"--output_groups=" + b.outputGroupsForMode(mode),
 		"--keep_going", // Build all possible packages
 	}, bazelFlags, bazelBuildFlags, labels)

--- a/go/tools/gopackagesdriver/main.go
+++ b/go/tools/gopackagesdriver/main.go
@@ -58,8 +58,8 @@ var (
 	bazelQueryScope       = getenvDefault("GOPACKAGESDRIVER_BAZEL_QUERY_SCOPE", "")
 	bazelBuildFlags       = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_BUILD_FLAGS"))
 	workspaceRoot         = os.Getenv("BUILD_WORKSPACE_DIRECTORY")
-	customAspect		  = getenvDefault("GOPACKAGESDRIVER_BAZEL_ASPECT", rulesGoRepositoryName + "//go/tools/gopackagesdriver:aspect.bzl%go_pkg_info_aspect")
-	additionalKinds		  = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_KINDS"))
+	customAspect          = getenvDefault("GOPACKAGESDRIVER_BAZEL_ASPECT", rulesGoRepositoryName+"//go/tools/gopackagesdriver:aspect.bzl%go_pkg_info_aspect")
+	additionalKinds       = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_KINDS"))
 	emptyResponse         = &driverResponse{
 		NotHandled: false,
 		Sizes:      types.SizesFor("gc", "amd64").(*types.StdSizes),

--- a/go/tools/gopackagesdriver/main.go
+++ b/go/tools/gopackagesdriver/main.go
@@ -58,6 +58,8 @@ var (
 	bazelQueryScope       = getenvDefault("GOPACKAGESDRIVER_BAZEL_QUERY_SCOPE", "")
 	bazelBuildFlags       = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_BUILD_FLAGS"))
 	workspaceRoot         = os.Getenv("BUILD_WORKSPACE_DIRECTORY")
+	customAspect		  = getenvDefault("GOPACKAGESDRIVER_BAZEL_ASPECT", rulesGoRepositoryName + "//go/tools/gopackagesdriver:aspect.bzl%go_pkg_info_aspect")
+	additionalKinds		  = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_KINDS"))
 	emptyResponse         = &driverResponse{
 		NotHandled: false,
 		Sizes:      types.SizesFor("gc", "amd64").(*types.StdSizes),


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

adds two new env variables for the packages driver:
- `GOPACKAGESDRIVER_BAZEL_KINDS`: Tells the packages driver to also query for the specified kinds alongside `go_default_(binary|library|test)`
- `GOPACKAGESDRIVER_BAZEL_ASPECT`: Lets the consumer define a custom aspect, to support querying these other kinds

Combining these two, users can add support for custom rules which consume and emit Go files in a nonstandard way. At Uber, for example, we have a code generator uses a Go file as its source and generates a matching Go file with inlined content. 

Having both of these Go files in the resulting `GoArchive` will not work for the Go compiler (since they define the same variables/methods/structs/..), which in turn means that the GoPackagesDriver doesn't know about this source Go file (only the generated output).

**Other notes for review**

An alternative approach would have been to call this custom aspect as an additional aspect, but I wasn't sure how the packages driver would handle multiple `GoPkgInfo` outputs.