### PR TITLE
Generalize `boringcrypto` to `GOEXPERIMENT` support

### DIFF
--- a/go/private/BUILD.sdk.bazel
+++ b/go/private/BUILD.sdk.bazel
@@ -41,7 +41,7 @@ go_sdk(
     libs = [":libs"],
     package_list = ":package_list",
     root_file = "ROOT",
-    boringcrypto = {boringcrypto},
+    experiments = {experiments},
     tools = [":tools"],
 )
 

--- a/go/private/actions/compilepkg.bzl
+++ b/go/private/actions/compilepkg.bzl
@@ -117,8 +117,7 @@ def emit_compilepkg(
         outputs.append(out_cgo_export_h)
     if testfilter:
         args.add("-testfilter", testfilter)
-    if go.sdk.boringcrypto:
-        args.add("-boringcrypto")
+    args.add_all(go.sdk.experiments, before_each = "-experiment")
 
     gc_flags = list(gc_goopts)
     gc_flags.extend(go.mode.gc_goopts)

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -175,8 +175,7 @@ def emit_link(
     builder_args.add("-p", archive.data.importmap)
     tool_args.add_all(gc_linkopts)
     tool_args.add_all(go.toolchain.flags.link)
-    if go.sdk.boringcrypto:
-        builder_args.add("-boringcrypto")
+    builder_args.add_all(go.sdk.experiments, before_each = "-experiment")
 
     # Do not remove, somehow this is needed when building for darwin/arm only.
     tool_args.add("-buildid=redacted")

--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -49,7 +49,7 @@ def _should_use_sdk_stdlib(go):
             not go.mode.race and  # TODO(jayconrod): use precompiled race
             not go.mode.msan and
             not go.mode.pure and
-            not go.sdk.boringcrypto and
+            not go.sdk.experiments and
             go.mode.link == LINKMODE_NORMAL)
 
 def _build_stdlib_list_json(go):
@@ -80,8 +80,7 @@ def _build_stdlib(go):
     args.add("-out", pkg.dirname)
     if go.mode.race:
         args.add("-race")
-    if go.sdk.boringcrypto:
-        args.add("-boringcrypto")
+    args.add_all(go.sdk.experiments, before_each = "-experiment")
     args.add_all(link_mode_args(go.mode))
     env = go.env
     if go.mode.pure:

--- a/go/private/providers.bzl
+++ b/go/private/providers.bzl
@@ -41,7 +41,7 @@ GoSDK = provider(
     fields = {
         "goos": "The host OS the SDK was built for.",
         "goarch": "The host architecture the SDK was built for.",
-        "boringcrypto": "Whether to build for boringcrypto",
+        "experiments": "Go experiments to enable via GOEXPERIMENT.",
         "root_file": "A file in the SDK root directory",
         "libs": ("List of pre-compiled .a files for the standard library " +
                  "built for the execution platform."),

--- a/go/private/rules/sdk.bzl
+++ b/go/private/rules/sdk.bzl
@@ -25,7 +25,7 @@ def _go_sdk_impl(ctx):
     return [GoSDK(
         goos = ctx.attr.goos,
         goarch = ctx.attr.goarch,
-        boringcrypto = ctx.attr.boringcrypto,
+        experiments = ctx.attr.experiments,
         root_file = ctx.file.root_file,
         package_list = package_list,
         libs = ctx.files.libs,
@@ -46,9 +46,9 @@ go_sdk = rule(
             mandatory = True,
             doc = "The host architecture the SDK was built for",
         ),
-        "boringcrypto": attr.bool(
+        "experiments": attr.string_list(
             mandatory = False,
-            doc = "Whether the toolchain should be built with boringcrypto support enabled",
+            doc = "Go experiments to enable via GOEXPERIMENT",
         ),
         "root_file": attr.label(
             mandatory = True,

--- a/go/toolchains.rst
+++ b/go/toolchains.rst
@@ -247,6 +247,10 @@ SDK version to use (for example, :value:`"1.15.5"`).
 | used for static analysis. The ``nogo`` binary will be used alongside the                         |
 | Go compiler when building packages.                                                              |
 +--------------------------------+-----------------------------+-----------------------------------+
+| :param:`experiments`           | :type:`string_list`         | :value:`[]`                       |
++--------------------------------+-----------------------------+-----------------------------------+
+| Go experiments to enable via `GOEXPERIMENT`.                                                     |
++--------------------------------+-----------------------------+-----------------------------------+
 
 go_download_sdk
 ~~~~~~~~~~~~~~~
@@ -367,6 +371,10 @@ used. Otherwise, ``go env GOROOT`` is used.
 | only when the build uses a Go toolchain and `toolchain resolution`_ results in this SDK being    |
 | chosen. Otherwise it will be created unconditionally.                                            |
 +--------------------------------+-----------------------------+-----------------------------------+
+| :param:`experiments`           | :type:`string_list`         | :value:`[]`                       |
++--------------------------------+-----------------------------+-----------------------------------+
+| Go experiments to enable via `GOEXPERIMENT`.                                                     |
++--------------------------------+-----------------------------+-----------------------------------+
 
 go_local_sdk
 ~~~~~~~~~~~~
@@ -391,6 +399,10 @@ This prepares a local path to use as the Go SDK in toolchains.
 | The version of the Go SDK. If specified, `go_local_sdk` will create its repository only when the |
 | build uses a Go toolchain and `toolchain resolution`_ results in this SDK being chosen.          |
 | Otherwise it will be created unconditionally.                                                    |
++--------------------------------+-----------------------------+-----------------------------------+
+| :param:`experiments`           | :type:`string_list`         | :value:`[]`                       |
++--------------------------------+-----------------------------+-----------------------------------+
+| Go experiments to enable via `GOEXPERIMENT`.                                                     |
 +--------------------------------+-----------------------------+-----------------------------------+
 
 
@@ -423,6 +435,10 @@ rule.
 | The version of the Go SDK. If specified, `go_wrap_sdk` will create its repository only when the  |
 | build uses a Go toolchain and `toolchain resolution`_ results in this SDK being chosen.          |
 | Otherwise it will be created unconditionally.                                                    |
++--------------------------------+-----------------------------+-----------------------------------+
+| :param:`experiments`           | :type:`string_list`         | :value:`[]`                       |
++--------------------------------+-----------------------------+-----------------------------------+
+| Go experiments to enable via `GOEXPERIMENT`.                                                     |
 +--------------------------------+-----------------------------+-----------------------------------+
 
 

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -56,7 +56,7 @@ func compilePkg(args []string) error {
 	var testFilter string
 	var gcFlags, asmFlags, cppFlags, cFlags, cxxFlags, objcFlags, objcxxFlags, ldFlags quoteMultiFlag
 	var coverFormat string
-	var boringcrypto bool
+	var experiments multiFlag
 	fs.Var(&unfilteredSrcs, "src", ".go, .c, .cc, .m, .mm, .s, or .S file to be filtered and compiled")
 	fs.Var(&coverSrcs, "cover", ".go file that should be instrumented for coverage (must also be a -src)")
 	fs.Var(&embedSrcs, "embedsrc", "file that may be compiled into the package with a //go:embed directive")
@@ -72,7 +72,7 @@ func compilePkg(args []string) error {
 	fs.Var(&cxxFlags, "cxxflags", "C++ compiler flags")
 	fs.Var(&objcFlags, "objcflags", "Objective-C compiler flags")
 	fs.Var(&objcxxFlags, "objcxxflags", "Objective-C++ compiler flags")
-	fs.BoolVar(&boringcrypto, "boringcrypto", false, "Build stdlib with boringcrypto")
+	fs.Var(&experiments, "experiment", "Go experiments to enable via GOEXPERIMENT")
 	fs.Var(&ldFlags, "ldflags", "C linker flags")
 	fs.StringVar(&nogoPath, "nogo", "", "The nogo binary. If unset, nogo will not be run.")
 	fs.StringVar(&packageListPath, "package_list", "", "The file containing the list of standard library packages")
@@ -132,8 +132,8 @@ func compilePkg(args []string) error {
 		return fmt.Errorf("invalid test filter %q", testFilter)
 	}
 
-	if boringcrypto {
-		os.Setenv("GOEXPERIMENT", "boringcrypto")
+	if len(experiments) > 0 {
+		os.Setenv("GOEXPERIMENT", strings.Join(experiments, ","))
 	}
 
 	return compileArchive(

--- a/go/tools/builders/link.go
+++ b/go/tools/builders/link.go
@@ -39,6 +39,7 @@ func link(args []string) error {
 	builderArgs, toolArgs := splitArgs(args)
 	stamps := multiFlag{}
 	xdefs := multiFlag{}
+	experiments := multiFlag{}
 	archives := archiveMultiFlag{}
 	flags := flag.NewFlagSet("link", flag.ExitOnError)
 	goenv := envFlags(flags)
@@ -48,9 +49,9 @@ func link(args []string) error {
 	flags.Var(&archives, "arc", "Label, package path, and file name of a dependency, separated by '='")
 	packageList := flags.String("package_list", "", "The file containing the list of standard library packages")
 	buildmode := flags.String("buildmode", "", "Build mode used.")
-	boringcrypto := flags.Bool("boringcrypto", false, "set boringcrypto GOEXPERIMENT")
 	flags.Var(&xdefs, "X", "A string variable to replace in the linked binary (repeated).")
 	flags.Var(&stamps, "stamp", "The name of a file with stamping values.")
+	flags.Var(&experiments, "experiment", "Go experiments to enable via GOEXPERIMENT")
 	conflictErrMsg := flags.String("conflict_err", "", "Error message about conflicts to report if there's a link error.")
 	if err := flags.Parse(builderArgs); err != nil {
 		return err
@@ -147,8 +148,8 @@ func link(args []string) error {
 	}
 	goargs = append(goargs, "-o", *outFile)
 
-	if *boringcrypto {
-		os.Setenv("GOEXPERIMENT", "boringcrypto")
+	if len(experiments) > 0 {
+		os.Setenv("GOEXPERIMENT", strings.Join(experiments, ","))
 	}
 
 	// add in the unprocess pass through options

--- a/go/tools/builders/stdlib.go
+++ b/go/tools/builders/stdlib.go
@@ -33,7 +33,8 @@ func stdlib(args []string) error {
 	race := flags.Bool("race", false, "Build in race mode")
 	shared := flags.Bool("shared", false, "Build in shared mode")
 	dynlink := flags.Bool("dynlink", false, "Build in dynlink mode")
-	boringcrypto := flags.Bool("boringcrypto", false, "Build stdlib with boringcrypto")
+	var experiments multiFlag
+	flags.Var(&experiments, "experiment", "Go experiments to enable via GOEXPERIMENT")
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
@@ -110,8 +111,8 @@ You may need to use the flags --cpu=x64_windows --compiler=mingw-gcc.`)
 	}
 	os.Setenv("CGO_LDFLAGS_ALLOW", b.String())
 
-	if *boringcrypto {
-		os.Setenv("GOEXPERIMENT", "boringcrypto")
+	if len(experiments) > 0 {
+		os.Setenv("GOEXPERIMENT", strings.Join(experiments, ","))
 	}
 
 	// Build the commands needed to build the std library in the right mode

--- a/tests/core/boringcrypto/boringcrypto_test.go
+++ b/tests/core/boringcrypto/boringcrypto_test.go
@@ -66,7 +66,7 @@ const origWrapSDK = `go_wrap_sdk(
 const wrapSDKBoringcrypto = `go_wrap_sdk(
     name = "go_sdk",
     root_file = "@local_go_sdk//:ROOT",
-    boringcrypto = True,
+    experiments = ["boringcrypto"],
 )`
 
 func TestBoringcryptoExperimentPresent(t *testing.T) {
@@ -91,30 +91,6 @@ func TestBoringcryptoExperimentPresent(t *testing.T) {
 
 	if !strings.Contains(string(out), "X:boringcrypto") {
 		t.Fatalf(`version of binary: got %q, want string containing "X:boringcrypto"`, string(out))
-	}
-}
-
-func TestGoRegisterToolchainsChecksVersion(t *testing.T) {
-	const (
-		from = `go_wrap_sdk(
-    name = "go_sdk",
-    root_file = "@local_go_sdk//:ROOT",
-)
-
-go_register_toolchains()`
-		to = `go_register_toolchains(version = "1.18.0", boringcrypto = True)`
-	)
-	mustReplaceInFile(t, "WORKSPACE", from, to)
-	defer mustReplaceInFile(t, "WORKSPACE", to, from)
-
-	out, err := bazel_testing.BazelCmd("build", "//:program").CombinedOutput()
-	if err == nil {
-		t.Fatal("bazel build succeeded; expected command failure\n output:", string(out))
-	}
-
-	wantMsg := "go_register_toolchains: boringcrypto is only supported for versions 1.19.0 and above"
-	if !strings.Contains(string(out), wantMsg) {
-		t.Fatalf("output of bazel build: expected to contain %q\ngot %v", wantMsg, string(out))
 	}
 }
 


### PR DESCRIPTION
The new `experiments` parameter on all SDK rules can now be used to enable Go experiments. This subsumes the previously special-cased `boringcrypto` support and allows us to push the duty to match the Go SDK version on the user.
