### PR TITLE
Mark `nogo` targets as `manual` to keep top-level symlinks

### DIFF
--- a/go/private/rules/nogo.bzl
+++ b/go/private/rules/nogo.bzl
@@ -121,6 +121,16 @@ def nogo(name, visibility = None, **kwargs):
         visibility = visibility,
     )
 
+    # With --use_top_level_targets_for_symlinks, which is enabled by default in
+    # Bazel 6.0.0, self-transitioning top-level targets prevent the bazel-bin
+    # convenience symlink from being created. Since nogo targets are of this
+    # type, their presence would trigger this behavior. Work around this by
+    # excluding them from wildcards - they are still transitively built as a
+    # tool dependency of every Go target.
+    kwargs.setdefault("tags", [])
+    if "manual" not in kwargs["tags"]:
+        kwargs["tags"].append("manual")
+
     _nogo(
         name = actual_name,
         visibility = visibility,


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

With --use_top_level_targets_for_symlinks, which is enabled by default in Bazel 6.0.0, self-transitioning top-level targets prevent the bazel-bin convenience symlink from being created. Since nogo targets are of this type, their presence would trigger this behavior. Work around this by excluding them from wildcards - they are still transitively built as a tool dependency of every Go target.

**Which issues(s) does this PR fix?**

Fixes #3409 