### PR TITLE
Avoid repository rule restarts in go_sdk

### DIFF
--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -38,6 +38,9 @@ go_host_sdk_rule = repository_rule(
         "experiments": attr.string_list(
             doc = "Go experiments to enable via GOEXPERIMENT",
         ),
+        "_sdk_build_file": attr.label(
+            default = Label("//go/private:BUILD.sdk.bazel"),
+        ),
     },
 )
 
@@ -139,6 +142,9 @@ go_download_sdk_rule = repository_rule(
         "urls": attr.string_list(default = ["https://dl.google.com/go/{}"]),
         "version": attr.string(),
         "strip_prefix": attr.string(default = "go"),
+        "_sdk_build_file": attr.label(
+            default = Label("//go/private:BUILD.sdk.bazel"),
+        ),
     },
 )
 
@@ -321,6 +327,9 @@ _go_local_sdk = repository_rule(
         "experiments": attr.string_list(
             doc = "Go experiments to enable via GOEXPERIMENT",
         ),
+        "_sdk_build_file": attr.label(
+            default = Label("//go/private:BUILD.sdk.bazel"),
+        ),
     },
 )
 
@@ -370,6 +379,9 @@ _go_wrap_sdk = repository_rule(
         "version": attr.string(),
         "experiments": attr.string_list(
             doc = "Go experiments to enable via GOEXPERIMENT",
+        ),
+        "_sdk_build_file": attr.label(
+            default = Label("//go/private:BUILD.sdk.bazel"),
         ),
     },
 )
@@ -437,7 +449,7 @@ def _sdk_build_file(ctx, platform, version, experiments):
 
     ctx.template(
         "BUILD.bazel",
-        Label("//go/private:BUILD.sdk.bazel"),
+        ctx.path(ctx.attr._sdk_build_file),
         executable = False,
         substitutions = {
             "{goos}": goos,


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Previously, `go_sdk` would always restart after fetching and extracting the SDK, as seen in Bazel profiles:

![Screen Shot 2023-03-13 at 11 50 20 AM](https://user-images.githubusercontent.com/98601/224800746-b9b9f708-16cf-4a6d-a089-525577d8b0ea.png)

The effectively doubles the amount of time it takes to run the rule implementation. [Repository rule restarts](https://docs.bazel.build/versions/5.0.0/skylark/repository_rules.html#when-is-the-implementation-function-executed) are discussed in https://github.com/bazelbuild/bazel-gazelle/issues/1175 but not resolved for `go_sdk`, or maybe this particular restart is a regression since that issue was resolved.

By adding debug `print`s, I determined that the restart is caused by this line:

https://github.com/bazelbuild/rules_go/blob/89e3296c36b789e8623e1178a59506547a98419e/go/private/sdk.bzl#L440

Moving the label to the default value of an attribute avoids the restarts, as seen here:

![Screen Shot 2023-03-13 at 11 55 36 AM](https://user-images.githubusercontent.com/98601/224801908-72a32476-d9c5-4c74-97fb-cdd095f3820f.png)
