### PR TITLE
Add repro for tzdata issue

### DIFF
--- a/tests/core/stdlib/BUILD.bazel
+++ b/tests/core/stdlib/BUILD.bazel
@@ -8,4 +8,11 @@ go_test(
     rundir = ".",
 )
 
+go_test(
+    name = "tzdata_test",
+    srcs = ["tzdata_test.go"],
+    race = "on",
+    gotags = ["timetzdata"],
+)
+
 stdlib_files(name = "stdlib_files")

--- a/tests/core/stdlib/tzdata_test.go
+++ b/tests/core/stdlib/tzdata_test.go
@@ -1,0 +1,21 @@
+package tzdata_test
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTzdata(t *testing.T) {
+	london, err := time.LoadLocation("Europe/London")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	datetime := time.Date(2022, 8, 26, 16, 10, 15, 0, london)
+
+	want := "2022-08-26 16:10+0100"
+	got := datetime.Format("2006-01-02 15:04-0700")
+	if want != got {
+		t.Fatal("want %q got %q", want, got)
+	}
+}


### PR DESCRIPTION
To reproduce, run the enclosed test in an environment without timezone data files present on the machine, e.g. the cut-down `ubuntu` docker image:
```console
% docker run -it --rm -v $(pwd):$(pwd) --workdir $(pwd) ubuntu@sha256:9a0bdde4188b896a372804be2384015e90e3f84906b750c1a53539b585fbbe7f
% apt-get update && apt-get install -y curl build-essential && curl --fail -L -o /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.16.0/bazelisk-linux-amd64 && chmod 0755 /usr/local/bin/bazel
% USE_BAZEL_VERSION=6.0.0 bazel test --test_output=errors //tests/core/stdlib:tzdata_test
```

Before 8d309d5af15814b4096d80b60f80fa86128c43f2 this passed After 8d309d5af15814b4096d80b60f80fa86128c43f2 this fails