### PR TITLE
Adapt `lcov_coverage_test` to `exec.Command` change

### DIFF
--- a/tests/core/coverage/lcov_coverage_test.go
+++ b/tests/core/coverage/lcov_coverage_test.go
@@ -117,6 +117,7 @@ package lib_test
 
 import (
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -130,7 +131,7 @@ func TestLib(t *testing.T) {
 }
 
 func TestTool(t *testing.T) {
-	err := exec.Command("Tool").Run()
+	err := exec.Command(filepath.Join(".", "Tool")).Run()
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
`exec.Command` no longer implicitly looks in the current directory with Go 1.19.
