### PR TITLE
Refactoring the extld related logic

### DIFF
--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -95,10 +95,11 @@ def emit_link(
         tool_args.add("-race")
     if go.mode.msan:
         tool_args.add("-msan")
-    if ((go.mode.static and not go.mode.pure) or
-        (go.mode.race and extld) or
+
+    if extld and (go.mode.static or
+        go.mode.race or
         go.mode.link != LINKMODE_NORMAL or
-        go.mode.goos == "windows" and (go.mode.race or go.mode.msan)):
+        go.mode.goos == "windows" and go.mode.msan):
         # Force external linking for the following conditions:
         # * Mode is static but not pure: -static must be passed to the C
         #   linker if the binary contains cgo code. See #2168, #2216.
@@ -114,10 +115,7 @@ def emit_link(
         #
         #       runtime/cgo(.text): relocation target memset not defined
         tool_args.add("-linkmode", "external")
-    if go.mode.pure:
-        # Force internal linking in pure mode. We don't have a C toolchain,
-        # so external linking is not possible.
-        tool_args.add("-linkmode", "internal")
+
     if go.mode.static:
         extldflags.append("-static")
     if go.mode.link != LINKMODE_NORMAL:

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -89,32 +89,35 @@ def emit_link(
     tool_args = go.tool_args(go)
 
     # Add in any mode specific behaviours
-    extld = extld_from_cc_toolchain(go)
-    tool_args.add_all(extld)
     if go.mode.race:
         tool_args.add("-race")
     if go.mode.msan:
         tool_args.add("-msan")
 
-    if extld and (go.mode.static or
-        go.mode.race or
-        go.mode.link != LINKMODE_NORMAL or
-        go.mode.goos == "windows" and go.mode.msan):
-        # Force external linking for the following conditions:
-        # * Mode is static but not pure: -static must be passed to the C
-        #   linker if the binary contains cgo code. See #2168, #2216.
-        # * Non-normal build mode: may not be strictly necessary, especially
-        #   for modes like "pie".
-        # * Race or msan build for Windows: Go linker has pairwise
-        #   incompatibilities with mingw, and we get link errors in race mode.
-        #   Using the C linker avoids that. Race and msan always require a
-        #   a C toolchain. See #2614.
-        # * Linux race builds: we get linker errors during build with Go's
-        #   internal linker. For example, when using zig cc v0.10
-        #   (clang-15.0.3):
-        #
-        #       runtime/cgo(.text): relocation target memset not defined
-        tool_args.add("-linkmode", "external")
+    if go.mode.pure:
+        tool_args.add("-linkmode", "internal")
+    else:
+        extld = extld_from_cc_toolchain(go)
+        tool_args.add_all(extld)
+        if extld and (go.mode.static or
+                      go.mode.race or
+                      go.mode.link != LINKMODE_NORMAL or
+                      go.mode.goos == "windows" and go.mode.msan):
+            # Force external linking for the following conditions:
+            # * Mode is static but not pure: -static must be passed to the C
+            #   linker if the binary contains cgo code. See #2168, #2216.
+            # * Non-normal build mode: may not be strictly necessary, especially
+            #   for modes like "pie".
+            # * Race or msan build for Windows: Go linker has pairwise
+            #   incompatibilities with mingw, and we get link errors in race mode.
+            #   Using the C linker avoids that. Race and msan always require a
+            #   a C toolchain. See #2614.
+            # * Linux race builds: we get linker errors during build with Go's
+            #   internal linker. For example, when using zig cc v0.10
+            #   (clang-15.0.3):
+            #
+            #       runtime/cgo(.text): relocation target memset not defined
+            tool_args.add("-linkmode", "external")
 
     if go.mode.static:
         extldflags.append("-static")

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -438,7 +438,7 @@ def go_context(ctx, attr = None):
     # See https://github.com/golang/go/wiki/MinimumRequirements#amd64
     if mode.amd64:
         env["GOAMD64"] = mode.amd64
-    if mode.pure:
+    if not cgo_context_info:
         crosstool = []
         cgo_tools = None
     else:


### PR DESCRIPTION
**What type of PR is this?**
Refactoring

**What does this PR do? Why is it needed?**
The original issue that this PR was trying to fix was fixed on zig side. This PR is reduced to a refactoring to:
* avoid adding both `-linkmode internal` and `-linkmode external` in some corner cases
* avoid using `-linkmode external` when external linker is not available
* add C toolchain to go_context as long as it's available, deferring to the link action to decide whether it should be passed down to the linker. This gives us more flexibility later on, for example, to use external linker even in pure mode.

