### PR TITLE
Read GOEXPERIMENT env var before setting it

### DIFF
--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -134,7 +134,11 @@ func compilePkg(args []string) error {
 	}
 
 	if len(experiments) > 0 {
-		os.Setenv("GOEXPERIMENT", strings.Join(experiments, ","))
+		if fromEnv := os.Getenv("GOEXPERIMENT"); fromEnv != "" {
+			os.Setenv("GOEXPERIMENT", fromEnv+","+strings.Join(experiments, ","))
+		} else {
+			os.Setenv("GOEXPERIMENT", strings.Join(experiments, ","))
+		}
 	}
 
 	return compileArchive(

--- a/go/tools/builders/link.go
+++ b/go/tools/builders/link.go
@@ -149,7 +149,11 @@ func link(args []string) error {
 	goargs = append(goargs, "-o", *outFile)
 
 	if len(experiments) > 0 {
-		os.Setenv("GOEXPERIMENT", strings.Join(experiments, ","))
+		if fromEnv := os.Getenv("GOEXPERIMENT"); fromEnv != "" {
+			os.Setenv("GOEXPERIMENT", fromEnv+","+strings.Join(experiments, ","))
+		} else {
+			os.Setenv("GOEXPERIMENT", strings.Join(experiments, ","))
+		}
 	}
 
 	// add in the unprocess pass through options

--- a/go/tools/builders/stdlib.go
+++ b/go/tools/builders/stdlib.go
@@ -113,7 +113,11 @@ You may need to use the flags --cpu=x64_windows --compiler=mingw-gcc.`)
 	os.Setenv("GODEBUG", "installgoroot=all")
 
 	if len(experiments) > 0 {
-		os.Setenv("GOEXPERIMENT", strings.Join(experiments, ","))
+		if fromEnv := os.Getenv("GOEXPERIMENT"); fromEnv != "" {
+			os.Setenv("GOEXPERIMENT", fromEnv+","+strings.Join(experiments, ","))
+		} else {
+			os.Setenv("GOEXPERIMENT", strings.Join(experiments, ","))
+		}
 	}
 
 	// Build the commands needed to build the std library in the right mode


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
When GOEXPERIMENT environment variable is set, this gets completely reset by builder to some other value if the build rule specifies goexperiment.

This patch changes that logic so that it appends to the existing GOEXPERIMENT environment variable if one exists.

**Which issues(s) does this PR fix?**

Fixes #3453

**Other notes for review**
