### PR TITLE
Quote `CC` if it contains whitespace

### DIFF
--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -436,6 +436,23 @@ func passLongArgsInResponseFiles(cmd *exec.Cmd) (cleanup func()) {
 	return cleanup
 }
 
+// quotePathIfNeeded quotes path if it contains whitespace and isn't already quoted.
+// Use this for paths that will be passed through
+// https://github.com/golang/go/blob/06264b740e3bfe619f5e90359d8f0d521bd47806/src/cmd/internal/quoted/quoted.go#L25
+func quotePathIfNeeded(path string) string {
+	if strings.HasPrefix(path, "\"") || strings.HasPrefix(path, "'") {
+		// Assume already quoted
+		return path
+	}
+	// https://github.com/golang/go/blob/06264b740e3bfe619f5e90359d8f0d521bd47806/src/cmd/internal/quoted/quoted.go#L16
+	if strings.IndexAny(path, " \t\n\r") < 0 {
+		// Does not require quoting
+		return path
+	}
+	// Escaping quotes is not supported, so we can assume path doesn't contain any quotes.
+	return "'" + path + "'"
+}
+
 func useResponseFile(path string, argLen int) bool {
 	// Unless the program uses objabi.Flagparse, which understands
 	// response files, don't use response files.

--- a/go/tools/builders/stdlib.go
+++ b/go/tools/builders/stdlib.go
@@ -79,7 +79,7 @@ You may need to use the flags --cpu=x64_windows --compiler=mingw-gcc.`)
 
 	// Make sure we have an absolute path to the C compiler.
 	// TODO(#1357): also take absolute paths of includes and other paths in flags.
-	os.Setenv("CC", abs(os.Getenv("CC")))
+	os.Setenv("CC", quotePathIfNeeded(abs(os.Getenv("CC"))))
 
 	// Ensure paths are absolute.
 	absPaths := []string{}

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -202,7 +202,7 @@ func stdliblist(args []string) error {
 	os.Setenv("GOROOT", newGoRoot)
 	// Make sure we have an absolute path to the C compiler.
 	// TODO(#1357): also take absolute paths of includes and other paths in flags.
-	os.Setenv("CC", abs(os.Getenv("CC")))
+	os.Setenv("CC", quotePathIfNeeded(abs(os.Getenv("CC"))))
 
 	cachePath := abs(*out + ".gocache")
 	defer os.RemoveAll(cachePath)


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix


**What does this PR do? Why is it needed?**

The `cgo` tool splits `CC` on unquoted whitespace, which can cause failures on Windows when `CC` points to an absolute path such as `C:\Program Files\some\compiler.exe`.
