### PR TITLE
Expand locations in `x_defs` values

### DIFF
--- a/docs/go/core/defines_and_stamping.md
+++ b/docs/go/core/defines_and_stamping.md
@@ -21,6 +21,9 @@ value. You can also override stamp values from libraries using `x_defs`
 on the `go_binary` rule if needed. The `--[no]stamp` option controls whether
 stamping of workspace variables is enabled.
 
+The values of the `x_defs` dictionary are subject to
+[location expansion](https://bazel.build/reference/be/make-variables#predefined_label_variables).
+
 **Example**
 
 Suppose we have a small library that contains the current version.

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -268,6 +268,7 @@ def _library_to_source(go, attr, library, coverage_instrumented):
     source["deps"] = _dedup_deps(source["deps"])
     x_defs = source["x_defs"]
     for k, v in getattr(attr, "x_defs", {}).items():
+        v = _expand_location(go, attr, v)
         if "." not in k:
             k = "{}.{}".format(library.importmap, k)
         x_defs[k] = v
@@ -878,6 +879,9 @@ go_config = rule(
 
 def _expand_opts(go, attribute_name, opts):
     return [go._ctx.expand_make_variables(attribute_name, opt, {}) for opt in opts]
+
+def _expand_location(go, attr, s):
+    return go._ctx.expand_location(s, getattr(attr, "data", []))
 
 _LIST_TYPE = type([])
 

--- a/tests/core/go_test/x_defs/BUILD.bazel
+++ b/tests/core/go_test/x_defs/BUILD.bazel
@@ -48,3 +48,26 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"Qux": "Qux"},
 )
+
+go_library(
+    name = "x_defs_lib",
+    srcs = ["x_defs_lib.go"],
+    data = ["x_defs_lib.go"],
+    importpath = "github.com/bazelbuild/rules_go/tests/core/go_test/x_defs/x_defs_lib",
+    x_defs = {
+        "LibGo": "$(rlocationpath x_defs_lib.go)",
+    },
+)
+
+go_test(
+    name = "x_defs_test",
+    srcs = ["x_defs_test.go"],
+    data = ["x_defs_test.go"],
+    x_defs = {
+        "BinGo": "$(rlocationpath x_defs_test.go)",
+    },
+    deps = [
+        ":x_defs_lib",
+        "//go/runfiles",
+    ],
+)

--- a/tests/core/go_test/x_defs/x_defs_lib.go
+++ b/tests/core/go_test/x_defs/x_defs_lib.go
@@ -1,0 +1,3 @@
+package x_defs_lib
+
+var LibGo = "not set"

--- a/tests/core/go_test/x_defs/x_defs_test.go
+++ b/tests/core/go_test/x_defs/x_defs_test.go
@@ -1,0 +1,34 @@
+package x_defs_lib_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/runfiles"
+
+	"github.com/bazelbuild/rules_go/tests/core/go_test/x_defs/x_defs_lib"
+)
+
+var BinGo = "not set"
+
+func TestLibGoPath(t *testing.T) {
+	libGoPath, err := runfiles.Rlocation(x_defs_lib.LibGo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = os.Stat(libGoPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBinGoPath(t *testing.T) {
+	binGoPath, err := runfiles.Rlocation(BinGo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = os.Stat(binGoPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Allows embedding rlocationpaths into binaries to allow them to find dependencies at runtime even when run from other tools, meaning that `args` and `env` can't be used for this purpose.

