### PR TITLE
Use protoc-gen-go-grpc as gRPC compiler

### DIFF
--- a/go/dependencies.rst
+++ b/go/dependencies.rst
@@ -154,8 +154,8 @@ gRPC dependencies
 
 In order to build ``go_proto_library`` rules with the gRPC plugin,
 several additional dependencies are needed. At minimum, you'll need to
-declare ``org_golang_google_grpc``, ``org_golang_x_net``, and
-``org_golang_x_text``.
+declare ``org_golang_google_grpc``, ``org_golang_google_grpc_cmd_protoc_gen_go_grpc``,
+``org_golang_x_net``, and ``org_golang_x_text``.
 
 If you're using Gazelle, and you already import ``google.golang.org/grpc``
 from a .go file somewhere in your repository, and you're also using Go modules
@@ -179,6 +179,14 @@ For example:
         importpath = "google.golang.org/grpc",
         sum = "h1:J0UbZOIrCAl+fpTOf8YLs4dJo8L/owV4LYVtAXQoPkw=",
         version = "v1.22.0",
+    )
+
+    go_repository(
+        name = "org_golang_google_grpc_cmd_protoc_gen_go_grpc",
+        build_file_proto_mode = "disable",
+        importpath = "google.golang.org/grpc/cmd/protoc-gen-go-grpc",
+        sum = "h1:TLkBREm4nIsEcexnCjgQd5GQWaHcqMzwQV0TX9pq8S0=",
+        version = "v1.2.0",
     )
 
     go_repository(

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -29,13 +29,14 @@ go_proto_compiler(
 
 go_proto_compiler(
     name = "go_grpc",
-    options = ["plugins=grpc"],
+    plugin = "@org_golang_google_grpc_cmd_protoc_gen_go_grpc//:protoc-gen-go-grpc",
+    suffix = "_grpc.pb.go",
+    valid_archive = False,
     visibility = ["//visibility:public"],
-    deps = PROTO_RUNTIME_DEPS + WELL_KNOWN_TYPES_APIV2 + [
+    deps = WELL_KNOWN_TYPES_APIV2 + [
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
-        "@org_golang_x_net//context:go_default_library",
     ],
 )
 

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -189,7 +189,13 @@ go_proto_library = rule(
 
 def go_grpc_library(**kwargs):
     # TODO: Deprecate once gazelle generates just go_proto_library
-    go_proto_library(compilers = [Label("//proto:go_grpc")], **kwargs)
+    go_proto_library(
+        compilers = [
+            Label("//proto:go_grpc"),
+            Label("//proto:go_proto"),
+        ],
+        **kwargs
+    )
 
 def proto_register_toolchains():
     print("You no longer need to call proto_register_toolchains(), it does nothing")

--- a/tests/grpc_repos.bzl
+++ b/tests/grpc_repos.bzl
@@ -24,6 +24,14 @@ def grpc_dependencies():
     )
 
     go_repository(
+        name = "org_golang_google_grpc_cmd_protoc_gen_go_grpc",
+        build_file_proto_mode = "disable",
+        importpath = "google.golang.org/grpc/cmd/protoc-gen-go-grpc",
+        sum = "h1:TLkBREm4nIsEcexnCjgQd5GQWaHcqMzwQV0TX9pq8S0=",
+        version = "v1.2.0",
+    )
+
+    go_repository(
         name = "org_golang_x_net",
         importpath = "golang.org/x/net",
         sum = "h1:oWX7TPOiFAMXLq8o0ikBYfCJVlRHBcsciT5bXOrH628=",

--- a/tests/integration/googleapis/BUILD.bazel
+++ b/tests/integration/googleapis/BUILD.bazel
@@ -13,7 +13,10 @@ proto_library(
 
 go_proto_library(
     name = "color_service_go_proto",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    compilers = [
+        "@io_bazel_rules_go//proto:go_grpc",
+        "@io_bazel_rules_go//proto:go_proto",
+    ],
     importpath = "github.com/bazelbuild/rules_go/tests/integration/googleapis/color_service_proto",
     proto = ":color_service_proto",
     deps = [


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Currently we use the deprecated gRPC mode of proto-gen-go. I believe rules_go should use this newer version.

**Which issues(s) does this PR fix?**

#3022, #2522

**Other notes for review**

From a first look, the change itself looks pretty straightforward. However, because `protoc-gen-go-grpc` no longer generates the Proto message, it requires both `go_proto` and `go_grpc`. That'd require updating Gazelle and `go_googleapis`, and I'm unsure how one would orchestrate that between the two codebases. I also believe that this would require updates to the dependency docs, I'd be great if I could get some pointers where to add that.