### PR TITLE
Release 0.37.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,7 @@
 module(
     name = "rules_go",
     repo_name = "io_bazel_rules_go",
-    version = "0.36.0",
+    version = "0.37.0",
     compatibility_level = 0,
 )
 

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -125,7 +125,7 @@ TOOLS_NOGO = [
 
 # Current version or next version to be tagged. Gazelle and other tools may
 # check this to determine compatibility.
-RULES_GO_VERSION = "0.36.0"
+RULES_GO_VERSION = "0.37.0"
 
 def declare_toolchains(host, sdk, builder, sdk_version_setting):
     host_goos, _, host_goarch = host.partition("_")


### PR DESCRIPTION
Depends on #3380 being merged first.

Suggested release notes:

```markdown
# Major New Features

- Support fetching packages for generated code in the Go Packages Driver

# What's Changed

- fix(gpd): Write large target patterns to file (#3372) by @JamyDev
- Fix normalization check for Rlocation path (#3378) by @fmeum
- Document that Rlocation can return relative paths (#3377) by @fmeum
- nogo: Add a _base key to be a default config for all Analyzers. (#3351) by @DolceTriade
- chore(gpd): export aspect utils for reusability (#3373) by @JamyDev
- fix(packagesdriver): bazelFlags should prefix the command (#3371) by @JamyDev
- Adding first example (#3317) by @chrislovecnm
- go link: use external linker when in race mode (#3370) by @motiejus
- Upgrade googleapis to 2022-11-21 by @linzhp
- Update README to use latest rules_go and Gazelle releases (#3368) by @linzhp
- Update docs regarding vendored proto files (#3360) by @garymm
- Reduce number of declared files in emit_stdlib (#3366) by @fmeum
- Remove unused variables in link action (#3367) by @fmeum
- feat(pkg-drv): add support for generated files (#3354) by @JamyDev
- link.bzl: ignore duplicate dep on coverdata (#3032) by @robfig
- Properly deprecate bindata, go_embed_data, and `go_embed_data_deps` (#3362) by @fmeum
- go_path: support go:embed of generated files (#3285) by @S-Chan
- Remove deprecated actions (#3173) by @fmeum
- Declare toolchains in a separate repository (#3348) by @jfirebaugh
- bzlmod: Add missing strip_prefix field to source.template.json (#3359) by @fmeum
- revert the upgrade of googleapis (#3358) by @linzhp

# New Contributors

- @DolceTriade made their first contribution in #3351
- @chrislovecnm made their first contribution in #3317
- @motiejus made their first contribution in #3370
- @garymm made their first contribution in #3360
- @S-Chan made their first contribution in #3285
- @jfirebaugh made their first contribution in #3348

Full Changelog: `TODO`


# `WORKSPACE` Code

TODO
```