### PR TITLE
feat: provide convenient access to Go binary

### DIFF
--- a/go/BUILD.bazel
+++ b/go/BUILD.bazel
@@ -1,10 +1,11 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
+# Provides a nice way to execute the Go binary used by rules_go. This can be
+# handy when running certain utility functions like `go mod tidy`.
 alias(
     name = "go",
     actual = "//go/tools/go_bin_runner",
-    # Meant to be run with `bazel run`, but should not be depended on.
-    visibility = ["//visibility:private"],
+    visibility = ["//visibility:public"],
 )
 
 filegroup(


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Make the binary target `@rules_go//go` available publicly. This is useful for client projects that define Bazel targets to run maintenance tasks (e.g. `go mod tidy`).

**Which issues(s) does this PR fix?**

NA

**Other notes for review**

I noticed that the 0.38.1 release archive does not include the `//go/tools/go_bin_runner` package. From the dates, it looks like it should exist. I looked for a list of packages that are used for packaging the release. The best that I can tell the archive is created by the `releaser` tool. That tool seems to just create a git archive of the repo in its current state. 🤷‍♂️