### PR TITLE
Rename `Path` to `Rlocation` in runfiles library

### DIFF
--- a/go/runfiles/fs.go
+++ b/go/runfiles/fs.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build go1.16
 // +build go1.16
 
 package runfiles
@@ -29,7 +30,7 @@ func (r *Runfiles) Open(name string) (fs.File, error) {
 	if !fs.ValidPath(name) {
 		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
 	}
-	p, err := r.Path(name)
+	p, err := r.Rlocation(name)
 	if errors.Is(err, ErrEmpty) {
 		return emptyFile(name), nil
 	}
@@ -44,7 +45,7 @@ func (r *Runfiles) Stat(name string) (fs.FileInfo, error) {
 	if !fs.ValidPath(name) {
 		return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrInvalid}
 	}
-	p, err := r.Path(name)
+	p, err := r.Rlocation(name)
 	if errors.Is(err, ErrEmpty) {
 		return emptyFileInfo(name), nil
 	}
@@ -59,7 +60,7 @@ func (r *Runfiles) ReadFile(name string) ([]byte, error) {
 	if !fs.ValidPath(name) {
 		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
 	}
-	p, err := r.Path(name)
+	p, err := r.Rlocation(name)
 	if errors.Is(err, ErrEmpty) {
 		return nil, nil
 	}

--- a/go/runfiles/global.go
+++ b/go/runfiles/global.go
@@ -16,16 +16,16 @@ package runfiles
 
 import "sync"
 
-// Path returns the absolute path name of a runfile.  The runfile name must be
+// Rlocation returns the absolute path name of a runfile.  The runfile name must be
 // a relative path, using the slash (not backslash) as directory separator.  If
 // the runfiles manifest maps s to an empty name (indicating an empty runfile
-// not present in the filesystem), Path returns an error that wraps ErrEmpty.
-func Path(s string) (string, error) {
+// not present in the filesystem), Rlocation returns an error that wraps ErrEmpty.
+func Rlocation(s string) (string, error) {
 	r, err := g.get()
 	if err != nil {
 		return "", err
 	}
-	return r.Path(s)
+	return r.Rlocation(s)
 }
 
 // Env returns additional environmental variables to pass to subprocesses.

--- a/go/runfiles/runfiles.go
+++ b/go/runfiles/runfiles.go
@@ -16,13 +16,13 @@
 //
 // Usage
 //
-// This package has two main entry points, the global functions Path and Env,
+// This package has two main entry points, the global functions Rlocation and Env,
 // and the Runfiles type.
 //
 // Global functions
 //
-// For simple use cases that don’t require hermetic behavior, use the Path and
-// Env functions to access runfiles.  Use Path to find the filesystem location
+// For simple use cases that don’t require hermetic behavior, use the Rlocation and
+// Env functions to access runfiles.  Use Rlocation to find the filesystem location
 // of a runfile, and use Env to obtain environmental variables to pass on to
 // subprocesses.
 //
@@ -30,7 +30,7 @@
 //
 // If you need hermetic behavior or want to change the runfiles discovery
 // process, use New to create a Runfiles object.  New accepts a few options to
-// change the discovery process.  Runfiles objects have methods Path and Env,
+// change the discovery process.  Runfiles objects have methods Rlocation and Env,
 // which correspond to the package-level functions.  On Go 1.16, *Runfiles
 // implements fs.FS, fs.StatFS, and fs.ReadFileFS.
 package runfiles
@@ -101,16 +101,16 @@ func New(opts ...Option) (*Runfiles, error) {
 	return nil, errors.New("runfiles: no runfiles found")
 }
 
-// Path returns the absolute path name of a runfile.  The runfile name must be a
+// Rlocation returns the absolute path name of a runfile.  The runfile name must be a
 // runfile-root relative path, using the slash (not backslash) as directory separator.
 // It is typically of the form "repo/path/to/pkg/file".
-// If r is the zero Runfiles object, Path always returns an error.  If the runfiles
+// If r is the zero Runfiles object, Rlocation always returns an error.  If the runfiles
 // manifest maps s to an empty name (indicating an empty runfile not present in the
-// filesystem), Path returns an error that wraps ErrEmpty.
+// filesystem), Rlocation returns an error that wraps ErrEmpty.
 //
 // See section “Library interface” in
 // https://docs.google.com/document/d/e/2PACX-1vSDIrFnFvEYhKsCMdGdD40wZRBX3m3aZ5HhVj4CtHPmiXKDCxioTUbYsDydjKtFDAzER5eg7OjJWs3V/pub.
-func (r *Runfiles) Path(path string) (string, error) {
+func (r *Runfiles) Rlocation(path string) (string, error) {
 	if r.impl == nil {
 		return "", errors.New("runfiles: uninitialized Runfiles object")
 	}

--- a/tests/runfiles/fs_test.go
+++ b/tests/runfiles/fs_test.go
@@ -43,9 +43,9 @@ func TestFS(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		// Currently the result of
 		//
-		//  fsys.Path("io_bazel_rules_go/go/runfiles/test.txt")
-		//  fsys.Path("bazel_tools/tools/bash/runfiles/runfiles.bash")
-		//  fsys.Path("io_bazel_rules_go/go/runfiles/testprog/testprog")
+		//  fsys.Rlocation("io_bazel_rules_go/go/runfiles/test.txt")
+		//  fsys.Rlocation("bazel_tools/tools/bash/runfiles/runfiles.bash")
+		//  fsys.Rlocation("io_bazel_rules_go/go/runfiles/testprog/testprog")
 		//
 		// would be a full path like these
 		//

--- a/tests/runfiles/runfiles_test.go
+++ b/tests/runfiles/runfiles_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestPath_FileLookup(t *testing.T) {
-	path, err := runfiles.Path("io_bazel_rules_go/tests/runfiles/test.txt")
+	path, err := runfiles.Rlocation("io_bazel_rules_go/tests/runfiles/test.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +53,7 @@ func TestPath_SubprocessRunfilesLookup(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		testprogRpath += ".exe"
 	}
-	prog, err := r.Path(testprogRpath)
+	prog, err := r.Rlocation(testprogRpath)
 	if err != nil {
 		panic(err)
 	}
@@ -79,7 +79,7 @@ func TestPath_errors(t *testing.T) {
 	}
 	for _, s := range []string{"", "/..", "../", "a/../b", "a//b", "a/./b", `\a`} {
 		t.Run(s, func(t *testing.T) {
-			if got, err := r.Path(s); err == nil {
+			if got, err := r.Rlocation(s); err == nil {
 				t.Errorf("got %q, want error", got)
 			}
 		})
@@ -88,8 +88,8 @@ func TestPath_errors(t *testing.T) {
 
 func TestRunfiles_zero(t *testing.T) {
 	var r runfiles.Runfiles
-	if got, err := r.Path("a"); err == nil {
-		t.Errorf("Path: got %q, want error", got)
+	if got, err := r.Rlocation("a"); err == nil {
+		t.Errorf("Rlocation: got %q, want error", got)
 	}
 	if got := r.Env(); got != nil {
 		t.Errorf("Env: got %v, want nil", got)
@@ -106,10 +106,10 @@ func TestRunfiles_empty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, got := r.Path("__init__.py")
+	_, got := r.Rlocation("__init__.py")
 	want := runfiles.ErrEmpty
 	if !errors.Is(got, want) {
-		t.Errorf("Path for empty file: got error %q, want something that wraps %q", got, want)
+		t.Errorf("Rlocation for empty file: got error %q, want something that wraps %q", got, want)
 	}
 }
 
@@ -130,12 +130,12 @@ func TestRunfiles_manifestWithDir(t *testing.T) {
 		"foo/dir/deeply/nested/file": filepath.FromSlash("path/to/foo/dir/deeply/nested/file"),
 	} {
 		t.Run(rlocation, func(t *testing.T) {
-			got, err := r.Path(rlocation)
+			got, err := r.Rlocation(rlocation)
 			if err != nil {
-				t.Fatalf("Path failed: got unexpected error %q", err)
+				t.Fatalf("Rlocation failed: got unexpected error %q", err)
 			}
 			if got != want {
-				t.Errorf("Path failed: got %q, want %q", got, want)
+				t.Errorf("Rlocation failed: got %q, want %q", got, want)
 			}
 		})
 	}

--- a/tests/runfiles/testprog/main.go
+++ b/tests/runfiles/testprog/main.go
@@ -22,7 +22,7 @@ import (
 )
 
 func main() {
-	path, err := runfiles.Path("io_bazel_rules_go/tests/runfiles/test.txt")
+	path, err := runfiles.Rlocation("io_bazel_rules_go/tests/runfiles/test.txt")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Improves consistency with other runfiles libraries.