### PR TITLE
Add a clarifying error about dependency cycle found for internal tests

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -63,9 +63,6 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
     out_cgo_export_h = None  # set if cgo used in c-shared or c-archive mode
 
     direct = [get_archive(dep) for dep in source.deps]
-    internal_deps = []
-    if recompile_internal_deps:
-        internal_deps = [get_archive(dep) for dep in recompile_internal_deps]
     runfiles = source.runfiles
     data_files = runfiles.files
 
@@ -135,7 +132,7 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
             gc_goopts = source.gc_goopts,
             cgo = False,
             testfilter = testfilter,
-            recompile_internal_deps = internal_deps,
+            recompile_internal_deps = recompile_internal_deps,
         )
 
     data = GoArchiveData(

--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -39,7 +39,7 @@ load(
     "emit_compilepkg",
 )
 
-def emit_archive(go, source = None, _recompile_suffix = ""):
+def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_deps = None):
     """See go/toolchains.rst#archive for full documentation."""
 
     if source == None:
@@ -63,6 +63,9 @@ def emit_archive(go, source = None, _recompile_suffix = ""):
     out_cgo_export_h = None  # set if cgo used in c-shared or c-archive mode
 
     direct = [get_archive(dep) for dep in source.deps]
+    internal_deps = []
+    if recompile_internal_deps:
+        internal_deps = [get_archive(dep) for dep in recompile_internal_deps]
     runfiles = source.runfiles
     data_files = runfiles.files
 
@@ -132,6 +135,7 @@ def emit_archive(go, source = None, _recompile_suffix = ""):
             gc_goopts = source.gc_goopts,
             cgo = False,
             testfilter = testfilter,
+            recompile_internal_deps = internal_deps,
         )
 
     data = GoArchiveData(

--- a/go/private/actions/compilepkg.bzl
+++ b/go/private/actions/compilepkg.bzl
@@ -59,7 +59,8 @@ def emit_compilepkg(
         out_export = None,
         out_cgo_export_h = None,
         gc_goopts = [],
-        testfilter = None):  # TODO: remove when test action compiles packages
+        testfilter = None,  # TODO: remove when test action compiles packages
+        recompile_internal_deps = []):
     """Compiles a complete Go package."""
     if sources == None:
         fail("sources is a required parameter")
@@ -99,6 +100,8 @@ def emit_compilepkg(
         args.add("-cover_format", go.cover_format)
         args.add_all(cover, before_each = "-cover")
     args.add_all(archives, before_each = "-arc", map_each = _archive)
+    if recompile_internal_deps:
+        args.add_all(recompile_internal_deps, before_each = "-recompile_internal_deps", map_each = _archive)
     if importpath:
         args.add("-importpath", importpath)
     else:

--- a/go/private/actions/compilepkg.bzl
+++ b/go/private/actions/compilepkg.bzl
@@ -101,7 +101,7 @@ def emit_compilepkg(
         args.add_all(cover, before_each = "-cover")
     args.add_all(archives, before_each = "-arc", map_each = _archive)
     if recompile_internal_deps:
-        args.add_all(recompile_internal_deps, before_each = "-recompile_internal_deps", map_each = _archive)
+        args.add_all(recompile_internal_deps, before_each = "-recompile_internal_deps")
     if importpath:
         args.add("-importpath", importpath)
     else:

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -593,6 +593,7 @@ def _recompile_external_deps(go, external_source, internal_archive, library_labe
     internal_source = internal_archive.source
 
     internal_deps = []
+
     # Pass internal dependencies that need to be recompiled down to the builder to check if the internal archive
     # tries to import any of the dependencies. If there is, that means that there is a dependency cycle.
     need_recompile_deps = []

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -592,15 +592,17 @@ def _recompile_external_deps(go, external_source, internal_archive, library_labe
     # can't import anything that imports itself.
     internal_source = internal_archive.source
 
+    internal_deps = []
     # Pass internal dependencies that need to be recompiled down to the builder to check if the internal archive
     # tries to import any of the dependencies. If there is, that means that there is a dependency cycle.
-    internal_deps = []
     need_recompile_deps = []
     for dep in internal_source.deps:
-        if not need_recompile[get_archive(dep).data.label]:
+        dep_data = get_archive(dep).data
+        if not need_recompile[dep_data.label]:
             internal_deps.append(dep)
         else:
-            need_recompile_deps.append(dep)
+            need_recompile_deps.append(dep_data.importpath)
+
     x_defs = dict(internal_source.x_defs)
     x_defs.update(internal_archive.x_defs)
     attrs = structs.to_dict(internal_source)

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -49,9 +49,8 @@ func compilePkg(args []string) error {
 
 	fs := flag.NewFlagSet("GoCompilePkg", flag.ExitOnError)
 	goenv := envFlags(fs)
-	var unfilteredSrcs, coverSrcs, embedSrcs, embedLookupDirs, embedRoots multiFlag
+	var unfilteredSrcs, coverSrcs, embedSrcs, embedLookupDirs, embedRoots, recompileInternalDeps multiFlag
 	var deps archiveMultiFlag
-	var recompileInternalDeps archiveMultiFlag
 	var importPath, packagePath, nogoPath, packageListPath, coverMode string
 	var outPath, outFactsPath, cgoExportHPath string
 	var testFilter string
@@ -83,7 +82,7 @@ func compilePkg(args []string) error {
 	fs.StringVar(&cgoExportHPath, "cgoexport", "", "The _cgo_exports.h file to write")
 	fs.StringVar(&testFilter, "testfilter", "off", "Controls test package filtering")
 	fs.StringVar(&coverFormat, "cover_format", "", "Emit source file paths in coverage instrumentation suitable for the specified coverage format")
-	fs.Var(&recompileInternalDeps, "recompile_internal_deps", "Import path, package path, and file name of a direct dependency that needs to be recompiled, separated by '='.")
+	fs.Var(&recompileInternalDeps, "recompile_internal_deps", "The import path of the direct dependencies that needs to be recompiled.")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -195,7 +194,7 @@ func compileArchive(
 	outXPath string,
 	cgoExportHPath string,
 	coverFormat string,
-	recompileInternalDeps []archive,
+	recompileInternalDeps []string,
 ) error {
 	workDir, cleanup, err := goenv.workDir()
 	if err != nil {
@@ -353,7 +352,7 @@ func compileArchive(
 
 	// Check that the filtered sources don't import anything outside of
 	// the standard library and the direct dependencies.
-	imports, err := checkImports(srcs.goSrcs, deps, recompileInternalDeps, packageListPath, importPath)
+	imports, err := checkImports(srcs.goSrcs, deps, packageListPath, importPath, recompileInternalDeps)
 	if err != nil {
 		return err
 	}

--- a/go/tools/builders/importcfg.go
+++ b/go/tools/builders/importcfg.go
@@ -33,11 +33,11 @@ type archive struct {
 }
 
 // checkImports verifies that each import in files refers to a
-// direct dependendency in archives or to a standard library package
+// direct dependency in archives or to a standard library package
 // listed in the file at stdPackageListPath. checkImports returns
 // a map from source import paths to elements of archives or to nil
 // for standard library packages.
-func checkImports(files []fileInfo, archives []archive, stdPackageListPath string) (map[string]*archive, error) {
+func checkImports(files []fileInfo, archives []archive, recompileInternalDeps []archive, stdPackageListPath string, importPath string) (map[string]*archive, error) {
 	// Read the standard package list.
 	packagesTxt, err := ioutil.ReadFile(stdPackageListPath)
 	if err != nil {
@@ -71,7 +71,11 @@ func checkImports(files []fileInfo, archives []archive, stdPackageListPath strin
 			importAliasToArchive[imp] = arc
 		}
 	}
-
+	// Construct recompileInternalDeps as a map to check if there are imports that are disallowed.
+	recompileInternalDepMap := make(map[string]bool)
+	for _, dep := range recompileInternalDeps {
+		recompileInternalDepMap[dep.importPath] = true
+	}
 	// Build the import map.
 	imports := make(map[string]*archive)
 	var derr depsError
@@ -82,6 +86,9 @@ func checkImports(files []fileInfo, archives []archive, stdPackageListPath strin
 				// TODO(#1645): Support local (relative) import paths. We don't emit
 				// errors for them here, but they will probably break something else.
 				continue
+			}
+			if recompileInternalDepMap[path] {
+				return nil, fmt.Errorf("dependency cycle detected between %q and %q in file %q", importPath, path, f.filename)
 			}
 			if stdPkgs[path] {
 				imports[path] = nil


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
Previously, we filtered out dependencies that needed recompiling (depend on embedded library) since internal tests can't import anything that imports itself.
However, if there is a dependency cycle that imports the embedded library transitively, a misleading error is thrown about the dependency not being provided when found in the import list.

```
Use --sandbox_debug to see verbose messages from the sandbox
compilepkg: missing strict dependencies:
	/private/var/tmp/_bazel_zplin/1b23f78923ad6c0028e8aab1a0a6d5fb/sandbox/darwin-sandbox/2/execroot/__main__/imports/client_test.go: import of "github.com/linzhp/bazel_examples/imports/testutils"
No dependencies were provided.
Check that imports in Go sources match importpath attributes in deps.
Target //imports:go_default_test failed to build
```
This PR passes down the list of direct dependencies that were filtered out in the internal test archive, down to the builder. The builder checks the imports of the internal test, and if it imports itself (either transitively or directly), throw a dependency cycle error detected between the internal test and imported dependency.

**Which issues(s) does this PR fix?**

Fixes #2583

**Other notes for review**
