### PR TITLE
explicitly build relative path for Tool command in lcov_coverage_test

### DIFF
--- a/tests/core/coverage/lcov_coverage_test.go
+++ b/tests/core/coverage/lcov_coverage_test.go
@@ -131,7 +131,7 @@ func TestLib(t *testing.T) {
 }
 
 func TestTool(t *testing.T) {
-	err := exec.Command("." + filepath.Separator + "Tool")).Run()
+	err := exec.Command("." + string(filepath.Separator) + "Tool").Run()
 	if err != nil {
 		t.Error(err)
 	}

--- a/tests/core/coverage/lcov_coverage_test.go
+++ b/tests/core/coverage/lcov_coverage_test.go
@@ -131,7 +131,7 @@ func TestLib(t *testing.T) {
 }
 
 func TestTool(t *testing.T) {
-	err := exec.Command(filepath.Join(".", "Tool")).Run()
+	err := exec.Command("." + filepath.Separator + "Tool")).Run()
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
filepath.Join(".", "Tool") is just "Tool" because the path is cleaned.

See https://go.dev/play/p/R1KWJ9612fN.

Build the relative path explicitly using "." + string(filepath.Separator) + "Tool".
