### PR TITLE
gopackagesdriver: default to NotHandled:true for package queries

### DIFF
--- a/go/tools/gopackagesdriver/main.go
+++ b/go/tools/gopackagesdriver/main.go
@@ -62,7 +62,7 @@ var (
 	additionalAspects     = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_ADDTL_ASPECTS"))
 	additionalKinds       = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_KINDS"))
 	emptyResponse         = &driverResponse{
-		NotHandled: false,
+		NotHandled: true,
 		Sizes:      types.SizesFor("gc", "amd64").(*types.StdSizes),
 		Roots:      []string{},
 		Packages:   []*FlatPackage{},


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
Bug fix / minor enhancement (?)

**What does this PR do? Why is it needed?**
Default the driver response with `NotHandled` set to `true` so that if any errors are encountered during `bazel query` or otherwise, the language server will fallback to its default implementation.

**Which issues(s) does this PR fix?**

Fixes #3334 by telling gopls to fallback if the gopackagesdriver can't `bazel query` about the requested file.

**Other notes for review**
No other change is needed because any driver response with actual contents will be populated with `false` here: https://github.com/bazelbuild/rules_go/blob/master/go/tools/gopackagesdriver/json_packages_driver.go#L54