### PR TITLE
don't set -undefined dynamic_lookup on darwin, ios

### DIFF
--- a/go/tools/builders/cgo2.go
+++ b/go/tools/builders/cgo2.go
@@ -64,7 +64,7 @@ func cgo2(goenv *env, goSrcs, cgoSrcs, cSrcs, cxxSrcs, objcSrcs, objcxxSrcs, sSr
 	// that a fragment of the path is stable and human friendly enough to be
 	// referenced in nogo configuration.
 	workDir = filepath.Join(workDir, "cgo", packagePath)
-	if err := os.MkdirAll(workDir, 0700); err != nil {
+	if err := os.MkdirAll(workDir, 0o700); err != nil {
 		return "", nil, nil, err
 	}
 
@@ -112,7 +112,7 @@ func cgo2(goenv *env, goSrcs, cgoSrcs, cSrcs, cxxSrcs, objcSrcs, objcxxSrcs, sSr
 		}
 	} else {
 		srcDir = filepath.Join(workDir, "cgosrcs")
-		if err := os.Mkdir(srcDir, 0777); err != nil {
+		if err := os.Mkdir(srcDir, 0o777); err != nil {
 			return "", nil, nil, err
 		}
 		copiedSrcs, err := gatherSrcs(srcDir, cgoSrcs)
@@ -207,12 +207,11 @@ func cgo2(goenv *env, goSrcs, cgoSrcs, cSrcs, cxxSrcs, objcSrcs, objcxxSrcs, sSr
 		// rightfully can't be resolved.
 		var allowUnresolvedSymbolsLdFlag string
 		switch os.Getenv("GOOS") {
-		case "windows":
+		case "windows", "darwin", "ios":
 			// MinGW's linker doesn't seem to support --unresolved-symbols
 			// and MSVC isn't supported at all.
+			// XCode's ld has deprecated `-undefined dynamic_lookup`.
 			return "", nil, nil, err
-		case "darwin", "ios":
-			allowUnresolvedSymbolsLdFlag = "-Wl,-undefined,dynamic_lookup"
 		default:
 			allowUnresolvedSymbolsLdFlag = "-Wl,--unresolved-symbols=ignore-all"
 		}

--- a/tests/core/cgo/BUILD.bazel
+++ b/tests/core/cgo/BUILD.bazel
@@ -419,6 +419,10 @@ go_library(
     name = "use_external_symbol",
     srcs = ["use_external_symbol.go"],
     cgo = True,
+    clinkopts = select({
+        "@platforms//os:osx": ["-Wl,-undefined,dynamic_lookup"],
+        "//conditions:default": [],
+    }),
     importpath = "github.com/bazelbuild/rules_go/tests/core/cgo/use_external_symbol",
     tags = ["manual"],
 )

--- a/tests/core/cgo/BUILD.bazel
+++ b/tests/core/cgo/BUILD.bazel
@@ -427,6 +427,10 @@ go_binary(
     name = "provide_external_symbol",
     srcs = ["provide_external_symbol.go"],
     cgo = True,
+    clinkopts = select({
+        "@platforms//os:osx": ["-Wl,-undefined,dynamic_lookup"],
+        "//conditions:default": [],
+    }),
     target_compatible_with = select({
         "@platforms//os:osx": [],
         "@platforms//os:linux": [],

--- a/tests/core/cgo/BUILD.bazel
+++ b/tests/core/cgo/BUILD.bazel
@@ -428,6 +428,7 @@ go_binary(
     srcs = ["provide_external_symbol.go"],
     cgo = True,
     target_compatible_with = select({
+        "@platforms//os:osx": [],
         "@platforms//os:linux": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),

--- a/tests/core/cgo/BUILD.bazel
+++ b/tests/core/cgo/BUILD.bazel
@@ -428,7 +428,6 @@ go_binary(
     srcs = ["provide_external_symbol.go"],
     cgo = True,
     target_compatible_with = select({
-        "@platforms//os:osx": [],
         "@platforms//os:linux": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Don't set -undefined dynamic_lookup when building cgo dependencies on darwin, ios.
Needed because that option is deprecated in XCode 14+.
See discussion [here](https://github.com/bazelbuild/bazel/issues/16413).

**Which issues(s) does this PR fix?**

Fixes https://github.com/bazelbuild/rules_go/issues/3315

**Other notes for review**

Not sure about testing.