### PR TITLE
Make `//go` usable in scripts run with `bazel run`

### DIFF
--- a/docs/go/core/defines_and_stamping.md
+++ b/docs/go/core/defines_and_stamping.md
@@ -21,6 +21,9 @@ value. You can also override stamp values from libraries using `x_defs`
 on the `go_binary` rule if needed. The `--[no]stamp` option controls whether
 stamping of workspace variables is enabled.
 
+The values of the `x_defs` dictionary are subject to
+[location expansion](https://bazel.build/reference/be/make-variables#predefined_label_variables).
+
 **Example**
 
 Suppose we have a small library that contains the current version.

--- a/go/BUILD.bazel
+++ b/go/BUILD.bazel
@@ -1,10 +1,14 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
+# The 'go' binary of the current Go toolchain compatible with the host.
+# Use this with `bazel run` to perform utility actions such as `go mod tidy` in
+# a hermetic fashion.
+# Note: This is not meant to and cannot be used as a tool in e.g. a genrule. If
+# you need this functionality, please file an issue describing your use case.
 alias(
     name = "go",
     actual = "//go/tools/go_bin_runner",
-    # Meant to be run with `bazel run`, but should not be depended on.
-    visibility = ["//visibility:private"],
+    visibility = ["//visibility:public"],
 )
 
 filegroup(

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -268,6 +268,7 @@ def _library_to_source(go, attr, library, coverage_instrumented):
     source["deps"] = _dedup_deps(source["deps"])
     x_defs = source["x_defs"]
     for k, v in getattr(attr, "x_defs", {}).items():
+        v = _expand_location(go, attr, v)
         if "." not in k:
             k = "{}.{}".format(library.importmap, k)
         x_defs[k] = v
@@ -878,6 +879,9 @@ go_config = rule(
 
 def _expand_opts(go, attribute_name, opts):
     return [go._ctx.expand_make_variables(attribute_name, opt, {}) for opt in opts]
+
+def _expand_location(go, attr, s):
+    return go._ctx.expand_location(s, getattr(attr, "data", []))
 
 _LIST_TYPE = type([])
 

--- a/go/private/rules/go_bin_for_host.bzl
+++ b/go/private/rules/go_bin_for_host.bzl
@@ -15,8 +15,21 @@
 load("@local_config_platform//:constraints.bzl", "HOST_CONSTRAINTS")
 load("//go/private:go_toolchain.bzl", "GO_TOOLCHAIN")
 
+def _ensure_target_cfg(ctx):
+    # A target is assumed to be built in the target configuration if it is neither in the exec nor
+    # the host configuration (the latter has been removed in Bazel 6). Since there is no API for
+    # this, use the output directory to determine the configuration, which is a common pattern.
+    if "-exec-" in ctx.bin_dir.path or "/host/" in ctx.bin_dir.path:
+        fail("//go is only meant to be used with 'bazel run', not as a tool. " +
+             "If you need to use it as a tool (e.g. in a genrule), please " +
+             "open an issue at " +
+             "https://github.com/bazelbuild/rules_go/issues/new explaining " +
+             "your use case.")
+
 def _go_bin_for_host_impl(ctx):
     """Exposes the go binary of the current Go toolchain for the host."""
+    _ensure_target_cfg(ctx)
+
     sdk = ctx.toolchains[GO_TOOLCHAIN].sdk
     sdk_files = ctx.runfiles([sdk.go] + sdk.headers + sdk.libs + sdk.srcs + sdk.tools)
 

--- a/go/tools/go_bin_runner/BUILD.bazel
+++ b/go/tools/go_bin_runner/BUILD.bazel
@@ -5,7 +5,7 @@ load("//go/private/rules:go_bin_for_host.bzl", "go_bin_for_host")
 
 go_bin_for_host(
     name = "go_bin_for_host",
-    visibility = ["//go:__pkg__"],
+    visibility = ["//visibility:private"],
 )
 
 go_library(
@@ -30,10 +30,10 @@ go_binary(
     name = "go_bin_runner",
     data = [":go_bin_for_host"],
     embed = [":go_bin_runner_lib"],
-    env = {
-        "GO_BIN_RLOCATIONPATH": "$(rlocationpath :go_bin_for_host)",
+    visibility = ["//go:__pkg__"],
+    x_defs = {
+        "GoBinRlocationPath": "$(rlocationpath :go_bin_for_host)",
     },
-    visibility = ["//visibility:public"],
 )
 
 filegroup(

--- a/go/tools/go_bin_runner/main.go
+++ b/go/tools/go_bin_runner/main.go
@@ -9,9 +9,10 @@ import (
 	"github.com/bazelbuild/rules_go/go/runfiles"
 )
 
+var GoBinRlocationPath = "not set"
+
 func main() {
-	goBinRlocation := os.Getenv("GO_BIN_RLOCATIONPATH")
-	goBin, err := runfiles.Rlocation(goBinRlocation)
+	goBin, err := runfiles.Rlocation(GoBinRlocationPath)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/tests/core/go_test/x_defs/BUILD.bazel
+++ b/tests/core/go_test/x_defs/BUILD.bazel
@@ -48,3 +48,26 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"Qux": "Qux"},
 )
+
+go_library(
+    name = "x_defs_lib",
+    srcs = ["x_defs_lib.go"],
+    data = ["x_defs_lib.go"],
+    importpath = "github.com/bazelbuild/rules_go/tests/core/go_test/x_defs/x_defs_lib",
+    x_defs = {
+        "LibGo": "$(rlocationpath x_defs_lib.go)",
+    },
+)
+
+go_test(
+    name = "x_defs_test",
+    srcs = ["x_defs_test.go"],
+    data = ["x_defs_test.go"],
+    x_defs = {
+        "BinGo": "$(rlocationpath x_defs_test.go)",
+    },
+    deps = [
+        ":x_defs_lib",
+        "//go/runfiles",
+    ],
+)

--- a/tests/core/go_test/x_defs/x_defs_lib.go
+++ b/tests/core/go_test/x_defs/x_defs_lib.go
@@ -1,0 +1,3 @@
+package x_defs_lib
+
+var LibGo = "not set"

--- a/tests/core/go_test/x_defs/x_defs_test.go
+++ b/tests/core/go_test/x_defs/x_defs_test.go
@@ -1,0 +1,34 @@
+package x_defs_lib_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/runfiles"
+
+	"github.com/bazelbuild/rules_go/tests/core/go_test/x_defs/x_defs_lib"
+)
+
+var BinGo = "not set"
+
+func TestLibGoPath(t *testing.T) {
+	libGoPath, err := runfiles.Rlocation(x_defs_lib.LibGo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = os.Stat(libGoPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBinGoPath(t *testing.T) {
+	binGoPath, err := runfiles.Rlocation(BinGo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = os.Stat(binGoPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/tests/integration/go_bin_runner/go_bin_runner_test.go
+++ b/tests/integration/go_bin_runner/go_bin_runner_test.go
@@ -24,7 +24,38 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	bazel_testing.TestMain(m, bazel_testing.Args{})
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: `
+-- BUILD.bazel --
+sh_binary(
+    name = "go_version",
+    srcs = ["go_version.sh"],
+    env = {"GO": "$(rlocationpath @io_bazel_rules_go//go)"},
+    data = ["@io_bazel_rules_go//go"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)
+
+genrule(
+    name = "foo",
+    outs = ["bar"],
+    tools = ["@io_bazel_rules_go//go"],
+    cmd = "$(location @io_bazel_rules_go//go) > $@",
+)
+
+-- go_version.sh --
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+$(rlocation "$GO") version
+`})
 }
 
 func TestGoEnv(t *testing.T) {
@@ -45,5 +76,32 @@ func TestGoEnv(t *testing.T) {
 	goRoot := strings.TrimSpace(string(goEnvOut))
 	if goRoot != filepath.Join(outputBase, "external", "go_sdk") {
 		t.Fatalf("GOROOT was not equal to %s", filepath.Join(outputBase, "external", "go_sdk"))
+	}
+}
+
+func TestGoVersionFromScript(t *testing.T) {
+	err := os.Chmod("go_version.sh", 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	goVersionOut, err := bazel_testing.BazelOutput("run", "//:go_version")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.HasPrefix(string(goVersionOut), "go version go1.") {
+		t.Fatalf("go version output did not start with \"go version go1.\": %s", string(goVersionOut))
+	}
+}
+
+func TestNoGoInExec(t *testing.T) {
+	_, err := bazel_testing.BazelOutput("build", "//:foo")
+	if err == nil {
+		t.Fatal("expected build to fail")
+	}
+	stderr := string(err.(*bazel_testing.StderrExitError).Err.Stderr)
+	if !strings.Contains(stderr, "//go is only meant to be used with 'bazel run'") {
+		t.Fatalf("expected \"//go is only meant to be used with 'bazel run'\" in stderr, got %s", stderr)
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Allows developers to build their own local convenience scripts around `go`, e.g. to run `go mod tidy` backed by a hermetic Go toolchain and without the need to hardcode the name of an SDK repository, which we want to get away from with Bzlmod.

This requires getting rid of the `env` attribute as it is not evaluated if the binary is run as a dependency of another target.

Since `//go` select a Go SDK suitable for the host, not the exec platform, we forbid its use in the exec configuration. As remarked in https://github.com/bazelbuild/rules_go/issues/2255, using raw `go` in a genrule is not a good idea to start with.


**Which issues(s) does this PR fix?**

https://bazelbuild.slack.com/archives/CDBP88Z0D/p1678384340169399

**Other notes for review**

Stacked on https://github.com/bazelbuild/rules_go/pull/3473
