### PR TITLE
Add new darwin CC toolchain for tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,8 @@
+build --enable_platform_specific_config
+build:macos --apple_crosstool_top=@local_config_apple_cc//:toolchain
+build:macos --crosstool_top=@local_config_apple_cc//:toolchain
+build:macos --host_crosstool_top=@local_config_apple_cc//:toolchain
+
 build:windows --cpu=x64_windows
 build:windows --compiler=mingw-gcc
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -164,3 +164,17 @@ http_archive(
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
 
 stardoc_repositories()
+
+# For testing objc_library interop, users should not need to install it
+http_archive(
+    name = "build_bazel_apple_support",
+    sha256 = "77a121a0f5d4cd88824429464ad2bfb54bdc8a3bccdb4d31a6c846003a3f5e44",
+    url = "https://github.com/bazelbuild/apple_support/releases/download/1.4.1/apple_support.1.4.1.tar.gz",
+)
+
+load(
+    "@build_bazel_apple_support//lib:repositories.bzl",
+    "apple_support_dependencies",
+)
+
+apple_support_dependencies()


### PR DESCRIPTION
With bazel 7.x the darwin toolchain that supports iOS / Objective-C is moving out of bazel and into apple_support. This adds that toolchain since it's exercised for tests.