### PR TITLE
bzlmod: Allow yanked versions in CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -27,10 +27,10 @@ tasks:
     bazel: b12f3a93a55019276879bd2d3edbd201c913675a
     working_directory: tests/bcr
     build_flags:
-      - "--allow_yanked_versions"
+      - "--allow_yanked_versions=all"
       - "--experimental_enable_bzlmod"
     test_flags:
-      - "--allow_yanked_versions"
+      - "--allow_yanked_versions=all"
       - "--experimental_enable_bzlmod"
     build_targets:
       - "//..."

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -27,8 +27,10 @@ tasks:
     bazel: b12f3a93a55019276879bd2d3edbd201c913675a
     working_directory: tests/bcr
     build_flags:
+      - "--allow_yanked_versions"
       - "--experimental_enable_bzlmod"
     test_flags:
+      - "--allow_yanked_versions"
       - "--experimental_enable_bzlmod"
     build_targets:
       - "//..."


### PR DESCRIPTION
Versions yanked from the BCR would otherwise non-hermetically fail our pipelines.