### PR TITLE
fix: Relative path of embedsrc

### DIFF
--- a/go/private/tools/path.bzl
+++ b/go/private/tools/path.bzl
@@ -84,6 +84,8 @@ def _go_path_impl(ctx):
             if src_dir == None:
                 fail("cannot relativize {}: src_dir is unset".format(f.path))
             embedpath = paths.relativize(f.path, f.root.path)
+            if ctx.bin_dir.path == f.root.path:
+                embedpath = f.path
             dst = pkg.dir + "/" + paths.relativize(embedpath, src_dir)
             _add_manifest_entry(manifest_entries, manifest_entry_map, inputs, f, dst)
     if ctx.attr.include_pkg:


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
The new relativize introduced by https://github.com/bazelbuild/rules_go/pull/3285 fails if the root path is the same as `ctx.bin_path`
**Which issues(s) does this PR fix?**

Fixes # 3405

**Other notes for review**
