### PR TITLE
Declare toolchains in a separate repository

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ use_repo(
 go_sdk = use_extension("//go:extensions.bzl", "go_sdk")
 go_sdk.download(name = "go_default_sdk", version = "1.18.3")
 use_repo(go_sdk, "go_default_sdk")
-register_toolchains("@go_default_sdk//:all")
+register_toolchains("@go_default_sdk_toolchains//:all")
 
 bazel_dep(name = "gazelle", version = "0.27.0")
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,7 +21,7 @@ use_repo(
 
 go_sdk = use_extension("//go:extensions.bzl", "go_sdk")
 go_sdk.download(name = "go_default_sdk", version = "1.18.3")
-use_repo(go_sdk, "go_default_sdk", "go_default_sdk_toolchains")
+use_repo(go_sdk, "go_default_sdk_toolchains")
 register_toolchains("@go_default_sdk_toolchains//:all")
 
 bazel_dep(name = "gazelle", version = "0.27.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,7 +21,7 @@ use_repo(
 
 go_sdk = use_extension("//go:extensions.bzl", "go_sdk")
 go_sdk.download(name = "go_default_sdk", version = "1.18.3")
-use_repo(go_sdk, "go_default_sdk")
+use_repo(go_sdk, "go_default_sdk", "go_default_sdk_toolchains")
 register_toolchains("@go_default_sdk_toolchains//:all")
 
 bazel_dep(name = "gazelle", version = "0.27.0")

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -127,9 +127,6 @@ TOOLS_NOGO = [
 # check this to determine compatibility.
 RULES_GO_VERSION = "0.35.0"
 
-declare_go_toolchains = _declare_go_toolchains
-declare_bazel_toolchains = _declare_bazel_toolchains
-
 def declare_toolchains(host, sdk, builder, sdk_version_setting):
     host_goos, _, host_goarch = host.partition("_")
     _declare_go_toolchains(

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -41,6 +41,7 @@ load(
 )
 load(
     "//go/private:go_toolchain.bzl",
+    _declare_go_toolchains = "declare_go_toolchains",
     _declare_toolchains = "declare_toolchains",
     _go_toolchain = "go_toolchain",
 )
@@ -126,6 +127,7 @@ TOOLS_NOGO = [
 # check this to determine compatibility.
 RULES_GO_VERSION = "0.35.0"
 
+declare_go_toolchains = _declare_go_toolchains
 declare_toolchains = _declare_toolchains
 go_context = _go_context
 go_embed_data = _go_embed_data

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -41,8 +41,8 @@ load(
 )
 load(
     "//go/private:go_toolchain.bzl",
+    _declare_bazel_toolchains = "declare_bazel_toolchains",
     _declare_go_toolchains = "declare_go_toolchains",
-    _declare_toolchains = "declare_toolchains",
     _go_toolchain = "go_toolchain",
 )
 load(
@@ -128,7 +128,22 @@ TOOLS_NOGO = [
 RULES_GO_VERSION = "0.35.0"
 
 declare_go_toolchains = _declare_go_toolchains
-declare_toolchains = _declare_toolchains
+declare_bazel_toolchains = _declare_bazel_toolchains
+
+def declare_toolchains(host, sdk, builder, sdk_version_setting):
+    host_goos, _, host_goarch = host.partition("_")
+    _declare_go_toolchains(
+        host_goos = host_goos,
+        sdk = sdk,
+        builder = builder,
+    )
+    _declare_bazel_toolchains(
+        host_goos = host_goos,
+        host_goarch = host_goarch,
+        toolchain_prefix = "",
+        sdk_version_setting = sdk_version_setting,
+    )
+
 go_context = _go_context
 go_embed_data = _go_embed_data
 gomock = _gomock

--- a/go/private/BUILD.sdk.bazel
+++ b/go/private/BUILD.sdk.bazel
@@ -1,6 +1,7 @@
 load("@{rules_go_repo_name}//go/private/rules:binary.bzl", "go_tool_binary")
 load("@{rules_go_repo_name}//go/private/rules:sdk.bzl", "package_list")
-load("@{rules_go_repo_name}//go:def.bzl", "declare_go_toolchains", "go_sdk")
+load("@{rules_go_repo_name}//go/private:go_toolchain.bzl", "declare_go_toolchains")
+load("@{rules_go_repo_name}//go:def.bzl", "go_sdk")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/go/private/BUILD.sdk.bazel
+++ b/go/private/BUILD.sdk.bazel
@@ -1,7 +1,6 @@
 load("@{rules_go_repo_name}//go/private/rules:binary.bzl", "go_tool_binary")
 load("@{rules_go_repo_name}//go/private/rules:sdk.bzl", "package_list")
-load("@{rules_go_repo_name}//go:def.bzl", "declare_toolchains", "go_sdk")
-load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@{rules_go_repo_name}//go:def.bzl", "declare_go_toolchains", "go_sdk")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -59,75 +58,10 @@ package_list(
     root_file = "ROOT",
 )
 
-sdk_version_label = "@{rules_go_repo_name}//go/toolchain:sdk_version"
-
-config_setting(
-    name = "match_all_versions",
-    flag_values = {
-        sdk_version_label: "",
-    },
-    visibility = ["//visibility:private"],
-)
-
-config_setting(
-    name = "match_major_version",
-    flag_values = {
-        sdk_version_label: "{major_version}",
-    },
-    visibility = ["//visibility:private"],
-)
-
-config_setting(
-    name = "match_major_minor_version",
-    flag_values = {
-        sdk_version_label: "{major_version}.{minor_version}",
-    },
-    visibility = ["//visibility:private"],
-)
-
-config_setting(
-    name = "match_patch_version",
-    flag_values = {
-        sdk_version_label: "{major_version}.{minor_version}.{patch_version}",
-    },
-    visibility = ["//visibility:private"],
-)
-
-# If prerelease version is "", this will be the same as ":match_patch_version", but that's fine since we use match_any in config_setting_group.
-config_setting(
-    name = "match_prerelease_version",
-    flag_values = {
-        sdk_version_label: "{major_version}.{minor_version}.{patch_version}{prerelease_suffix}",
-    },
-    visibility = ["//visibility:private"],
-)
-
-config_setting(
-    name = "match_sdk_type",
-    flag_values = {
-        sdk_version_label: "{sdk_type}",
-    },
-    visibility = ["//visibility:private"],
-)
-
-selects.config_setting_group(
-    name = "sdk_version_setting",
-    match_any = [
-        ":match_all_versions",
-        ":match_major_version",
-        ":match_major_minor_version",
-        ":match_patch_version",
-        ":match_prerelease_version",
-        ":match_sdk_type",
-    ],
-    visibility = ["//visibility:private"],
-)
-
-declare_toolchains(
+declare_go_toolchains(
     builder = ":builder",
-    host = "{goos}_{goarch}",
+    host_goos = "{goos}",
     sdk = ":go_sdk",
-    sdk_version_setting = ":sdk_version_setting",
 )
 
 filegroup(

--- a/go/private/BUILD.toolchains.bazel
+++ b/go/private/BUILD.toolchains.bazel
@@ -1,4 +1,4 @@
-load("@{rules_go_repo_name}//go:def.bzl", "declare_toolchains")
+load("@{rules_go_repo_name}//go:def.bzl", "declare_bazel_toolchains")
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
 {version_constants}
@@ -69,9 +69,9 @@ selects.config_setting_group(
     visibility = ["//visibility:private"],
 )
 
-declare_toolchains(
+declare_bazel_toolchains(
     host_goos = "{goos}",
     host_goarch = "{goarch}",
-    sdk_repo = "{sdk_repo}",
+    toolchain_prefix = "@{sdk_repo}//",
     sdk_version_setting = ":sdk_version_setting",
 )

--- a/go/private/BUILD.toolchains.bazel
+++ b/go/private/BUILD.toolchains.bazel
@@ -1,4 +1,4 @@
-load("@{rules_go_repo_name}//go:def.bzl", "declare_bazel_toolchains")
+load("@{rules_go_repo_name}//go/private:go_toolchain.bzl", "declare_bazel_toolchains")
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
 {version_constants}

--- a/go/private/BUILD.toolchains.bazel
+++ b/go/private/BUILD.toolchains.bazel
@@ -1,0 +1,77 @@
+load("@{rules_go_repo_name}//go:def.bzl", "declare_toolchains")
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+{version_constants}
+
+package(default_visibility = ["//visibility:public"])
+
+sdk_version_label = "@{rules_go_repo_name}//go/toolchain:sdk_version"
+
+config_setting(
+    name = "match_all_versions",
+    flag_values = {
+        sdk_version_label: "",
+    },
+    visibility = ["//visibility:private"],
+)
+
+config_setting(
+    name = "match_major_version",
+    flag_values = {
+        sdk_version_label: MAJOR_VERSION,
+    },
+    visibility = ["//visibility:private"],
+)
+
+config_setting(
+    name = "match_major_minor_version",
+    flag_values = {
+        sdk_version_label: MAJOR_VERSION + "." + MINOR_VERSION,
+    },
+    visibility = ["//visibility:private"],
+)
+
+config_setting(
+    name = "match_patch_version",
+    flag_values = {
+        sdk_version_label: MAJOR_VERSION + "." + MINOR_VERSION + "." + PATCH_VERSION,
+    },
+    visibility = ["//visibility:private"],
+)
+
+# If prerelease version is "", this will be the same as ":match_patch_version", but that's fine since we use match_any in config_setting_group.
+config_setting(
+    name = "match_prerelease_version",
+    flag_values = {
+        sdk_version_label: MAJOR_VERSION + "." + MINOR_VERSION + "." + PATCH_VERSION + PRERELEASE_SUFFIX,
+    },
+    visibility = ["//visibility:private"],
+)
+
+config_setting(
+    name = "match_sdk_type",
+    flag_values = {
+        sdk_version_label: "{sdk_type}",
+    },
+    visibility = ["//visibility:private"],
+)
+
+selects.config_setting_group(
+    name = "sdk_version_setting",
+    match_any = [
+        ":match_all_versions",
+        ":match_major_version",
+        ":match_major_minor_version",
+        ":match_patch_version",
+        ":match_prerelease_version",
+        ":match_sdk_type",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+declare_toolchains(
+    host_goos = "{goos}",
+    host_goarch = "{goarch}",
+    sdk_repo = "{sdk_repo}",
+    sdk_version_setting = ":sdk_version_setting",
+)

--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -92,11 +92,8 @@ go_toolchain = rule(
     provides = [platform_common.ToolchainInfo],
 )
 
-def declare_toolchains(host, sdk, builder, sdk_version_setting):
-    """Declares go_toolchain and toolchain targets for each platform."""
-
-    # keep in sync with generate_toolchain_names
-    host_goos, _, host_goarch = host.partition("_")
+def declare_go_toolchains(host_goos, sdk, builder):
+    """Declares go_toolchain targets for each platform."""
     for p in PLATFORMS:
         if p.cgo:
             # Don't declare separate toolchains for cgo_on / cgo_off.
@@ -111,17 +108,8 @@ def declare_toolchains(host, sdk, builder, sdk_version_setting):
         if host_goos == "linux":
             cgo_link_flags.append("-Wl,-whole-archive")
 
-        toolchain_name = "go_" + p.name
-        impl_name = toolchain_name + "-impl"
-
-        cgo_constraints = (
-            "@io_bazel_rules_go//go/toolchain:cgo_off",
-            "@io_bazel_rules_go//go/toolchain:cgo_on",
-        )
-        constraints = [c for c in p.constraints if c not in cgo_constraints]
-
         go_toolchain(
-            name = impl_name,
+            name = "go_" + p.name + "-impl",
             goos = p.goos,
             goarch = p.goarch,
             sdk = sdk,
@@ -131,8 +119,25 @@ def declare_toolchains(host, sdk, builder, sdk_version_setting):
             tags = ["manual"],
             visibility = ["//visibility:public"],
         )
+
+def declare_toolchains(host_goos, host_goarch, sdk_repo, sdk_version_setting):
+    """Declares toolchain targets for each platform."""
+    for p in PLATFORMS:
+        if p.cgo:
+            # Don't declare separate toolchains for cgo_on / cgo_off.
+            # This is controlled by the cgo_context_data dependency of
+            # go_context_data, which is configured using constraint_values.
+            continue
+
+        cgo_constraints = (
+            "@io_bazel_rules_go//go/toolchain:cgo_off",
+            "@io_bazel_rules_go//go/toolchain:cgo_on",
+        )
+        constraints = [c for c in p.constraints if c not in cgo_constraints]
+
         native.toolchain(
-            name = toolchain_name,
+            # keep in sync with generate_toolchain_names
+            name = "go_" + p.name,
             toolchain_type = GO_TOOLCHAIN,
             exec_compatible_with = [
                 "@io_bazel_rules_go//go/toolchain:" + host_goos,
@@ -140,5 +145,5 @@ def declare_toolchains(host, sdk, builder, sdk_version_setting):
             ],
             target_compatible_with = constraints,
             target_settings = [sdk_version_setting],
-            toolchain = ":" + impl_name,
+            toolchain = "@" + sdk_repo + "//:go_" + p.name + "-impl",
         )

--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -120,7 +120,7 @@ def declare_go_toolchains(host_goos, sdk, builder):
             visibility = ["//visibility:public"],
         )
 
-def declare_toolchains(host_goos, host_goarch, sdk_repo, sdk_version_setting):
+def declare_bazel_toolchains(host_goos, host_goarch, toolchain_prefix, sdk_version_setting):
     """Declares toolchain targets for each platform."""
     for p in PLATFORMS:
         if p.cgo:
@@ -145,5 +145,5 @@ def declare_toolchains(host_goos, host_goarch, sdk_repo, sdk_version_setting):
             ],
             target_compatible_with = constraints,
             target_settings = [sdk_version_setting],
-            toolchain = "@" + sdk_repo + "//:go_" + p.name + "-impl",
+            toolchain = toolchain_prefix + ":go_" + p.name + "-impl",
         )

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -31,16 +31,27 @@ def _go_host_sdk_impl(ctx):
     goroot = _detect_host_sdk(ctx)
     platform = _detect_sdk_platform(ctx, goroot)
     version = _detect_sdk_version(ctx, goroot)
-    _sdk_build_file(ctx, platform, version, "host")
+    _sdk_build_file(ctx, platform, version)
     _local_sdk(ctx, goroot)
 
 _go_host_sdk = repository_rule(
     implementation = _go_host_sdk_impl,
     environ = ["GOROOT"],
+    attrs = {
+        "version": attr.string(),
+    },
 )
 
 def go_host_sdk(name, register_toolchains = True, **kwargs):
     _go_host_sdk(name = name, **kwargs)
+    _go_toolchains(
+        name = name + "_toolchains",
+        sdk_repo = name,
+        sdk_type = "host",
+        sdk_version = kwargs.get("version"),
+        goos = kwargs.get("goos"),
+        goarch = kwargs.get("goarch"),
+    )
     if register_toolchains:
         _register_toolchains(name)
 
@@ -129,8 +140,82 @@ _go_download_sdk = repository_rule(
     },
 )
 
+def _version_constants(version):
+    pv = _parse_version(version)
+    if pv == None or len(pv) < 3:
+        fail("error parsing sdk version: " + version)
+    major, minor, patch = pv[0], pv[1], pv[2]
+    prerelease = pv[3] if len(pv) > 3 else ""
+    return """
+MAJOR_VERSION = "{major}"
+MINOR_VERSION = "{minor}"
+PATCH_VERSION = "{patch}"
+PRERELEASE_SUFFIX = "{prerelease}"
+""".format(
+        major = major,
+        minor = minor,
+        patch = patch,
+        prerelease = prerelease,
+    )
+
+def _go_toolchains_impl(ctx):
+    if not ctx.attr.goos and not ctx.attr.goarch:
+        goos, goarch = _detect_host_platform(ctx)
+    else:
+        if not ctx.attr.goos:
+            fail("goarch set but goos not set")
+        if not ctx.attr.goarch:
+            fail("goos set but goarch not set")
+        goos, goarch = ctx.attr.goos, ctx.attr.goarch
+
+    sdk_repo = ctx.attr.sdk_repo
+    sdk_type = ctx.attr.sdk_type
+
+    # If a sdk_version attribute is provided, use that version. This avoids
+    # eagerly fetching the SDK repository. But if it's not provided, we have
+    # no choice and must load version constants from the version.bzl file that
+    # _sdk_build_file creates. This will trigger an eager fetch.
+    version = ctx.attr.sdk_version
+    if version:
+        version_constants = _version_constants(version)
+    else:
+        version_constants = 'load("@{}//:version.bzl", "MAJOR_VERSION", "MINOR_VERSION", "PATCH_VERSION", "PRERELEASE_SUFFIX")'.format(sdk_repo)
+
+    ctx.template(
+        "BUILD.bazel",
+        Label("//go/private:BUILD.toolchains.bazel"),
+        executable = False,
+        substitutions = {
+            "{goos}": goos,
+            "{goarch}": goarch,
+            "{sdk_repo}": sdk_repo,
+            "{sdk_type}": sdk_type,
+            "{rules_go_repo_name}": "io_bazel_rules_go",
+            "{version_constants}": version_constants,
+        },
+    )
+
+_go_toolchains = repository_rule(
+    implementation = _go_toolchains_impl,
+    attrs = {
+        "sdk_repo": attr.string(mandatory = True),
+        "sdk_type": attr.string(mandatory = True),
+        "sdk_version": attr.string(),
+        "goos": attr.string(),
+        "goarch": attr.string(),
+    },
+)
+
 def go_download_sdk(name, register_toolchains = True, **kwargs):
     _go_download_sdk(name = name, **kwargs)
+    _go_toolchains(
+        name = name + "_toolchains",
+        sdk_repo = name,
+        sdk_type = "remote",
+        sdk_version = kwargs.get("version"),
+        goos = kwargs.get("goos"),
+        goarch = kwargs.get("goarch"),
+    )
     if register_toolchains:
         _register_toolchains(name)
 
@@ -145,11 +230,20 @@ _go_local_sdk = repository_rule(
     implementation = _go_local_sdk_impl,
     attrs = {
         "path": attr.string(),
+        "version": attr.string(),
     },
 )
 
 def go_local_sdk(name, register_toolchains = True, **kwargs):
     _go_local_sdk(name = name, **kwargs)
+    _go_toolchains(
+        name = name + "_toolchains",
+        sdk_repo = name,
+        sdk_type = "remote",
+        sdk_version = kwargs.get("version"),
+        goos = kwargs.get("goos"),
+        goarch = kwargs.get("goarch"),
+    )
     if register_toolchains:
         _register_toolchains(name)
 
@@ -183,17 +277,26 @@ _go_wrap_sdk = repository_rule(
             mandatory = False,
             doc = "A set of mappings from the host platform to a file in the SDK's root directory",
         ),
+        "version": attr.string(),
     },
 )
 
 def go_wrap_sdk(name, register_toolchains = True, **kwargs):
     _go_wrap_sdk(name = name, **kwargs)
+    _go_toolchains(
+        name = name + "_toolchains",
+        sdk_repo = name,
+        sdk_type = "remote",
+        sdk_version = kwargs.get("version"),
+        goos = kwargs.get("goos"),
+        goarch = kwargs.get("goarch"),
+    )
     if register_toolchains:
         _register_toolchains(name)
 
 def _register_toolchains(repo):
     labels = [
-        "@{}//:{}".format(repo, name)
+        "@{}_toolchains//:{}".format(repo, name)
         for name in generate_toolchain_names()
     ]
     native.register_toolchains(*labels)
@@ -231,15 +334,9 @@ def _local_sdk(ctx, path):
     for entry in ["src", "pkg", "bin", "lib", "misc"]:
         ctx.symlink(path + "/" + entry, entry)
 
-def _sdk_build_file(ctx, platform, version, sdk_type = "remote"):
+def _sdk_build_file(ctx, platform, version):
     ctx.file("ROOT")
     goos, _, goarch = platform.partition("_")
-
-    pv = _parse_version(version)
-    if pv == None or len(pv) < 3:
-        fail("error parsing sdk version: " + version)
-    major, minor, patch = pv[0], pv[1], pv[2]
-    prerelease = pv[3] if len(pv) > 3 else ""
 
     ctx.template(
         "BUILD.bazel",
@@ -250,12 +347,13 @@ def _sdk_build_file(ctx, platform, version, sdk_type = "remote"):
             "{goarch}": goarch,
             "{exe}": ".exe" if goos == "windows" else "",
             "{rules_go_repo_name}": "io_bazel_rules_go",
-            "{major_version}": str(major),
-            "{minor_version}": str(minor),
-            "{patch_version}": str(patch),
-            "{prerelease_suffix}": prerelease,
-            "{sdk_type}": sdk_type,
         },
+    )
+
+    ctx.file(
+        "version.bzl",
+        executable = False,
+        content = _version_constants(version),
     )
 
 def _detect_host_platform(ctx):
@@ -305,10 +403,11 @@ def _detect_sdk_platform(ctx, goroot):
 def _detect_sdk_version(ctx, goroot):
     version_file_path = goroot + "/VERSION"
     if ctx.path(version_file_path).exists:
-        version_contents = ctx.read(version_file_path)
-
         # VERSION file has version prefixed by go, eg. go1.18.3
-        return version_contents[2:]
+        version = ctx.read(version_file_path)[2:]
+        if ctx.attr.version and ctx.attr.version != version:
+            fail("SDK is version %s, but version %s was expected" % (version, ctx.attr.version))
+        return version
 
     # The top-level VERSION file does not exist in all Go SDK distributions, e.g. those shipped by Debian or Fedora.
     # Falling back to running "go version"
@@ -334,6 +433,8 @@ def _detect_sdk_version(ctx, goroot):
         fail("Could not parse SDK version from '%s version' output: %s" % (go_binary_path, result.stdout))
     if _parse_version(version) == None:
         fail("Could not parse SDK version from '%s version' output: %s" % (go_binary_path, result.stdout))
+    if ctx.attr.version and ctx.attr.version != version:
+        fail("SDK is version %s, but version %s was expected" % (version, ctx.attr.version))
     return version
 
 def _parse_versions_json(data):

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -140,7 +140,7 @@ _go_download_sdk = repository_rule(
     },
 )
 
-def _version_constants(version):
+def _define_version_constants(version):
     pv = _parse_version(version)
     if pv == None or len(pv) < 3:
         fail("error parsing sdk version: " + version)
@@ -177,7 +177,7 @@ def _go_toolchains_impl(ctx):
     # _sdk_build_file creates. This will trigger an eager fetch.
     version = ctx.attr.sdk_version
     if version:
-        version_constants = _version_constants(version)
+        version_constants = _define_version_constants(version)
     else:
         version_constants = 'load("@{}//:version.bzl", "MAJOR_VERSION", "MINOR_VERSION", "PATCH_VERSION", "PRERELEASE_SUFFIX")'.format(sdk_repo)
 
@@ -353,7 +353,7 @@ def _sdk_build_file(ctx, platform, version):
     ctx.file(
         "version.bzl",
         executable = False,
-        content = _version_constants(version),
+        content = _define_version_constants(version),
     )
 
 def _detect_host_platform(ctx):

--- a/go/toolchains.rst
+++ b/go/toolchains.rst
@@ -88,6 +88,16 @@ the rules register these toolchains automatically. Bazel will select a
 registered toolchain automatically based on the execution and target platforms,
 specified with ``--host_platform`` and ``--platforms``, respectively.
 
+The workspace rules define the toolchains in a separate repository from the
+SDK. For example, if the SDK repository is `@go_sdk`, the toolchains will be
+defined in `@go_sdk_toolchains`. The `@go_sdk_toolchains` repository must be
+eagerly fetched in order to register the toolchain, but fetching the `@go_sdk`
+repository may be delayed until the toolchain is needed to build something. To
+activate lazily fetching the SDK, you must provide a `version` attribute to the
+workspace rule that defines the SDK (`go_download_sdk`, `go_host_sdk`, `go_local_sdk`,
+`go_wrap_sdk`, or `go_register_toolchains`). The value must match the actual
+version of the SDK; rules_go will validate this when the toolchain is used.
+
 The toolchain itself should be considered opaque. You should only access
 its contents through `the context`_.
 
@@ -225,6 +235,10 @@ SDK version to use (for example, :value:`"1.15.5"`).
 | Normally this is set to a Go version like :value:`"1.15.5"`. It may also be                      |
 | set to :value:`"host"`, which will cause rules_go to use the Go toolchain                        |
 | installed on the host system (found using ``GOROOT`` or ``PATH``).                               |
+|                                                                                                  |
+| If ``version`` is specified and is not set to :value:`"host"`, the SDK will be lazily fetched    |
+| when the Go toolchain is required. Otherwise it will be eagerly fetched during the analysis      |
+| phase.                                                                                           |
 +--------------------------------+-----------------------------+-----------------------------------+
 | :param:`nogo`                  | :type:`label`               | :value:`None`                     |
 +--------------------------------+-----------------------------+-----------------------------------+
@@ -267,6 +281,8 @@ This downloads a Go SDK for use in toolchains.
 | pick the highest version. If ``version`` is specified but ``sdks`` is                                      |
 | unspecified, ``go_download_sdk`` will list available versions on golang.org                                |
 | to determine the correct file name and SHA-256 sum.                                                        |
+| If ``version`` is specified, the SDK will be lazily fetched when the Go toolchain is required. Otherwise   |
+| it will be eagerly fetched during the analysis phase.                                                      |
 +--------------------------------+-----------------------------+---------------------------------------------+
 | :param:`urls`                  | :type:`string_list`         | :value:`[https://dl.google.com/go/{}]`      |
 +--------------------------------+-----------------------------+---------------------------------------------+
@@ -344,7 +360,11 @@ used. Otherwise, ``go env GOROOT`` is used.
 | A unique name for this SDK. This should almost always be :value:`go_sdk` if you want the SDK     |
 | to be used by toolchains.                                                                        |
 +--------------------------------+-----------------------------+-----------------------------------+
-
+| :param:`version`               | :type:`string`              | :value:`None`                     |
++--------------------------------+-----------------------------+-----------------------------------+
+| The version of Go installed on the host. If specified, `go_host_sdk` will create its repository  |
+| lazily, when the Go toolchain is required.                                                       |
++--------------------------------+-----------------------------+-----------------------------------+
 
 go_local_sdk
 ~~~~~~~~~~~~
@@ -363,6 +383,11 @@ This prepares a local path to use as the Go SDK in toolchains.
 +--------------------------------+-----------------------------+-----------------------------------+
 | The local path to a pre-installed Go SDK. The path must contain the go binary, the tools it      |
 | invokes and the standard library sources.                                                        |
++--------------------------------+-----------------------------+-----------------------------------+
+| :param:`version`               | :type:`string`              | :value:`None`                     |
++--------------------------------+-----------------------------+-----------------------------------+
+| The version of the Go SDK. If specified, `go_local_sdk` will create its repository lazily, when  |
+| the Go toolchain is required.                                                                    |
 +--------------------------------+-----------------------------+-----------------------------------+
 
 
@@ -389,6 +414,11 @@ rule.
 +--------------------------------+-----------------------------+-----------------------------------+
 | A set of mappings from the host platform to a Bazel label referencing a file in the SDK's root   |
 | directory. This attribute and `root_file` cannot be both provided.                               |
++--------------------------------+-----------------------------+-----------------------------------+
+| :param:`version`               | :type:`string`              | :value:`None`                     |
++--------------------------------+-----------------------------+-----------------------------------+
+| The version of the Go SDK. If specified, `go_wrap_sdk` will create its repository lazily, when   |
+| the Go toolchain is required.                                                                    |
 +--------------------------------+-----------------------------+-----------------------------------+
 
 

--- a/go/toolchains.rst
+++ b/go/toolchains.rst
@@ -20,6 +20,7 @@ Go toolchains
 .. _nogo: nogo.rst#nogo
 .. _register: Registration_
 .. _register_toolchains: https://docs.bazel.build/versions/master/skylark/lib/globals.html#register_toolchains
+.. _toolchain resolution: https://bazel.build/extending/toolchains#toolchain-resolution
 
 .. role:: param(kbd)
 .. role:: type(emphasis)
@@ -236,9 +237,9 @@ SDK version to use (for example, :value:`"1.15.5"`).
 | set to :value:`"host"`, which will cause rules_go to use the Go toolchain                        |
 | installed on the host system (found using ``GOROOT`` or ``PATH``).                               |
 |                                                                                                  |
-| If ``version`` is specified and is not set to :value:`"host"`, the SDK will be lazily fetched    |
-| when the Go toolchain is required. Otherwise it will be eagerly fetched during the analysis      |
-| phase.                                                                                           |
+| If ``version`` is specified and is not set to :value:`"host"`, the SDK will be fetched only when |
+| the build uses a Go toolchain and `toolchain resolution`_ results in  this SDK being chosen.     |
+| Otherwise it will be fetched unconditionally.                                                    |
 +--------------------------------+-----------------------------+-----------------------------------+
 | :param:`nogo`                  | :type:`label`               | :value:`None`                     |
 +--------------------------------+-----------------------------+-----------------------------------+
@@ -281,8 +282,8 @@ This downloads a Go SDK for use in toolchains.
 | pick the highest version. If ``version`` is specified but ``sdks`` is                                      |
 | unspecified, ``go_download_sdk`` will list available versions on golang.org                                |
 | to determine the correct file name and SHA-256 sum.                                                        |
-| If ``version`` is specified, the SDK will be lazily fetched when the Go toolchain is required. Otherwise   |
-| it will be eagerly fetched during the analysis phase.                                                      |
+| If ``version`` is specified, the SDK will be fetched only when the build uses a Go toolchain and           |
+| `toolchain resolution`_ results in this SDK being chosen. Otherwise it will be fetched unconditionally.    |
 +--------------------------------+-----------------------------+---------------------------------------------+
 | :param:`urls`                  | :type:`string_list`         | :value:`[https://dl.google.com/go/{}]`      |
 +--------------------------------+-----------------------------+---------------------------------------------+
@@ -363,7 +364,8 @@ used. Otherwise, ``go env GOROOT`` is used.
 | :param:`version`               | :type:`string`              | :value:`None`                     |
 +--------------------------------+-----------------------------+-----------------------------------+
 | The version of Go installed on the host. If specified, `go_host_sdk` will create its repository  |
-| lazily, when the Go toolchain is required.                                                       |
+| only when the build uses a Go toolchain and `toolchain resolution`_ results in this SDK being    |
+| chosen. Otherwise it will be created unconditionally.                                            |
 +--------------------------------+-----------------------------+-----------------------------------+
 
 go_local_sdk
@@ -386,8 +388,9 @@ This prepares a local path to use as the Go SDK in toolchains.
 +--------------------------------+-----------------------------+-----------------------------------+
 | :param:`version`               | :type:`string`              | :value:`None`                     |
 +--------------------------------+-----------------------------+-----------------------------------+
-| The version of the Go SDK. If specified, `go_local_sdk` will create its repository lazily, when  |
-| the Go toolchain is required.                                                                    |
+| The version of the Go SDK. If specified, `go_local_sdk` will create its repository only when the |
+| build uses a Go toolchain and `toolchain resolution`_ results in this SDK being chosen.          |
+| Otherwise it will be created unconditionally.                                                    |
 +--------------------------------+-----------------------------+-----------------------------------+
 
 
@@ -417,8 +420,9 @@ rule.
 +--------------------------------+-----------------------------+-----------------------------------+
 | :param:`version`               | :type:`string`              | :value:`None`                     |
 +--------------------------------+-----------------------------+-----------------------------------+
-| The version of the Go SDK. If specified, `go_wrap_sdk` will create its repository lazily, when   |
-| the Go toolchain is required.                                                                    |
+| The version of the Go SDK. If specified, `go_wrap_sdk` will create its repository only when the  |
+| build uses a Go toolchain and `toolchain resolution`_ results in this SDK being chosen.          |
+| Otherwise it will be created unconditionally.                                                    |
 +--------------------------------+-----------------------------+-----------------------------------+
 
 


### PR DESCRIPTION
**What type of PR is this?**

Other (performance improvement)

**What does this PR do? Why is it needed?**

Declares toolchains in a separate repository. For instance, if the SDK repository is `@go_sdk`, the toolchain rules will be defined in `@go_sdk_toolchains`. This avoids eagerly fetching `@go_sdk`, fixing #3196.

One caveat: `:sdk_version_setting` needs to be defined in the same repo as the toolchain rule, e.g. in `@go_sdk_toolchains`. I tried `target_settings = "@go_sdk//:sdk_version_setting"`, but that causes `@go_sdk` to be eagerly fetched again.

This means that `@go_sdk_toolchains` needs to know the SDK version. There are two possibilities:
* The user specifies the version up front, for instance via `go_register_toolchains(version = ...)`. In that case, `@go_sdk_toolchains` uses this version.
* The user does not specify the version up front. `go_wrap_sdk`, `go_download_sdk`, and `go_local_sdk` do not require a `version` attribute. In this case, we have no choice but to inspect the SDK itself to obtain the version, forcing an eager load. However, we can at least add an optional `version` attribute to these rules, so that users can avoid the eager fetch if they wish.

In all cases, when a `version` attribute is provided by the user, the implementation (lazily) validates that it matches the actual SDK version.

**Which issues(s) does this PR fix?**

Fixes #3196.

**Other notes for review**

As discussed on Slack: https://bazelbuild.slack.com/archives/CDBP88Z0D/p1668022802395059