### PR TITLE
fix(packagesdriver): bazelFlags should prefix the command

### DIFF
--- a/go/tools/gopackagesdriver/bazel.go
+++ b/go/tools/gopackagesdriver/bazel.go
@@ -34,10 +34,10 @@ const (
 )
 
 type Bazel struct {
-	bazelBin      string
-	workspaceRoot string
-	bazelFlags    []string
-	info          map[string]string
+	bazelBin          string
+	workspaceRoot     string
+	bazelStartupFlags []string
+	info              map[string]string
 }
 
 // Minimal BEP structs to access the build outputs
@@ -50,11 +50,11 @@ type BEPNamedSet struct {
 	} `json:"namedSetOfFiles"`
 }
 
-func NewBazel(ctx context.Context, bazelBin, workspaceRoot string, bazelFlags []string) (*Bazel, error) {
+func NewBazel(ctx context.Context, bazelBin, workspaceRoot string, bazelStartupFlags []string) (*Bazel, error) {
 	b := &Bazel{
-		bazelBin:      bazelBin,
-		workspaceRoot: workspaceRoot,
-		bazelFlags:    bazelFlags,
+		bazelBin:          bazelBin,
+		workspaceRoot:     workspaceRoot,
+		bazelStartupFlags: bazelStartupFlags,
 	}
 	if err := b.fillInfo(ctx); err != nil {
 		return nil, fmt.Errorf("unable to query bazel info: %w", err)
@@ -82,7 +82,7 @@ func (b *Bazel) run(ctx context.Context, command string, args ...string) (string
 		"--tool_tag=" + toolTag,
 		"--ui_actions_shown=0",
 	}
-	cmd := exec.CommandContext(ctx, b.bazelBin, concatStringsArrays(b.bazelFlags, defaultArgs, args)...)
+	cmd := exec.CommandContext(ctx, b.bazelBin, concatStringsArrays(b.bazelStartupFlags, defaultArgs, args)...)
 	fmt.Fprintln(os.Stderr, "Running:", cmd.Args)
 	cmd.Dir = b.WorkspaceRoot()
 	cmd.Stderr = os.Stderr

--- a/go/tools/gopackagesdriver/bazel.go
+++ b/go/tools/gopackagesdriver/bazel.go
@@ -36,6 +36,7 @@ const (
 type Bazel struct {
 	bazelBin      string
 	workspaceRoot string
+	bazelFlags []string
 	info          map[string]string
 }
 
@@ -49,7 +50,7 @@ type BEPNamedSet struct {
 	} `json:"namedSetOfFiles"`
 }
 
-func NewBazel(ctx context.Context, bazelBin, workspaceRoot string) (*Bazel, error) {
+func NewBazel(ctx context.Context, bazelBin, workspaceRoot string, bazelFlags []string) (*Bazel, error) {
 	b := &Bazel{
 		bazelBin:      bazelBin,
 		workspaceRoot: workspaceRoot,
@@ -75,11 +76,12 @@ func (b *Bazel) fillInfo(ctx context.Context) error {
 }
 
 func (b *Bazel) run(ctx context.Context, command string, args ...string) (string, error) {
-	cmd := exec.CommandContext(ctx, b.bazelBin, append([]string{
+	defaultArgs := []string{
 		command,
 		"--tool_tag=" + toolTag,
 		"--ui_actions_shown=0",
-	}, args...)...)
+	}
+	cmd := exec.CommandContext(ctx, b.bazelBin, concatStringsArrays(b.bazelFlags, defaultArgs, args)...)
 	fmt.Fprintln(os.Stderr, "Running:", cmd.Args)
 	cmd.Dir = b.WorkspaceRoot()
 	cmd.Stderr = os.Stderr

--- a/go/tools/gopackagesdriver/bazel.go
+++ b/go/tools/gopackagesdriver/bazel.go
@@ -36,7 +36,7 @@ const (
 type Bazel struct {
 	bazelBin      string
 	workspaceRoot string
-	bazelFlags []string
+	bazelFlags    []string
 	info          map[string]string
 }
 
@@ -54,6 +54,7 @@ func NewBazel(ctx context.Context, bazelBin, workspaceRoot string, bazelFlags []
 	b := &Bazel{
 		bazelBin:      bazelBin,
 		workspaceRoot: workspaceRoot,
+		bazelFlags:    bazelFlags,
 	}
 	if err := b.fillInfo(ctx); err != nil {
 		return nil, fmt.Errorf("unable to query bazel info: %w", err)

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -130,7 +130,7 @@ func (b *BazelJSONBuilder) outputGroupsForMode(mode LoadMode) string {
 }
 
 func (b *BazelJSONBuilder) query(ctx context.Context, query string) ([]string, error) {
-	queryArgs := concatStringsArrays(bazelFlags, bazelQueryFlags, []string{
+	queryArgs := concatStringsArrays(bazelQueryFlags, []string{
 		"--ui_event_filters=-info,-stderr",
 		"--noshow_progress",
 		"--order_output=no",
@@ -166,7 +166,7 @@ func (b *BazelJSONBuilder) Build(ctx context.Context, mode LoadMode) ([]string, 
 		"--aspects=" + strings.Join(aspects, ","),
 		"--output_groups=" + b.outputGroupsForMode(mode),
 		"--keep_going", // Build all possible packages
-	}, bazelFlags, bazelBuildFlags, labels)
+	}, bazelBuildFlags, labels)
 	files, err := b.bazel.Build(ctx, buildArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("unable to bazel build %v: %w", buildArgs, err)

--- a/go/tools/gopackagesdriver/main.go
+++ b/go/tools/gopackagesdriver/main.go
@@ -54,7 +54,7 @@ var (
 	rulesGoRepositoryName = getenvDefault("GOPACKAGESDRIVER_RULES_GO_REPOSITORY_NAME", "@io_bazel_rules_go")
 	goDefaultAspect       = rulesGoRepositoryName + "//go/tools/gopackagesdriver:aspect.bzl%go_pkg_info_aspect"
 	bazelBin              = getenvDefault("GOPACKAGESDRIVER_BAZEL", "bazel")
-	bazelFlags            = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_FLAGS"))
+	bazelStartupFlags     = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_FLAGS"))
 	bazelQueryFlags       = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_QUERY_FLAGS"))
 	bazelQueryScope       = getenvDefault("GOPACKAGESDRIVER_BAZEL_QUERY_SCOPE", "")
 	bazelBuildFlags       = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_BUILD_FLAGS"))
@@ -80,7 +80,7 @@ func run() (*driverResponse, error) {
 		return emptyResponse, fmt.Errorf("unable to read request: %w", err)
 	}
 
-	bazel, err := NewBazel(ctx, bazelBin, workspaceRoot, bazelFlags)
+	bazel, err := NewBazel(ctx, bazelBin, workspaceRoot, bazelStartupFlags)
 	if err != nil {
 		return emptyResponse, fmt.Errorf("unable to create bazel instance: %w", err)
 	}

--- a/go/tools/gopackagesdriver/main.go
+++ b/go/tools/gopackagesdriver/main.go
@@ -80,7 +80,7 @@ func run() (*driverResponse, error) {
 		return emptyResponse, fmt.Errorf("unable to read request: %w", err)
 	}
 
-	bazel, err := NewBazel(ctx, bazelBin, workspaceRoot)
+	bazel, err := NewBazel(ctx, bazelBin, workspaceRoot, bazelFlags)
 	if err != nil {
 		return emptyResponse, fmt.Errorf("unable to create bazel instance: %w", err)
 	}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

General bazel flags (eg `--output_base`) are required to be set before the action/command you'd like to run.

This PR adds the bazelFlags that are defined by the `GOPACKAGESDRVER_BAZEL_FLAGS` env variable into the Bazel struct, so we can prefix them ahead of the command to be ran. `GOPACKAGESDRVER_BAZEL_BUILD_FLAGS` and `GOPACKAGESDRVER_BAZEL_QUERY_FLAGS` are still appended at the end.

```
▶ bazel info --output_base=/some/path 
ERROR: --output_base=/some/path :: Unrecognized option: --output_base=/home/user/.cache/bazel/_bazel_jamy/b97476d719d716accead0f2d5b93104f_pkgdrv

▶ bazel --output_base=/some/path info 
bazel-bin: /some/path/execroot/__main__/bazel-out/k8-fastbuild/bin
bazel-genfiles: /some/path/execroot/__main__/bazel-out/k8-fastbuild/bin
bazel-testlogs: /some/path/execroot/__main__/bazel-out/k8-fastbuild/testlogs
...
output_base: /some/path
output_path: /some/path/execroot/__main__/bazel-out
...
```

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
