### PR TITLE
feat(pkg-drv): add support for generated files

### DIFF
--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -52,15 +52,15 @@ func (b *BazelJSONBuilder) fileQuery(filename string) string {
 	}
 
 	relToBin, err := filepath.Rel(b.bazel.info["bazel-bin"], filename)
-	if err == nil && !strings.Contains(relToBin, "../") {
-		fmt.Fprintln(os.Stderr, "File is under bazel-bin, reverse walking tree to find matching BUILD.bazel.")
+	if err == nil && !strings.HasPrefix(relToBin, "../") {
 
 		// We've effectively converted filename from bazel-bin/some/path.go to some/path.go;
 		// Check if a BUILD.bazel files exists under this dir, if not walk up and repeat.
 		relToBin = filepath.Dir(relToBin)
 		_, err = os.Stat(filepath.Join(b.bazel.WorkspaceRoot(), relToBin, "BUILD.bazel"))
-		for ; errors.Is(err, os.ErrNotExist) && relToBin != "."; _, err = os.Stat(filepath.Join(b.bazel.WorkspaceRoot(), relToBin, "BUILD.bazel")) {
+		for errors.Is(err, os.ErrNotExist) && relToBin != "." {
 			relToBin = filepath.Dir(relToBin)
+			_, err = os.Stat(filepath.Join(b.bazel.WorkspaceRoot(), relToBin, "BUILD.bazel"))
 		}
 
 		if err == nil {

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -53,7 +53,7 @@ func (b *BazelJSONBuilder) fileQuery(filename string) string {
 
 	relToBin, err := filepath.Rel(b.bazel.info["bazel-bin"], filename)
 	if err == nil && !strings.Contains(relToBin, "../") {
-		fmt.Fprintf(os.Stderr, "File is under bazel-bin, reverse walking tree to find matching BUILD.bazel.")
+		fmt.Fprintln(os.Stderr, "File is under bazel-bin, reverse walking tree to find matching BUILD.bazel.")
 
 		// We've effectively converted filename from bazel-bin/some/path.go to some/path.go;
 		// Check if a BUILD.bazel files exists under this dir, if not walk up and repeat.

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -51,9 +51,10 @@ func (b *BazelJSONBuilder) fileQuery(filename string) string {
 		label = fmt.Sprintf("@%s//%s", matches[1], strings.Join(matches[2:], ":"))
 	}
 
-	relToBin, err := filepath.Rel(b.bazel.info["bazel-bin"], filename)
+	relToBin, err := filepath.Rel(b.bazel.info["output_path"], filename)
 	if err == nil && !strings.HasPrefix(relToBin, "../") {
-
+		parts := strings.SplitN(relToBin, string(filepath.Separator), 3)
+		relToBin = parts[2]
 		// We've effectively converted filename from bazel-bin/some/path.go to some/path.go;
 		// Check if a BUILD.bazel files exists under this dir, if not walk up and repeat.
 		relToBin = filepath.Dir(relToBin)


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

When an IDE like VIM or VSCode queries for packages, some of these packages might report generated code as an import. When that import is followed we're now inside `bazel-out`, which means if the IDE wants to query for packages for this file (often the case in VIM, whereas VSCode tends to cache results better), the query will fail:

```
▶ echo {} | ./tools/gopadrv.sh file=/home/user/.cache/bazel/_bazel_jamy/b97476d719d716accead0f2d5b93104f/execroot/__main__/bazel-out/k8-fastbuild/bin/idl/path/to/pkg/pkg_go_thriftrw_/path/to/pkg/name/type/thriftrw-gen.go
INFO: Analyzed target @io_bazel_rules_go//go/tools/gopackagesdriver:gopackagesdriver (101 packages loaded, 9265 targets configured).
INFO: Found 1 target...
Target @io_bazel_rules_go//go/tools/gopackagesdriver:gopackagesdriver up-to-date:
  bazel-bin/external/io_bazel_rules_go/go/tools/gopackagesdriver/gopackagesdriver_/gopackagesdriver
INFO: Elapsed time: 10.086s, Critical Path: 0.34s
INFO: 3 processes: 1 internal, 2 processwrapper-sandbox.
INFO: Build completed successfully, 3 total actions
INFO: Running command line: bazel-bin/external/io_bazel_rules_go/go/tools/gopackagesdriver/gopackagesdriver_/gopackagesdriver 'file=/home/user/.cache/bazel/_bazel_jamy/b97476d719d716accead0f2d5b93104f/execroot/__main__/bazel-out/k8-fastbuild/bin/idl/path/to/pkg/pkg_go_thriftrw_/path/to/pkg/name/type/thriftrw-gen.go
INFO: Build completed successfully, 3 total actions
Running: [bazel info --tool_tag=gopackagesdriver --ui_actions_shown=0]
Running: [bazel query --tool_tag=gopackagesdriver --ui_actions_shown=0 --ui_event_filters=-info,-stderr --noshow_progress --order_output=no --output=label --nodep_deps --noimplicit_deps --notool_deps kind("go_library|go_test|go_binary", same_pkg_direct_rdeps("../.cache/bazel/_bazel_jamy/b97476d719d716accead0f2d5b93104f/execroot/__main__/bazel-out/k8-fastbuild/bin/idl/path/to/pkg/pkg_go_thriftrw_/path/to/pkg/name/type/thriftrw-gen.go"))]
ERROR: Bad target pattern '../.cache/bazel/_bazel_jamy/b97476d719d716accead0f2d5b93104f/execroot/__main__/bazel-out/k8-fastbuild/bin/idl/path/to/pkg/pkg_go_thriftrw_/path/to/pkg/name/type/thriftrw-gen.go': package name component contains only '.' characters
{"NotHandled":true,"Sizes":{"WordSize":8,"MaxAlign":8},"Packages":[]}
error: unable to build JSON files: query failed: unable to query: bazel query failed: exit status 7
```

Querying for generated files directly (go_thrift, etc) isn't currently supported by the packages driver since the Bazel query for these type of files doesn't work. 

On top of this, generated files often don't map 1-1 to paths in your sources (eg `path/to/gen/code/BUILD.bazel` can generate `bazel-out/path/to/gen/code/name/of/target/thrift-gen.go`); So we have to walk up until we hit a BUILD.bazel file and then query all the targets in this directory.

Finally we can't just filter by go_library since generated code doesn't map back to a go library. So in this case we use `go_*`

Output after fix:

```
▶ echo {} | ./tools/gopadrv.sh file=/home/user/.cache/bazel/_bazel_jamy/b97476d719d716accead0f2d5b93104f/execroot/__main__/bazel-out/k8-fastbuild/bin/idl/path/to/pkg/pkg_go_thriftrw_/path/to/pkg/name/type/thriftrw-gen.go
INFO: Analyzed target @io_bazel_rules_go//go/tools/gopackagesdriver:gopackagesdriver (101 packages loaded, 9265 targets configured).
INFO: Found 1 target...
Target @io_bazel_rules_go//go/tools/gopackagesdriver:gopackagesdriver up-to-date:
  bazel-bin/external/io_bazel_rules_go/go/tools/gopackagesdriver/gopackagesdriver_/gopackagesdriver
INFO: Elapsed time: 10.086s, Critical Path: 0.34s
INFO: 3 processes: 1 internal, 2 processwrapper-sandbox.
INFO: Build completed successfully, 3 total actions
INFO: Running command line: bazel-bin/external/io_bazel_rules_go/go/tools/gopackagesdriver/gopackagesdriver_/gopackagesdriver 'file=/home/user/.cache/bazel/_bazel_jamy/b97476d719d716accead0f2d5b93104f/execroot/__main__/bazel-out/k8-fastbuild/bin/idl/path/to/pkg/pkg_go_thriftrw_/path/to/pkg/name/type/thriftrw-gen.go
INFO: Build completed successfully, 3 total actions
Running: [bazel info --tool_tag=gopackagesdriver --ui_actions_shown=0]
File is under bazel-bin, reverse walking tree to find matching BUILD.bazel.
Running: [bazel query --tool_tag=gopackagesdriver --ui_actions_shown=0 --ui_event_filters=-info,-stderr --noshow_progress --order_output=no --output=label --nodep_deps --noimplicit_deps --notool_deps kind("go_library|go_test|go_binary|cff|go_.*", same_pkg_direct_rdeps("//idl/path/to/pkg:all"))]
Running: [bazel build --tool_tag=gopackagesdriver --ui_actions_shown=0 --show_result=0 --build_event_json_file=/tmp/gopackagesdriver_bep_1446857791 --build_event_json_file_path_conversion=no --experimental_convenience_symlinks=ignore --ui_event_filters=-info,-stderr --noshow_progress --aspects=//tools/ide/packagesdriver:aspect.bzl%cff_pkg_info_aspect,@io_bazel_rules_go//go/tools/gopackagesdriver:aspect.bzl%go_pkg_info_aspect --output_groups=go_pkg_driver_json_file,go_pkg_driver_stdlib_json_file,go_pkg_driver_srcs --keep_going //idl/path/to/pkg:name1_go_thriftrw ... //idl/path/to/pkg:name2_go_thriftrw]
{...packages output...}
```

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
