### PR TITLE
preserve intermediate files if `-work` is specified

### DIFF
--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -376,7 +376,9 @@ func compileArchive(
 	if err != nil {
 		return err
 	}
-	defer os.Remove(importcfgPath)
+	if !goenv.shouldPreserveWorkDir {
+		defer os.Remove(importcfgPath)
+	}
 
 	// Build an embedcfg file mapping embed patterns to filenames.
 	// Embed patterns are relative to any one of a list of root directories
@@ -406,7 +408,9 @@ func compileArchive(
 		return err
 	}
 	if embedcfgPath != "" {
-		defer os.Remove(embedcfgPath)
+		if !goenv.shouldPreserveWorkDir {
+			defer os.Remove(embedcfgPath)
+		}
 	}
 
 	// Run nogo concurrently.
@@ -453,7 +457,9 @@ func compileArchive(
 	}
 	symabisPath, err := buildSymabisFile(goenv, srcs.sSrcs, srcs.hSrcs, asmHdrPath)
 	if symabisPath != "" {
-		defer os.Remove(symabisPath)
+		if !goenv.shouldPreserveWorkDir {
+			defer os.Remove(symabisPath)
+		}
 	}
 	if err != nil {
 		return err

--- a/go/tools/builders/link.go
+++ b/go/tools/builders/link.go
@@ -100,7 +100,9 @@ func link(args []string) error {
 	if err != nil {
 		return err
 	}
-	defer os.Remove(importcfgName)
+	if !goenv.shouldPreserveWorkDir {
+		defer os.Remove(importcfgName)
+	}
 
 	// generate any additional link options we need
 	goargs := goenv.goTool("link")


### PR DESCRIPTION
If a compilation fails and we need to invoke an intermediate step, we need to ensure the intermediate files are available.

`-work` is meant exactly for that, but it is not always consulted. Lets consult it for a couple more files too.
