### PR TITLE
Match GOARCH ppc64 to @platforms//cpu:ppc as well.

### DIFF
--- a/go/private/platforms.bzl
+++ b/go/private/platforms.bzl
@@ -30,6 +30,7 @@ BAZEL_GOARCH_CONSTRAINTS = {
     "amd64": "@platforms//cpu:x86_64",
     "arm": "@platforms//cpu:arm",
     "arm64": "@platforms//cpu:aarch64",
+    "ppc64": "@platforms//cpu:ppc",
     "ppc64le": "@platforms//cpu:ppc",
     "s390x": "@platforms//cpu:s390x",
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

It matches GOARCH ppc64 to something so that rules_go would work on linux/ppc64.

**Which issues(s) does this PR fix?**

Fixes #3335

**Other notes for review**

ppc64 is the big endian version of 64-bit PowerPC.
While it is not very common these days, I think it makes sense to support ppc64 as long as Go itself supports ppc64.