### PR TITLE
nogo: Add a _base key to be a default config for all Analyzers.

### DIFF
--- a/go/nogo.rst
+++ b/go/nogo.rst
@@ -204,6 +204,9 @@ contain the following key-value pairs:
 | ``flag.Value`` specified by the analyzer.                                                        |
 +----------------------------+---------------------------------------------------------------------+
 
+``nogo`` also supports a special key to specify the same config for all analyzers, even if they are
+not explicitly specified called ``_base``. See below for an example of its usage.
+
 Example
 ^^^^^^^
 
@@ -216,6 +219,12 @@ on a command line driver.
 .. code:: json
 
     {
+      "_base": {
+        "description": "Base config that all subsequent analyzers, even unspecified will inherit.",
+        "exclude_files": {
+          "third_party/": "exclude all third_party code for all analyzers"
+        }
+      },
       "importunsafe": {
         "exclude_files": {
           "src/foo\\.go": "manually verified that behavior is working-as-intended",

--- a/tests/core/nogo/custom/custom_test.go
+++ b/tests/core/nogo/custom/custom_test.go
@@ -297,6 +297,24 @@ func run(pass *analysis.Pass) (interface{}, error) {
   }
 }
 
+-- baseconfig.json --
+{
+  "_base": {
+    "exclude_files": {
+      "has_.*\\.go": "Visibility analyzer not specified. Still inherits this special exception."
+    }
+  },
+  "importfmt": {
+    "only_files": {
+      "has_errors\\.go": ""
+    }
+  },
+  "foofuncname": {
+    "description": "no exemptions since we know this check is 100% accurate, so override base config",
+    "exclude_files": {}
+  }
+}
+
 -- has_errors.go --
 package haserrors
 
@@ -409,6 +427,18 @@ func Test(t *testing.T) {
 		}, {
 			desc:        "custom_config_linedirective",
 			config:      "config.json",
+			target:      "//:has_errors_linedirective",
+			wantSuccess: false,
+			includes: []string{
+				`linedirective_foofuncname.go:.*function must not be named Foo \(foofuncname\)`,
+				`linedirective_visibility.go:.*function D is not visible in this package \(visibility\)`,
+			},
+			excludes: []string{
+				`importfmt`,
+			},
+		}, {
+			desc:        "custom_config_with_base_linedirective",
+			config:      "baseconfig.json",
 			target:      "//:has_errors_linedirective",
 			wantSuccess: false,
 			includes: []string{


### PR DESCRIPTION
This is useful for situations where you want to exclude/include the same directories for all the analyzers. Specifying a config for a particular analyzer will cause the _base config, if it exists, to be underlayed for that analyzer (ie, if the analyzer doesn't set an option, it will use the options specified by the _base config).

You can use it like so:
```
{
	"_base": {
		"exclude_files": {
			"external/": "third_party",
			"proto/": "generated protobuf"
		}
	},
	"override":
		"description": "oops, I actually don't want to exclude any files here...",
		"exclude_files": {}
	}
}
```
**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
nogo: Add a _base key to be a default config for all Analyzers.

**Which issues(s) does this PR fix?**

Partially addresses #2513

**Other notes for review**
Now that we have agreed on the approach, this PR has been updated with a test and docs.
Thanks!