### PR TITLE
chore: remove experimental warning from bzlmod module

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,8 +5,6 @@ module(
     compatibility_level = 0,
 )
 
-print("WARNING: The rules_go Bazel module is still highly experimental and subject to change at any time. Only use it to try out bzlmod for now.")
-
 bazel_dep(name = "bazel_skylib", version = "1.2.0")
 bazel_dep(name = "platforms", version = "0.0.4")
 bazel_dep(name = "rules_proto", version = "4.0.0")


### PR DESCRIPTION
In practice, now that Bazel 6.0.0 has shipped, rules_go is working about as well as any other supported languages in the ecosystem. Also, if users find bugs with it, those are important and we'll fix them.
