### PR TITLE
Replace `cfg = "host"` with `cfg = "exec"`

### DIFF
--- a/extras/bindata.bzl
+++ b/extras/bindata.bzl
@@ -76,7 +76,7 @@ bindata = rule(
         "extra_args": attr.string_list(),
         "_bindata": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             default = "@com_github_kevinburke_go_bindata//go-bindata:go-bindata",
         ),
         "_go_context_data": attr.label(

--- a/extras/embed_data.bzl
+++ b/extras/embed_data.bzl
@@ -135,7 +135,7 @@ go_embed_data = rule(
         "_embed": attr.label(
             default = "//go/tools/builders:embed",
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "_go_context_data": attr.label(
             default = "//:go_context_data",


### PR DESCRIPTION
Become compatible with
`--incompatible_disable_starlark_host_transitions`, which will be
flipped in Bazel 7.

Work towards https://github.com/bazelbuild/bazel/issues/17032
(fixing the issue requires rules_go and bazel-gazelle releases)