### PR TITLE
Properly deprecate `bindata`, `go_embed_data`, and `go_embed_data_deps`

### DIFF
--- a/docs/go/extras/extras.md
+++ b/docs/go/extras/extras.md
@@ -40,6 +40,8 @@ This rule has moved. See [gazelle rule] in the Gazelle repository.
 go_embed_data(<a href="#go_embed_data-name">name</a>, <a href="#go_embed_data-flatten">flatten</a>, <a href="#go_embed_data-package">package</a>, <a href="#go_embed_data-src">src</a>, <a href="#go_embed_data-srcs">srcs</a>, <a href="#go_embed_data-string">string</a>, <a href="#go_embed_data-unpack">unpack</a>, <a href="#go_embed_data-var">var</a>)
 </pre>
 
+**Deprecated**: Will be removed in rules_go 0.39.
+
 `go_embed_data` generates a .go file that contains data from a file or a
 list of files. It should be consumed in the srcs list of one of the
 [core go rules].

--- a/extras/bindata.bzl
+++ b/extras/bindata.bzl
@@ -24,6 +24,7 @@ load(
 )
 
 def _bindata_impl(ctx):
+    print("Embedding is now better handled by using rules_go's built-in embedding functionality (https://github.com/bazelbuild/rules_go/blob/master/docs/go/core/rules.md#go_library-embedsrcs). The `bindata` rule is deprecated and will be removed in rules_go version 0.39.")
     go = go_context(ctx)
     out = go.declare_file(go, ext = ".go")
     arguments = ctx.actions.args()

--- a/extras/embed_data.bzl
+++ b/extras/embed_data.bzl
@@ -21,7 +21,9 @@ load(
     "GO_TOOLCHAIN",
 )
 
-_DOC = """`go_embed_data` generates a .go file that contains data from a file or a
+_DOC = """**Deprecated**: Will be removed in rules_go 0.39.
+
+`go_embed_data` generates a .go file that contains data from a file or a
 list of files. It should be consumed in the srcs list of one of the
 [core go rules].
 
@@ -38,7 +40,7 @@ go_embed_data_dependencies()
 """
 
 def _go_embed_data_impl(ctx):
-    print("Embedding is now better handled by using rules_go's built in https://github.com/bazelbuild/rules_go/blob/master/docs/go/core/embedding.md functionality. The `bindata` rule is deprecated and will be removed in rules_go version 0.35.")
+    print("Embedding is now better handled by using rules_go's built-in embedding functionality (https://github.com/bazelbuild/rules_go/blob/master/docs/go/core/rules.md#go_library-embedsrcs). The `go_embed_data` rule is deprecated and will be removed in rules_go version 0.39.")
 
     go = go_context(ctx)
     if ctx.attr.src and ctx.attr.srcs:

--- a/extras/embed_data_deps.bzl
+++ b/extras/embed_data_deps.bzl
@@ -20,6 +20,8 @@ load(
 )
 
 def go_embed_data_dependencies():
+    print("Embedding is now better handled by using rules_go's built-in embedding functionality (https://github.com/bazelbuild/rules_go/blob/master/docs/go/core/rules.md#go_library-embedsrcs). The `go_embed_data_dependencies` macro is deprecated and will be removed in rules_go version 0.39.")
+
     if "com_github_kevinburke_go_bindata" not in native.existing_rules():
         git_repository(
             name = "com_github_kevinburke_go_bindata",


### PR DESCRIPTION
The deprecation warnings weren't complete and linked to an unrelated docs page.