### PR TITLE
bzlmod: Add missing repository metadata

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -7,6 +7,9 @@
       "name": "Fabian Meumertzheim"
     }
   ],
+  "repository": [
+    "github:bazelbuild/rules_go"
+  ],
   "versions": [],
   "yanked_versions": {}
 }


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel-central-registry/pull/311#discussion_r1041304177