### PR TITLE
Extract generated code from BUILD.toolchains.bazel into a macro

### DIFF
--- a/go/def.bzl
+++ b/go/def.bzl
@@ -41,8 +41,6 @@ load(
 )
 load(
     "//go/private:go_toolchain.bzl",
-    _declare_bazel_toolchains = "declare_bazel_toolchains",
-    _declare_go_toolchains = "declare_go_toolchains",
     _go_toolchain = "go_toolchain",
 )
 load(
@@ -126,20 +124,6 @@ TOOLS_NOGO = [
 # Current version or next version to be tagged. Gazelle and other tools may
 # check this to determine compatibility.
 RULES_GO_VERSION = "0.38.0"
-
-def declare_toolchains(host, sdk, builder, sdk_version_setting):
-    host_goos, _, host_goarch = host.partition("_")
-    _declare_go_toolchains(
-        host_goos = host_goos,
-        sdk = sdk,
-        builder = builder,
-    )
-    _declare_bazel_toolchains(
-        host_goos = host_goos,
-        host_goarch = host_goarch,
-        toolchain_prefix = "",
-        sdk_version_setting = sdk_version_setting,
-    )
 
 go_context = _go_context
 go_embed_data = _go_embed_data

--- a/go/private/BUILD.bazel
+++ b/go/private/BUILD.bazel
@@ -66,6 +66,7 @@ bzl_library(
         "//go/private/actions:binary",
         "//go/private/actions:link",
         "//go/private/actions:stdlib",
+        "@bazel_skylib//lib:selects",
     ],
 )
 

--- a/go/private/BUILD.sdk.bazel
+++ b/go/private/BUILD.sdk.bazel
@@ -1,8 +1,8 @@
-load("@{rules_go_repo_name}//go/private/rules:binary.bzl", "go_tool_binary")
-load("@{rules_go_repo_name}//go/private/rules:sdk.bzl", "package_list")
-load("@{rules_go_repo_name}//go/private/rules:transition.bzl", "non_go_reset_target")
-load("@{rules_go_repo_name}//go/private:go_toolchain.bzl", "declare_go_toolchains")
-load("@{rules_go_repo_name}//go:def.bzl", "go_sdk")
+load("@io_bazel_rules_go//go/private/rules:binary.bzl", "go_tool_binary")
+load("@io_bazel_rules_go//go/private/rules:sdk.bzl", "package_list")
+load("@io_bazel_rules_go//go/private/rules:transition.bzl", "non_go_reset_target")
+load("@io_bazel_rules_go//go/private:go_toolchain.bzl", "declare_go_toolchains")
+load("@io_bazel_rules_go//go:def.bzl", "go_sdk")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -50,7 +50,7 @@ go_sdk(
 
 go_tool_binary(
     name = "builder",
-    srcs = ["@{rules_go_repo_name}//go/tools/builders:builder_srcs"],
+    srcs = ["@io_bazel_rules_go//go/tools/builders:builder_srcs"],
     sdk = ":go_sdk",
 )
 

--- a/go/private/BUILD.toolchains.bazel
+++ b/go/private/BUILD.toolchains.bazel
@@ -1,77 +1,16 @@
-load("@{rules_go_repo_name}//go/private:go_toolchain.bzl", "declare_bazel_toolchains")
-load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@io_bazel_rules_go//go/private:go_toolchain.bzl", "declare_bazel_toolchains")
 
 {version_constants}
 
 package(default_visibility = ["//visibility:public"])
 
-sdk_version_label = "@{rules_go_repo_name}//go/toolchain:sdk_version"
-
-config_setting(
-    name = "match_all_versions",
-    flag_values = {
-        sdk_version_label: "",
-    },
-    visibility = ["//visibility:private"],
-)
-
-config_setting(
-    name = "match_major_version",
-    flag_values = {
-        sdk_version_label: MAJOR_VERSION,
-    },
-    visibility = ["//visibility:private"],
-)
-
-config_setting(
-    name = "match_major_minor_version",
-    flag_values = {
-        sdk_version_label: MAJOR_VERSION + "." + MINOR_VERSION,
-    },
-    visibility = ["//visibility:private"],
-)
-
-config_setting(
-    name = "match_patch_version",
-    flag_values = {
-        sdk_version_label: MAJOR_VERSION + "." + MINOR_VERSION + "." + PATCH_VERSION,
-    },
-    visibility = ["//visibility:private"],
-)
-
-# If prerelease version is "", this will be the same as ":match_patch_version", but that's fine since we use match_any in config_setting_group.
-config_setting(
-    name = "match_prerelease_version",
-    flag_values = {
-        sdk_version_label: MAJOR_VERSION + "." + MINOR_VERSION + "." + PATCH_VERSION + PRERELEASE_SUFFIX,
-    },
-    visibility = ["//visibility:private"],
-)
-
-config_setting(
-    name = "match_sdk_type",
-    flag_values = {
-        sdk_version_label: "{sdk_type}",
-    },
-    visibility = ["//visibility:private"],
-)
-
-selects.config_setting_group(
-    name = "sdk_version_setting",
-    match_any = [
-        ":match_all_versions",
-        ":match_major_version",
-        ":match_major_minor_version",
-        ":match_patch_version",
-        ":match_prerelease_version",
-        ":match_sdk_type",
-    ],
-    visibility = ["//visibility:private"],
-)
-
 declare_bazel_toolchains(
+    go_toolchain_repo = "@{sdk_repo}",
     host_goarch = "{goarch}",
     host_goos = "{goos}",
-    sdk_version_setting = ":sdk_version_setting",
-    toolchain_prefix = "@{sdk_repo}//",
+    major = MAJOR_VERSION,
+    minor = MINOR_VERSION,
+    patch = PATCH_VERSION,
+    prerelease = PRERELEASE_SUFFIX,
+    sdk_type = "{sdk_type}",
 )

--- a/go/private/platforms.bzl
+++ b/go/private/platforms.bzl
@@ -178,7 +178,3 @@ def _generate_platforms():
     return platforms
 
 PLATFORMS = _generate_platforms()
-
-def generate_toolchain_names():
-    # keep in sync with declare_toolchains
-    return ["go_" + p.name for p in PLATFORMS if not p.cgo]

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -20,10 +20,6 @@ load(
     "//go/private:nogo.bzl",
     "go_register_nogo",
 )
-load(
-    "//go/private:platforms.bzl",
-    "generate_toolchain_names",
-)
 
 MIN_SUPPORTED_VERSION = (1, 14, 0)
 
@@ -196,7 +192,6 @@ def _go_toolchains_impl(ctx):
             "{goarch}": goarch,
             "{sdk_repo}": sdk_repo,
             "{sdk_type}": sdk_type,
-            "{rules_go_repo_name}": "io_bazel_rules_go",
             "{version_constants}": version_constants,
         },
     )
@@ -307,11 +302,7 @@ def go_wrap_sdk(name, register_toolchains = True, **kwargs):
         _register_toolchains(name)
 
 def _register_toolchains(repo):
-    labels = [
-        "@{}_toolchains//:{}".format(repo, name)
-        for name in generate_toolchain_names()
-    ]
-    native.register_toolchains(*labels)
+    native.register_toolchains("@{}_toolchains//:all".format(repo))
 
 def _remote_sdk(ctx, urls, strip_prefix, sha256):
     if len(urls) == 0:
@@ -366,7 +357,6 @@ def _sdk_build_file(ctx, platform, version, experiments):
             "{goos}": goos,
             "{goarch}": goarch,
             "{exe}": ".exe" if goos == "windows" else "",
-            "{rules_go_repo_name}": "io_bazel_rules_go",
             "{version}": version,
             "{experiments}": repr(experiments),
         },


### PR DESCRIPTION
**What type of PR is this?**

Refactoring

**What does this PR do? Why is it needed?**

As a macro, the code is cleaner and easier to reuse. In a follow-up change, it will be used to simplify toolchain registration with Bzlmod.
    
This commit also removes the public `declare_toolchains` macro. It seems to have been public only because it was accessed by the generated SDK repos. It has never been documented and subject to backwards incompatible changes in recent releases.
