### PR TITLE
prepare release 0.39

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_go",
-    version = "0.38.1",
+    version = "0.39.0",
     compatibility_level = 0,
     repo_name = "io_bazel_rules_go",
 )

--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,13 @@ Slack: `#go on Bazel Slack`_, `#bazel on Go Slack`_
 
 Announcements
 -------------
+2023-03-27
+  Release
+  `v0.39.0 <https://github.com/bazelbuild/rules_go/releases/tag/v0.39.0>`_
+  is now available. This release includes a simpler interface for Bzlmod
+  `go_sdk` registration, makes the `//go` tool available to users, and
+  fixes various bugs.
+
 2022-12-06
   Release
   `v0.37.0 <https://github.com/bazelbuild/rules_go/releases/tag/v0.37.0>`_

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -123,7 +123,7 @@ TOOLS_NOGO = [
 
 # Current version or next version to be tagged. Gazelle and other tools may
 # check this to determine compatibility.
-RULES_GO_VERSION = "0.38.0"
+RULES_GO_VERSION = "0.39.0"
 
 go_context = _go_context
 go_embed_data = _go_embed_data

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -50,12 +50,12 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "bazel_skylib",
-        # 1.3.0, latest as of 2023-01-22
+        # 1.4.1, latest as of 2023-03-27
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
-            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
         ],
-        sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
+        sha256 = "b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7",
         strip_prefix = "",
     )
 
@@ -86,13 +86,13 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "org_golang_x_sys",
-        # v0.4.0, latest as of 2023-01-22
+        # v0.6.0, latest as of 2023-03-27
         urls = [
-            "https://mirror.bazel.build/github.com/golang/sys/archive/refs/tags/v0.4.0.zip",
-            "https://github.com/golang/sys/archive/refs/tags/v0.4.0.zip",
+            "https://mirror.bazel.build/github.com/golang/sys/archive/refs/tags/v0.6.0.zip",
+            "https://github.com/golang/sys/archive/refs/tags/v0.6.0.zip",
         ],
-        sha256 = "30995c105724d9d7efb229df3cb26492b47e666bb6f5022530899532896c209b",
-        strip_prefix = "sys-0.4.0",
+        sha256 = "7f2399398b2eb4f1f495cc754d6353566e0ad934ee0eb46505e55162e0def56d",
+        strip_prefix = "sys-0.6.0",
         patches = [
             # releaser:patch-cmd gazelle -repo_root . -go_prefix golang.org/x/sys -go_naming_convention import_alias
             Label("//third_party:org_golang_x_sys-gazelle.patch"),
@@ -105,7 +105,7 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "org_golang_x_xerrors",
-        # master, as of 2023-01-22
+        # master, as of 2023-03-27
         urls = [
             "https://mirror.bazel.build/github.com/golang/xerrors/archive/04be3eba64a22a838cdb17b8dca15a52871c08b4.zip",
             "https://github.com/golang/xerrors/archive/04be3eba64a22a838cdb17b8dca15a52871c08b4.zip",
@@ -140,13 +140,13 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "org_golang_google_protobuf",
-        sha256 = "cbaac40c1faf6a3647316d46ec9c614e99aa92c539a78b7c1e4dec3ff5f73694",
-        # v1.28.1, latest as of 2023-01-22
+        sha256 = "cb1a05581c33b3705ede6c08edf9b9c1dbc579559ba30f532704c324e42bf801",
+        # v1.30.0, latest as of 2023-03-27
         urls = [
-            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf-go/archive/refs/tags/v1.28.1.zip",
-            "https://github.com/protocolbuffers/protobuf-go/archive/refs/tags/v1.28.1.zip",
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf-go/archive/refs/tags/v1.30.0.zip",
+            "https://github.com/protocolbuffers/protobuf-go/archive/refs/tags/v1.30.0.zip",
         ],
-        strip_prefix = "protobuf-go-1.28.1",
+        strip_prefix = "protobuf-go-1.30.0",
         patches = [
             # releaser:patch-cmd gazelle -repo_root . -go_prefix google.golang.org/protobuf -go_naming_convention import_alias -proto disable_global
             Label("//third_party:org_golang_google_protobuf-gazelle.patch"),
@@ -163,13 +163,13 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "com_github_golang_protobuf",
-        # v1.5.2, latest as of 2023-01-22
+        # v1.5.3, latest as of 2023-03-27
         urls = [
-            "https://mirror.bazel.build/github.com/golang/protobuf/archive/refs/tags/v1.5.2.zip",
-            "https://github.com/golang/protobuf/archive/refs/tags/v1.5.2.zip",
+            "https://mirror.bazel.build/github.com/golang/protobuf/archive/refs/tags/v1.5.3.zip",
+            "https://github.com/golang/protobuf/archive/refs/tags/v1.5.3.zip",
         ],
-        sha256 = "5bd0a70e2f3829db9d0e340887af4e921c5e0e5bb3f8d1be49a934204cb16445",
-        strip_prefix = "protobuf-1.5.2",
+        sha256 = "2dced4544ae5372281e20f1e48ca76368355a01b31353724718c4d6e3dcbb430",
+        strip_prefix = "protobuf-1.5.3",
         patches = [
             # releaser:patch-cmd gazelle -repo_root . -go_prefix github.com/golang/protobuf -go_naming_convention import_alias -proto disable_global
             Label("//third_party:com_github_golang_protobuf-gazelle.patch"),
@@ -183,7 +183,7 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "com_github_mwitkow_go_proto_validators",
-        # v0.3.2, latest as of 2023-01-22
+        # v0.3.2, latest as of 2023-03-27
         urls = [
             "https://mirror.bazel.build/github.com/mwitkow/go-proto-validators/archive/refs/tags/v0.3.2.zip",
             "https://github.com/mwitkow/go-proto-validators/archive/refs/tags/v0.3.2.zip",
@@ -197,7 +197,7 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "com_github_gogo_protobuf",
-        # v1.3.2, latest as of 2023-01-22
+        # v1.3.2, latest as of 2023-03-27
         urls = [
             "https://mirror.bazel.build/github.com/gogo/protobuf/archive/refs/tags/v1.3.2.zip",
             "https://github.com/gogo/protobuf/archive/refs/tags/v1.3.2.zip",
@@ -224,13 +224,13 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "org_golang_google_genproto",
-        # main, as of 2023-01-22
+        # main, as of 2023-03-27
         urls = [
-            "https://mirror.bazel.build/github.com/googleapis/go-genproto/archive/9d59e20e5cd16f7c64a2107aeec4c4e843a6df73.zip",
-            "https://github.com/googleapis/go-genproto/archive/9d59e20e5cd16f7c64a2107aeec4c4e843a6df73.zip",
+            "https://mirror.bazel.build/github.com/googleapis/go-genproto/archive/6ac7f18bb9d5eeeb13a9f1ae4f21e4374a1952f8.zip",
+            "https://github.com/googleapis/go-genproto/archive/6ac7f18bb9d5eeeb13a9f1ae4f21e4374a1952f8.zip",
         ],
-        sha256 = "8896d6cf7041c5300d4e3963887fc50a641f0afa969d2bc9323879a6b8c80ce4",
-        strip_prefix = "go-genproto-9d59e20e5cd16f7c64a2107aeec4c4e843a6df73",
+        sha256 = "3470e7a89b24971b20c4bb8900a668df25279e4b741f72bc09418c1f22543215",
+        strip_prefix = "go-genproto-6ac7f18bb9d5eeeb13a9f1ae4f21e4374a1952f8",
         patches = [
             # releaser:patch-cmd gazelle -repo_root . -go_prefix google.golang.org/genproto -go_naming_convention import_alias -proto disable_global
             Label("//third_party:org_golang_google_genproto-gazelle.patch"),
@@ -269,7 +269,7 @@ def go_rules_dependencies(force = False):
     _maybe(
         http_archive,
         name = "com_github_golang_mock",
-        # v1.7.0-rc.1, latest as of 2023-01-22
+        # v1.7.0-rc.1, latest as of 2023-03-27
         urls = [
             "https://mirror.bazel.build/github.com/golang/mock/archive/refs/tags/v1.7.0-rc.1.zip",
             "https://github.com/golang/mock/archive/refs/tags/v1.7.0-rc.1.zip",

--- a/third_party/com_github_gogo_protobuf-gazelle.patch
+++ b/third_party/com_github_gogo_protobuf-gazelle.patch
@@ -1,5 +1,5 @@
 diff -urN a/codec/BUILD.bazel b/codec/BUILD.bazel
---- a/codec/BUILD.bazel	1969-12-31 16:00:00
+--- a/codec/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/codec/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -25,7 +25,7 @@ diff -urN a/codec/BUILD.bazel b/codec/BUILD.bazel
 +    deps = ["//test"],
 +)
 diff -urN a/conformance/BUILD.bazel b/conformance/BUILD.bazel
---- a/conformance/BUILD.bazel	1969-12-31 16:00:00
+--- a/conformance/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/conformance/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -48,7 +48,7 @@ diff -urN a/conformance/BUILD.bazel b/conformance/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/conformance/internal/conformance_proto/BUILD.bazel b/conformance/internal/conformance_proto/BUILD.bazel
---- a/conformance/internal/conformance_proto/BUILD.bazel	1969-12-31 16:00:00
+--- a/conformance/internal/conformance_proto/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/conformance/internal/conformance_proto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -76,7 +76,7 @@ diff -urN a/conformance/internal/conformance_proto/BUILD.bazel b/conformance/int
 +    visibility = ["//conformance:__subpackages__"],
 +)
 diff -urN a/gogoproto/BUILD.bazel b/gogoproto/BUILD.bazel
---- a/gogoproto/BUILD.bazel	1969-12-31 16:00:00
+--- a/gogoproto/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/gogoproto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -108,7 +108,7 @@ diff -urN a/gogoproto/BUILD.bazel b/gogoproto/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/gogoreplace/BUILD.bazel b/gogoreplace/BUILD.bazel
---- a/gogoreplace/BUILD.bazel	1969-12-31 16:00:00
+--- a/gogoreplace/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/gogoreplace/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -126,7 +126,7 @@ diff -urN a/gogoreplace/BUILD.bazel b/gogoreplace/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/io/BUILD.bazel b/io/BUILD.bazel
---- a/io/BUILD.bazel	1969-12-31 16:00:00
+--- a/io/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/io/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -163,7 +163,7 @@ diff -urN a/io/BUILD.bazel b/io/BUILD.bazel
 +    ],
 +)
 diff -urN a/jsonpb/BUILD.bazel b/jsonpb/BUILD.bazel
---- a/jsonpb/BUILD.bazel	1969-12-31 16:00:00
+--- a/jsonpb/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/jsonpb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -197,7 +197,7 @@ diff -urN a/jsonpb/BUILD.bazel b/jsonpb/BUILD.bazel
 +    ],
 +)
 diff -urN a/jsonpb/jsonpb_test_proto/BUILD.bazel b/jsonpb/jsonpb_test_proto/BUILD.bazel
---- a/jsonpb/jsonpb_test_proto/BUILD.bazel	1969-12-31 16:00:00
+--- a/jsonpb/jsonpb_test_proto/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/jsonpb/jsonpb_test_proto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -232,7 +232,7 @@ diff -urN a/jsonpb/jsonpb_test_proto/BUILD.bazel b/jsonpb/jsonpb_test_proto/BUIL
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/plugin/compare/BUILD.bazel b/plugin/compare/BUILD.bazel
---- a/plugin/compare/BUILD.bazel	1969-12-31 16:00:00
+--- a/plugin/compare/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/plugin/compare/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -261,7 +261,7 @@ diff -urN a/plugin/compare/BUILD.bazel b/plugin/compare/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/plugin/defaultcheck/BUILD.bazel b/plugin/defaultcheck/BUILD.bazel
---- a/plugin/defaultcheck/BUILD.bazel	1969-12-31 16:00:00
+--- a/plugin/defaultcheck/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/plugin/defaultcheck/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -283,7 +283,7 @@ diff -urN a/plugin/defaultcheck/BUILD.bazel b/plugin/defaultcheck/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/plugin/description/BUILD.bazel b/plugin/description/BUILD.bazel
---- a/plugin/description/BUILD.bazel	1969-12-31 16:00:00
+--- a/plugin/description/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/plugin/description/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -311,7 +311,7 @@ diff -urN a/plugin/description/BUILD.bazel b/plugin/description/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/plugin/embedcheck/BUILD.bazel b/plugin/embedcheck/BUILD.bazel
---- a/plugin/embedcheck/BUILD.bazel	1969-12-31 16:00:00
+--- a/plugin/embedcheck/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/plugin/embedcheck/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -333,7 +333,7 @@ diff -urN a/plugin/embedcheck/BUILD.bazel b/plugin/embedcheck/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/plugin/enumstringer/BUILD.bazel b/plugin/enumstringer/BUILD.bazel
---- a/plugin/enumstringer/BUILD.bazel	1969-12-31 16:00:00
+--- a/plugin/enumstringer/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/plugin/enumstringer/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -355,7 +355,7 @@ diff -urN a/plugin/enumstringer/BUILD.bazel b/plugin/enumstringer/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/plugin/equal/BUILD.bazel b/plugin/equal/BUILD.bazel
---- a/plugin/equal/BUILD.bazel	1969-12-31 16:00:00
+--- a/plugin/equal/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/plugin/equal/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -384,7 +384,7 @@ diff -urN a/plugin/equal/BUILD.bazel b/plugin/equal/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/plugin/face/BUILD.bazel b/plugin/face/BUILD.bazel
---- a/plugin/face/BUILD.bazel	1969-12-31 16:00:00
+--- a/plugin/face/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/plugin/face/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -410,7 +410,7 @@ diff -urN a/plugin/face/BUILD.bazel b/plugin/face/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/plugin/gostring/BUILD.bazel b/plugin/gostring/BUILD.bazel
---- a/plugin/gostring/BUILD.bazel	1969-12-31 16:00:00
+--- a/plugin/gostring/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/plugin/gostring/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -436,7 +436,7 @@ diff -urN a/plugin/gostring/BUILD.bazel b/plugin/gostring/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/plugin/marshalto/BUILD.bazel b/plugin/marshalto/BUILD.bazel
---- a/plugin/marshalto/BUILD.bazel	1969-12-31 16:00:00
+--- a/plugin/marshalto/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/plugin/marshalto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -461,7 +461,7 @@ diff -urN a/plugin/marshalto/BUILD.bazel b/plugin/marshalto/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/plugin/oneofcheck/BUILD.bazel b/plugin/oneofcheck/BUILD.bazel
---- a/plugin/oneofcheck/BUILD.bazel	1969-12-31 16:00:00
+--- a/plugin/oneofcheck/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/plugin/oneofcheck/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -483,7 +483,7 @@ diff -urN a/plugin/oneofcheck/BUILD.bazel b/plugin/oneofcheck/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/plugin/populate/BUILD.bazel b/plugin/populate/BUILD.bazel
---- a/plugin/populate/BUILD.bazel	1969-12-31 16:00:00
+--- a/plugin/populate/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/plugin/populate/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -508,7 +508,7 @@ diff -urN a/plugin/populate/BUILD.bazel b/plugin/populate/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/plugin/size/BUILD.bazel b/plugin/size/BUILD.bazel
---- a/plugin/size/BUILD.bazel	1969-12-31 16:00:00
+--- a/plugin/size/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/plugin/size/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -537,7 +537,7 @@ diff -urN a/plugin/size/BUILD.bazel b/plugin/size/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/plugin/stringer/BUILD.bazel b/plugin/stringer/BUILD.bazel
---- a/plugin/stringer/BUILD.bazel	1969-12-31 16:00:00
+--- a/plugin/stringer/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/plugin/stringer/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -563,7 +563,7 @@ diff -urN a/plugin/stringer/BUILD.bazel b/plugin/stringer/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/plugin/testgen/BUILD.bazel b/plugin/testgen/BUILD.bazel
---- a/plugin/testgen/BUILD.bazel	1969-12-31 16:00:00
+--- a/plugin/testgen/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/plugin/testgen/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -585,7 +585,7 @@ diff -urN a/plugin/testgen/BUILD.bazel b/plugin/testgen/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/plugin/union/BUILD.bazel b/plugin/union/BUILD.bazel
---- a/plugin/union/BUILD.bazel	1969-12-31 16:00:00
+--- a/plugin/union/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/plugin/union/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -611,7 +611,7 @@ diff -urN a/plugin/union/BUILD.bazel b/plugin/union/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/plugin/unmarshal/BUILD.bazel b/plugin/unmarshal/BUILD.bazel
---- a/plugin/unmarshal/BUILD.bazel	1969-12-31 16:00:00
+--- a/plugin/unmarshal/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/plugin/unmarshal/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -635,7 +635,7 @@ diff -urN a/plugin/unmarshal/BUILD.bazel b/plugin/unmarshal/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/proto/BUILD.bazel b/proto/BUILD.bazel
---- a/proto/BUILD.bazel	1969-12-31 16:00:00
+--- a/proto/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/proto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,78 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -717,7 +717,7 @@ diff -urN a/proto/BUILD.bazel b/proto/BUILD.bazel
 +    ],
 +)
 diff -urN a/proto/proto3_proto/BUILD.bazel b/proto/proto3_proto/BUILD.bazel
---- a/proto/proto3_proto/BUILD.bazel	1969-12-31 16:00:00
+--- a/proto/proto3_proto/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/proto/proto3_proto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -746,7 +746,7 @@ diff -urN a/proto/proto3_proto/BUILD.bazel b/proto/proto3_proto/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/proto/test_proto/BUILD.bazel b/proto/test_proto/BUILD.bazel
---- a/proto/test_proto/BUILD.bazel	1969-12-31 16:00:00
+--- a/proto/test_proto/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/proto/test_proto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -771,7 +771,7 @@ diff -urN a/proto/test_proto/BUILD.bazel b/proto/test_proto/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protobuf/google/protobuf/BUILD.bazel b/protobuf/google/protobuf/BUILD.bazel
---- a/protobuf/google/protobuf/BUILD.bazel	1969-12-31 16:00:00
+--- a/protobuf/google/protobuf/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protobuf/google/protobuf/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,17 @@
 +filegroup(
@@ -792,7 +792,7 @@ diff -urN a/protobuf/google/protobuf/BUILD.bazel b/protobuf/google/protobuf/BUIL
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protobuf/google/protobuf/compiler/BUILD.bazel b/protobuf/google/protobuf/compiler/BUILD.bazel
---- a/protobuf/google/protobuf/compiler/BUILD.bazel	1969-12-31 16:00:00
+--- a/protobuf/google/protobuf/compiler/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protobuf/google/protobuf/compiler/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,5 @@
 +filegroup(
@@ -801,7 +801,7 @@ diff -urN a/protobuf/google/protobuf/compiler/BUILD.bazel b/protobuf/google/prot
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-combo/BUILD.bazel b/protoc-gen-combo/BUILD.bazel
---- a/protoc-gen-combo/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-combo/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-combo/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -820,7 +820,7 @@ diff -urN a/protoc-gen-combo/BUILD.bazel b/protoc-gen-combo/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-gofast/BUILD.bazel b/protoc-gen-gofast/BUILD.bazel
---- a/protoc-gen-gofast/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gofast/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gofast/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -842,7 +842,7 @@ diff -urN a/protoc-gen-gofast/BUILD.bazel b/protoc-gen-gofast/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-gogo/BUILD.bazel b/protoc-gen-gogo/BUILD.bazel
---- a/protoc-gen-gogo/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gogo/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gogo/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
@@ -867,7 +867,7 @@ diff -urN a/protoc-gen-gogo/BUILD.bazel b/protoc-gen-gogo/BUILD.bazel
 +    embed = [":protoc-gen-gogo_lib"],
 +)
 diff -urN a/protoc-gen-gogo/descriptor/BUILD.bazel b/protoc-gen-gogo/descriptor/BUILD.bazel
---- a/protoc-gen-gogo/descriptor/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gogo/descriptor/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gogo/descriptor/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,29 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -900,7 +900,7 @@ diff -urN a/protoc-gen-gogo/descriptor/BUILD.bazel b/protoc-gen-gogo/descriptor/
 +    ],
 +)
 diff -urN a/protoc-gen-gogo/generator/BUILD.bazel b/protoc-gen-gogo/generator/BUILD.bazel
---- a/protoc-gen-gogo/generator/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gogo/generator/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gogo/generator/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -935,7 +935,7 @@ diff -urN a/protoc-gen-gogo/generator/BUILD.bazel b/protoc-gen-gogo/generator/BU
 +    deps = ["//protoc-gen-gogo/descriptor"],
 +)
 diff -urN a/protoc-gen-gogo/generator/internal/remap/BUILD.bazel b/protoc-gen-gogo/generator/internal/remap/BUILD.bazel
---- a/protoc-gen-gogo/generator/internal/remap/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gogo/generator/internal/remap/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gogo/generator/internal/remap/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -959,7 +959,7 @@ diff -urN a/protoc-gen-gogo/generator/internal/remap/BUILD.bazel b/protoc-gen-go
 +    embed = [":remap"],
 +)
 diff -urN a/protoc-gen-gogo/grpc/BUILD.bazel b/protoc-gen-gogo/grpc/BUILD.bazel
---- a/protoc-gen-gogo/grpc/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gogo/grpc/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gogo/grpc/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -981,7 +981,7 @@ diff -urN a/protoc-gen-gogo/grpc/BUILD.bazel b/protoc-gen-gogo/grpc/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-gogo/plugin/BUILD.bazel b/protoc-gen-gogo/plugin/BUILD.bazel
---- a/protoc-gen-gogo/plugin/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gogo/plugin/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gogo/plugin/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1003,7 +1003,7 @@ diff -urN a/protoc-gen-gogo/plugin/BUILD.bazel b/protoc-gen-gogo/plugin/BUILD.ba
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-gogo/testdata/BUILD.bazel b/protoc-gen-gogo/testdata/BUILD.bazel
---- a/protoc-gen-gogo/testdata/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gogo/testdata/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gogo/testdata/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,16 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_test")
@@ -1023,7 +1023,7 @@ diff -urN a/protoc-gen-gogo/testdata/BUILD.bazel b/protoc-gen-gogo/testdata/BUIL
 +    ],
 +)
 diff -urN a/protoc-gen-gogo/testdata/deprecated/BUILD.bazel b/protoc-gen-gogo/testdata/deprecated/BUILD.bazel
---- a/protoc-gen-gogo/testdata/deprecated/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gogo/testdata/deprecated/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gogo/testdata/deprecated/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1053,7 +1053,7 @@ diff -urN a/protoc-gen-gogo/testdata/deprecated/BUILD.bazel b/protoc-gen-gogo/te
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-gogo/testdata/extension_base/BUILD.bazel b/protoc-gen-gogo/testdata/extension_base/BUILD.bazel
---- a/protoc-gen-gogo/testdata/extension_base/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gogo/testdata/extension_base/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gogo/testdata/extension_base/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1078,7 +1078,7 @@ diff -urN a/protoc-gen-gogo/testdata/extension_base/BUILD.bazel b/protoc-gen-gog
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-gogo/testdata/extension_extra/BUILD.bazel b/protoc-gen-gogo/testdata/extension_extra/BUILD.bazel
---- a/protoc-gen-gogo/testdata/extension_extra/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gogo/testdata/extension_extra/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gogo/testdata/extension_extra/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1103,7 +1103,7 @@ diff -urN a/protoc-gen-gogo/testdata/extension_extra/BUILD.bazel b/protoc-gen-go
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-gogo/testdata/extension_user/BUILD.bazel b/protoc-gen-gogo/testdata/extension_user/BUILD.bazel
---- a/protoc-gen-gogo/testdata/extension_user/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gogo/testdata/extension_user/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gogo/testdata/extension_user/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1132,7 +1132,7 @@ diff -urN a/protoc-gen-gogo/testdata/extension_user/BUILD.bazel b/protoc-gen-gog
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-gogo/testdata/grpc/BUILD.bazel b/protoc-gen-gogo/testdata/grpc/BUILD.bazel
---- a/protoc-gen-gogo/testdata/grpc/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gogo/testdata/grpc/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gogo/testdata/grpc/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,32 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1168,7 +1168,7 @@ diff -urN a/protoc-gen-gogo/testdata/grpc/BUILD.bazel b/protoc-gen-gogo/testdata
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-gogo/testdata/import_public/BUILD.bazel b/protoc-gen-gogo/testdata/import_public/BUILD.bazel
---- a/protoc-gen-gogo/testdata/import_public/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gogo/testdata/import_public/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gogo/testdata/import_public/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1202,7 +1202,7 @@ diff -urN a/protoc-gen-gogo/testdata/import_public/BUILD.bazel b/protoc-gen-gogo
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-gogo/testdata/import_public/importing/BUILD.bazel b/protoc-gen-gogo/testdata/import_public/importing/BUILD.bazel
---- a/protoc-gen-gogo/testdata/import_public/importing/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gogo/testdata/import_public/importing/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gogo/testdata/import_public/importing/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1231,7 +1231,7 @@ diff -urN a/protoc-gen-gogo/testdata/import_public/importing/BUILD.bazel b/proto
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-gogo/testdata/import_public/sub/BUILD.bazel b/protoc-gen-gogo/testdata/import_public/sub/BUILD.bazel
---- a/protoc-gen-gogo/testdata/import_public/sub/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gogo/testdata/import_public/sub/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gogo/testdata/import_public/sub/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1262,7 +1262,7 @@ diff -urN a/protoc-gen-gogo/testdata/import_public/sub/BUILD.bazel b/protoc-gen-
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-gogo/testdata/imports/BUILD.bazel b/protoc-gen-gogo/testdata/imports/BUILD.bazel
---- a/protoc-gen-gogo/testdata/imports/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gogo/testdata/imports/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gogo/testdata/imports/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1301,7 +1301,7 @@ diff -urN a/protoc-gen-gogo/testdata/imports/BUILD.bazel b/protoc-gen-gogo/testd
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-gogo/testdata/imports/fmt/BUILD.bazel b/protoc-gen-gogo/testdata/imports/fmt/BUILD.bazel
---- a/protoc-gen-gogo/testdata/imports/fmt/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gogo/testdata/imports/fmt/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gogo/testdata/imports/fmt/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1326,7 +1326,7 @@ diff -urN a/protoc-gen-gogo/testdata/imports/fmt/BUILD.bazel b/protoc-gen-gogo/t
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-gogo/testdata/imports/test_a_1/BUILD.bazel b/protoc-gen-gogo/testdata/imports/test_a_1/BUILD.bazel
---- a/protoc-gen-gogo/testdata/imports/test_a_1/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gogo/testdata/imports/test_a_1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gogo/testdata/imports/test_a_1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1357,7 +1357,7 @@ diff -urN a/protoc-gen-gogo/testdata/imports/test_a_1/BUILD.bazel b/protoc-gen-g
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-gogo/testdata/imports/test_a_2/BUILD.bazel b/protoc-gen-gogo/testdata/imports/test_a_2/BUILD.bazel
---- a/protoc-gen-gogo/testdata/imports/test_a_2/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gogo/testdata/imports/test_a_2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gogo/testdata/imports/test_a_2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1388,7 +1388,7 @@ diff -urN a/protoc-gen-gogo/testdata/imports/test_a_2/BUILD.bazel b/protoc-gen-g
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-gogo/testdata/imports/test_b_1/BUILD.bazel b/protoc-gen-gogo/testdata/imports/test_b_1/BUILD.bazel
---- a/protoc-gen-gogo/testdata/imports/test_b_1/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gogo/testdata/imports/test_b_1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gogo/testdata/imports/test_b_1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1419,7 +1419,7 @@ diff -urN a/protoc-gen-gogo/testdata/imports/test_b_1/BUILD.bazel b/protoc-gen-g
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-gogo/testdata/multi/BUILD.bazel b/protoc-gen-gogo/testdata/multi/BUILD.bazel
---- a/protoc-gen-gogo/testdata/multi/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gogo/testdata/multi/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gogo/testdata/multi/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,9 @@
 +filegroup(
@@ -1432,7 +1432,7 @@ diff -urN a/protoc-gen-gogo/testdata/multi/BUILD.bazel b/protoc-gen-gogo/testdat
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-gogo/testdata/my_test/BUILD.bazel b/protoc-gen-gogo/testdata/my_test/BUILD.bazel
---- a/protoc-gen-gogo/testdata/my_test/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gogo/testdata/my_test/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gogo/testdata/my_test/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1457,7 +1457,7 @@ diff -urN a/protoc-gen-gogo/testdata/my_test/BUILD.bazel b/protoc-gen-gogo/testd
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-gogo/testdata/proto3/BUILD.bazel b/protoc-gen-gogo/testdata/proto3/BUILD.bazel
---- a/protoc-gen-gogo/testdata/proto3/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gogo/testdata/proto3/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gogo/testdata/proto3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1482,7 +1482,7 @@ diff -urN a/protoc-gen-gogo/testdata/proto3/BUILD.bazel b/protoc-gen-gogo/testda
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-gogofast/BUILD.bazel b/protoc-gen-gogofast/BUILD.bazel
---- a/protoc-gen-gogofast/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gogofast/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gogofast/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -1504,7 +1504,7 @@ diff -urN a/protoc-gen-gogofast/BUILD.bazel b/protoc-gen-gogofast/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-gogofaster/BUILD.bazel b/protoc-gen-gogofaster/BUILD.bazel
---- a/protoc-gen-gogofaster/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gogofaster/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gogofaster/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -1526,7 +1526,7 @@ diff -urN a/protoc-gen-gogofaster/BUILD.bazel b/protoc-gen-gogofaster/BUILD.baze
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-gogoslick/BUILD.bazel b/protoc-gen-gogoslick/BUILD.bazel
---- a/protoc-gen-gogoslick/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gogoslick/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gogoslick/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -1548,7 +1548,7 @@ diff -urN a/protoc-gen-gogoslick/BUILD.bazel b/protoc-gen-gogoslick/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-gogotypes/BUILD.bazel b/protoc-gen-gogotypes/BUILD.bazel
---- a/protoc-gen-gogotypes/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gogotypes/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gogotypes/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -1570,7 +1570,7 @@ diff -urN a/protoc-gen-gogotypes/BUILD.bazel b/protoc-gen-gogotypes/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-gostring/BUILD.bazel b/protoc-gen-gostring/BUILD.bazel
---- a/protoc-gen-gostring/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-gostring/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-gostring/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -1592,7 +1592,7 @@ diff -urN a/protoc-gen-gostring/BUILD.bazel b/protoc-gen-gostring/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-min-version/BUILD.bazel b/protoc-min-version/BUILD.bazel
---- a/protoc-min-version/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-min-version/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-min-version/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -1611,7 +1611,7 @@ diff -urN a/protoc-min-version/BUILD.bazel b/protoc-min-version/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/sortkeys/BUILD.bazel b/sortkeys/BUILD.bazel
---- a/sortkeys/BUILD.bazel	1969-12-31 16:00:00
+--- a/sortkeys/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/sortkeys/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1628,8 +1628,45 @@ diff -urN a/sortkeys/BUILD.bazel b/sortkeys/BUILD.bazel
 +    actual = ":sortkeys",
 +    visibility = ["//visibility:public"],
 +)
+diff -urN a/test/asymetric-issue125/BUILD.bazel b/test/asymetric-issue125/BUILD.bazel
+--- a/test/asymetric-issue125/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/test/asymetric-issue125/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,33 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++filegroup(
++    name = "go_default_library_protos",
++    srcs = ["asym.proto"],
++    visibility = ["//visibility:public"],
++)
++
++go_library(
++    name = "asymetric-issue125",
++    srcs = [
++        "asym.pb.go",
++        "pop.go",
++    ],
++    importpath = "github.com/gogo/protobuf/test/asymetric-issue125",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//gogoproto",
++        "//proto",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":asymetric-issue125",
++    visibility = ["//visibility:public"],
++)
++
++go_test(
++    name = "asymetric-issue125_test",
++    srcs = ["asym_test.go"],
++    embed = [":asymetric-issue125"],
++)
 diff -urN a/test/BUILD.bazel b/test/BUILD.bazel
---- a/test/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,48 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1680,45 +1717,8 @@ diff -urN a/test/BUILD.bazel b/test/BUILD.bazel
 +        "//proto",
 +    ],
 +)
-diff -urN a/test/asymetric-issue125/BUILD.bazel b/test/asymetric-issue125/BUILD.bazel
---- a/test/asymetric-issue125/BUILD.bazel	1969-12-31 16:00:00
-+++ b/test/asymetric-issue125/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,33 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-+
-+filegroup(
-+    name = "go_default_library_protos",
-+    srcs = ["asym.proto"],
-+    visibility = ["//visibility:public"],
-+)
-+
-+go_library(
-+    name = "asymetric-issue125",
-+    srcs = [
-+        "asym.pb.go",
-+        "pop.go",
-+    ],
-+    importpath = "github.com/gogo/protobuf/test/asymetric-issue125",
-+    visibility = ["//visibility:public"],
-+    deps = [
-+        "//gogoproto",
-+        "//proto",
-+    ],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":asymetric-issue125",
-+    visibility = ["//visibility:public"],
-+)
-+
-+go_test(
-+    name = "asymetric-issue125_test",
-+    srcs = ["asym_test.go"],
-+    embed = [":asymetric-issue125"],
-+)
 diff -urN a/test/cachedsize/BUILD.bazel b/test/cachedsize/BUILD.bazel
---- a/test/cachedsize/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/cachedsize/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/cachedsize/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1753,7 +1753,7 @@ diff -urN a/test/cachedsize/BUILD.bazel b/test/cachedsize/BUILD.bazel
 +    deps = ["//proto"],
 +)
 diff -urN a/test/casttype/BUILD.bazel b/test/casttype/BUILD.bazel
---- a/test/casttype/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/casttype/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/casttype/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1777,7 +1777,7 @@ diff -urN a/test/casttype/BUILD.bazel b/test/casttype/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/test/casttype/combos/both/BUILD.bazel b/test/casttype/combos/both/BUILD.bazel
---- a/test/casttype/combos/both/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/casttype/combos/both/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/casttype/combos/both/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1819,7 +1819,7 @@ diff -urN a/test/casttype/combos/both/BUILD.bazel b/test/casttype/combos/both/BU
 +    ],
 +)
 diff -urN a/test/casttype/combos/marshaler/BUILD.bazel b/test/casttype/combos/marshaler/BUILD.bazel
---- a/test/casttype/combos/marshaler/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/casttype/combos/marshaler/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/casttype/combos/marshaler/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1861,7 +1861,7 @@ diff -urN a/test/casttype/combos/marshaler/BUILD.bazel b/test/casttype/combos/ma
 +    ],
 +)
 diff -urN a/test/casttype/combos/neither/BUILD.bazel b/test/casttype/combos/neither/BUILD.bazel
---- a/test/casttype/combos/neither/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/casttype/combos/neither/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/casttype/combos/neither/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1903,7 +1903,7 @@ diff -urN a/test/casttype/combos/neither/BUILD.bazel b/test/casttype/combos/neit
 +    ],
 +)
 diff -urN a/test/casttype/combos/unmarshaler/BUILD.bazel b/test/casttype/combos/unmarshaler/BUILD.bazel
---- a/test/casttype/combos/unmarshaler/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/casttype/combos/unmarshaler/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/casttype/combos/unmarshaler/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1945,7 +1945,7 @@ diff -urN a/test/casttype/combos/unmarshaler/BUILD.bazel b/test/casttype/combos/
 +    ],
 +)
 diff -urN a/test/castvalue/BUILD.bazel b/test/castvalue/BUILD.bazel
---- a/test/castvalue/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/castvalue/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/castvalue/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,40 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1989,7 +1989,7 @@ diff -urN a/test/castvalue/BUILD.bazel b/test/castvalue/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/castvalue/combos/both/BUILD.bazel b/test/castvalue/combos/both/BUILD.bazel
---- a/test/castvalue/combos/both/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/castvalue/combos/both/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/castvalue/combos/both/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,40 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2033,7 +2033,7 @@ diff -urN a/test/castvalue/combos/both/BUILD.bazel b/test/castvalue/combos/both/
 +    ],
 +)
 diff -urN a/test/castvalue/combos/marshaler/BUILD.bazel b/test/castvalue/combos/marshaler/BUILD.bazel
---- a/test/castvalue/combos/marshaler/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/castvalue/combos/marshaler/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/castvalue/combos/marshaler/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,40 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2077,7 +2077,7 @@ diff -urN a/test/castvalue/combos/marshaler/BUILD.bazel b/test/castvalue/combos/
 +    ],
 +)
 diff -urN a/test/castvalue/combos/unmarshaler/BUILD.bazel b/test/castvalue/combos/unmarshaler/BUILD.bazel
---- a/test/castvalue/combos/unmarshaler/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/castvalue/combos/unmarshaler/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/castvalue/combos/unmarshaler/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,40 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2121,7 +2121,7 @@ diff -urN a/test/castvalue/combos/unmarshaler/BUILD.bazel b/test/castvalue/combo
 +    ],
 +)
 diff -urN a/test/combos/both/BUILD.bazel b/test/combos/both/BUILD.bazel
---- a/test/combos/both/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/combos/both/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/combos/both/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,46 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2171,7 +2171,7 @@ diff -urN a/test/combos/both/BUILD.bazel b/test/combos/both/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/combos/marshaler/BUILD.bazel b/test/combos/marshaler/BUILD.bazel
---- a/test/combos/marshaler/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/combos/marshaler/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/combos/marshaler/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,46 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2221,7 +2221,7 @@ diff -urN a/test/combos/marshaler/BUILD.bazel b/test/combos/marshaler/BUILD.baze
 +    ],
 +)
 diff -urN a/test/combos/unmarshaler/BUILD.bazel b/test/combos/unmarshaler/BUILD.bazel
---- a/test/combos/unmarshaler/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/combos/unmarshaler/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/combos/unmarshaler/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,46 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2271,7 +2271,7 @@ diff -urN a/test/combos/unmarshaler/BUILD.bazel b/test/combos/unmarshaler/BUILD.
 +    ],
 +)
 diff -urN a/test/custom/BUILD.bazel b/test/custom/BUILD.bazel
---- a/test/custom/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/custom/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/custom/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2294,26 +2294,8 @@ diff -urN a/test/custom/BUILD.bazel b/test/custom/BUILD.bazel
 +    srcs = ["custom_test.go"],
 +    embed = [":custom"],
 +)
-diff -urN a/test/custom-dash-type/BUILD.bazel b/test/custom-dash-type/BUILD.bazel
---- a/test/custom-dash-type/BUILD.bazel	1969-12-31 16:00:00
-+++ b/test/custom-dash-type/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,14 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "custom-dash-type",
-+    srcs = ["customdash.go"],
-+    importpath = "github.com/gogo/protobuf/test/custom-dash-type",
-+    visibility = ["//visibility:public"],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":custom-dash-type",
-+    visibility = ["//visibility:public"],
-+)
 diff -urN a/test/custombytesnonstruct/BUILD.bazel b/test/custombytesnonstruct/BUILD.bazel
---- a/test/custombytesnonstruct/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/custombytesnonstruct/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/custombytesnonstruct/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2349,8 +2331,26 @@ diff -urN a/test/custombytesnonstruct/BUILD.bazel b/test/custombytesnonstruct/BU
 +    srcs = ["custombytesnonstruct_test.go"],
 +    embed = [":custombytesnonstruct"],
 +)
+diff -urN a/test/custom-dash-type/BUILD.bazel b/test/custom-dash-type/BUILD.bazel
+--- a/test/custom-dash-type/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/test/custom-dash-type/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,14 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "custom-dash-type",
++    srcs = ["customdash.go"],
++    importpath = "github.com/gogo/protobuf/test/custom-dash-type",
++    visibility = ["//visibility:public"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":custom-dash-type",
++    visibility = ["//visibility:public"],
++)
 diff -urN a/test/dashfilename/BUILD.bazel b/test/dashfilename/BUILD.bazel
---- a/test/dashfilename/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/dashfilename/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/dashfilename/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2380,7 +2380,7 @@ diff -urN a/test/dashfilename/BUILD.bazel b/test/dashfilename/BUILD.bazel
 +    embed = [":dashfilename"],
 +)
 diff -urN a/test/data/BUILD.bazel b/test/data/BUILD.bazel
---- a/test/data/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/data/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/data/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2419,7 +2419,7 @@ diff -urN a/test/data/BUILD.bazel b/test/data/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/defaultconflict/BUILD.bazel b/test/defaultconflict/BUILD.bazel
---- a/test/defaultconflict/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/defaultconflict/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/defaultconflict/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,32 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2455,7 +2455,7 @@ diff -urN a/test/defaultconflict/BUILD.bazel b/test/defaultconflict/BUILD.bazel
 +    embed = [":defaultconflict"],
 +)
 diff -urN a/test/deterministic/BUILD.bazel b/test/deterministic/BUILD.bazel
---- a/test/deterministic/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/deterministic/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/deterministic/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,32 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2491,7 +2491,7 @@ diff -urN a/test/deterministic/BUILD.bazel b/test/deterministic/BUILD.bazel
 +    deps = ["//proto"],
 +)
 diff -urN a/test/embedconflict/BUILD.bazel b/test/embedconflict/BUILD.bazel
---- a/test/embedconflict/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/embedconflict/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/embedconflict/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2528,7 +2528,7 @@ diff -urN a/test/embedconflict/BUILD.bazel b/test/embedconflict/BUILD.bazel
 +    embed = [":embedconflict"],
 +)
 diff -urN a/test/empty-issue70/BUILD.bazel b/test/empty-issue70/BUILD.bazel
---- a/test/empty-issue70/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/empty-issue70/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/empty-issue70/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2562,7 +2562,7 @@ diff -urN a/test/empty-issue70/BUILD.bazel b/test/empty-issue70/BUILD.bazel
 +    embed = [":empty-issue70"],
 +)
 diff -urN a/test/enumcustomname/BUILD.bazel b/test/enumcustomname/BUILD.bazel
---- a/test/enumcustomname/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/enumcustomname/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/enumcustomname/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2591,7 +2591,7 @@ diff -urN a/test/enumcustomname/BUILD.bazel b/test/enumcustomname/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/test/enumdecl/BUILD.bazel b/test/enumdecl/BUILD.bazel
---- a/test/enumdecl/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/enumdecl/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/enumdecl/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2633,7 +2633,7 @@ diff -urN a/test/enumdecl/BUILD.bazel b/test/enumdecl/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/enumdecl_all/BUILD.bazel b/test/enumdecl_all/BUILD.bazel
---- a/test/enumdecl_all/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/enumdecl_all/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/enumdecl_all/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2675,7 +2675,7 @@ diff -urN a/test/enumdecl_all/BUILD.bazel b/test/enumdecl_all/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/enumprefix/BUILD.bazel b/test/enumprefix/BUILD.bazel
---- a/test/enumprefix/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/enumprefix/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/enumprefix/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2704,7 +2704,7 @@ diff -urN a/test/enumprefix/BUILD.bazel b/test/enumprefix/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/test/enumstringer/BUILD.bazel b/test/enumstringer/BUILD.bazel
---- a/test/enumstringer/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/enumstringer/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/enumstringer/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2746,7 +2746,7 @@ diff -urN a/test/enumstringer/BUILD.bazel b/test/enumstringer/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/example/BUILD.bazel b/test/example/BUILD.bazel
---- a/test/example/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/example/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/example/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,41 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2791,7 +2791,7 @@ diff -urN a/test/example/BUILD.bazel b/test/example/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/filedotname/BUILD.bazel b/test/filedotname/BUILD.bazel
---- a/test/filedotname/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/filedotname/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/filedotname/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2831,7 +2831,7 @@ diff -urN a/test/filedotname/BUILD.bazel b/test/filedotname/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/fuzztests/BUILD.bazel b/test/fuzztests/BUILD.bazel
---- a/test/fuzztests/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/fuzztests/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/fuzztests/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2866,7 +2866,7 @@ diff -urN a/test/fuzztests/BUILD.bazel b/test/fuzztests/BUILD.bazel
 +    deps = ["//proto"],
 +)
 diff -urN a/test/group/BUILD.bazel b/test/group/BUILD.bazel
---- a/test/group/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/group/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/group/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2906,7 +2906,7 @@ diff -urN a/test/group/BUILD.bazel b/test/group/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/importcustom-issue389/imported/BUILD.bazel b/test/importcustom-issue389/imported/BUILD.bazel
---- a/test/importcustom-issue389/imported/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/importcustom-issue389/imported/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/importcustom-issue389/imported/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2948,7 +2948,7 @@ diff -urN a/test/importcustom-issue389/imported/BUILD.bazel b/test/importcustom-
 +    ],
 +)
 diff -urN a/test/importcustom-issue389/importing/BUILD.bazel b/test/importcustom-issue389/importing/BUILD.bazel
---- a/test/importcustom-issue389/importing/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/importcustom-issue389/importing/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/importcustom-issue389/importing/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,37 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2989,7 +2989,7 @@ diff -urN a/test/importcustom-issue389/importing/BUILD.bazel b/test/importcustom
 +    ],
 +)
 diff -urN a/test/importdedup/BUILD.bazel b/test/importdedup/BUILD.bazel
---- a/test/importdedup/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/importdedup/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/importdedup/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3024,7 +3024,7 @@ diff -urN a/test/importdedup/BUILD.bazel b/test/importdedup/BUILD.bazel
 +    embed = [":importdedup"],
 +)
 diff -urN a/test/importdedup/subpkg/BUILD.bazel b/test/importdedup/subpkg/BUILD.bazel
---- a/test/importdedup/subpkg/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/importdedup/subpkg/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/importdedup/subpkg/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3055,7 +3055,7 @@ diff -urN a/test/importdedup/subpkg/BUILD.bazel b/test/importdedup/subpkg/BUILD.
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/test/importduplicate/BUILD.bazel b/test/importduplicate/BUILD.bazel
---- a/test/importduplicate/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/importduplicate/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/importduplicate/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,43 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3102,7 +3102,7 @@ diff -urN a/test/importduplicate/BUILD.bazel b/test/importduplicate/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/importduplicate/proto/BUILD.bazel b/test/importduplicate/proto/BUILD.bazel
---- a/test/importduplicate/proto/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/importduplicate/proto/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/importduplicate/proto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3141,7 +3141,7 @@ diff -urN a/test/importduplicate/proto/BUILD.bazel b/test/importduplicate/proto/
 +    ],
 +)
 diff -urN a/test/importduplicate/sortkeys/BUILD.bazel b/test/importduplicate/sortkeys/BUILD.bazel
---- a/test/importduplicate/sortkeys/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/importduplicate/sortkeys/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/importduplicate/sortkeys/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3180,7 +3180,7 @@ diff -urN a/test/importduplicate/sortkeys/BUILD.bazel b/test/importduplicate/sor
 +    ],
 +)
 diff -urN a/test/indeximport-issue72/BUILD.bazel b/test/indeximport-issue72/BUILD.bazel
---- a/test/indeximport-issue72/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/indeximport-issue72/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/indeximport-issue72/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,37 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3221,7 +3221,7 @@ diff -urN a/test/indeximport-issue72/BUILD.bazel b/test/indeximport-issue72/BUIL
 +    ],
 +)
 diff -urN a/test/indeximport-issue72/index/BUILD.bazel b/test/indeximport-issue72/index/BUILD.bazel
---- a/test/indeximport-issue72/index/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/indeximport-issue72/index/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/indeximport-issue72/index/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3260,7 +3260,7 @@ diff -urN a/test/indeximport-issue72/index/BUILD.bazel b/test/indeximport-issue7
 +    ],
 +)
 diff -urN a/test/int64support/BUILD.bazel b/test/int64support/BUILD.bazel
---- a/test/int64support/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/int64support/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/int64support/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,41 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3305,7 +3305,7 @@ diff -urN a/test/int64support/BUILD.bazel b/test/int64support/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/issue260/BUILD.bazel b/test/issue260/BUILD.bazel
---- a/test/issue260/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/issue260/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/issue260/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,41 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3350,7 +3350,7 @@ diff -urN a/test/issue260/BUILD.bazel b/test/issue260/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/issue261/BUILD.bazel b/test/issue261/BUILD.bazel
---- a/test/issue261/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/issue261/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/issue261/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3380,7 +3380,7 @@ diff -urN a/test/issue261/BUILD.bazel b/test/issue261/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/test/issue262/BUILD.bazel b/test/issue262/BUILD.bazel
---- a/test/issue262/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/issue262/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/issue262/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3408,8 +3408,29 @@ diff -urN a/test/issue262/BUILD.bazel b/test/issue262/BUILD.bazel
 +    actual = ":issue262",
 +    visibility = ["//visibility:public"],
 +)
+diff -urN a/test/issue270/a/BUILD.bazel b/test/issue270/a/BUILD.bazel
+--- a/test/issue270/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/test/issue270/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,8 @@
++filegroup(
++    name = "go_default_library_protos",
++    srcs = [
++        "a1.proto",
++        "a2.proto",
++    ],
++    visibility = ["//visibility:public"],
++)
+diff -urN a/test/issue270/b/BUILD.bazel b/test/issue270/b/BUILD.bazel
+--- a/test/issue270/b/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/test/issue270/b/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,5 @@
++filegroup(
++    name = "go_default_library_protos",
++    srcs = ["b.proto"],
++    visibility = ["//visibility:public"],
++)
 diff -urN a/test/issue270/BUILD.bazel b/test/issue270/BUILD.bazel
---- a/test/issue270/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/issue270/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/issue270/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3432,29 +3453,8 @@ diff -urN a/test/issue270/BUILD.bazel b/test/issue270/BUILD.bazel
 +    srcs = ["issue270_test.go"],
 +    embed = [":issue270"],
 +)
-diff -urN a/test/issue270/a/BUILD.bazel b/test/issue270/a/BUILD.bazel
---- a/test/issue270/a/BUILD.bazel	1969-12-31 16:00:00
-+++ b/test/issue270/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,8 @@
-+filegroup(
-+    name = "go_default_library_protos",
-+    srcs = [
-+        "a1.proto",
-+        "a2.proto",
-+    ],
-+    visibility = ["//visibility:public"],
-+)
-diff -urN a/test/issue270/b/BUILD.bazel b/test/issue270/b/BUILD.bazel
---- a/test/issue270/b/BUILD.bazel	1969-12-31 16:00:00
-+++ b/test/issue270/b/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,5 @@
-+filegroup(
-+    name = "go_default_library_protos",
-+    srcs = ["b.proto"],
-+    visibility = ["//visibility:public"],
-+)
 diff -urN a/test/issue312/BUILD.bazel b/test/issue312/BUILD.bazel
---- a/test/issue312/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/issue312/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/issue312/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3482,7 +3482,7 @@ diff -urN a/test/issue312/BUILD.bazel b/test/issue312/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/test/issue312/events/BUILD.bazel b/test/issue312/events/BUILD.bazel
---- a/test/issue312/events/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/issue312/events/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/issue312/events/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,37 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3523,7 +3523,7 @@ diff -urN a/test/issue312/events/BUILD.bazel b/test/issue312/events/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/issue322/BUILD.bazel b/test/issue322/BUILD.bazel
---- a/test/issue322/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/issue322/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/issue322/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3562,7 +3562,7 @@ diff -urN a/test/issue322/BUILD.bazel b/test/issue322/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/issue330/BUILD.bazel b/test/issue330/BUILD.bazel
---- a/test/issue330/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/issue330/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/issue330/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3604,7 +3604,7 @@ diff -urN a/test/issue330/BUILD.bazel b/test/issue330/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/issue34/BUILD.bazel b/test/issue34/BUILD.bazel
---- a/test/issue34/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/issue34/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/issue34/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3639,7 +3639,7 @@ diff -urN a/test/issue34/BUILD.bazel b/test/issue34/BUILD.bazel
 +    deps = ["//proto"],
 +)
 diff -urN a/test/issue411/BUILD.bazel b/test/issue411/BUILD.bazel
---- a/test/issue411/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/issue411/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/issue411/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,37 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3680,7 +3680,7 @@ diff -urN a/test/issue411/BUILD.bazel b/test/issue411/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/issue427/BUILD.bazel b/test/issue427/BUILD.bazel
---- a/test/issue427/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/issue427/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/issue427/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,5 @@
 +filegroup(
@@ -3689,7 +3689,7 @@ diff -urN a/test/issue427/BUILD.bazel b/test/issue427/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/test/issue42order/BUILD.bazel b/test/issue42order/BUILD.bazel
---- a/test/issue42order/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/issue42order/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/issue42order/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3724,7 +3724,7 @@ diff -urN a/test/issue42order/BUILD.bazel b/test/issue42order/BUILD.bazel
 +    deps = ["//proto"],
 +)
 diff -urN a/test/issue435/BUILD.bazel b/test/issue435/BUILD.bazel
---- a/test/issue435/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/issue435/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/issue435/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3759,7 +3759,7 @@ diff -urN a/test/issue435/BUILD.bazel b/test/issue435/BUILD.bazel
 +    deps = ["//proto"],
 +)
 diff -urN a/test/issue438/BUILD.bazel b/test/issue438/BUILD.bazel
---- a/test/issue438/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/issue438/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/issue438/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3788,7 +3788,7 @@ diff -urN a/test/issue438/BUILD.bazel b/test/issue438/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/test/issue444/BUILD.bazel b/test/issue444/BUILD.bazel
---- a/test/issue444/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/issue444/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/issue444/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3822,7 +3822,7 @@ diff -urN a/test/issue444/BUILD.bazel b/test/issue444/BUILD.bazel
 +    embed = [":issue444"],
 +)
 diff -urN a/test/issue449/BUILD.bazel b/test/issue449/BUILD.bazel
---- a/test/issue449/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/issue449/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/issue449/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3857,7 +3857,7 @@ diff -urN a/test/issue449/BUILD.bazel b/test/issue449/BUILD.bazel
 +    deps = ["//proto"],
 +)
 diff -urN a/test/issue498/BUILD.bazel b/test/issue498/BUILD.bazel
---- a/test/issue498/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/issue498/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/issue498/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3896,7 +3896,7 @@ diff -urN a/test/issue498/BUILD.bazel b/test/issue498/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/issue503/BUILD.bazel b/test/issue503/BUILD.bazel
---- a/test/issue503/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/issue503/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/issue503/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3931,7 +3931,7 @@ diff -urN a/test/issue503/BUILD.bazel b/test/issue503/BUILD.bazel
 +    deps = ["//proto"],
 +)
 diff -urN a/test/issue530/BUILD.bazel b/test/issue530/BUILD.bazel
---- a/test/issue530/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/issue530/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/issue530/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,39 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3974,7 +3974,7 @@ diff -urN a/test/issue530/BUILD.bazel b/test/issue530/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/issue617/BUILD.bazel b/test/issue617/BUILD.bazel
---- a/test/issue617/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/issue617/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/issue617/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4002,7 +4002,7 @@ diff -urN a/test/issue617/BUILD.bazel b/test/issue617/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/test/issue620/BUILD.bazel b/test/issue620/BUILD.bazel
---- a/test/issue620/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/issue620/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/issue620/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4037,7 +4037,7 @@ diff -urN a/test/issue620/BUILD.bazel b/test/issue620/BUILD.bazel
 +    deps = ["//proto"],
 +)
 diff -urN a/test/issue630/BUILD.bazel b/test/issue630/BUILD.bazel
---- a/test/issue630/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/issue630/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/issue630/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4071,7 +4071,7 @@ diff -urN a/test/issue630/BUILD.bazel b/test/issue630/BUILD.bazel
 +    embed = [":issue630"],
 +)
 diff -urN a/test/issue8/BUILD.bazel b/test/issue8/BUILD.bazel
---- a/test/issue8/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/issue8/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/issue8/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4110,7 +4110,7 @@ diff -urN a/test/issue8/BUILD.bazel b/test/issue8/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/jsonpb-gogo/BUILD.bazel b/test/jsonpb-gogo/BUILD.bazel
---- a/test/jsonpb-gogo/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/jsonpb-gogo/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/jsonpb-gogo/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4135,7 +4135,7 @@ diff -urN a/test/jsonpb-gogo/BUILD.bazel b/test/jsonpb-gogo/BUILD.bazel
 +    deps = ["//jsonpb"],
 +)
 diff -urN a/test/mapdefaults/BUILD.bazel b/test/mapdefaults/BUILD.bazel
---- a/test/mapdefaults/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/mapdefaults/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/mapdefaults/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4160,7 +4160,7 @@ diff -urN a/test/mapdefaults/BUILD.bazel b/test/mapdefaults/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/test/mapdefaults/combos/both/BUILD.bazel b/test/mapdefaults/combos/both/BUILD.bazel
---- a/test/mapdefaults/combos/both/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/mapdefaults/combos/both/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/mapdefaults/combos/both/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,41 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4205,7 +4205,7 @@ diff -urN a/test/mapdefaults/combos/both/BUILD.bazel b/test/mapdefaults/combos/b
 +    ],
 +)
 diff -urN a/test/mapdefaults/combos/marshaler/BUILD.bazel b/test/mapdefaults/combos/marshaler/BUILD.bazel
---- a/test/mapdefaults/combos/marshaler/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/mapdefaults/combos/marshaler/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/mapdefaults/combos/marshaler/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,40 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4249,7 +4249,7 @@ diff -urN a/test/mapdefaults/combos/marshaler/BUILD.bazel b/test/mapdefaults/com
 +    ],
 +)
 diff -urN a/test/mapdefaults/combos/neither/BUILD.bazel b/test/mapdefaults/combos/neither/BUILD.bazel
---- a/test/mapdefaults/combos/neither/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/mapdefaults/combos/neither/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/mapdefaults/combos/neither/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,40 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4293,7 +4293,7 @@ diff -urN a/test/mapdefaults/combos/neither/BUILD.bazel b/test/mapdefaults/combo
 +    ],
 +)
 diff -urN a/test/mapdefaults/combos/unmarshaler/BUILD.bazel b/test/mapdefaults/combos/unmarshaler/BUILD.bazel
---- a/test/mapdefaults/combos/unmarshaler/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/mapdefaults/combos/unmarshaler/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/mapdefaults/combos/unmarshaler/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,41 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4338,7 +4338,7 @@ diff -urN a/test/mapdefaults/combos/unmarshaler/BUILD.bazel b/test/mapdefaults/c
 +    ],
 +)
 diff -urN a/test/mapsproto2/BUILD.bazel b/test/mapsproto2/BUILD.bazel
---- a/test/mapsproto2/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/mapsproto2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/mapsproto2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4365,7 +4365,7 @@ diff -urN a/test/mapsproto2/BUILD.bazel b/test/mapsproto2/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/test/mapsproto2/combos/both/BUILD.bazel b/test/mapsproto2/combos/both/BUILD.bazel
---- a/test/mapsproto2/combos/both/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/mapsproto2/combos/both/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/mapsproto2/combos/both/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,42 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4411,7 +4411,7 @@ diff -urN a/test/mapsproto2/combos/both/BUILD.bazel b/test/mapsproto2/combos/bot
 +    ],
 +)
 diff -urN a/test/mapsproto2/combos/marshaler/BUILD.bazel b/test/mapsproto2/combos/marshaler/BUILD.bazel
---- a/test/mapsproto2/combos/marshaler/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/mapsproto2/combos/marshaler/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/mapsproto2/combos/marshaler/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,42 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4457,7 +4457,7 @@ diff -urN a/test/mapsproto2/combos/marshaler/BUILD.bazel b/test/mapsproto2/combo
 +    ],
 +)
 diff -urN a/test/mapsproto2/combos/neither/BUILD.bazel b/test/mapsproto2/combos/neither/BUILD.bazel
---- a/test/mapsproto2/combos/neither/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/mapsproto2/combos/neither/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/mapsproto2/combos/neither/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,42 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4503,7 +4503,7 @@ diff -urN a/test/mapsproto2/combos/neither/BUILD.bazel b/test/mapsproto2/combos/
 +    ],
 +)
 diff -urN a/test/mapsproto2/combos/unmarshaler/BUILD.bazel b/test/mapsproto2/combos/unmarshaler/BUILD.bazel
---- a/test/mapsproto2/combos/unmarshaler/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/mapsproto2/combos/unmarshaler/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/mapsproto2/combos/unmarshaler/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,42 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4549,7 +4549,7 @@ diff -urN a/test/mapsproto2/combos/unmarshaler/BUILD.bazel b/test/mapsproto2/com
 +    ],
 +)
 diff -urN a/test/merge/BUILD.bazel b/test/merge/BUILD.bazel
---- a/test/merge/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/merge/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/merge/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4584,7 +4584,7 @@ diff -urN a/test/merge/BUILD.bazel b/test/merge/BUILD.bazel
 +    deps = ["//proto"],
 +)
 diff -urN a/test/mixbench/BUILD.bazel b/test/mixbench/BUILD.bazel
---- a/test/mixbench/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/mixbench/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/mixbench/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -4602,7 +4602,7 @@ diff -urN a/test/mixbench/BUILD.bazel b/test/mixbench/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/test/moredefaults/BUILD.bazel b/test/moredefaults/BUILD.bazel
---- a/test/moredefaults/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/moredefaults/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/moredefaults/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,40 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4646,7 +4646,7 @@ diff -urN a/test/moredefaults/BUILD.bazel b/test/moredefaults/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/nopackage/BUILD.bazel b/test/nopackage/BUILD.bazel
---- a/test/nopackage/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/nopackage/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/nopackage/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4677,7 +4677,7 @@ diff -urN a/test/nopackage/BUILD.bazel b/test/nopackage/BUILD.bazel
 +    embed = [":nopackage"],
 +)
 diff -urN a/test/oneof/BUILD.bazel b/test/oneof/BUILD.bazel
---- a/test/oneof/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/oneof/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/oneof/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4701,7 +4701,7 @@ diff -urN a/test/oneof/BUILD.bazel b/test/oneof/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/test/oneof/combos/both/BUILD.bazel b/test/oneof/combos/both/BUILD.bazel
---- a/test/oneof/combos/both/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/oneof/combos/both/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/oneof/combos/both/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4743,7 +4743,7 @@ diff -urN a/test/oneof/combos/both/BUILD.bazel b/test/oneof/combos/both/BUILD.ba
 +    ],
 +)
 diff -urN a/test/oneof/combos/marshaler/BUILD.bazel b/test/oneof/combos/marshaler/BUILD.bazel
---- a/test/oneof/combos/marshaler/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/oneof/combos/marshaler/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/oneof/combos/marshaler/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4785,7 +4785,7 @@ diff -urN a/test/oneof/combos/marshaler/BUILD.bazel b/test/oneof/combos/marshale
 +    ],
 +)
 diff -urN a/test/oneof/combos/neither/BUILD.bazel b/test/oneof/combos/neither/BUILD.bazel
---- a/test/oneof/combos/neither/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/oneof/combos/neither/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/oneof/combos/neither/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4827,7 +4827,7 @@ diff -urN a/test/oneof/combos/neither/BUILD.bazel b/test/oneof/combos/neither/BU
 +    ],
 +)
 diff -urN a/test/oneof/combos/unmarshaler/BUILD.bazel b/test/oneof/combos/unmarshaler/BUILD.bazel
---- a/test/oneof/combos/unmarshaler/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/oneof/combos/unmarshaler/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/oneof/combos/unmarshaler/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4869,7 +4869,7 @@ diff -urN a/test/oneof/combos/unmarshaler/BUILD.bazel b/test/oneof/combos/unmars
 +    ],
 +)
 diff -urN a/test/oneof3/BUILD.bazel b/test/oneof3/BUILD.bazel
---- a/test/oneof3/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/oneof3/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/oneof3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4893,7 +4893,7 @@ diff -urN a/test/oneof3/BUILD.bazel b/test/oneof3/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/test/oneof3/combos/both/BUILD.bazel b/test/oneof3/combos/both/BUILD.bazel
---- a/test/oneof3/combos/both/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/oneof3/combos/both/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/oneof3/combos/both/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4933,7 +4933,7 @@ diff -urN a/test/oneof3/combos/both/BUILD.bazel b/test/oneof3/combos/both/BUILD.
 +    ],
 +)
 diff -urN a/test/oneof3/combos/marshaler/BUILD.bazel b/test/oneof3/combos/marshaler/BUILD.bazel
---- a/test/oneof3/combos/marshaler/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/oneof3/combos/marshaler/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/oneof3/combos/marshaler/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4973,7 +4973,7 @@ diff -urN a/test/oneof3/combos/marshaler/BUILD.bazel b/test/oneof3/combos/marsha
 +    ],
 +)
 diff -urN a/test/oneof3/combos/neither/BUILD.bazel b/test/oneof3/combos/neither/BUILD.bazel
---- a/test/oneof3/combos/neither/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/oneof3/combos/neither/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/oneof3/combos/neither/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -5013,7 +5013,7 @@ diff -urN a/test/oneof3/combos/neither/BUILD.bazel b/test/oneof3/combos/neither/
 +    ],
 +)
 diff -urN a/test/oneof3/combos/unmarshaler/BUILD.bazel b/test/oneof3/combos/unmarshaler/BUILD.bazel
---- a/test/oneof3/combos/unmarshaler/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/oneof3/combos/unmarshaler/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/oneof3/combos/unmarshaler/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -5053,7 +5053,7 @@ diff -urN a/test/oneof3/combos/unmarshaler/BUILD.bazel b/test/oneof3/combos/unma
 +    ],
 +)
 diff -urN a/test/oneofembed/BUILD.bazel b/test/oneofembed/BUILD.bazel
---- a/test/oneofembed/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/oneofembed/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/oneofembed/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -5092,7 +5092,7 @@ diff -urN a/test/oneofembed/BUILD.bazel b/test/oneofembed/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/packed/BUILD.bazel b/test/packed/BUILD.bazel
---- a/test/packed/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/packed/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/packed/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,34 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -5130,7 +5130,7 @@ diff -urN a/test/packed/BUILD.bazel b/test/packed/BUILD.bazel
 +    deps = ["//proto"],
 +)
 diff -urN a/test/proto3extension/BUILD.bazel b/test/proto3extension/BUILD.bazel
---- a/test/proto3extension/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/proto3extension/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/proto3extension/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5158,7 +5158,7 @@ diff -urN a/test/proto3extension/BUILD.bazel b/test/proto3extension/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/test/protobuffer/BUILD.bazel b/test/protobuffer/BUILD.bazel
---- a/test/protobuffer/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/protobuffer/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/protobuffer/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -5193,7 +5193,7 @@ diff -urN a/test/protobuffer/BUILD.bazel b/test/protobuffer/BUILD.bazel
 +    deps = ["//proto"],
 +)
 diff -urN a/test/protosize/BUILD.bazel b/test/protosize/BUILD.bazel
---- a/test/protosize/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/protosize/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/protosize/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -5235,7 +5235,7 @@ diff -urN a/test/protosize/BUILD.bazel b/test/protosize/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/registration/BUILD.bazel b/test/registration/BUILD.bazel
---- a/test/registration/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/registration/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/registration/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,5 @@
 +filegroup(
@@ -5244,7 +5244,7 @@ diff -urN a/test/registration/BUILD.bazel b/test/registration/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/test/required/BUILD.bazel b/test/required/BUILD.bazel
---- a/test/required/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/required/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/required/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,34 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -5282,7 +5282,7 @@ diff -urN a/test/required/BUILD.bazel b/test/required/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/setextensionbytes/BUILD.bazel b/test/setextensionbytes/BUILD.bazel
---- a/test/setextensionbytes/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/setextensionbytes/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/setextensionbytes/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -5317,7 +5317,7 @@ diff -urN a/test/setextensionbytes/BUILD.bazel b/test/setextensionbytes/BUILD.ba
 +    deps = ["//proto"],
 +)
 diff -urN a/test/sizerconflict/BUILD.bazel b/test/sizerconflict/BUILD.bazel
---- a/test/sizerconflict/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/sizerconflict/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/sizerconflict/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -5347,7 +5347,7 @@ diff -urN a/test/sizerconflict/BUILD.bazel b/test/sizerconflict/BUILD.bazel
 +    embed = [":sizerconflict"],
 +)
 diff -urN a/test/sizeunderscore/BUILD.bazel b/test/sizeunderscore/BUILD.bazel
---- a/test/sizeunderscore/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/sizeunderscore/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/sizeunderscore/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -5386,7 +5386,7 @@ diff -urN a/test/sizeunderscore/BUILD.bazel b/test/sizeunderscore/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/stdtypes/BUILD.bazel b/test/stdtypes/BUILD.bazel
---- a/test/stdtypes/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/stdtypes/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/stdtypes/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,41 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -5431,7 +5431,7 @@ diff -urN a/test/stdtypes/BUILD.bazel b/test/stdtypes/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/tags/BUILD.bazel b/test/tags/BUILD.bazel
---- a/test/tags/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/tags/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/tags/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -5468,7 +5468,7 @@ diff -urN a/test/tags/BUILD.bazel b/test/tags/BUILD.bazel
 +    embed = [":tags"],
 +)
 diff -urN a/test/theproto3/BUILD.bazel b/test/theproto3/BUILD.bazel
---- a/test/theproto3/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/theproto3/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/theproto3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5497,7 +5497,7 @@ diff -urN a/test/theproto3/BUILD.bazel b/test/theproto3/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/test/theproto3/combos/both/BUILD.bazel b/test/theproto3/combos/both/BUILD.bazel
---- a/test/theproto3/combos/both/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/theproto3/combos/both/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/theproto3/combos/both/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,43 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -5544,7 +5544,7 @@ diff -urN a/test/theproto3/combos/both/BUILD.bazel b/test/theproto3/combos/both/
 +    ],
 +)
 diff -urN a/test/theproto3/combos/marshaler/BUILD.bazel b/test/theproto3/combos/marshaler/BUILD.bazel
---- a/test/theproto3/combos/marshaler/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/theproto3/combos/marshaler/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/theproto3/combos/marshaler/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,43 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -5591,7 +5591,7 @@ diff -urN a/test/theproto3/combos/marshaler/BUILD.bazel b/test/theproto3/combos/
 +    ],
 +)
 diff -urN a/test/theproto3/combos/neither/BUILD.bazel b/test/theproto3/combos/neither/BUILD.bazel
---- a/test/theproto3/combos/neither/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/theproto3/combos/neither/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/theproto3/combos/neither/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,43 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -5638,7 +5638,7 @@ diff -urN a/test/theproto3/combos/neither/BUILD.bazel b/test/theproto3/combos/ne
 +    ],
 +)
 diff -urN a/test/theproto3/combos/unmarshaler/BUILD.bazel b/test/theproto3/combos/unmarshaler/BUILD.bazel
---- a/test/theproto3/combos/unmarshaler/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/theproto3/combos/unmarshaler/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/theproto3/combos/unmarshaler/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,43 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -5685,7 +5685,7 @@ diff -urN a/test/theproto3/combos/unmarshaler/BUILD.bazel b/test/theproto3/combo
 +    ],
 +)
 diff -urN a/test/typedecl/BUILD.bazel b/test/typedecl/BUILD.bazel
---- a/test/typedecl/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/typedecl/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/typedecl/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,39 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -5728,7 +5728,7 @@ diff -urN a/test/typedecl/BUILD.bazel b/test/typedecl/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/typedecl_all/BUILD.bazel b/test/typedecl_all/BUILD.bazel
---- a/test/typedecl_all/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/typedecl_all/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/typedecl_all/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,39 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -5771,7 +5771,7 @@ diff -urN a/test/typedecl_all/BUILD.bazel b/test/typedecl_all/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/typedeclimport/BUILD.bazel b/test/typedeclimport/BUILD.bazel
---- a/test/typedeclimport/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/typedeclimport/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/typedeclimport/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,34 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -5809,7 +5809,7 @@ diff -urN a/test/typedeclimport/BUILD.bazel b/test/typedeclimport/BUILD.bazel
 +    embed = [":typedeclimport"],
 +)
 diff -urN a/test/typedeclimport/subpkg/BUILD.bazel b/test/typedeclimport/subpkg/BUILD.bazel
---- a/test/typedeclimport/subpkg/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/typedeclimport/subpkg/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/typedeclimport/subpkg/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5837,7 +5837,7 @@ diff -urN a/test/typedeclimport/subpkg/BUILD.bazel b/test/typedeclimport/subpkg/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/test/types/BUILD.bazel b/test/types/BUILD.bazel
---- a/test/types/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/types/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/types/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,5 @@
 +filegroup(
@@ -5846,7 +5846,7 @@ diff -urN a/test/types/BUILD.bazel b/test/types/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/test/types/combos/both/BUILD.bazel b/test/types/combos/both/BUILD.bazel
---- a/test/types/combos/both/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/types/combos/both/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/types/combos/both/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,40 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -5890,7 +5890,7 @@ diff -urN a/test/types/combos/both/BUILD.bazel b/test/types/combos/both/BUILD.ba
 +    ],
 +)
 diff -urN a/test/types/combos/marshaler/BUILD.bazel b/test/types/combos/marshaler/BUILD.bazel
---- a/test/types/combos/marshaler/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/types/combos/marshaler/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/types/combos/marshaler/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,40 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -5934,7 +5934,7 @@ diff -urN a/test/types/combos/marshaler/BUILD.bazel b/test/types/combos/marshale
 +    ],
 +)
 diff -urN a/test/types/combos/neither/BUILD.bazel b/test/types/combos/neither/BUILD.bazel
---- a/test/types/combos/neither/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/types/combos/neither/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/types/combos/neither/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,40 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -5978,7 +5978,7 @@ diff -urN a/test/types/combos/neither/BUILD.bazel b/test/types/combos/neither/BU
 +    ],
 +)
 diff -urN a/test/types/combos/unmarshaler/BUILD.bazel b/test/types/combos/unmarshaler/BUILD.bazel
---- a/test/types/combos/unmarshaler/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/types/combos/unmarshaler/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/types/combos/unmarshaler/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,40 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -6022,7 +6022,7 @@ diff -urN a/test/types/combos/unmarshaler/BUILD.bazel b/test/types/combos/unmars
 +    ],
 +)
 diff -urN a/test/unmarshalmerge/BUILD.bazel b/test/unmarshalmerge/BUILD.bazel
---- a/test/unmarshalmerge/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/unmarshalmerge/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/unmarshalmerge/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -6064,7 +6064,7 @@ diff -urN a/test/unmarshalmerge/BUILD.bazel b/test/unmarshalmerge/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/unrecognized/BUILD.bazel b/test/unrecognized/BUILD.bazel
---- a/test/unrecognized/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/unrecognized/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/unrecognized/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,39 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -6107,7 +6107,7 @@ diff -urN a/test/unrecognized/BUILD.bazel b/test/unrecognized/BUILD.bazel
 +    ],
 +)
 diff -urN a/test/unrecognizedgroup/BUILD.bazel b/test/unrecognizedgroup/BUILD.bazel
---- a/test/unrecognizedgroup/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/unrecognizedgroup/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/unrecognizedgroup/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,39 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -6150,7 +6150,7 @@ diff -urN a/test/unrecognizedgroup/BUILD.bazel b/test/unrecognizedgroup/BUILD.ba
 +    ],
 +)
 diff -urN a/test/xxxfields/BUILD.bazel b/test/xxxfields/BUILD.bazel
---- a/test/xxxfields/BUILD.bazel	1969-12-31 16:00:00
+--- a/test/xxxfields/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/test/xxxfields/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -6189,7 +6189,7 @@ diff -urN a/test/xxxfields/BUILD.bazel b/test/xxxfields/BUILD.bazel
 +    ],
 +)
 diff -urN a/types/BUILD.bazel b/types/BUILD.bazel
---- a/types/BUILD.bazel	1969-12-31 16:00:00
+--- a/types/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/types/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,51 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -6244,7 +6244,7 @@ diff -urN a/types/BUILD.bazel b/types/BUILD.bazel
 +    ],
 +)
 diff -urN a/vanity/BUILD.bazel b/vanity/BUILD.bazel
---- a/vanity/BUILD.bazel	1969-12-31 16:00:00
+--- a/vanity/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/vanity/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6273,7 +6273,7 @@ diff -urN a/vanity/BUILD.bazel b/vanity/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/vanity/command/BUILD.bazel b/vanity/command/BUILD.bazel
---- a/vanity/command/BUILD.bazel	1969-12-31 16:00:00
+--- a/vanity/command/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/vanity/command/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6313,7 +6313,7 @@ diff -urN a/vanity/command/BUILD.bazel b/vanity/command/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/vanity/test/BUILD.bazel b/vanity/test/BUILD.bazel
---- a/vanity/test/BUILD.bazel	1969-12-31 16:00:00
+--- a/vanity/test/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/vanity/test/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -6352,7 +6352,7 @@ diff -urN a/vanity/test/BUILD.bazel b/vanity/test/BUILD.bazel
 +    ],
 +)
 diff -urN a/vanity/test/fast/BUILD.bazel b/vanity/test/fast/BUILD.bazel
---- a/vanity/test/fast/BUILD.bazel	1969-12-31 16:00:00
+--- a/vanity/test/fast/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/vanity/test/fast/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6378,7 +6378,7 @@ diff -urN a/vanity/test/fast/BUILD.bazel b/vanity/test/fast/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/vanity/test/faster/BUILD.bazel b/vanity/test/faster/BUILD.bazel
---- a/vanity/test/faster/BUILD.bazel	1969-12-31 16:00:00
+--- a/vanity/test/faster/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/vanity/test/faster/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6404,7 +6404,7 @@ diff -urN a/vanity/test/faster/BUILD.bazel b/vanity/test/faster/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/vanity/test/slick/BUILD.bazel b/vanity/test/slick/BUILD.bazel
---- a/vanity/test/slick/BUILD.bazel	1969-12-31 16:00:00
+--- a/vanity/test/slick/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/vanity/test/slick/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6430,7 +6430,7 @@ diff -urN a/vanity/test/slick/BUILD.bazel b/vanity/test/slick/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/version/BUILD.bazel b/version/BUILD.bazel
---- a/version/BUILD.bazel	1969-12-31 16:00:00
+--- a/version/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/version/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")

--- a/third_party/com_github_golang_mock-gazelle.patch
+++ b/third_party/com_github_golang_mock-gazelle.patch
@@ -1,5 +1,5 @@
 diff -urN a/gomock/BUILD.bazel b/gomock/BUILD.bazel
---- a/gomock/BUILD.bazel	1969-12-31 16:00:00
+--- a/gomock/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/gomock/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,34 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -37,7 +37,7 @@ diff -urN a/gomock/BUILD.bazel b/gomock/BUILD.bazel
 +    deps = ["//gomock/internal/mock_gomock"],
 +)
 diff -urN a/gomock/internal/mock_gomock/BUILD.bazel b/gomock/internal/mock_gomock/BUILD.bazel
---- a/gomock/internal/mock_gomock/BUILD.bazel	1969-12-31 16:00:00
+--- a/gomock/internal/mock_gomock/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/gomock/internal/mock_gomock/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -56,7 +56,7 @@ diff -urN a/gomock/internal/mock_gomock/BUILD.bazel b/gomock/internal/mock_gomoc
 +    visibility = ["//gomock:__subpackages__"],
 +)
 diff -urN a/mockgen/BUILD.bazel b/mockgen/BUILD.bazel
---- a/mockgen/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
@@ -96,7 +96,7 @@ diff -urN a/mockgen/BUILD.bazel b/mockgen/BUILD.bazel
 +    deps = ["//mockgen/model"],
 +)
 diff -urN a/mockgen/internal/tests/aux_imports_embedded_interface/BUILD.bazel b/mockgen/internal/tests/aux_imports_embedded_interface/BUILD.bazel
---- a/mockgen/internal/tests/aux_imports_embedded_interface/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/aux_imports_embedded_interface/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/aux_imports_embedded_interface/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -128,7 +128,7 @@ diff -urN a/mockgen/internal/tests/aux_imports_embedded_interface/BUILD.bazel b/
 +    deps = ["//gomock"],
 +)
 diff -urN a/mockgen/internal/tests/aux_imports_embedded_interface/faux/BUILD.bazel b/mockgen/internal/tests/aux_imports_embedded_interface/faux/BUILD.bazel
---- a/mockgen/internal/tests/aux_imports_embedded_interface/faux/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/aux_imports_embedded_interface/faux/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/aux_imports_embedded_interface/faux/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -146,7 +146,7 @@ diff -urN a/mockgen/internal/tests/aux_imports_embedded_interface/faux/BUILD.baz
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/internal/tests/const_array_length/BUILD.bazel b/mockgen/internal/tests/const_array_length/BUILD.bazel
---- a/mockgen/internal/tests/const_array_length/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/const_array_length/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/const_array_length/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -168,7 +168,7 @@ diff -urN a/mockgen/internal/tests/const_array_length/BUILD.bazel b/mockgen/inte
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/internal/tests/copyright_file/BUILD.bazel b/mockgen/internal/tests/copyright_file/BUILD.bazel
---- a/mockgen/internal/tests/copyright_file/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/copyright_file/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/copyright_file/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -190,7 +190,7 @@ diff -urN a/mockgen/internal/tests/copyright_file/BUILD.bazel b/mockgen/internal
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/internal/tests/custom_package_name/client/v1/BUILD.bazel b/mockgen/internal/tests/custom_package_name/client/v1/BUILD.bazel
---- a/mockgen/internal/tests/custom_package_name/client/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/custom_package_name/client/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/custom_package_name/client/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -208,7 +208,7 @@ diff -urN a/mockgen/internal/tests/custom_package_name/client/v1/BUILD.bazel b/m
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/internal/tests/custom_package_name/greeter/BUILD.bazel b/mockgen/internal/tests/custom_package_name/greeter/BUILD.bazel
---- a/mockgen/internal/tests/custom_package_name/greeter/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/custom_package_name/greeter/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/custom_package_name/greeter/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -243,7 +243,7 @@ diff -urN a/mockgen/internal/tests/custom_package_name/greeter/BUILD.bazel b/moc
 +    ],
 +)
 diff -urN a/mockgen/internal/tests/custom_package_name/validator/BUILD.bazel b/mockgen/internal/tests/custom_package_name/validator/BUILD.bazel
---- a/mockgen/internal/tests/custom_package_name/validator/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/custom_package_name/validator/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/custom_package_name/validator/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -261,7 +261,7 @@ diff -urN a/mockgen/internal/tests/custom_package_name/validator/BUILD.bazel b/m
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/internal/tests/dot_imports/BUILD.bazel b/mockgen/internal/tests/dot_imports/BUILD.bazel
---- a/mockgen/internal/tests/dot_imports/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/dot_imports/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/dot_imports/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -283,7 +283,7 @@ diff -urN a/mockgen/internal/tests/dot_imports/BUILD.bazel b/mockgen/internal/te
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/internal/tests/empty_interface/BUILD.bazel b/mockgen/internal/tests/empty_interface/BUILD.bazel
---- a/mockgen/internal/tests/empty_interface/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/empty_interface/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/empty_interface/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -305,7 +305,7 @@ diff -urN a/mockgen/internal/tests/empty_interface/BUILD.bazel b/mockgen/interna
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/internal/tests/extra_import/BUILD.bazel b/mockgen/internal/tests/extra_import/BUILD.bazel
---- a/mockgen/internal/tests/extra_import/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/extra_import/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/extra_import/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -327,7 +327,7 @@ diff -urN a/mockgen/internal/tests/extra_import/BUILD.bazel b/mockgen/internal/t
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/internal/tests/generated_identifier_conflict/BUILD.bazel b/mockgen/internal/tests/generated_identifier_conflict/BUILD.bazel
---- a/mockgen/internal/tests/generated_identifier_conflict/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/generated_identifier_conflict/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/generated_identifier_conflict/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -356,7 +356,7 @@ diff -urN a/mockgen/internal/tests/generated_identifier_conflict/BUILD.bazel b/m
 +    deps = ["//gomock"],
 +)
 diff -urN a/mockgen/internal/tests/generics/BUILD.bazel b/mockgen/internal/tests/generics/BUILD.bazel
---- a/mockgen/internal/tests/generics/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/generics/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/generics/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -381,7 +381,7 @@ diff -urN a/mockgen/internal/tests/generics/BUILD.bazel b/mockgen/internal/tests
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/internal/tests/generics/other/BUILD.bazel b/mockgen/internal/tests/generics/other/BUILD.bazel
---- a/mockgen/internal/tests/generics/other/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/generics/other/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/generics/other/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -399,7 +399,7 @@ diff -urN a/mockgen/internal/tests/generics/other/BUILD.bazel b/mockgen/internal
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/internal/tests/generics/source/BUILD.bazel b/mockgen/internal/tests/generics/source/BUILD.bazel
---- a/mockgen/internal/tests/generics/source/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/generics/source/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/generics/source/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_test")
@@ -418,7 +418,7 @@ diff -urN a/mockgen/internal/tests/generics/source/BUILD.bazel b/mockgen/interna
 +    ],
 +)
 diff -urN a/mockgen/internal/tests/import_embedded_interface/BUILD.bazel b/mockgen/internal/tests/import_embedded_interface/BUILD.bazel
---- a/mockgen/internal/tests/import_embedded_interface/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/import_embedded_interface/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/import_embedded_interface/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -458,7 +458,7 @@ diff -urN a/mockgen/internal/tests/import_embedded_interface/BUILD.bazel b/mockg
 +    deps = ["//gomock"],
 +)
 diff -urN a/mockgen/internal/tests/import_embedded_interface/ersatz/BUILD.bazel b/mockgen/internal/tests/import_embedded_interface/ersatz/BUILD.bazel
---- a/mockgen/internal/tests/import_embedded_interface/ersatz/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/import_embedded_interface/ersatz/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/import_embedded_interface/ersatz/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -476,7 +476,7 @@ diff -urN a/mockgen/internal/tests/import_embedded_interface/ersatz/BUILD.bazel 
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/internal/tests/import_embedded_interface/faux/BUILD.bazel b/mockgen/internal/tests/import_embedded_interface/faux/BUILD.bazel
---- a/mockgen/internal/tests/import_embedded_interface/faux/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/import_embedded_interface/faux/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/import_embedded_interface/faux/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -501,7 +501,7 @@ diff -urN a/mockgen/internal/tests/import_embedded_interface/faux/BUILD.bazel b/
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/internal/tests/import_embedded_interface/other/ersatz/BUILD.bazel b/mockgen/internal/tests/import_embedded_interface/other/ersatz/BUILD.bazel
---- a/mockgen/internal/tests/import_embedded_interface/other/ersatz/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/import_embedded_interface/other/ersatz/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/import_embedded_interface/other/ersatz/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -519,7 +519,7 @@ diff -urN a/mockgen/internal/tests/import_embedded_interface/other/ersatz/BUILD.
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/internal/tests/import_embedded_interface/other/log/BUILD.bazel b/mockgen/internal/tests/import_embedded_interface/other/log/BUILD.bazel
---- a/mockgen/internal/tests/import_embedded_interface/other/log/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/import_embedded_interface/other/log/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/import_embedded_interface/other/log/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -537,7 +537,7 @@ diff -urN a/mockgen/internal/tests/import_embedded_interface/other/log/BUILD.baz
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/internal/tests/import_source/BUILD.bazel b/mockgen/internal/tests/import_source/BUILD.bazel
---- a/mockgen/internal/tests/import_source/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/import_source/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/import_source/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -559,7 +559,7 @@ diff -urN a/mockgen/internal/tests/import_source/BUILD.bazel b/mockgen/internal/
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/internal/tests/import_source/definition/BUILD.bazel b/mockgen/internal/tests/import_source/definition/BUILD.bazel
---- a/mockgen/internal/tests/import_source/definition/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/import_source/definition/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/import_source/definition/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -581,7 +581,7 @@ diff -urN a/mockgen/internal/tests/import_source/definition/BUILD.bazel b/mockge
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/internal/tests/internal_pkg/BUILD.bazel b/mockgen/internal/tests/internal_pkg/BUILD.bazel
---- a/mockgen/internal/tests/internal_pkg/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/internal_pkg/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/internal_pkg/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -599,7 +599,7 @@ diff -urN a/mockgen/internal/tests/internal_pkg/BUILD.bazel b/mockgen/internal/t
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/BUILD.bazel b/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/BUILD.bazel
---- a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -617,7 +617,7 @@ diff -urN a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/BUILD.bazel 
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/reflect_output/BUILD.bazel b/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/reflect_output/BUILD.bazel
---- a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/reflect_output/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/reflect_output/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/reflect_output/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -639,7 +639,7 @@ diff -urN a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/reflect_outp
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/source_output/BUILD.bazel b/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/source_output/BUILD.bazel
---- a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/source_output/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/source_output/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/source_output/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -661,7 +661,7 @@ diff -urN a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/source_outpu
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/internal/tests/missing_import/output/BUILD.bazel b/mockgen/internal/tests/missing_import/output/BUILD.bazel
---- a/mockgen/internal/tests/missing_import/output/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/missing_import/output/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/missing_import/output/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -683,7 +683,7 @@ diff -urN a/mockgen/internal/tests/missing_import/output/BUILD.bazel b/mockgen/i
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/internal/tests/missing_import/source/BUILD.bazel b/mockgen/internal/tests/missing_import/source/BUILD.bazel
---- a/mockgen/internal/tests/missing_import/source/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/missing_import/source/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/missing_import/source/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -701,7 +701,7 @@ diff -urN a/mockgen/internal/tests/missing_import/source/BUILD.bazel b/mockgen/i
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/internal/tests/mock_in_test_package/BUILD.bazel b/mockgen/internal/tests/mock_in_test_package/BUILD.bazel
---- a/mockgen/internal/tests/mock_in_test_package/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/mock_in_test_package/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/mock_in_test_package/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -728,7 +728,7 @@ diff -urN a/mockgen/internal/tests/mock_in_test_package/BUILD.bazel b/mockgen/in
 +    ],
 +)
 diff -urN a/mockgen/internal/tests/overlapping_methods/BUILD.bazel b/mockgen/internal/tests/overlapping_methods/BUILD.bazel
---- a/mockgen/internal/tests/overlapping_methods/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/overlapping_methods/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/overlapping_methods/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -758,7 +758,7 @@ diff -urN a/mockgen/internal/tests/overlapping_methods/BUILD.bazel b/mockgen/int
 +    deps = ["//gomock"],
 +)
 diff -urN a/mockgen/internal/tests/panicing_test/BUILD.bazel b/mockgen/internal/tests/panicing_test/BUILD.bazel
---- a/mockgen/internal/tests/panicing_test/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/panicing_test/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/panicing_test/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -783,7 +783,7 @@ diff -urN a/mockgen/internal/tests/panicing_test/BUILD.bazel b/mockgen/internal/
 +    deps = ["//gomock"],
 +)
 diff -urN a/mockgen/internal/tests/parenthesized_parameter_type/BUILD.bazel b/mockgen/internal/tests/parenthesized_parameter_type/BUILD.bazel
---- a/mockgen/internal/tests/parenthesized_parameter_type/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/parenthesized_parameter_type/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/parenthesized_parameter_type/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -805,7 +805,7 @@ diff -urN a/mockgen/internal/tests/parenthesized_parameter_type/BUILD.bazel b/mo
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/internal/tests/performance/big_interface/BUILD.bazel b/mockgen/internal/tests/performance/big_interface/BUILD.bazel
---- a/mockgen/internal/tests/performance/big_interface/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/performance/big_interface/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/performance/big_interface/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -823,7 +823,7 @@ diff -urN a/mockgen/internal/tests/performance/big_interface/BUILD.bazel b/mockg
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/internal/tests/self_package/BUILD.bazel b/mockgen/internal/tests/self_package/BUILD.bazel
---- a/mockgen/internal/tests/self_package/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/self_package/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/self_package/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -845,7 +845,7 @@ diff -urN a/mockgen/internal/tests/self_package/BUILD.bazel b/mockgen/internal/t
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/internal/tests/test_package/BUILD.bazel b/mockgen/internal/tests/test_package/BUILD.bazel
---- a/mockgen/internal/tests/test_package/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/test_package/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/test_package/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -872,7 +872,7 @@ diff -urN a/mockgen/internal/tests/test_package/BUILD.bazel b/mockgen/internal/t
 +    deps = ["//gomock"],
 +)
 diff -urN a/mockgen/internal/tests/unexported_method/BUILD.bazel b/mockgen/internal/tests/unexported_method/BUILD.bazel
---- a/mockgen/internal/tests/unexported_method/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/unexported_method/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/unexported_method/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -901,7 +901,7 @@ diff -urN a/mockgen/internal/tests/unexported_method/BUILD.bazel b/mockgen/inter
 +    deps = ["//gomock"],
 +)
 diff -urN a/mockgen/internal/tests/vendor_dep/BUILD.bazel b/mockgen/internal/tests/vendor_dep/BUILD.bazel
---- a/mockgen/internal/tests/vendor_dep/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/vendor_dep/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/vendor_dep/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -927,7 +927,7 @@ diff -urN a/mockgen/internal/tests/vendor_dep/BUILD.bazel b/mockgen/internal/tes
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/internal/tests/vendor_dep/source_mock_package/BUILD.bazel b/mockgen/internal/tests/vendor_dep/source_mock_package/BUILD.bazel
---- a/mockgen/internal/tests/vendor_dep/source_mock_package/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/vendor_dep/source_mock_package/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/vendor_dep/source_mock_package/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -949,7 +949,7 @@ diff -urN a/mockgen/internal/tests/vendor_dep/source_mock_package/BUILD.bazel b/
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/internal/tests/vendor_pkg/BUILD.bazel b/mockgen/internal/tests/vendor_pkg/BUILD.bazel
---- a/mockgen/internal/tests/vendor_pkg/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/internal/tests/vendor_pkg/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/vendor_pkg/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -971,7 +971,7 @@ diff -urN a/mockgen/internal/tests/vendor_pkg/BUILD.bazel b/mockgen/internal/tes
 +    visibility = ["//mockgen:__subpackages__"],
 +)
 diff -urN a/mockgen/model/BUILD.bazel b/mockgen/model/BUILD.bazel
---- a/mockgen/model/BUILD.bazel	1969-12-31 16:00:00
+--- a/mockgen/model/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/model/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -995,7 +995,7 @@ diff -urN a/mockgen/model/BUILD.bazel b/mockgen/model/BUILD.bazel
 +    embed = [":model"],
 +)
 diff -urN a/sample/BUILD.bazel b/sample/BUILD.bazel
---- a/sample/BUILD.bazel	1969-12-31 16:00:00
+--- a/sample/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/sample/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1035,7 +1035,7 @@ diff -urN a/sample/BUILD.bazel b/sample/BUILD.bazel
 +    ],
 +)
 diff -urN a/sample/concurrent/BUILD.bazel b/sample/concurrent/BUILD.bazel
---- a/sample/concurrent/BUILD.bazel	1969-12-31 16:00:00
+--- a/sample/concurrent/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/sample/concurrent/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1063,7 +1063,7 @@ diff -urN a/sample/concurrent/BUILD.bazel b/sample/concurrent/BUILD.bazel
 +    ],
 +)
 diff -urN a/sample/concurrent/mock/BUILD.bazel b/sample/concurrent/mock/BUILD.bazel
---- a/sample/concurrent/mock/BUILD.bazel	1969-12-31 16:00:00
+--- a/sample/concurrent/mock/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/sample/concurrent/mock/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1082,7 +1082,7 @@ diff -urN a/sample/concurrent/mock/BUILD.bazel b/sample/concurrent/mock/BUILD.ba
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/sample/imp1/BUILD.bazel b/sample/imp1/BUILD.bazel
---- a/sample/imp1/BUILD.bazel	1969-12-31 16:00:00
+--- a/sample/imp1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/sample/imp1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1100,7 +1100,7 @@ diff -urN a/sample/imp1/BUILD.bazel b/sample/imp1/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/sample/imp2/BUILD.bazel b/sample/imp2/BUILD.bazel
---- a/sample/imp2/BUILD.bazel	1969-12-31 16:00:00
+--- a/sample/imp2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/sample/imp2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1118,7 +1118,7 @@ diff -urN a/sample/imp2/BUILD.bazel b/sample/imp2/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/sample/imp3/BUILD.bazel b/sample/imp3/BUILD.bazel
---- a/sample/imp3/BUILD.bazel	1969-12-31 16:00:00
+--- a/sample/imp3/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/sample/imp3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1136,7 +1136,7 @@ diff -urN a/sample/imp3/BUILD.bazel b/sample/imp3/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/sample/imp4/BUILD.bazel b/sample/imp4/BUILD.bazel
---- a/sample/imp4/BUILD.bazel	1969-12-31 16:00:00
+--- a/sample/imp4/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/sample/imp4/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")

--- a/third_party/com_github_golang_protobuf-gazelle.patch
+++ b/third_party/com_github_golang_protobuf-gazelle.patch
@@ -1,5 +1,5 @@
 diff -urN a/descriptor/BUILD.bazel b/descriptor/BUILD.bazel
---- a/descriptor/BUILD.bazel	1969-12-31 16:00:00
+--- a/descriptor/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/descriptor/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,46 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -49,7 +49,7 @@ diff -urN a/descriptor/BUILD.bazel b/descriptor/BUILD.bazel
 +    ],
 +)
 diff -urN a/internal/cmd/generate-alias/BUILD.bazel b/internal/cmd/generate-alias/BUILD.bazel
---- a/internal/cmd/generate-alias/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/cmd/generate-alias/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/cmd/generate-alias/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,29 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -82,7 +82,7 @@ diff -urN a/internal/cmd/generate-alias/BUILD.bazel b/internal/cmd/generate-alia
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/gengogrpc/BUILD.bazel b/internal/gengogrpc/BUILD.bazel
---- a/internal/gengogrpc/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/gengogrpc/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/gengogrpc/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -104,7 +104,7 @@ diff -urN a/internal/gengogrpc/BUILD.bazel b/internal/gengogrpc/BUILD.bazel
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/jsonpb_proto/BUILD.bazel b/internal/testprotos/jsonpb_proto/BUILD.bazel
---- a/internal/testprotos/jsonpb_proto/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/jsonpb_proto/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/jsonpb_proto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -133,7 +133,7 @@ diff -urN a/internal/testprotos/jsonpb_proto/BUILD.bazel b/internal/testprotos/j
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/proto2_proto/BUILD.bazel b/internal/testprotos/proto2_proto/BUILD.bazel
---- a/internal/testprotos/proto2_proto/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/proto2_proto/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/proto2_proto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -152,7 +152,7 @@ diff -urN a/internal/testprotos/proto2_proto/BUILD.bazel b/internal/testprotos/p
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/proto3_proto/BUILD.bazel b/internal/testprotos/proto3_proto/BUILD.bazel
---- a/internal/testprotos/proto3_proto/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/proto3_proto/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/proto3_proto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -175,7 +175,7 @@ diff -urN a/internal/testprotos/proto3_proto/BUILD.bazel b/internal/testprotos/p
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/jsonpb/BUILD.bazel b/jsonpb/BUILD.bazel
---- a/jsonpb/BUILD.bazel	1969-12-31 16:00:00
+--- a/jsonpb/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/jsonpb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,50 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -229,7 +229,7 @@ diff -urN a/jsonpb/BUILD.bazel b/jsonpb/BUILD.bazel
 +    ],
 +)
 diff -urN a/proto/BUILD.bazel b/proto/BUILD.bazel
---- a/proto/BUILD.bazel	1969-12-31 16:00:00
+--- a/proto/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/proto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,61 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -294,7 +294,7 @@ diff -urN a/proto/BUILD.bazel b/proto/BUILD.bazel
 +    ],
 +)
 diff -urN a/protoc-gen-go/BUILD.bazel b/protoc-gen-go/BUILD.bazel
---- a/protoc-gen-go/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-go/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-go/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -317,7 +317,7 @@ diff -urN a/protoc-gen-go/BUILD.bazel b/protoc-gen-go/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-go/descriptor/BUILD.bazel b/protoc-gen-go/descriptor/BUILD.bazel
---- a/protoc-gen-go/descriptor/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-go/descriptor/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-go/descriptor/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -340,7 +340,7 @@ diff -urN a/protoc-gen-go/descriptor/BUILD.bazel b/protoc-gen-go/descriptor/BUIL
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-go/generator/BUILD.bazel b/protoc-gen-go/generator/BUILD.bazel
---- a/protoc-gen-go/generator/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-go/generator/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-go/generator/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -377,7 +377,7 @@ diff -urN a/protoc-gen-go/generator/BUILD.bazel b/protoc-gen-go/generator/BUILD.
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-go/generator/internal/remap/BUILD.bazel b/protoc-gen-go/generator/internal/remap/BUILD.bazel
---- a/protoc-gen-go/generator/internal/remap/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-go/generator/internal/remap/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-go/generator/internal/remap/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -401,7 +401,7 @@ diff -urN a/protoc-gen-go/generator/internal/remap/BUILD.bazel b/protoc-gen-go/g
 +    embed = [":remap"],
 +)
 diff -urN a/protoc-gen-go/grpc/BUILD.bazel b/protoc-gen-go/grpc/BUILD.bazel
---- a/protoc-gen-go/grpc/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-go/grpc/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-go/grpc/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -423,7 +423,7 @@ diff -urN a/protoc-gen-go/grpc/BUILD.bazel b/protoc-gen-go/grpc/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protoc-gen-go/plugin/BUILD.bazel b/protoc-gen-go/plugin/BUILD.bazel
---- a/protoc-gen-go/plugin/BUILD.bazel	1969-12-31 16:00:00
+--- a/protoc-gen-go/plugin/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protoc-gen-go/plugin/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -445,8 +445,31 @@ diff -urN a/protoc-gen-go/plugin/BUILD.bazel b/protoc-gen-go/plugin/BUILD.bazel
 +    actual = ":plugin",
 +    visibility = ["//visibility:public"],
 +)
+diff -urN a/ptypes/any/BUILD.bazel b/ptypes/any/BUILD.bazel
+--- a/ptypes/any/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/ptypes/any/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "any",
++    srcs = ["any.pb.go"],
++    importpath = "github.com/golang/protobuf/ptypes/any",
++    visibility = ["//visibility:public"],
++    deps = [
++        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
++        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
++        "@org_golang_google_protobuf//types/known/anypb:go_default_library",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":any",
++    visibility = ["//visibility:public"],
++)
 diff -urN a/ptypes/BUILD.bazel b/ptypes/BUILD.bazel
---- a/ptypes/BUILD.bazel	1969-12-31 16:00:00
+--- a/ptypes/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/ptypes/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,64 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -513,31 +536,8 @@ diff -urN a/ptypes/BUILD.bazel b/ptypes/BUILD.bazel
 +        "//ptypes/timestamp",
 +    ],
 +)
-diff -urN a/ptypes/any/BUILD.bazel b/ptypes/any/BUILD.bazel
---- a/ptypes/any/BUILD.bazel	1969-12-31 16:00:00
-+++ b/ptypes/any/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,19 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "any",
-+    srcs = ["any.pb.go"],
-+    importpath = "github.com/golang/protobuf/ptypes/any",
-+    visibility = ["//visibility:public"],
-+    deps = [
-+        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
-+        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
-+        "@org_golang_google_protobuf//types/known/anypb:go_default_library",
-+    ],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":any",
-+    visibility = ["//visibility:public"],
-+)
 diff -urN a/ptypes/duration/BUILD.bazel b/ptypes/duration/BUILD.bazel
---- a/ptypes/duration/BUILD.bazel	1969-12-31 16:00:00
+--- a/ptypes/duration/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/ptypes/duration/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -560,7 +560,7 @@ diff -urN a/ptypes/duration/BUILD.bazel b/ptypes/duration/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/ptypes/empty/BUILD.bazel b/ptypes/empty/BUILD.bazel
---- a/ptypes/empty/BUILD.bazel	1969-12-31 16:00:00
+--- a/ptypes/empty/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/ptypes/empty/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -583,7 +583,7 @@ diff -urN a/ptypes/empty/BUILD.bazel b/ptypes/empty/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/ptypes/struct/BUILD.bazel b/ptypes/struct/BUILD.bazel
---- a/ptypes/struct/BUILD.bazel	1969-12-31 16:00:00
+--- a/ptypes/struct/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/ptypes/struct/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -606,7 +606,7 @@ diff -urN a/ptypes/struct/BUILD.bazel b/ptypes/struct/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/ptypes/timestamp/BUILD.bazel b/ptypes/timestamp/BUILD.bazel
---- a/ptypes/timestamp/BUILD.bazel	1969-12-31 16:00:00
+--- a/ptypes/timestamp/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/ptypes/timestamp/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -629,7 +629,7 @@ diff -urN a/ptypes/timestamp/BUILD.bazel b/ptypes/timestamp/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/ptypes/wrappers/BUILD.bazel b/ptypes/wrappers/BUILD.bazel
---- a/ptypes/wrappers/BUILD.bazel	1969-12-31 16:00:00
+--- a/ptypes/wrappers/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/ptypes/wrappers/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")

--- a/third_party/org_golang_google_genproto-gazelle.patch
+++ b/third_party/org_golang_google_genproto-gazelle.patch
@@ -1,5 +1,5 @@
 diff -urN a/firestore/bundle/BUILD.bazel b/firestore/bundle/BUILD.bazel
---- a/firestore/bundle/BUILD.bazel	1969-12-31 16:00:00
+--- a/firestore/bundle/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/firestore/bundle/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -24,7 +24,7 @@ diff -urN a/firestore/bundle/BUILD.bazel b/firestore/bundle/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/actions/sdk/v2/BUILD.bazel b/googleapis/actions/sdk/v2/BUILD.bazel
---- a/googleapis/actions/sdk/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/actions/sdk/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/actions/sdk/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,51 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -79,7 +79,7 @@ diff -urN a/googleapis/actions/sdk/v2/BUILD.bazel b/googleapis/actions/sdk/v2/BU
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/actions/sdk/v2/conversation/BUILD.bazel b/googleapis/actions/sdk/v2/conversation/BUILD.bazel
---- a/googleapis/actions/sdk/v2/conversation/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/actions/sdk/v2/conversation/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/actions/sdk/v2/conversation/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -118,7 +118,7 @@ diff -urN a/googleapis/actions/sdk/v2/conversation/BUILD.bazel b/googleapis/acti
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/actions/sdk/v2/interactionmodel/BUILD.bazel b/googleapis/actions/sdk/v2/interactionmodel/BUILD.bazel
---- a/googleapis/actions/sdk/v2/interactionmodel/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/actions/sdk/v2/interactionmodel/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/actions/sdk/v2/interactionmodel/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -153,7 +153,7 @@ diff -urN a/googleapis/actions/sdk/v2/interactionmodel/BUILD.bazel b/googleapis/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/actions/sdk/v2/interactionmodel/prompt/BUILD.bazel b/googleapis/actions/sdk/v2/interactionmodel/prompt/BUILD.bazel
---- a/googleapis/actions/sdk/v2/interactionmodel/prompt/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/actions/sdk/v2/interactionmodel/prompt/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/actions/sdk/v2/interactionmodel/prompt/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -193,7 +193,7 @@ diff -urN a/googleapis/actions/sdk/v2/interactionmodel/prompt/BUILD.bazel b/goog
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/actions/sdk/v2/interactionmodel/type/BUILD.bazel b/googleapis/actions/sdk/v2/interactionmodel/type/BUILD.bazel
---- a/googleapis/actions/sdk/v2/interactionmodel/type/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/actions/sdk/v2/interactionmodel/type/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/actions/sdk/v2/interactionmodel/type/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -223,7 +223,7 @@ diff -urN a/googleapis/actions/sdk/v2/interactionmodel/type/BUILD.bazel b/google
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/analytics/admin/v1alpha/BUILD.bazel b/googleapis/analytics/admin/v1alpha/BUILD.bazel
---- a/googleapis/analytics/admin/v1alpha/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/analytics/admin/v1alpha/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/analytics/admin/v1alpha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -245,14 +245,15 @@ diff -urN a/googleapis/analytics/admin/v1alpha/BUILD.bazel b/googleapis/analytic
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/analytics/admin/v1beta/BUILD.bazel b/googleapis/analytics/admin/v1beta/BUILD.bazel
---- a/googleapis/analytics/admin/v1beta/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/analytics/admin/v1beta/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/analytics/admin/v1beta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
 +    name = "v1beta",
 +    srcs = [
++        "access_report.pb.go",
 +        "analytics_admin.pb.go",
 +        "resources.pb.go",
 +    ],
@@ -278,7 +279,7 @@ diff -urN a/googleapis/analytics/admin/v1beta/BUILD.bazel b/googleapis/analytics
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/analytics/data/v1alpha/BUILD.bazel b/googleapis/analytics/data/v1alpha/BUILD.bazel
---- a/googleapis/analytics/data/v1alpha/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/analytics/data/v1alpha/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/analytics/data/v1alpha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -308,7 +309,7 @@ diff -urN a/googleapis/analytics/data/v1alpha/BUILD.bazel b/googleapis/analytics
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/analytics/data/v1beta/BUILD.bazel b/googleapis/analytics/data/v1beta/BUILD.bazel
---- a/googleapis/analytics/data/v1beta/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/analytics/data/v1beta/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/analytics/data/v1beta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -337,7 +338,7 @@ diff -urN a/googleapis/analytics/data/v1beta/BUILD.bazel b/googleapis/analytics/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/analytics/management/v1alpha/BUILD.bazel b/googleapis/analytics/management/v1alpha/BUILD.bazel
---- a/googleapis/analytics/management/v1alpha/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/analytics/management/v1alpha/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/analytics/management/v1alpha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,29 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -369,30 +370,8 @@ diff -urN a/googleapis/analytics/management/v1alpha/BUILD.bazel b/googleapis/ana
 +    actual = ":v1alpha",
 +    visibility = ["//visibility:public"],
 +)
-diff -urN a/googleapis/api/BUILD.bazel b/googleapis/api/BUILD.bazel
---- a/googleapis/api/BUILD.bazel	1969-12-31 16:00:00
-+++ b/googleapis/api/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,18 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "api",
-+    srcs = ["launch_stage.pb.go"],
-+    importpath = "google.golang.org/genproto/googleapis/api",
-+    visibility = ["//visibility:public"],
-+    deps = [
-+        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
-+        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
-+    ],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":api",
-+    visibility = ["//visibility:public"],
-+)
 diff -urN a/googleapis/api/annotations/BUILD.bazel b/googleapis/api/annotations/BUILD.bazel
---- a/googleapis/api/annotations/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/api/annotations/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/api/annotations/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -424,29 +403,19 @@ diff -urN a/googleapis/api/annotations/BUILD.bazel b/googleapis/api/annotations/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/api/apikeys/v2/BUILD.bazel b/googleapis/api/apikeys/v2/BUILD.bazel
---- a/googleapis/api/apikeys/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/api/apikeys/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/api/apikeys/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,28 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
 +    name = "apikeys",
-+    srcs = [
-+        "apikeys.pb.go",
-+        "resources.pb.go",
-+    ],
++    srcs = ["alias.go"],
 +    importpath = "google.golang.org/genproto/googleapis/api/apikeys/v2",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "//googleapis/api/annotations",
-+        "//googleapis/longrunning",
++        "@com_google_cloud_go_apikeys//apiv2/apikeyspb:go_default_library",
 +        "@org_golang_google_grpc//:go_default_library",
-+        "@org_golang_google_grpc//codes:go_default_library",
-+        "@org_golang_google_grpc//status:go_default_library",
-+        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
-+        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
-+        "@org_golang_google_protobuf//types/known/fieldmaskpb:go_default_library",
-+        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
 +    ],
 +)
 +
@@ -455,8 +424,30 @@ diff -urN a/googleapis/api/apikeys/v2/BUILD.bazel b/googleapis/api/apikeys/v2/BU
 +    actual = ":apikeys",
 +    visibility = ["//visibility:public"],
 +)
+diff -urN a/googleapis/api/BUILD.bazel b/googleapis/api/BUILD.bazel
+--- a/googleapis/api/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/googleapis/api/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,18 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "api",
++    srcs = ["launch_stage.pb.go"],
++    importpath = "google.golang.org/genproto/googleapis/api",
++    visibility = ["//visibility:public"],
++    deps = [
++        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
++        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":api",
++    visibility = ["//visibility:public"],
++)
 diff -urN a/googleapis/api/configchange/BUILD.bazel b/googleapis/api/configchange/BUILD.bazel
---- a/googleapis/api/configchange/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/api/configchange/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/api/configchange/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -478,7 +469,7 @@ diff -urN a/googleapis/api/configchange/BUILD.bazel b/googleapis/api/configchang
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/api/distribution/BUILD.bazel b/googleapis/api/distribution/BUILD.bazel
---- a/googleapis/api/distribution/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/api/distribution/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/api/distribution/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -502,7 +493,7 @@ diff -urN a/googleapis/api/distribution/BUILD.bazel b/googleapis/api/distributio
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/api/error_reason/BUILD.bazel b/googleapis/api/error_reason/BUILD.bazel
---- a/googleapis/api/error_reason/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/api/error_reason/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/api/error_reason/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -524,7 +515,7 @@ diff -urN a/googleapis/api/error_reason/BUILD.bazel b/googleapis/api/error_reaso
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/api/expr/conformance/v1alpha1/BUILD.bazel b/googleapis/api/expr/conformance/v1alpha1/BUILD.bazel
---- a/googleapis/api/expr/conformance/v1alpha1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/api/expr/conformance/v1alpha1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/api/expr/conformance/v1alpha1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -552,7 +543,7 @@ diff -urN a/googleapis/api/expr/conformance/v1alpha1/BUILD.bazel b/googleapis/ap
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/api/expr/v1alpha1/BUILD.bazel b/googleapis/api/expr/v1alpha1/BUILD.bazel
---- a/googleapis/api/expr/v1alpha1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/api/expr/v1alpha1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/api/expr/v1alpha1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -586,7 +577,7 @@ diff -urN a/googleapis/api/expr/v1alpha1/BUILD.bazel b/googleapis/api/expr/v1alp
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/api/expr/v1beta1/BUILD.bazel b/googleapis/api/expr/v1beta1/BUILD.bazel
---- a/googleapis/api/expr/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/api/expr/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/api/expr/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -617,7 +608,7 @@ diff -urN a/googleapis/api/expr/v1beta1/BUILD.bazel b/googleapis/api/expr/v1beta
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/api/httpbody/BUILD.bazel b/googleapis/api/httpbody/BUILD.bazel
---- a/googleapis/api/httpbody/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/api/httpbody/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/api/httpbody/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -640,7 +631,7 @@ diff -urN a/googleapis/api/httpbody/BUILD.bazel b/googleapis/api/httpbody/BUILD.
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/api/label/BUILD.bazel b/googleapis/api/label/BUILD.bazel
---- a/googleapis/api/label/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/api/label/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/api/label/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -662,7 +653,7 @@ diff -urN a/googleapis/api/label/BUILD.bazel b/googleapis/api/label/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/api/metric/BUILD.bazel b/googleapis/api/metric/BUILD.bazel
---- a/googleapis/api/metric/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/api/metric/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/api/metric/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -687,7 +678,7 @@ diff -urN a/googleapis/api/metric/BUILD.bazel b/googleapis/api/metric/BUILD.baze
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/api/monitoredres/BUILD.bazel b/googleapis/api/monitoredres/BUILD.bazel
---- a/googleapis/api/monitoredres/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/api/monitoredres/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/api/monitoredres/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -712,7 +703,7 @@ diff -urN a/googleapis/api/monitoredres/BUILD.bazel b/googleapis/api/monitoredre
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/api/serviceconfig/BUILD.bazel b/googleapis/api/serviceconfig/BUILD.bazel
---- a/googleapis/api/serviceconfig/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/api/serviceconfig/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/api/serviceconfig/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,43 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -759,7 +750,7 @@ diff -urN a/googleapis/api/serviceconfig/BUILD.bazel b/googleapis/api/servicecon
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/api/servicecontrol/v1/BUILD.bazel b/googleapis/api/servicecontrol/v1/BUILD.bazel
---- a/googleapis/api/servicecontrol/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/api/servicecontrol/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/api/servicecontrol/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -781,7 +772,7 @@ diff -urN a/googleapis/api/servicecontrol/v1/BUILD.bazel b/googleapis/api/servic
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/api/servicecontrol/v2/BUILD.bazel b/googleapis/api/servicecontrol/v2/BUILD.bazel
---- a/googleapis/api/servicecontrol/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/api/servicecontrol/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/api/servicecontrol/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -809,7 +800,7 @@ diff -urN a/googleapis/api/servicecontrol/v2/BUILD.bazel b/googleapis/api/servic
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/api/servicemanagement/v1/BUILD.bazel b/googleapis/api/servicemanagement/v1/BUILD.bazel
---- a/googleapis/api/servicemanagement/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/api/servicemanagement/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/api/servicemanagement/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -831,7 +822,7 @@ diff -urN a/googleapis/api/servicemanagement/v1/BUILD.bazel b/googleapis/api/ser
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/api/serviceusage/v1/BUILD.bazel b/googleapis/api/serviceusage/v1/BUILD.bazel
---- a/googleapis/api/serviceusage/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/api/serviceusage/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/api/serviceusage/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -853,7 +844,7 @@ diff -urN a/googleapis/api/serviceusage/v1/BUILD.bazel b/googleapis/api/serviceu
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/api/serviceusage/v1beta1/BUILD.bazel b/googleapis/api/serviceusage/v1beta1/BUILD.bazel
---- a/googleapis/api/serviceusage/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/api/serviceusage/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/api/serviceusage/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -887,7 +878,7 @@ diff -urN a/googleapis/api/serviceusage/v1beta1/BUILD.bazel b/googleapis/api/ser
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/api/visibility/BUILD.bazel b/googleapis/api/visibility/BUILD.bazel
---- a/googleapis/api/visibility/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/api/visibility/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/api/visibility/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -910,7 +901,7 @@ diff -urN a/googleapis/api/visibility/BUILD.bazel b/googleapis/api/visibility/BU
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/appengine/legacy/BUILD.bazel b/googleapis/appengine/legacy/BUILD.bazel
---- a/googleapis/appengine/legacy/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/appengine/legacy/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/appengine/legacy/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -932,7 +923,7 @@ diff -urN a/googleapis/appengine/legacy/BUILD.bazel b/googleapis/appengine/legac
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/appengine/logging/v1/BUILD.bazel b/googleapis/appengine/logging/v1/BUILD.bazel
---- a/googleapis/appengine/logging/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/appengine/logging/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/appengine/logging/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -957,7 +948,7 @@ diff -urN a/googleapis/appengine/logging/v1/BUILD.bazel b/googleapis/appengine/l
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/appengine/v1/BUILD.bazel b/googleapis/appengine/v1/BUILD.bazel
---- a/googleapis/appengine/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/appengine/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/appengine/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -979,7 +970,7 @@ diff -urN a/googleapis/appengine/v1/BUILD.bazel b/googleapis/appengine/v1/BUILD.
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/appengine/v1beta/BUILD.bazel b/googleapis/appengine/v1beta/BUILD.bazel
---- a/googleapis/appengine/v1beta/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/appengine/v1beta/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/appengine/v1beta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,45 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1028,7 +1019,7 @@ diff -urN a/googleapis/appengine/v1beta/BUILD.bazel b/googleapis/appengine/v1bet
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/apps/alertcenter/v1beta1/BUILD.bazel b/googleapis/apps/alertcenter/v1beta1/BUILD.bazel
---- a/googleapis/apps/alertcenter/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/apps/alertcenter/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/apps/alertcenter/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1058,7 +1049,7 @@ diff -urN a/googleapis/apps/alertcenter/v1beta1/BUILD.bazel b/googleapis/apps/al
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/apps/drive/activity/v2/BUILD.bazel b/googleapis/apps/drive/activity/v2/BUILD.bazel
---- a/googleapis/apps/drive/activity/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/apps/drive/activity/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/apps/drive/activity/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1093,7 +1084,7 @@ diff -urN a/googleapis/apps/drive/activity/v2/BUILD.bazel b/googleapis/apps/driv
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/apps/drive/labels/v2/BUILD.bazel b/googleapis/apps/drive/labels/v2/BUILD.bazel
---- a/googleapis/apps/drive/labels/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/apps/drive/labels/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/apps/drive/labels/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,34 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1131,7 +1122,7 @@ diff -urN a/googleapis/apps/drive/labels/v2/BUILD.bazel b/googleapis/apps/drive/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/apps/drive/labels/v2beta/BUILD.bazel b/googleapis/apps/drive/labels/v2beta/BUILD.bazel
---- a/googleapis/apps/drive/labels/v2beta/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/apps/drive/labels/v2beta/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/apps/drive/labels/v2beta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,39 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1174,7 +1165,7 @@ diff -urN a/googleapis/apps/drive/labels/v2beta/BUILD.bazel b/googleapis/apps/dr
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/apps/script/type/BUILD.bazel b/googleapis/apps/script/type/BUILD.bazel
---- a/googleapis/apps/script/type/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/apps/script/type/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/apps/script/type/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1202,7 +1193,7 @@ diff -urN a/googleapis/apps/script/type/BUILD.bazel b/googleapis/apps/script/typ
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/apps/script/type/calendar/BUILD.bazel b/googleapis/apps/script/type/calendar/BUILD.bazel
---- a/googleapis/apps/script/type/calendar/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/apps/script/type/calendar/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/apps/script/type/calendar/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1226,7 +1217,7 @@ diff -urN a/googleapis/apps/script/type/calendar/BUILD.bazel b/googleapis/apps/s
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/apps/script/type/docs/BUILD.bazel b/googleapis/apps/script/type/docs/BUILD.bazel
---- a/googleapis/apps/script/type/docs/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/apps/script/type/docs/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/apps/script/type/docs/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1250,7 +1241,7 @@ diff -urN a/googleapis/apps/script/type/docs/BUILD.bazel b/googleapis/apps/scrip
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/apps/script/type/drive/BUILD.bazel b/googleapis/apps/script/type/drive/BUILD.bazel
---- a/googleapis/apps/script/type/drive/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/apps/script/type/drive/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/apps/script/type/drive/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1273,7 +1264,7 @@ diff -urN a/googleapis/apps/script/type/drive/BUILD.bazel b/googleapis/apps/scri
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/apps/script/type/gmail/BUILD.bazel b/googleapis/apps/script/type/gmail/BUILD.bazel
---- a/googleapis/apps/script/type/gmail/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/apps/script/type/gmail/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/apps/script/type/gmail/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1296,7 +1287,7 @@ diff -urN a/googleapis/apps/script/type/gmail/BUILD.bazel b/googleapis/apps/scri
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/apps/script/type/sheets/BUILD.bazel b/googleapis/apps/script/type/sheets/BUILD.bazel
---- a/googleapis/apps/script/type/sheets/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/apps/script/type/sheets/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/apps/script/type/sheets/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1320,7 +1311,7 @@ diff -urN a/googleapis/apps/script/type/sheets/BUILD.bazel b/googleapis/apps/scr
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/apps/script/type/slides/BUILD.bazel b/googleapis/apps/script/type/slides/BUILD.bazel
---- a/googleapis/apps/script/type/slides/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/apps/script/type/slides/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/apps/script/type/slides/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1344,7 +1335,7 @@ diff -urN a/googleapis/apps/script/type/slides/BUILD.bazel b/googleapis/apps/scr
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/area120/tables/v1alpha1/BUILD.bazel b/googleapis/area120/tables/v1alpha1/BUILD.bazel
---- a/googleapis/area120/tables/v1alpha1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/area120/tables/v1alpha1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/area120/tables/v1alpha1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1366,7 +1357,7 @@ diff -urN a/googleapis/area120/tables/v1alpha1/BUILD.bazel b/googleapis/area120/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/assistant/embedded/v1alpha1/BUILD.bazel b/googleapis/assistant/embedded/v1alpha1/BUILD.bazel
---- a/googleapis/assistant/embedded/v1alpha1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/assistant/embedded/v1alpha1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/assistant/embedded/v1alpha1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1393,7 +1384,7 @@ diff -urN a/googleapis/assistant/embedded/v1alpha1/BUILD.bazel b/googleapis/assi
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/assistant/embedded/v1alpha2/BUILD.bazel b/googleapis/assistant/embedded/v1alpha2/BUILD.bazel
---- a/googleapis/assistant/embedded/v1alpha2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/assistant/embedded/v1alpha2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/assistant/embedded/v1alpha2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1420,7 +1411,7 @@ diff -urN a/googleapis/assistant/embedded/v1alpha2/BUILD.bazel b/googleapis/assi
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/bigtable/admin/cluster/v1/BUILD.bazel b/googleapis/bigtable/admin/cluster/v1/BUILD.bazel
---- a/googleapis/bigtable/admin/cluster/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/bigtable/admin/cluster/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/bigtable/admin/cluster/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1454,7 +1445,7 @@ diff -urN a/googleapis/bigtable/admin/cluster/v1/BUILD.bazel b/googleapis/bigtab
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/bigtable/admin/table/v1/BUILD.bazel b/googleapis/bigtable/admin/table/v1/BUILD.bazel
---- a/googleapis/bigtable/admin/table/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/bigtable/admin/table/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/bigtable/admin/table/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1488,7 +1479,7 @@ diff -urN a/googleapis/bigtable/admin/table/v1/BUILD.bazel b/googleapis/bigtable
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/bigtable/admin/v2/BUILD.bazel b/googleapis/bigtable/admin/v2/BUILD.bazel
---- a/googleapis/bigtable/admin/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/bigtable/admin/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/bigtable/admin/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1527,7 +1518,7 @@ diff -urN a/googleapis/bigtable/admin/v2/BUILD.bazel b/googleapis/bigtable/admin
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/bigtable/v1/BUILD.bazel b/googleapis/bigtable/v1/BUILD.bazel
---- a/googleapis/bigtable/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/bigtable/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/bigtable/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,29 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1560,9 +1551,9 @@ diff -urN a/googleapis/bigtable/v1/BUILD.bazel b/googleapis/bigtable/v1/BUILD.ba
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/bigtable/v2/BUILD.bazel b/googleapis/bigtable/v2/BUILD.bazel
---- a/googleapis/bigtable/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/bigtable/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/bigtable/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,30 @@
+@@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -1584,6 +1575,7 @@ diff -urN a/googleapis/bigtable/v2/BUILD.bazel b/googleapis/bigtable/v2/BUILD.ba
 +        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
 +        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
 +        "@org_golang_google_protobuf//types/known/durationpb:go_default_library",
++        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
 +        "@org_golang_google_protobuf//types/known/wrapperspb:go_default_library",
 +    ],
 +)
@@ -1594,7 +1586,7 @@ diff -urN a/googleapis/bigtable/v2/BUILD.bazel b/googleapis/bigtable/v2/BUILD.ba
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/bytestream/BUILD.bazel b/googleapis/bytestream/BUILD.bazel
---- a/googleapis/bytestream/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/bytestream/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/bytestream/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1621,7 +1613,7 @@ diff -urN a/googleapis/bytestream/BUILD.bazel b/googleapis/bytestream/BUILD.baze
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/ccc/hosted/marketplace/v2/BUILD.bazel b/googleapis/ccc/hosted/marketplace/v2/BUILD.bazel
---- a/googleapis/ccc/hosted/marketplace/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/ccc/hosted/marketplace/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/ccc/hosted/marketplace/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1650,7 +1642,7 @@ diff -urN a/googleapis/ccc/hosted/marketplace/v2/BUILD.bazel b/googleapis/ccc/ho
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/chat/dynamite/integration/logging/v1/BUILD.bazel b/googleapis/chat/dynamite/integration/logging/v1/BUILD.bazel
---- a/googleapis/chat/dynamite/integration/logging/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/chat/dynamite/integration/logging/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/chat/dynamite/integration/logging/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1673,7 +1665,7 @@ diff -urN a/googleapis/chat/dynamite/integration/logging/v1/BUILD.bazel b/google
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/chat/logging/v1/BUILD.bazel b/googleapis/chat/logging/v1/BUILD.bazel
---- a/googleapis/chat/logging/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/chat/logging/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/chat/logging/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1696,7 +1688,7 @@ diff -urN a/googleapis/chat/logging/v1/BUILD.bazel b/googleapis/chat/logging/v1/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/chromeos/moblab/v1beta1/BUILD.bazel b/googleapis/chromeos/moblab/v1beta1/BUILD.bazel
---- a/googleapis/chromeos/moblab/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/chromeos/moblab/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/chromeos/moblab/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1728,7 +1720,7 @@ diff -urN a/googleapis/chromeos/moblab/v1beta1/BUILD.bazel b/googleapis/chromeos
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/chromeos/uidetection/v1/BUILD.bazel b/googleapis/chromeos/uidetection/v1/BUILD.bazel
---- a/googleapis/chromeos/uidetection/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/chromeos/uidetection/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/chromeos/uidetection/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1754,7 +1746,7 @@ diff -urN a/googleapis/chromeos/uidetection/v1/BUILD.bazel b/googleapis/chromeos
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/accessapproval/v1/BUILD.bazel b/googleapis/cloud/accessapproval/v1/BUILD.bazel
---- a/googleapis/cloud/accessapproval/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/accessapproval/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/accessapproval/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1776,7 +1768,7 @@ diff -urN a/googleapis/cloud/accessapproval/v1/BUILD.bazel b/googleapis/cloud/ac
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/aiplatform/logging/BUILD.bazel b/googleapis/cloud/aiplatform/logging/BUILD.bazel
---- a/googleapis/cloud/aiplatform/logging/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/aiplatform/logging/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/aiplatform/logging/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1799,7 +1791,7 @@ diff -urN a/googleapis/cloud/aiplatform/logging/BUILD.bazel b/googleapis/cloud/a
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/aiplatform/v1/BUILD.bazel b/googleapis/cloud/aiplatform/v1/BUILD.bazel
---- a/googleapis/cloud/aiplatform/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/aiplatform/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/aiplatform/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1821,7 +1813,7 @@ diff -urN a/googleapis/cloud/aiplatform/v1/BUILD.bazel b/googleapis/cloud/aiplat
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/aiplatform/v1/schema/predict/instance/BUILD.bazel b/googleapis/cloud/aiplatform/v1/schema/predict/instance/BUILD.bazel
---- a/googleapis/cloud/aiplatform/v1/schema/predict/instance/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/aiplatform/v1/schema/predict/instance/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/aiplatform/v1/schema/predict/instance/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1853,7 +1845,7 @@ diff -urN a/googleapis/cloud/aiplatform/v1/schema/predict/instance/BUILD.bazel b
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/aiplatform/v1/schema/predict/params/BUILD.bazel b/googleapis/cloud/aiplatform/v1/schema/predict/params/BUILD.bazel
---- a/googleapis/cloud/aiplatform/v1/schema/predict/params/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/aiplatform/v1/schema/predict/params/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/aiplatform/v1/schema/predict/params/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1882,7 +1874,7 @@ diff -urN a/googleapis/cloud/aiplatform/v1/schema/predict/params/BUILD.bazel b/g
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/aiplatform/v1/schema/predict/prediction/BUILD.bazel b/googleapis/cloud/aiplatform/v1/schema/predict/prediction/BUILD.bazel
---- a/googleapis/cloud/aiplatform/v1/schema/predict/prediction/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/aiplatform/v1/schema/predict/prediction/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/aiplatform/v1/schema/predict/prediction/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,32 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1918,7 +1910,7 @@ diff -urN a/googleapis/cloud/aiplatform/v1/schema/predict/prediction/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/aiplatform/v1/schema/trainingjob/definition/BUILD.bazel b/googleapis/cloud/aiplatform/v1/schema/trainingjob/definition/BUILD.bazel
---- a/googleapis/cloud/aiplatform/v1/schema/trainingjob/definition/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/aiplatform/v1/schema/trainingjob/definition/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/aiplatform/v1/schema/trainingjob/definition/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1955,7 +1947,7 @@ diff -urN a/googleapis/cloud/aiplatform/v1/schema/trainingjob/definition/BUILD.b
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/aiplatform/v1beta1/BUILD.bazel b/googleapis/cloud/aiplatform/v1beta1/BUILD.bazel
---- a/googleapis/cloud/aiplatform/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/aiplatform/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/aiplatform/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1977,7 +1969,7 @@ diff -urN a/googleapis/cloud/aiplatform/v1beta1/BUILD.bazel b/googleapis/cloud/a
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/aiplatform/v1beta1/schema/BUILD.bazel b/googleapis/cloud/aiplatform/v1beta1/schema/BUILD.bazel
---- a/googleapis/cloud/aiplatform/v1beta1/schema/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/aiplatform/v1beta1/schema/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/aiplatform/v1beta1/schema/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2012,7 +2004,7 @@ diff -urN a/googleapis/cloud/aiplatform/v1beta1/schema/BUILD.bazel b/googleapis/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/aiplatform/v1beta1/schema/predict/instance/BUILD.bazel b/googleapis/cloud/aiplatform/v1beta1/schema/predict/instance/BUILD.bazel
---- a/googleapis/cloud/aiplatform/v1beta1/schema/predict/instance/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/aiplatform/v1beta1/schema/predict/instance/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/aiplatform/v1beta1/schema/predict/instance/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2044,7 +2036,7 @@ diff -urN a/googleapis/cloud/aiplatform/v1beta1/schema/predict/instance/BUILD.ba
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/aiplatform/v1beta1/schema/predict/params/BUILD.bazel b/googleapis/cloud/aiplatform/v1beta1/schema/predict/params/BUILD.bazel
---- a/googleapis/cloud/aiplatform/v1beta1/schema/predict/params/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/aiplatform/v1beta1/schema/predict/params/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/aiplatform/v1beta1/schema/predict/params/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2073,7 +2065,7 @@ diff -urN a/googleapis/cloud/aiplatform/v1beta1/schema/predict/params/BUILD.baze
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/aiplatform/v1beta1/schema/predict/prediction/BUILD.bazel b/googleapis/cloud/aiplatform/v1beta1/schema/predict/prediction/BUILD.bazel
---- a/googleapis/cloud/aiplatform/v1beta1/schema/predict/prediction/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/aiplatform/v1beta1/schema/predict/prediction/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/aiplatform/v1beta1/schema/predict/prediction/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2110,7 +2102,7 @@ diff -urN a/googleapis/cloud/aiplatform/v1beta1/schema/predict/prediction/BUILD.
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/aiplatform/v1beta1/schema/trainingjob/definition/BUILD.bazel b/googleapis/cloud/aiplatform/v1beta1/schema/trainingjob/definition/BUILD.bazel
---- a/googleapis/cloud/aiplatform/v1beta1/schema/trainingjob/definition/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/aiplatform/v1beta1/schema/trainingjob/definition/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/aiplatform/v1beta1/schema/trainingjob/definition/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2145,7 +2137,7 @@ diff -urN a/googleapis/cloud/aiplatform/v1beta1/schema/trainingjob/definition/BU
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/apigateway/v1/BUILD.bazel b/googleapis/cloud/apigateway/v1/BUILD.bazel
---- a/googleapis/cloud/apigateway/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/apigateway/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/apigateway/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2167,7 +2159,7 @@ diff -urN a/googleapis/cloud/apigateway/v1/BUILD.bazel b/googleapis/cloud/apigat
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/apigeeconnect/v1/BUILD.bazel b/googleapis/cloud/apigeeconnect/v1/BUILD.bazel
---- a/googleapis/cloud/apigeeconnect/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/apigeeconnect/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/apigeeconnect/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2189,32 +2181,19 @@ diff -urN a/googleapis/cloud/apigeeconnect/v1/BUILD.bazel b/googleapis/cloud/api
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/apigeeregistry/v1/BUILD.bazel b/googleapis/cloud/apigeeregistry/v1/BUILD.bazel
---- a/googleapis/cloud/apigeeregistry/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/apigeeregistry/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/apigeeregistry/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,31 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
 +    name = "apigeeregistry",
-+    srcs = [
-+        "provisioning_service.pb.go",
-+        "registry_models.pb.go",
-+        "registry_service.pb.go",
-+    ],
++    srcs = ["alias.go"],
 +    importpath = "google.golang.org/genproto/googleapis/cloud/apigeeregistry/v1",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "//googleapis/api/annotations",
-+        "//googleapis/api/httpbody",
-+        "//googleapis/longrunning",
++        "@com_google_cloud_go_apigeeregistry//apiv1/apigeeregistrypb:go_default_library",
 +        "@org_golang_google_grpc//:go_default_library",
-+        "@org_golang_google_grpc//codes:go_default_library",
-+        "@org_golang_google_grpc//status:go_default_library",
-+        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
-+        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
-+        "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
-+        "@org_golang_google_protobuf//types/known/fieldmaskpb:go_default_library",
-+        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
 +    ],
 +)
 +
@@ -2224,7 +2203,7 @@ diff -urN a/googleapis/cloud/apigeeregistry/v1/BUILD.bazel b/googleapis/cloud/ap
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/asset/v1/BUILD.bazel b/googleapis/cloud/asset/v1/BUILD.bazel
---- a/googleapis/cloud/asset/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/asset/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/asset/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2246,7 +2225,7 @@ diff -urN a/googleapis/cloud/asset/v1/BUILD.bazel b/googleapis/cloud/asset/v1/BU
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/asset/v1p1beta1/BUILD.bazel b/googleapis/cloud/asset/v1p1beta1/BUILD.bazel
---- a/googleapis/cloud/asset/v1p1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/asset/v1p1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/asset/v1p1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2276,7 +2255,7 @@ diff -urN a/googleapis/cloud/asset/v1p1beta1/BUILD.bazel b/googleapis/cloud/asse
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/asset/v1p2beta1/BUILD.bazel b/googleapis/cloud/asset/v1p2beta1/BUILD.bazel
---- a/googleapis/cloud/asset/v1p2beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/asset/v1p2beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/asset/v1p2beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2298,7 +2277,7 @@ diff -urN a/googleapis/cloud/asset/v1p2beta1/BUILD.bazel b/googleapis/cloud/asse
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/asset/v1p4beta1/BUILD.bazel b/googleapis/cloud/asset/v1p4beta1/BUILD.bazel
---- a/googleapis/cloud/asset/v1p4beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/asset/v1p4beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/asset/v1p4beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,29 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2331,7 +2310,7 @@ diff -urN a/googleapis/cloud/asset/v1p4beta1/BUILD.bazel b/googleapis/cloud/asse
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/asset/v1p5beta1/BUILD.bazel b/googleapis/cloud/asset/v1p5beta1/BUILD.bazel
---- a/googleapis/cloud/asset/v1p5beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/asset/v1p5beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/asset/v1p5beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2353,7 +2332,7 @@ diff -urN a/googleapis/cloud/asset/v1p5beta1/BUILD.bazel b/googleapis/cloud/asse
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/asset/v1p7beta1/BUILD.bazel b/googleapis/cloud/asset/v1p7beta1/BUILD.bazel
---- a/googleapis/cloud/asset/v1p7beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/asset/v1p7beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/asset/v1p7beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2388,7 +2367,7 @@ diff -urN a/googleapis/cloud/asset/v1p7beta1/BUILD.bazel b/googleapis/cloud/asse
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/assuredworkloads/regulatoryintercept/logging/v1/BUILD.bazel b/googleapis/cloud/assuredworkloads/regulatoryintercept/logging/v1/BUILD.bazel
---- a/googleapis/cloud/assuredworkloads/regulatoryintercept/logging/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/assuredworkloads/regulatoryintercept/logging/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/assuredworkloads/regulatoryintercept/logging/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2410,7 +2389,7 @@ diff -urN a/googleapis/cloud/assuredworkloads/regulatoryintercept/logging/v1/BUI
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/assuredworkloads/v1/BUILD.bazel b/googleapis/cloud/assuredworkloads/v1/BUILD.bazel
---- a/googleapis/cloud/assuredworkloads/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/assuredworkloads/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/assuredworkloads/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2432,7 +2411,7 @@ diff -urN a/googleapis/cloud/assuredworkloads/v1/BUILD.bazel b/googleapis/cloud/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/assuredworkloads/v1beta1/BUILD.bazel b/googleapis/cloud/assuredworkloads/v1beta1/BUILD.bazel
---- a/googleapis/cloud/assuredworkloads/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/assuredworkloads/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/assuredworkloads/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2454,7 +2433,7 @@ diff -urN a/googleapis/cloud/assuredworkloads/v1beta1/BUILD.bazel b/googleapis/c
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/audit/BUILD.bazel b/googleapis/cloud/audit/BUILD.bazel
---- a/googleapis/cloud/audit/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/audit/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/audit/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,29 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2487,7 +2466,7 @@ diff -urN a/googleapis/cloud/audit/BUILD.bazel b/googleapis/cloud/audit/BUILD.ba
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/automl/v1/BUILD.bazel b/googleapis/cloud/automl/v1/BUILD.bazel
---- a/googleapis/cloud/automl/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/automl/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/automl/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2509,7 +2488,7 @@ diff -urN a/googleapis/cloud/automl/v1/BUILD.bazel b/googleapis/cloud/automl/v1/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/automl/v1beta1/BUILD.bazel b/googleapis/cloud/automl/v1beta1/BUILD.bazel
---- a/googleapis/cloud/automl/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/automl/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/automl/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2531,7 +2510,7 @@ diff -urN a/googleapis/cloud/automl/v1beta1/BUILD.bazel b/googleapis/cloud/autom
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/backupdr/logging/v1/BUILD.bazel b/googleapis/cloud/backupdr/logging/v1/BUILD.bazel
---- a/googleapis/cloud/backupdr/logging/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/backupdr/logging/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/backupdr/logging/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2554,7 +2533,7 @@ diff -urN a/googleapis/cloud/backupdr/logging/v1/BUILD.bazel b/googleapis/cloud/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/baremetalsolution/v2/BUILD.bazel b/googleapis/cloud/baremetalsolution/v2/BUILD.bazel
---- a/googleapis/cloud/baremetalsolution/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/baremetalsolution/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/baremetalsolution/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2576,7 +2555,7 @@ diff -urN a/googleapis/cloud/baremetalsolution/v2/BUILD.bazel b/googleapis/cloud
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/batch/v1/BUILD.bazel b/googleapis/cloud/batch/v1/BUILD.bazel
---- a/googleapis/cloud/batch/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/batch/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/batch/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2598,9 +2577,9 @@ diff -urN a/googleapis/cloud/batch/v1/BUILD.bazel b/googleapis/cloud/batch/v1/BU
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/batch/v1alpha/BUILD.bazel b/googleapis/cloud/batch/v1alpha/BUILD.bazel
---- a/googleapis/cloud/batch/v1alpha/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/batch/v1alpha/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/batch/v1alpha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,30 @@
+@@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -2622,6 +2601,7 @@ diff -urN a/googleapis/cloud/batch/v1alpha/BUILD.bazel b/googleapis/cloud/batch/
 +        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
 +        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
 +        "@org_golang_google_protobuf//types/known/durationpb:go_default_library",
++        "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
 +        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
 +    ],
 +)
@@ -2632,7 +2612,7 @@ diff -urN a/googleapis/cloud/batch/v1alpha/BUILD.bazel b/googleapis/cloud/batch/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/batch/v1alpha1/BUILD.bazel b/googleapis/cloud/batch/v1alpha1/BUILD.bazel
---- a/googleapis/cloud/batch/v1alpha1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/batch/v1alpha1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/batch/v1alpha1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2666,7 +2646,7 @@ diff -urN a/googleapis/cloud/batch/v1alpha1/BUILD.bazel b/googleapis/cloud/batch
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/batch/v1main/BUILD.bazel b/googleapis/cloud/batch/v1main/BUILD.bazel
---- a/googleapis/cloud/batch/v1main/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/batch/v1main/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/batch/v1main/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2690,7 +2670,7 @@ diff -urN a/googleapis/cloud/batch/v1main/BUILD.bazel b/googleapis/cloud/batch/v
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/beyondcorp/appconnections/v1/BUILD.bazel b/googleapis/cloud/beyondcorp/appconnections/v1/BUILD.bazel
---- a/googleapis/cloud/beyondcorp/appconnections/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/beyondcorp/appconnections/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/beyondcorp/appconnections/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2712,7 +2692,7 @@ diff -urN a/googleapis/cloud/beyondcorp/appconnections/v1/BUILD.bazel b/googleap
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/beyondcorp/appconnectors/v1/BUILD.bazel b/googleapis/cloud/beyondcorp/appconnectors/v1/BUILD.bazel
---- a/googleapis/cloud/beyondcorp/appconnectors/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/beyondcorp/appconnectors/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/beyondcorp/appconnectors/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2734,7 +2714,7 @@ diff -urN a/googleapis/cloud/beyondcorp/appconnectors/v1/BUILD.bazel b/googleapi
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/beyondcorp/appgateways/v1/BUILD.bazel b/googleapis/cloud/beyondcorp/appgateways/v1/BUILD.bazel
---- a/googleapis/cloud/beyondcorp/appgateways/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/beyondcorp/appgateways/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/beyondcorp/appgateways/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2756,7 +2736,7 @@ diff -urN a/googleapis/cloud/beyondcorp/appgateways/v1/BUILD.bazel b/googleapis/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/beyondcorp/clientconnectorservices/v1/BUILD.bazel b/googleapis/cloud/beyondcorp/clientconnectorservices/v1/BUILD.bazel
---- a/googleapis/cloud/beyondcorp/clientconnectorservices/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/beyondcorp/clientconnectorservices/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/beyondcorp/clientconnectorservices/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2778,7 +2758,7 @@ diff -urN a/googleapis/cloud/beyondcorp/clientconnectorservices/v1/BUILD.bazel b
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/beyondcorp/clientgateways/v1/BUILD.bazel b/googleapis/cloud/beyondcorp/clientgateways/v1/BUILD.bazel
---- a/googleapis/cloud/beyondcorp/clientgateways/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/beyondcorp/clientgateways/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/beyondcorp/clientgateways/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2800,7 +2780,7 @@ diff -urN a/googleapis/cloud/beyondcorp/clientgateways/v1/BUILD.bazel b/googleap
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/bigquery/analyticshub/v1/BUILD.bazel b/googleapis/cloud/bigquery/analyticshub/v1/BUILD.bazel
---- a/googleapis/cloud/bigquery/analyticshub/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/bigquery/analyticshub/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/bigquery/analyticshub/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2822,7 +2802,7 @@ diff -urN a/googleapis/cloud/bigquery/analyticshub/v1/BUILD.bazel b/googleapis/c
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/bigquery/connection/v1/BUILD.bazel b/googleapis/cloud/bigquery/connection/v1/BUILD.bazel
---- a/googleapis/cloud/bigquery/connection/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/bigquery/connection/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/bigquery/connection/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2844,7 +2824,7 @@ diff -urN a/googleapis/cloud/bigquery/connection/v1/BUILD.bazel b/googleapis/clo
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/bigquery/connection/v1beta1/BUILD.bazel b/googleapis/cloud/bigquery/connection/v1beta1/BUILD.bazel
---- a/googleapis/cloud/bigquery/connection/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/bigquery/connection/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/bigquery/connection/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2866,7 +2846,7 @@ diff -urN a/googleapis/cloud/bigquery/connection/v1beta1/BUILD.bazel b/googleapi
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/bigquery/dataexchange/common/BUILD.bazel b/googleapis/cloud/bigquery/dataexchange/common/BUILD.bazel
---- a/googleapis/cloud/bigquery/dataexchange/common/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/bigquery/dataexchange/common/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/bigquery/dataexchange/common/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2888,7 +2868,7 @@ diff -urN a/googleapis/cloud/bigquery/dataexchange/common/BUILD.bazel b/googleap
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/bigquery/dataexchange/v1beta1/BUILD.bazel b/googleapis/cloud/bigquery/dataexchange/v1beta1/BUILD.bazel
---- a/googleapis/cloud/bigquery/dataexchange/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/bigquery/dataexchange/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/bigquery/dataexchange/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2909,37 +2889,8 @@ diff -urN a/googleapis/cloud/bigquery/dataexchange/v1beta1/BUILD.bazel b/googlea
 +    actual = ":v1beta1",
 +    visibility = ["//visibility:public"],
 +)
-diff -urN a/googleapis/cloud/bigquery/datapolicies/v1/BUILD.bazel b/googleapis/cloud/bigquery/datapolicies/v1/BUILD.bazel
---- a/googleapis/cloud/bigquery/datapolicies/v1/BUILD.bazel	1969-12-31 16:00:00
-+++ b/googleapis/cloud/bigquery/datapolicies/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,25 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "datapolicies",
-+    srcs = ["datapolicy.pb.go"],
-+    importpath = "google.golang.org/genproto/googleapis/cloud/bigquery/datapolicies/v1",
-+    visibility = ["//visibility:public"],
-+    deps = [
-+        "//googleapis/api/annotations",
-+        "//googleapis/iam/v1:iam",
-+        "@org_golang_google_grpc//:go_default_library",
-+        "@org_golang_google_grpc//codes:go_default_library",
-+        "@org_golang_google_grpc//status:go_default_library",
-+        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
-+        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
-+        "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
-+        "@org_golang_google_protobuf//types/known/fieldmaskpb:go_default_library",
-+    ],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":datapolicies",
-+    visibility = ["//visibility:public"],
-+)
 diff -urN a/googleapis/cloud/bigquery/datapolicies/v1beta1/BUILD.bazel b/googleapis/cloud/bigquery/datapolicies/v1beta1/BUILD.bazel
---- a/googleapis/cloud/bigquery/datapolicies/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/bigquery/datapolicies/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/bigquery/datapolicies/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2961,7 +2912,7 @@ diff -urN a/googleapis/cloud/bigquery/datapolicies/v1beta1/BUILD.bazel b/googlea
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/bigquery/datatransfer/v1/BUILD.bazel b/googleapis/cloud/bigquery/datatransfer/v1/BUILD.bazel
---- a/googleapis/cloud/bigquery/datatransfer/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/bigquery/datatransfer/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/bigquery/datatransfer/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2983,7 +2934,7 @@ diff -urN a/googleapis/cloud/bigquery/datatransfer/v1/BUILD.bazel b/googleapis/c
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/bigquery/logging/v1/BUILD.bazel b/googleapis/cloud/bigquery/logging/v1/BUILD.bazel
---- a/googleapis/cloud/bigquery/logging/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/bigquery/logging/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/bigquery/logging/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3009,7 +2960,7 @@ diff -urN a/googleapis/cloud/bigquery/logging/v1/BUILD.bazel b/googleapis/cloud/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/bigquery/migration/tasks/assessment/v2alpha/BUILD.bazel b/googleapis/cloud/bigquery/migration/tasks/assessment/v2alpha/BUILD.bazel
---- a/googleapis/cloud/bigquery/migration/tasks/assessment/v2alpha/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/bigquery/migration/tasks/assessment/v2alpha/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/bigquery/migration/tasks/assessment/v2alpha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3032,7 +2983,7 @@ diff -urN a/googleapis/cloud/bigquery/migration/tasks/assessment/v2alpha/BUILD.b
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/bigquery/migration/tasks/translation/v2alpha/BUILD.bazel b/googleapis/cloud/bigquery/migration/tasks/translation/v2alpha/BUILD.bazel
---- a/googleapis/cloud/bigquery/migration/tasks/translation/v2alpha/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/bigquery/migration/tasks/translation/v2alpha/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/bigquery/migration/tasks/translation/v2alpha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3058,7 +3009,7 @@ diff -urN a/googleapis/cloud/bigquery/migration/tasks/translation/v2alpha/BUILD.
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/bigquery/migration/v2/BUILD.bazel b/googleapis/cloud/bigquery/migration/v2/BUILD.bazel
---- a/googleapis/cloud/bigquery/migration/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/bigquery/migration/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/bigquery/migration/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3080,7 +3031,7 @@ diff -urN a/googleapis/cloud/bigquery/migration/v2/BUILD.bazel b/googleapis/clou
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/bigquery/migration/v2alpha/BUILD.bazel b/googleapis/cloud/bigquery/migration/v2alpha/BUILD.bazel
---- a/googleapis/cloud/bigquery/migration/v2alpha/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/bigquery/migration/v2alpha/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/bigquery/migration/v2alpha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3102,7 +3053,7 @@ diff -urN a/googleapis/cloud/bigquery/migration/v2alpha/BUILD.bazel b/googleapis
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/bigquery/reservation/v1/BUILD.bazel b/googleapis/cloud/bigquery/reservation/v1/BUILD.bazel
---- a/googleapis/cloud/bigquery/reservation/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/bigquery/reservation/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/bigquery/reservation/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3124,7 +3075,7 @@ diff -urN a/googleapis/cloud/bigquery/reservation/v1/BUILD.bazel b/googleapis/cl
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/bigquery/reservation/v1beta1/BUILD.bazel b/googleapis/cloud/bigquery/reservation/v1beta1/BUILD.bazel
---- a/googleapis/cloud/bigquery/reservation/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/bigquery/reservation/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/bigquery/reservation/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3154,7 +3105,7 @@ diff -urN a/googleapis/cloud/bigquery/reservation/v1beta1/BUILD.bazel b/googleap
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/bigquery/storage/v1/BUILD.bazel b/googleapis/cloud/bigquery/storage/v1/BUILD.bazel
---- a/googleapis/cloud/bigquery/storage/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/bigquery/storage/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/bigquery/storage/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3176,7 +3127,7 @@ diff -urN a/googleapis/cloud/bigquery/storage/v1/BUILD.bazel b/googleapis/cloud/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/bigquery/storage/v1alpha2/BUILD.bazel b/googleapis/cloud/bigquery/storage/v1alpha2/BUILD.bazel
---- a/googleapis/cloud/bigquery/storage/v1alpha2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/bigquery/storage/v1alpha2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/bigquery/storage/v1alpha2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3213,7 +3164,7 @@ diff -urN a/googleapis/cloud/bigquery/storage/v1alpha2/BUILD.bazel b/googleapis/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/bigquery/storage/v1beta1/BUILD.bazel b/googleapis/cloud/bigquery/storage/v1beta1/BUILD.bazel
---- a/googleapis/cloud/bigquery/storage/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/bigquery/storage/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/bigquery/storage/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3235,7 +3186,7 @@ diff -urN a/googleapis/cloud/bigquery/storage/v1beta1/BUILD.bazel b/googleapis/c
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/bigquery/storage/v1beta2/BUILD.bazel b/googleapis/cloud/bigquery/storage/v1beta2/BUILD.bazel
---- a/googleapis/cloud/bigquery/storage/v1beta2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/bigquery/storage/v1beta2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/bigquery/storage/v1beta2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3257,7 +3208,7 @@ diff -urN a/googleapis/cloud/bigquery/storage/v1beta2/BUILD.bazel b/googleapis/c
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/bigquery/v2/BUILD.bazel b/googleapis/cloud/bigquery/v2/BUILD.bazel
---- a/googleapis/cloud/bigquery/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/bigquery/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/bigquery/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3292,7 +3243,7 @@ diff -urN a/googleapis/cloud/bigquery/v2/BUILD.bazel b/googleapis/cloud/bigquery
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/billing/budgets/v1/BUILD.bazel b/googleapis/cloud/billing/budgets/v1/BUILD.bazel
---- a/googleapis/cloud/billing/budgets/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/billing/budgets/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/billing/budgets/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3314,7 +3265,7 @@ diff -urN a/googleapis/cloud/billing/budgets/v1/BUILD.bazel b/googleapis/cloud/b
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/billing/budgets/v1alpha1/BUILD.bazel b/googleapis/cloud/billing/budgets/v1alpha1/BUILD.bazel
---- a/googleapis/cloud/billing/budgets/v1alpha1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/billing/budgets/v1alpha1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/billing/budgets/v1alpha1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3348,7 +3299,7 @@ diff -urN a/googleapis/cloud/billing/budgets/v1alpha1/BUILD.bazel b/googleapis/c
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/billing/budgets/v1beta1/BUILD.bazel b/googleapis/cloud/billing/budgets/v1beta1/BUILD.bazel
---- a/googleapis/cloud/billing/budgets/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/billing/budgets/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/billing/budgets/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3370,7 +3321,7 @@ diff -urN a/googleapis/cloud/billing/budgets/v1beta1/BUILD.bazel b/googleapis/cl
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/billing/v1/BUILD.bazel b/googleapis/cloud/billing/v1/BUILD.bazel
---- a/googleapis/cloud/billing/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/billing/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/billing/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3392,7 +3343,7 @@ diff -urN a/googleapis/cloud/billing/v1/BUILD.bazel b/googleapis/cloud/billing/v
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/binaryauthorization/v1/BUILD.bazel b/googleapis/cloud/binaryauthorization/v1/BUILD.bazel
---- a/googleapis/cloud/binaryauthorization/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/binaryauthorization/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/binaryauthorization/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3414,7 +3365,7 @@ diff -urN a/googleapis/cloud/binaryauthorization/v1/BUILD.bazel b/googleapis/clo
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/binaryauthorization/v1beta1/BUILD.bazel b/googleapis/cloud/binaryauthorization/v1beta1/BUILD.bazel
---- a/googleapis/cloud/binaryauthorization/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/binaryauthorization/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/binaryauthorization/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3436,7 +3387,7 @@ diff -urN a/googleapis/cloud/binaryauthorization/v1beta1/BUILD.bazel b/googleapi
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/certificatemanager/logging/v1/BUILD.bazel b/googleapis/cloud/certificatemanager/logging/v1/BUILD.bazel
---- a/googleapis/cloud/certificatemanager/logging/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/certificatemanager/logging/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/certificatemanager/logging/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3459,7 +3410,7 @@ diff -urN a/googleapis/cloud/certificatemanager/logging/v1/BUILD.bazel b/googlea
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/certificatemanager/v1/BUILD.bazel b/googleapis/cloud/certificatemanager/v1/BUILD.bazel
---- a/googleapis/cloud/certificatemanager/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/certificatemanager/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/certificatemanager/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3481,7 +3432,7 @@ diff -urN a/googleapis/cloud/certificatemanager/v1/BUILD.bazel b/googleapis/clou
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/channel/v1/BUILD.bazel b/googleapis/cloud/channel/v1/BUILD.bazel
---- a/googleapis/cloud/channel/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/channel/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/channel/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3503,7 +3454,7 @@ diff -urN a/googleapis/cloud/channel/v1/BUILD.bazel b/googleapis/cloud/channel/v
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/clouddms/logging/v1/BUILD.bazel b/googleapis/cloud/clouddms/logging/v1/BUILD.bazel
---- a/googleapis/cloud/clouddms/logging/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/clouddms/logging/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/clouddms/logging/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3529,7 +3480,7 @@ diff -urN a/googleapis/cloud/clouddms/logging/v1/BUILD.bazel b/googleapis/cloud/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/clouddms/v1/BUILD.bazel b/googleapis/cloud/clouddms/v1/BUILD.bazel
---- a/googleapis/cloud/clouddms/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/clouddms/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/clouddms/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3551,7 +3502,7 @@ diff -urN a/googleapis/cloud/clouddms/v1/BUILD.bazel b/googleapis/cloud/clouddms
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/cloudsetup/logging/v1/BUILD.bazel b/googleapis/cloud/cloudsetup/logging/v1/BUILD.bazel
---- a/googleapis/cloud/cloudsetup/logging/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/cloudsetup/logging/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/cloudsetup/logging/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3575,7 +3526,7 @@ diff -urN a/googleapis/cloud/cloudsetup/logging/v1/BUILD.bazel b/googleapis/clou
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/commerce/consumer/procurement/v1alpha1/BUILD.bazel b/googleapis/cloud/commerce/consumer/procurement/v1alpha1/BUILD.bazel
---- a/googleapis/cloud/commerce/consumer/procurement/v1alpha1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/commerce/consumer/procurement/v1alpha1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/commerce/consumer/procurement/v1alpha1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3606,7 +3557,7 @@ diff -urN a/googleapis/cloud/commerce/consumer/procurement/v1alpha1/BUILD.bazel 
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/common/BUILD.bazel b/googleapis/cloud/common/BUILD.bazel
---- a/googleapis/cloud/common/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/common/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/common/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3630,7 +3581,7 @@ diff -urN a/googleapis/cloud/common/BUILD.bazel b/googleapis/cloud/common/BUILD.
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/compute/v1/BUILD.bazel b/googleapis/cloud/compute/v1/BUILD.bazel
---- a/googleapis/cloud/compute/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/compute/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/compute/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3652,7 +3603,7 @@ diff -urN a/googleapis/cloud/compute/v1/BUILD.bazel b/googleapis/cloud/compute/v
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/connectors/v1/BUILD.bazel b/googleapis/cloud/connectors/v1/BUILD.bazel
---- a/googleapis/cloud/connectors/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/connectors/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/connectors/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3692,7 +3643,7 @@ diff -urN a/googleapis/cloud/connectors/v1/BUILD.bazel b/googleapis/cloud/connec
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/contactcenterinsights/v1/BUILD.bazel b/googleapis/cloud/contactcenterinsights/v1/BUILD.bazel
---- a/googleapis/cloud/contactcenterinsights/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/contactcenterinsights/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/contactcenterinsights/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3714,7 +3665,7 @@ diff -urN a/googleapis/cloud/contactcenterinsights/v1/BUILD.bazel b/googleapis/c
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/containers/workflow/analysis/BUILD.bazel b/googleapis/cloud/containers/workflow/analysis/BUILD.bazel
---- a/googleapis/cloud/containers/workflow/analysis/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/containers/workflow/analysis/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/containers/workflow/analysis/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3736,7 +3687,7 @@ diff -urN a/googleapis/cloud/containers/workflow/analysis/BUILD.bazel b/googleap
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/contentwarehouse/v1/BUILD.bazel b/googleapis/cloud/contentwarehouse/v1/BUILD.bazel
---- a/googleapis/cloud/contentwarehouse/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/contentwarehouse/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/contentwarehouse/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,46 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3785,39 +3736,8 @@ diff -urN a/googleapis/cloud/contentwarehouse/v1/BUILD.bazel b/googleapis/cloud/
 +    actual = ":contentwarehouse",
 +    visibility = ["//visibility:public"],
 +)
-diff -urN a/googleapis/cloud/datacatalog/lineage/v1/BUILD.bazel b/googleapis/cloud/datacatalog/lineage/v1/BUILD.bazel
---- a/googleapis/cloud/datacatalog/lineage/v1/BUILD.bazel	1969-12-31 16:00:00
-+++ b/googleapis/cloud/datacatalog/lineage/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,27 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "lineage",
-+    srcs = ["lineage.pb.go"],
-+    importpath = "google.golang.org/genproto/googleapis/cloud/datacatalog/lineage/v1",
-+    visibility = ["//visibility:public"],
-+    deps = [
-+        "//googleapis/api/annotations",
-+        "//googleapis/longrunning",
-+        "@org_golang_google_grpc//:go_default_library",
-+        "@org_golang_google_grpc//codes:go_default_library",
-+        "@org_golang_google_grpc//status:go_default_library",
-+        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
-+        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
-+        "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
-+        "@org_golang_google_protobuf//types/known/fieldmaskpb:go_default_library",
-+        "@org_golang_google_protobuf//types/known/structpb:go_default_library",
-+        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
-+    ],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":lineage",
-+    visibility = ["//visibility:public"],
-+)
 diff -urN a/googleapis/cloud/datacatalog/v1/BUILD.bazel b/googleapis/cloud/datacatalog/v1/BUILD.bazel
---- a/googleapis/cloud/datacatalog/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/datacatalog/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/datacatalog/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3839,7 +3759,7 @@ diff -urN a/googleapis/cloud/datacatalog/v1/BUILD.bazel b/googleapis/cloud/datac
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/datacatalog/v1beta1/BUILD.bazel b/googleapis/cloud/datacatalog/v1beta1/BUILD.bazel
---- a/googleapis/cloud/datacatalog/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/datacatalog/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/datacatalog/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3861,7 +3781,7 @@ diff -urN a/googleapis/cloud/datacatalog/v1beta1/BUILD.bazel b/googleapis/cloud/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/dataform/v1alpha2/BUILD.bazel b/googleapis/cloud/dataform/v1alpha2/BUILD.bazel
---- a/googleapis/cloud/dataform/v1alpha2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/dataform/v1alpha2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/dataform/v1alpha2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3883,7 +3803,7 @@ diff -urN a/googleapis/cloud/dataform/v1alpha2/BUILD.bazel b/googleapis/cloud/da
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/dataform/v1beta1/BUILD.bazel b/googleapis/cloud/dataform/v1beta1/BUILD.bazel
---- a/googleapis/cloud/dataform/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/dataform/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/dataform/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3905,7 +3825,7 @@ diff -urN a/googleapis/cloud/dataform/v1beta1/BUILD.bazel b/googleapis/cloud/dat
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/datafusion/v1/BUILD.bazel b/googleapis/cloud/datafusion/v1/BUILD.bazel
---- a/googleapis/cloud/datafusion/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/datafusion/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/datafusion/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3927,7 +3847,7 @@ diff -urN a/googleapis/cloud/datafusion/v1/BUILD.bazel b/googleapis/cloud/datafu
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/datafusion/v1beta1/BUILD.bazel b/googleapis/cloud/datafusion/v1beta1/BUILD.bazel
---- a/googleapis/cloud/datafusion/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/datafusion/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/datafusion/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3958,7 +3878,7 @@ diff -urN a/googleapis/cloud/datafusion/v1beta1/BUILD.bazel b/googleapis/cloud/d
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/datalabeling/v1beta1/BUILD.bazel b/googleapis/cloud/datalabeling/v1beta1/BUILD.bazel
---- a/googleapis/cloud/datalabeling/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/datalabeling/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/datalabeling/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3980,7 +3900,7 @@ diff -urN a/googleapis/cloud/datalabeling/v1beta1/BUILD.bazel b/googleapis/cloud
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/datapipelines/logging/v1/BUILD.bazel b/googleapis/cloud/datapipelines/logging/v1/BUILD.bazel
---- a/googleapis/cloud/datapipelines/logging/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/datapipelines/logging/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/datapipelines/logging/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4003,7 +3923,7 @@ diff -urN a/googleapis/cloud/datapipelines/logging/v1/BUILD.bazel b/googleapis/c
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/dataplex/v1/BUILD.bazel b/googleapis/cloud/dataplex/v1/BUILD.bazel
---- a/googleapis/cloud/dataplex/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/dataplex/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/dataplex/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4025,7 +3945,7 @@ diff -urN a/googleapis/cloud/dataplex/v1/BUILD.bazel b/googleapis/cloud/dataplex
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/dataproc/logging/BUILD.bazel b/googleapis/cloud/dataproc/logging/BUILD.bazel
---- a/googleapis/cloud/dataproc/logging/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/dataproc/logging/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/dataproc/logging/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4048,7 +3968,7 @@ diff -urN a/googleapis/cloud/dataproc/logging/BUILD.bazel b/googleapis/cloud/dat
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/dataproc/v1/BUILD.bazel b/googleapis/cloud/dataproc/v1/BUILD.bazel
---- a/googleapis/cloud/dataproc/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/dataproc/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/dataproc/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4070,7 +3990,7 @@ diff -urN a/googleapis/cloud/dataproc/v1/BUILD.bazel b/googleapis/cloud/dataproc
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/dataproc/v1beta2/BUILD.bazel b/googleapis/cloud/dataproc/v1beta2/BUILD.bazel
---- a/googleapis/cloud/dataproc/v1beta2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/dataproc/v1beta2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/dataproc/v1beta2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,34 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4108,7 +4028,7 @@ diff -urN a/googleapis/cloud/dataproc/v1beta2/BUILD.bazel b/googleapis/cloud/dat
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/dataqna/v1alpha/BUILD.bazel b/googleapis/cloud/dataqna/v1alpha/BUILD.bazel
---- a/googleapis/cloud/dataqna/v1alpha/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/dataqna/v1alpha/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/dataqna/v1alpha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4130,7 +4050,7 @@ diff -urN a/googleapis/cloud/dataqna/v1alpha/BUILD.bazel b/googleapis/cloud/data
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/datastream/logging/v1/BUILD.bazel b/googleapis/cloud/datastream/logging/v1/BUILD.bazel
---- a/googleapis/cloud/datastream/logging/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/datastream/logging/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/datastream/logging/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4152,7 +4072,7 @@ diff -urN a/googleapis/cloud/datastream/logging/v1/BUILD.bazel b/googleapis/clou
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/datastream/v1/BUILD.bazel b/googleapis/cloud/datastream/v1/BUILD.bazel
---- a/googleapis/cloud/datastream/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/datastream/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/datastream/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4174,7 +4094,7 @@ diff -urN a/googleapis/cloud/datastream/v1/BUILD.bazel b/googleapis/cloud/datast
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/datastream/v1alpha1/BUILD.bazel b/googleapis/cloud/datastream/v1alpha1/BUILD.bazel
---- a/googleapis/cloud/datastream/v1alpha1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/datastream/v1alpha1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/datastream/v1alpha1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4196,7 +4116,7 @@ diff -urN a/googleapis/cloud/datastream/v1alpha1/BUILD.bazel b/googleapis/cloud/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/deploy/v1/BUILD.bazel b/googleapis/cloud/deploy/v1/BUILD.bazel
---- a/googleapis/cloud/deploy/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/deploy/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/deploy/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4218,7 +4138,7 @@ diff -urN a/googleapis/cloud/deploy/v1/BUILD.bazel b/googleapis/cloud/deploy/v1/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/dialogflow/cx/v3/BUILD.bazel b/googleapis/cloud/dialogflow/cx/v3/BUILD.bazel
---- a/googleapis/cloud/dialogflow/cx/v3/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/dialogflow/cx/v3/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/dialogflow/cx/v3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4240,7 +4160,7 @@ diff -urN a/googleapis/cloud/dialogflow/cx/v3/BUILD.bazel b/googleapis/cloud/dia
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/dialogflow/cx/v3beta1/BUILD.bazel b/googleapis/cloud/dialogflow/cx/v3beta1/BUILD.bazel
---- a/googleapis/cloud/dialogflow/cx/v3beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/dialogflow/cx/v3beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/dialogflow/cx/v3beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4262,7 +4182,7 @@ diff -urN a/googleapis/cloud/dialogflow/cx/v3beta1/BUILD.bazel b/googleapis/clou
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/dialogflow/v2/BUILD.bazel b/googleapis/cloud/dialogflow/v2/BUILD.bazel
---- a/googleapis/cloud/dialogflow/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/dialogflow/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/dialogflow/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4284,53 +4204,19 @@ diff -urN a/googleapis/cloud/dialogflow/v2/BUILD.bazel b/googleapis/cloud/dialog
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/dialogflow/v2beta1/BUILD.bazel b/googleapis/cloud/dialogflow/v2beta1/BUILD.bazel
---- a/googleapis/cloud/dialogflow/v2beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/dialogflow/v2beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/dialogflow/v2beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,52 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
 +    name = "v2beta1",
-+    srcs = [
-+        "agent.pb.go",
-+        "answer_record.pb.go",
-+        "audio_config.pb.go",
-+        "context.pb.go",
-+        "conversation.pb.go",
-+        "conversation_event.pb.go",
-+        "conversation_profile.pb.go",
-+        "document.pb.go",
-+        "entity_type.pb.go",
-+        "environment.pb.go",
-+        "fulfillment.pb.go",
-+        "gcs.pb.go",
-+        "human_agent_assistant_event.pb.go",
-+        "intent.pb.go",
-+        "knowledge_base.pb.go",
-+        "participant.pb.go",
-+        "session.pb.go",
-+        "session_entity_type.pb.go",
-+        "validation_result.pb.go",
-+        "version.pb.go",
-+        "webhook.pb.go",
-+    ],
++    srcs = ["alias.go"],
 +    importpath = "google.golang.org/genproto/googleapis/cloud/dialogflow/v2beta1",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "//googleapis/api/annotations",
-+        "//googleapis/longrunning",
-+        "//googleapis/rpc/status",
-+        "//googleapis/type/latlng",
++        "@com_google_cloud_go_dialogflow//apiv2beta1/dialogflowpb:go_default_library",
 +        "@org_golang_google_grpc//:go_default_library",
-+        "@org_golang_google_grpc//codes:go_default_library",
-+        "@org_golang_google_grpc//status:go_default_library",
-+        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
-+        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
-+        "@org_golang_google_protobuf//types/known/durationpb:go_default_library",
-+        "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
-+        "@org_golang_google_protobuf//types/known/fieldmaskpb:go_default_library",
-+        "@org_golang_google_protobuf//types/known/structpb:go_default_library",
-+        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
 +    ],
 +)
 +
@@ -4339,52 +4225,10 @@ diff -urN a/googleapis/cloud/dialogflow/v2beta1/BUILD.bazel b/googleapis/cloud/d
 +    actual = ":v2beta1",
 +    visibility = ["//visibility:public"],
 +)
-diff -urN a/googleapis/cloud/discoveryengine/v1beta/BUILD.bazel b/googleapis/cloud/discoveryengine/v1beta/BUILD.bazel
---- a/googleapis/cloud/discoveryengine/v1beta/BUILD.bazel	1969-12-31 16:00:00
-+++ b/googleapis/cloud/discoveryengine/v1beta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,38 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "v1beta",
-+    srcs = [
-+        "common.pb.go",
-+        "document.pb.go",
-+        "document_service.pb.go",
-+        "import_config.pb.go",
-+        "recommendation_service.pb.go",
-+        "user_event.pb.go",
-+        "user_event_service.pb.go",
-+    ],
-+    importpath = "google.golang.org/genproto/googleapis/cloud/discoveryengine/v1beta",
-+    visibility = ["//visibility:public"],
-+    deps = [
-+        "//googleapis/api/annotations",
-+        "//googleapis/api/httpbody",
-+        "//googleapis/longrunning",
-+        "//googleapis/rpc/status",
-+        "//googleapis/type/date",
-+        "@org_golang_google_grpc//:go_default_library",
-+        "@org_golang_google_grpc//codes:go_default_library",
-+        "@org_golang_google_grpc//status:go_default_library",
-+        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
-+        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
-+        "@org_golang_google_protobuf//types/known/durationpb:go_default_library",
-+        "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
-+        "@org_golang_google_protobuf//types/known/structpb:go_default_library",
-+        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
-+    ],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":v1beta",
-+    visibility = ["//visibility:public"],
-+)
 diff -urN a/googleapis/cloud/documentai/v1/BUILD.bazel b/googleapis/cloud/documentai/v1/BUILD.bazel
---- a/googleapis/cloud/documentai/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/documentai/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/documentai/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -4392,7 +4236,10 @@ diff -urN a/googleapis/cloud/documentai/v1/BUILD.bazel b/googleapis/cloud/docume
 +    srcs = ["alias.go"],
 +    importpath = "google.golang.org/genproto/googleapis/cloud/documentai/v1",
 +    visibility = ["//visibility:public"],
-+    deps = ["@org_golang_google_grpc//:go_default_library"],
++    deps = [
++        "@com_google_cloud_go_documentai//apiv1/documentaipb:go_default_library",
++        "@org_golang_google_grpc//:go_default_library",
++    ],
 +)
 +
 +alias(
@@ -4401,7 +4248,7 @@ diff -urN a/googleapis/cloud/documentai/v1/BUILD.bazel b/googleapis/cloud/docume
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/documentai/v1beta1/BUILD.bazel b/googleapis/cloud/documentai/v1beta1/BUILD.bazel
---- a/googleapis/cloud/documentai/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/documentai/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/documentai/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4435,7 +4282,7 @@ diff -urN a/googleapis/cloud/documentai/v1beta1/BUILD.bazel b/googleapis/cloud/d
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/documentai/v1beta2/BUILD.bazel b/googleapis/cloud/documentai/v1beta2/BUILD.bazel
---- a/googleapis/cloud/documentai/v1beta2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/documentai/v1beta2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/documentai/v1beta2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4469,7 +4316,7 @@ diff -urN a/googleapis/cloud/documentai/v1beta2/BUILD.bazel b/googleapis/cloud/d
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/documentai/v1beta3/BUILD.bazel b/googleapis/cloud/documentai/v1beta3/BUILD.bazel
---- a/googleapis/cloud/documentai/v1beta3/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/documentai/v1beta3/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/documentai/v1beta3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4491,7 +4338,7 @@ diff -urN a/googleapis/cloud/documentai/v1beta3/BUILD.bazel b/googleapis/cloud/d
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/domains/v1/BUILD.bazel b/googleapis/cloud/domains/v1/BUILD.bazel
---- a/googleapis/cloud/domains/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/domains/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/domains/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4522,7 +4369,7 @@ diff -urN a/googleapis/cloud/domains/v1/BUILD.bazel b/googleapis/cloud/domains/v
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/domains/v1alpha2/BUILD.bazel b/googleapis/cloud/domains/v1alpha2/BUILD.bazel
---- a/googleapis/cloud/domains/v1alpha2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/domains/v1alpha2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/domains/v1alpha2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4553,7 +4400,7 @@ diff -urN a/googleapis/cloud/domains/v1alpha2/BUILD.bazel b/googleapis/cloud/dom
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/domains/v1beta1/BUILD.bazel b/googleapis/cloud/domains/v1beta1/BUILD.bazel
---- a/googleapis/cloud/domains/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/domains/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/domains/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4575,9 +4422,9 @@ diff -urN a/googleapis/cloud/domains/v1beta1/BUILD.bazel b/googleapis/cloud/doma
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/edgecontainer/v1/BUILD.bazel b/googleapis/cloud/edgecontainer/v1/BUILD.bazel
---- a/googleapis/cloud/edgecontainer/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/edgecontainer/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/edgecontainer/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -4585,7 +4432,10 @@ diff -urN a/googleapis/cloud/edgecontainer/v1/BUILD.bazel b/googleapis/cloud/edg
 +    srcs = ["alias.go"],
 +    importpath = "google.golang.org/genproto/googleapis/cloud/edgecontainer/v1",
 +    visibility = ["//visibility:public"],
-+    deps = ["@org_golang_google_grpc//:go_default_library"],
++    deps = [
++        "@com_google_cloud_go_edgecontainer//apiv1/edgecontainerpb:go_default_library",
++        "@org_golang_google_grpc//:go_default_library",
++    ],
 +)
 +
 +alias(
@@ -4594,7 +4444,7 @@ diff -urN a/googleapis/cloud/edgecontainer/v1/BUILD.bazel b/googleapis/cloud/edg
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/enterpriseknowledgegraph/v1/BUILD.bazel b/googleapis/cloud/enterpriseknowledgegraph/v1/BUILD.bazel
---- a/googleapis/cloud/enterpriseknowledgegraph/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/enterpriseknowledgegraph/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/enterpriseknowledgegraph/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4629,7 +4479,7 @@ diff -urN a/googleapis/cloud/enterpriseknowledgegraph/v1/BUILD.bazel b/googleapi
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/essentialcontacts/v1/BUILD.bazel b/googleapis/cloud/essentialcontacts/v1/BUILD.bazel
---- a/googleapis/cloud/essentialcontacts/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/essentialcontacts/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/essentialcontacts/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4651,7 +4501,7 @@ diff -urN a/googleapis/cloud/essentialcontacts/v1/BUILD.bazel b/googleapis/cloud
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/eventarc/publishing/v1/BUILD.bazel b/googleapis/cloud/eventarc/publishing/v1/BUILD.bazel
---- a/googleapis/cloud/eventarc/publishing/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/eventarc/publishing/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/eventarc/publishing/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4673,7 +4523,7 @@ diff -urN a/googleapis/cloud/eventarc/publishing/v1/BUILD.bazel b/googleapis/clo
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/eventarc/v1/BUILD.bazel b/googleapis/cloud/eventarc/v1/BUILD.bazel
---- a/googleapis/cloud/eventarc/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/eventarc/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/eventarc/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4695,7 +4545,7 @@ diff -urN a/googleapis/cloud/eventarc/v1/BUILD.bazel b/googleapis/cloud/eventarc
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/extendedops/BUILD.bazel b/googleapis/cloud/extendedops/BUILD.bazel
---- a/googleapis/cloud/extendedops/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/extendedops/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/extendedops/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4718,7 +4568,7 @@ diff -urN a/googleapis/cloud/extendedops/BUILD.bazel b/googleapis/cloud/extended
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/filestore/v1/BUILD.bazel b/googleapis/cloud/filestore/v1/BUILD.bazel
---- a/googleapis/cloud/filestore/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/filestore/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/filestore/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4740,7 +4590,7 @@ diff -urN a/googleapis/cloud/filestore/v1/BUILD.bazel b/googleapis/cloud/filesto
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/filestore/v1beta1/BUILD.bazel b/googleapis/cloud/filestore/v1beta1/BUILD.bazel
---- a/googleapis/cloud/filestore/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/filestore/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/filestore/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4771,7 +4621,7 @@ diff -urN a/googleapis/cloud/filestore/v1beta1/BUILD.bazel b/googleapis/cloud/fi
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/functions/v1/BUILD.bazel b/googleapis/cloud/functions/v1/BUILD.bazel
---- a/googleapis/cloud/functions/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/functions/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/functions/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4793,9 +4643,9 @@ diff -urN a/googleapis/cloud/functions/v1/BUILD.bazel b/googleapis/cloud/functio
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/functions/v1beta2/BUILD.bazel b/googleapis/cloud/functions/v1beta2/BUILD.bazel
---- a/googleapis/cloud/functions/v1beta2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/functions/v1beta2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/functions/v1beta2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -4810,6 +4660,7 @@ diff -urN a/googleapis/cloud/functions/v1beta2/BUILD.bazel b/googleapis/cloud/fu
 +        "//googleapis/api/annotations",
 +        "//googleapis/longrunning",
 +        "@com_github_golang_protobuf//proto:go_default_library",
++        "@com_github_golang_protobuf//ptypes/any:go_default_library",
 +        "@com_github_golang_protobuf//ptypes/duration:go_default_library",
 +        "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
 +        "@org_golang_google_grpc//:go_default_library",
@@ -4826,7 +4677,7 @@ diff -urN a/googleapis/cloud/functions/v1beta2/BUILD.bazel b/googleapis/cloud/fu
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/functions/v2/BUILD.bazel b/googleapis/cloud/functions/v2/BUILD.bazel
---- a/googleapis/cloud/functions/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/functions/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/functions/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4848,7 +4699,7 @@ diff -urN a/googleapis/cloud/functions/v2/BUILD.bazel b/googleapis/cloud/functio
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/functions/v2alpha/BUILD.bazel b/googleapis/cloud/functions/v2alpha/BUILD.bazel
---- a/googleapis/cloud/functions/v2alpha/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/functions/v2alpha/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/functions/v2alpha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4878,7 +4729,7 @@ diff -urN a/googleapis/cloud/functions/v2alpha/BUILD.bazel b/googleapis/cloud/fu
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/functions/v2beta/BUILD.bazel b/googleapis/cloud/functions/v2beta/BUILD.bazel
---- a/googleapis/cloud/functions/v2beta/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/functions/v2beta/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/functions/v2beta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4900,7 +4751,7 @@ diff -urN a/googleapis/cloud/functions/v2beta/BUILD.bazel b/googleapis/cloud/fun
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/gaming/allocationendpoint/v1alpha/BUILD.bazel b/googleapis/cloud/gaming/allocationendpoint/v1alpha/BUILD.bazel
---- a/googleapis/cloud/gaming/allocationendpoint/v1alpha/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/gaming/allocationendpoint/v1alpha/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/gaming/allocationendpoint/v1alpha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4926,7 +4777,7 @@ diff -urN a/googleapis/cloud/gaming/allocationendpoint/v1alpha/BUILD.bazel b/goo
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/gaming/v1/BUILD.bazel b/googleapis/cloud/gaming/v1/BUILD.bazel
---- a/googleapis/cloud/gaming/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/gaming/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/gaming/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4948,7 +4799,7 @@ diff -urN a/googleapis/cloud/gaming/v1/BUILD.bazel b/googleapis/cloud/gaming/v1/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/gaming/v1beta/BUILD.bazel b/googleapis/cloud/gaming/v1beta/BUILD.bazel
---- a/googleapis/cloud/gaming/v1beta/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/gaming/v1beta/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/gaming/v1beta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4970,7 +4821,7 @@ diff -urN a/googleapis/cloud/gaming/v1beta/BUILD.bazel b/googleapis/cloud/gaming
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/gkebackup/logging/v1/BUILD.bazel b/googleapis/cloud/gkebackup/logging/v1/BUILD.bazel
---- a/googleapis/cloud/gkebackup/logging/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/gkebackup/logging/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/gkebackup/logging/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5001,7 +4852,7 @@ diff -urN a/googleapis/cloud/gkebackup/logging/v1/BUILD.bazel b/googleapis/cloud
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/gkebackup/v1/BUILD.bazel b/googleapis/cloud/gkebackup/v1/BUILD.bazel
---- a/googleapis/cloud/gkebackup/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/gkebackup/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/gkebackup/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5023,7 +4874,7 @@ diff -urN a/googleapis/cloud/gkebackup/v1/BUILD.bazel b/googleapis/cloud/gkeback
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/gkeconnect/gateway/v1/BUILD.bazel b/googleapis/cloud/gkeconnect/gateway/v1/BUILD.bazel
---- a/googleapis/cloud/gkeconnect/gateway/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/gkeconnect/gateway/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/gkeconnect/gateway/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5047,7 +4898,7 @@ diff -urN a/googleapis/cloud/gkeconnect/gateway/v1/BUILD.bazel b/googleapis/clou
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/gkeconnect/gateway/v1alpha1/BUILD.bazel b/googleapis/cloud/gkeconnect/gateway/v1alpha1/BUILD.bazel
---- a/googleapis/cloud/gkeconnect/gateway/v1alpha1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/gkeconnect/gateway/v1alpha1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/gkeconnect/gateway/v1alpha1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5071,7 +4922,7 @@ diff -urN a/googleapis/cloud/gkeconnect/gateway/v1alpha1/BUILD.bazel b/googleapi
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/gkeconnect/gateway/v1beta1/BUILD.bazel b/googleapis/cloud/gkeconnect/gateway/v1beta1/BUILD.bazel
---- a/googleapis/cloud/gkeconnect/gateway/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/gkeconnect/gateway/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/gkeconnect/gateway/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5093,7 +4944,7 @@ diff -urN a/googleapis/cloud/gkeconnect/gateway/v1beta1/BUILD.bazel b/googleapis
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/gkehub/cloudauditlogging/v1alpha/BUILD.bazel b/googleapis/cloud/gkehub/cloudauditlogging/v1alpha/BUILD.bazel
---- a/googleapis/cloud/gkehub/cloudauditlogging/v1alpha/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/gkehub/cloudauditlogging/v1alpha/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/gkehub/cloudauditlogging/v1alpha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5115,7 +4966,7 @@ diff -urN a/googleapis/cloud/gkehub/cloudauditlogging/v1alpha/BUILD.bazel b/goog
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/gkehub/configmanagement/v1/BUILD.bazel b/googleapis/cloud/gkehub/configmanagement/v1/BUILD.bazel
---- a/googleapis/cloud/gkehub/configmanagement/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/gkehub/configmanagement/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/gkehub/configmanagement/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5138,7 +4989,7 @@ diff -urN a/googleapis/cloud/gkehub/configmanagement/v1/BUILD.bazel b/googleapis
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/gkehub/configmanagement/v1alpha/BUILD.bazel b/googleapis/cloud/gkehub/configmanagement/v1alpha/BUILD.bazel
---- a/googleapis/cloud/gkehub/configmanagement/v1alpha/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/gkehub/configmanagement/v1alpha/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/gkehub/configmanagement/v1alpha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5161,7 +5012,7 @@ diff -urN a/googleapis/cloud/gkehub/configmanagement/v1alpha/BUILD.bazel b/googl
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/gkehub/configmanagement/v1beta/BUILD.bazel b/googleapis/cloud/gkehub/configmanagement/v1beta/BUILD.bazel
---- a/googleapis/cloud/gkehub/configmanagement/v1beta/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/gkehub/configmanagement/v1beta/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/gkehub/configmanagement/v1beta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5184,7 +5035,7 @@ diff -urN a/googleapis/cloud/gkehub/configmanagement/v1beta/BUILD.bazel b/google
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/gkehub/metering/v1alpha/BUILD.bazel b/googleapis/cloud/gkehub/metering/v1alpha/BUILD.bazel
---- a/googleapis/cloud/gkehub/metering/v1alpha/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/gkehub/metering/v1alpha/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/gkehub/metering/v1alpha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5207,7 +5058,7 @@ diff -urN a/googleapis/cloud/gkehub/metering/v1alpha/BUILD.bazel b/googleapis/cl
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/gkehub/metering/v1beta/BUILD.bazel b/googleapis/cloud/gkehub/metering/v1beta/BUILD.bazel
---- a/googleapis/cloud/gkehub/metering/v1beta/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/gkehub/metering/v1beta/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/gkehub/metering/v1beta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5230,7 +5081,7 @@ diff -urN a/googleapis/cloud/gkehub/metering/v1beta/BUILD.bazel b/googleapis/clo
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/gkehub/multiclusteringress/v1/BUILD.bazel b/googleapis/cloud/gkehub/multiclusteringress/v1/BUILD.bazel
---- a/googleapis/cloud/gkehub/multiclusteringress/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/gkehub/multiclusteringress/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/gkehub/multiclusteringress/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5252,7 +5103,7 @@ diff -urN a/googleapis/cloud/gkehub/multiclusteringress/v1/BUILD.bazel b/googlea
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/gkehub/multiclusteringress/v1alpha/BUILD.bazel b/googleapis/cloud/gkehub/multiclusteringress/v1alpha/BUILD.bazel
---- a/googleapis/cloud/gkehub/multiclusteringress/v1alpha/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/gkehub/multiclusteringress/v1alpha/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/gkehub/multiclusteringress/v1alpha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5274,7 +5125,7 @@ diff -urN a/googleapis/cloud/gkehub/multiclusteringress/v1alpha/BUILD.bazel b/go
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/gkehub/multiclusteringress/v1beta/BUILD.bazel b/googleapis/cloud/gkehub/multiclusteringress/v1beta/BUILD.bazel
---- a/googleapis/cloud/gkehub/multiclusteringress/v1beta/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/gkehub/multiclusteringress/v1beta/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/gkehub/multiclusteringress/v1beta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5296,7 +5147,7 @@ diff -urN a/googleapis/cloud/gkehub/multiclusteringress/v1beta/BUILD.bazel b/goo
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/gkehub/servicemesh/v1alpha/BUILD.bazel b/googleapis/cloud/gkehub/servicemesh/v1alpha/BUILD.bazel
---- a/googleapis/cloud/gkehub/servicemesh/v1alpha/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/gkehub/servicemesh/v1alpha/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/gkehub/servicemesh/v1alpha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5320,7 +5171,7 @@ diff -urN a/googleapis/cloud/gkehub/servicemesh/v1alpha/BUILD.bazel b/googleapis
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/gkehub/v1/BUILD.bazel b/googleapis/cloud/gkehub/v1/BUILD.bazel
---- a/googleapis/cloud/gkehub/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/gkehub/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/gkehub/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5355,7 +5206,7 @@ diff -urN a/googleapis/cloud/gkehub/v1/BUILD.bazel b/googleapis/cloud/gkehub/v1/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/gkehub/v1alpha/BUILD.bazel b/googleapis/cloud/gkehub/v1alpha/BUILD.bazel
---- a/googleapis/cloud/gkehub/v1alpha/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/gkehub/v1alpha/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/gkehub/v1alpha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5392,7 +5243,7 @@ diff -urN a/googleapis/cloud/gkehub/v1alpha/BUILD.bazel b/googleapis/cloud/gkehu
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/gkehub/v1alpha2/BUILD.bazel b/googleapis/cloud/gkehub/v1alpha2/BUILD.bazel
---- a/googleapis/cloud/gkehub/v1alpha2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/gkehub/v1alpha2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/gkehub/v1alpha2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5421,7 +5272,7 @@ diff -urN a/googleapis/cloud/gkehub/v1alpha2/BUILD.bazel b/googleapis/cloud/gkeh
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/gkehub/v1beta/BUILD.bazel b/googleapis/cloud/gkehub/v1beta/BUILD.bazel
---- a/googleapis/cloud/gkehub/v1beta/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/gkehub/v1beta/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/gkehub/v1beta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5456,7 +5307,7 @@ diff -urN a/googleapis/cloud/gkehub/v1beta/BUILD.bazel b/googleapis/cloud/gkehub
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/gkehub/v1beta1/BUILD.bazel b/googleapis/cloud/gkehub/v1beta1/BUILD.bazel
---- a/googleapis/cloud/gkehub/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/gkehub/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/gkehub/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5478,7 +5329,7 @@ diff -urN a/googleapis/cloud/gkehub/v1beta1/BUILD.bazel b/googleapis/cloud/gkehu
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/gkemulticloud/v1/BUILD.bazel b/googleapis/cloud/gkemulticloud/v1/BUILD.bazel
---- a/googleapis/cloud/gkemulticloud/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/gkemulticloud/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/gkemulticloud/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5500,7 +5351,7 @@ diff -urN a/googleapis/cloud/gkemulticloud/v1/BUILD.bazel b/googleapis/cloud/gke
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/gsuiteaddons/logging/v1/BUILD.bazel b/googleapis/cloud/gsuiteaddons/logging/v1/BUILD.bazel
---- a/googleapis/cloud/gsuiteaddons/logging/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/gsuiteaddons/logging/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/gsuiteaddons/logging/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5523,7 +5374,7 @@ diff -urN a/googleapis/cloud/gsuiteaddons/logging/v1/BUILD.bazel b/googleapis/cl
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/gsuiteaddons/v1/BUILD.bazel b/googleapis/cloud/gsuiteaddons/v1/BUILD.bazel
---- a/googleapis/cloud/gsuiteaddons/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/gsuiteaddons/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/gsuiteaddons/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5545,7 +5396,7 @@ diff -urN a/googleapis/cloud/gsuiteaddons/v1/BUILD.bazel b/googleapis/cloud/gsui
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/healthcare/logging/BUILD.bazel b/googleapis/cloud/healthcare/logging/BUILD.bazel
---- a/googleapis/cloud/healthcare/logging/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/healthcare/logging/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/healthcare/logging/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5575,7 +5426,7 @@ diff -urN a/googleapis/cloud/healthcare/logging/BUILD.bazel b/googleapis/cloud/h
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/iap/v1/BUILD.bazel b/googleapis/cloud/iap/v1/BUILD.bazel
---- a/googleapis/cloud/iap/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/iap/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/iap/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5597,7 +5448,7 @@ diff -urN a/googleapis/cloud/iap/v1/BUILD.bazel b/googleapis/cloud/iap/v1/BUILD.
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/iap/v1beta1/BUILD.bazel b/googleapis/cloud/iap/v1beta1/BUILD.bazel
---- a/googleapis/cloud/iap/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/iap/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/iap/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5624,7 +5475,7 @@ diff -urN a/googleapis/cloud/iap/v1beta1/BUILD.bazel b/googleapis/cloud/iap/v1be
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/identitytoolkit/logging/BUILD.bazel b/googleapis/cloud/identitytoolkit/logging/BUILD.bazel
---- a/googleapis/cloud/identitytoolkit/logging/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/identitytoolkit/logging/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/identitytoolkit/logging/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5648,7 +5499,7 @@ diff -urN a/googleapis/cloud/identitytoolkit/logging/BUILD.bazel b/googleapis/cl
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/identitytoolkit/v2/BUILD.bazel b/googleapis/cloud/identitytoolkit/v2/BUILD.bazel
---- a/googleapis/cloud/identitytoolkit/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/identitytoolkit/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/identitytoolkit/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5679,7 +5530,7 @@ diff -urN a/googleapis/cloud/identitytoolkit/v2/BUILD.bazel b/googleapis/cloud/i
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/ids/logging/v1/BUILD.bazel b/googleapis/cloud/ids/logging/v1/BUILD.bazel
---- a/googleapis/cloud/ids/logging/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/ids/logging/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/ids/logging/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5703,7 +5554,7 @@ diff -urN a/googleapis/cloud/ids/logging/v1/BUILD.bazel b/googleapis/cloud/ids/l
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/ids/v1/BUILD.bazel b/googleapis/cloud/ids/v1/BUILD.bazel
---- a/googleapis/cloud/ids/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/ids/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/ids/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5725,7 +5576,7 @@ diff -urN a/googleapis/cloud/ids/v1/BUILD.bazel b/googleapis/cloud/ids/v1/BUILD.
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/integrations/v1alpha/BUILD.bazel b/googleapis/cloud/integrations/v1alpha/BUILD.bazel
---- a/googleapis/cloud/integrations/v1alpha/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/integrations/v1alpha/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/integrations/v1alpha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5756,7 +5607,7 @@ diff -urN a/googleapis/cloud/integrations/v1alpha/BUILD.bazel b/googleapis/cloud
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/iot/v1/BUILD.bazel b/googleapis/cloud/iot/v1/BUILD.bazel
---- a/googleapis/cloud/iot/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/iot/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/iot/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5778,7 +5629,7 @@ diff -urN a/googleapis/cloud/iot/v1/BUILD.bazel b/googleapis/cloud/iot/v1/BUILD.
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/irm/v1alpha2/BUILD.bazel b/googleapis/cloud/irm/v1alpha2/BUILD.bazel
---- a/googleapis/cloud/irm/v1alpha2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/irm/v1alpha2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/irm/v1alpha2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,29 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5811,7 +5662,7 @@ diff -urN a/googleapis/cloud/irm/v1alpha2/BUILD.bazel b/googleapis/cloud/irm/v1a
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/kms/v1/BUILD.bazel b/googleapis/cloud/kms/v1/BUILD.bazel
---- a/googleapis/cloud/kms/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/kms/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/kms/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5833,7 +5684,7 @@ diff -urN a/googleapis/cloud/kms/v1/BUILD.bazel b/googleapis/cloud/kms/v1/BUILD.
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/kubernetes/security/containersecurity_logging/BUILD.bazel b/googleapis/cloud/kubernetes/security/containersecurity_logging/BUILD.bazel
---- a/googleapis/cloud/kubernetes/security/containersecurity_logging/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/kubernetes/security/containersecurity_logging/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/kubernetes/security/containersecurity_logging/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5856,7 +5707,7 @@ diff -urN a/googleapis/cloud/kubernetes/security/containersecurity_logging/BUILD
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/language/v1/BUILD.bazel b/googleapis/cloud/language/v1/BUILD.bazel
---- a/googleapis/cloud/language/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/language/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/language/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5878,7 +5729,7 @@ diff -urN a/googleapis/cloud/language/v1/BUILD.bazel b/googleapis/cloud/language
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/language/v1beta1/BUILD.bazel b/googleapis/cloud/language/v1beta1/BUILD.bazel
---- a/googleapis/cloud/language/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/language/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/language/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5904,7 +5755,7 @@ diff -urN a/googleapis/cloud/language/v1beta1/BUILD.bazel b/googleapis/cloud/lan
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/language/v1beta2/BUILD.bazel b/googleapis/cloud/language/v1beta2/BUILD.bazel
---- a/googleapis/cloud/language/v1beta2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/language/v1beta2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/language/v1beta2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5926,7 +5777,7 @@ diff -urN a/googleapis/cloud/language/v1beta2/BUILD.bazel b/googleapis/cloud/lan
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/lifesciences/v2beta/BUILD.bazel b/googleapis/cloud/lifesciences/v2beta/BUILD.bazel
---- a/googleapis/cloud/lifesciences/v2beta/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/lifesciences/v2beta/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/lifesciences/v2beta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5948,7 +5799,7 @@ diff -urN a/googleapis/cloud/lifesciences/v2beta/BUILD.bazel b/googleapis/cloud/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/location/BUILD.bazel b/googleapis/cloud/location/BUILD.bazel
---- a/googleapis/cloud/location/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/location/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/location/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5975,7 +5826,7 @@ diff -urN a/googleapis/cloud/location/BUILD.bazel b/googleapis/cloud/location/BU
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/managedidentities/v1/BUILD.bazel b/googleapis/cloud/managedidentities/v1/BUILD.bazel
---- a/googleapis/cloud/managedidentities/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/managedidentities/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/managedidentities/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5997,7 +5848,7 @@ diff -urN a/googleapis/cloud/managedidentities/v1/BUILD.bazel b/googleapis/cloud
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/managedidentities/v1beta1/BUILD.bazel b/googleapis/cloud/managedidentities/v1beta1/BUILD.bazel
---- a/googleapis/cloud/managedidentities/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/managedidentities/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/managedidentities/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6029,7 +5880,7 @@ diff -urN a/googleapis/cloud/managedidentities/v1beta1/BUILD.bazel b/googleapis/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/mediatranslation/v1alpha1/BUILD.bazel b/googleapis/cloud/mediatranslation/v1alpha1/BUILD.bazel
---- a/googleapis/cloud/mediatranslation/v1alpha1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/mediatranslation/v1alpha1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/mediatranslation/v1alpha1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6056,7 +5907,7 @@ diff -urN a/googleapis/cloud/mediatranslation/v1alpha1/BUILD.bazel b/googleapis/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/mediatranslation/v1beta1/BUILD.bazel b/googleapis/cloud/mediatranslation/v1beta1/BUILD.bazel
---- a/googleapis/cloud/mediatranslation/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/mediatranslation/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/mediatranslation/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6078,7 +5929,7 @@ diff -urN a/googleapis/cloud/mediatranslation/v1beta1/BUILD.bazel b/googleapis/c
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/memcache/v1/BUILD.bazel b/googleapis/cloud/memcache/v1/BUILD.bazel
---- a/googleapis/cloud/memcache/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/memcache/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/memcache/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6100,7 +5951,7 @@ diff -urN a/googleapis/cloud/memcache/v1/BUILD.bazel b/googleapis/cloud/memcache
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/memcache/v1beta2/BUILD.bazel b/googleapis/cloud/memcache/v1beta2/BUILD.bazel
---- a/googleapis/cloud/memcache/v1beta2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/memcache/v1beta2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/memcache/v1beta2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6122,7 +5973,7 @@ diff -urN a/googleapis/cloud/memcache/v1beta2/BUILD.bazel b/googleapis/cloud/mem
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/metastore/logging/v1/BUILD.bazel b/googleapis/cloud/metastore/logging/v1/BUILD.bazel
---- a/googleapis/cloud/metastore/logging/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/metastore/logging/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/metastore/logging/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6144,7 +5995,7 @@ diff -urN a/googleapis/cloud/metastore/logging/v1/BUILD.bazel b/googleapis/cloud
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/metastore/v1/BUILD.bazel b/googleapis/cloud/metastore/v1/BUILD.bazel
---- a/googleapis/cloud/metastore/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/metastore/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/metastore/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6166,7 +6017,7 @@ diff -urN a/googleapis/cloud/metastore/v1/BUILD.bazel b/googleapis/cloud/metasto
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/metastore/v1alpha/BUILD.bazel b/googleapis/cloud/metastore/v1alpha/BUILD.bazel
---- a/googleapis/cloud/metastore/v1alpha/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/metastore/v1alpha/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/metastore/v1alpha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6188,7 +6039,7 @@ diff -urN a/googleapis/cloud/metastore/v1alpha/BUILD.bazel b/googleapis/cloud/me
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/metastore/v1beta/BUILD.bazel b/googleapis/cloud/metastore/v1beta/BUILD.bazel
---- a/googleapis/cloud/metastore/v1beta/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/metastore/v1beta/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/metastore/v1beta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6210,7 +6061,7 @@ diff -urN a/googleapis/cloud/metastore/v1beta/BUILD.bazel b/googleapis/cloud/met
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/ml/v1/BUILD.bazel b/googleapis/cloud/ml/v1/BUILD.bazel
---- a/googleapis/cloud/ml/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/ml/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/ml/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6247,7 +6098,7 @@ diff -urN a/googleapis/cloud/ml/v1/BUILD.bazel b/googleapis/cloud/ml/v1/BUILD.ba
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/networkanalyzer/logging/v1/BUILD.bazel b/googleapis/cloud/networkanalyzer/logging/v1/BUILD.bazel
---- a/googleapis/cloud/networkanalyzer/logging/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/networkanalyzer/logging/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/networkanalyzer/logging/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6270,7 +6121,7 @@ diff -urN a/googleapis/cloud/networkanalyzer/logging/v1/BUILD.bazel b/googleapis
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/networkconnectivity/v1/BUILD.bazel b/googleapis/cloud/networkconnectivity/v1/BUILD.bazel
---- a/googleapis/cloud/networkconnectivity/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/networkconnectivity/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/networkconnectivity/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6292,7 +6143,7 @@ diff -urN a/googleapis/cloud/networkconnectivity/v1/BUILD.bazel b/googleapis/clo
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/networkconnectivity/v1alpha1/BUILD.bazel b/googleapis/cloud/networkconnectivity/v1alpha1/BUILD.bazel
---- a/googleapis/cloud/networkconnectivity/v1alpha1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/networkconnectivity/v1alpha1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/networkconnectivity/v1alpha1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6314,7 +6165,7 @@ diff -urN a/googleapis/cloud/networkconnectivity/v1alpha1/BUILD.bazel b/googleap
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/networkmanagement/v1/BUILD.bazel b/googleapis/cloud/networkmanagement/v1/BUILD.bazel
---- a/googleapis/cloud/networkmanagement/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/networkmanagement/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/networkmanagement/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6336,7 +6187,7 @@ diff -urN a/googleapis/cloud/networkmanagement/v1/BUILD.bazel b/googleapis/cloud
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/networkmanagement/v1beta1/BUILD.bazel b/googleapis/cloud/networkmanagement/v1beta1/BUILD.bazel
---- a/googleapis/cloud/networkmanagement/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/networkmanagement/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/networkmanagement/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6370,7 +6221,7 @@ diff -urN a/googleapis/cloud/networkmanagement/v1beta1/BUILD.bazel b/googleapis/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/networksecurity/v1/BUILD.bazel b/googleapis/cloud/networksecurity/v1/BUILD.bazel
---- a/googleapis/cloud/networksecurity/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/networksecurity/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/networksecurity/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,32 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6406,7 +6257,7 @@ diff -urN a/googleapis/cloud/networksecurity/v1/BUILD.bazel b/googleapis/cloud/n
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/networksecurity/v1beta1/BUILD.bazel b/googleapis/cloud/networksecurity/v1beta1/BUILD.bazel
---- a/googleapis/cloud/networksecurity/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/networksecurity/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/networksecurity/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6428,7 +6279,7 @@ diff -urN a/googleapis/cloud/networksecurity/v1beta1/BUILD.bazel b/googleapis/cl
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/networkservices/v1/BUILD.bazel b/googleapis/cloud/networkservices/v1/BUILD.bazel
---- a/googleapis/cloud/networkservices/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/networkservices/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/networkservices/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,37 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6469,7 +6320,7 @@ diff -urN a/googleapis/cloud/networkservices/v1/BUILD.bazel b/googleapis/cloud/n
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/networkservices/v1beta1/BUILD.bazel b/googleapis/cloud/networkservices/v1beta1/BUILD.bazel
---- a/googleapis/cloud/networkservices/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/networkservices/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/networkservices/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,29 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6502,7 +6353,7 @@ diff -urN a/googleapis/cloud/networkservices/v1beta1/BUILD.bazel b/googleapis/cl
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/notebooks/logging/v1/BUILD.bazel b/googleapis/cloud/notebooks/logging/v1/BUILD.bazel
---- a/googleapis/cloud/notebooks/logging/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/notebooks/logging/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/notebooks/logging/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6525,7 +6376,7 @@ diff -urN a/googleapis/cloud/notebooks/logging/v1/BUILD.bazel b/googleapis/cloud
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/notebooks/v1/BUILD.bazel b/googleapis/cloud/notebooks/v1/BUILD.bazel
---- a/googleapis/cloud/notebooks/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/notebooks/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/notebooks/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6547,7 +6398,7 @@ diff -urN a/googleapis/cloud/notebooks/v1/BUILD.bazel b/googleapis/cloud/noteboo
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/notebooks/v1beta1/BUILD.bazel b/googleapis/cloud/notebooks/v1beta1/BUILD.bazel
---- a/googleapis/cloud/notebooks/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/notebooks/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/notebooks/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6569,7 +6420,7 @@ diff -urN a/googleapis/cloud/notebooks/v1beta1/BUILD.bazel b/googleapis/cloud/no
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/optimization/v1/BUILD.bazel b/googleapis/cloud/optimization/v1/BUILD.bazel
---- a/googleapis/cloud/optimization/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/optimization/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/optimization/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6591,7 +6442,7 @@ diff -urN a/googleapis/cloud/optimization/v1/BUILD.bazel b/googleapis/cloud/opti
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/orchestration/airflow/service/v1/BUILD.bazel b/googleapis/cloud/orchestration/airflow/service/v1/BUILD.bazel
---- a/googleapis/cloud/orchestration/airflow/service/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/orchestration/airflow/service/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/orchestration/airflow/service/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6613,7 +6464,7 @@ diff -urN a/googleapis/cloud/orchestration/airflow/service/v1/BUILD.bazel b/goog
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/orchestration/airflow/service/v1beta1/BUILD.bazel b/googleapis/cloud/orchestration/airflow/service/v1beta1/BUILD.bazel
---- a/googleapis/cloud/orchestration/airflow/service/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/orchestration/airflow/service/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/orchestration/airflow/service/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6647,7 +6498,7 @@ diff -urN a/googleapis/cloud/orchestration/airflow/service/v1beta1/BUILD.bazel b
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/orgpolicy/v1/BUILD.bazel b/googleapis/cloud/orgpolicy/v1/BUILD.bazel
---- a/googleapis/cloud/orgpolicy/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/orgpolicy/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/orgpolicy/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6670,7 +6521,7 @@ diff -urN a/googleapis/cloud/orgpolicy/v1/BUILD.bazel b/googleapis/cloud/orgpoli
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/orgpolicy/v2/BUILD.bazel b/googleapis/cloud/orgpolicy/v2/BUILD.bazel
---- a/googleapis/cloud/orgpolicy/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/orgpolicy/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/orgpolicy/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6692,7 +6543,7 @@ diff -urN a/googleapis/cloud/orgpolicy/v2/BUILD.bazel b/googleapis/cloud/orgpoli
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/osconfig/agentendpoint/v1/BUILD.bazel b/googleapis/cloud/osconfig/agentendpoint/v1/BUILD.bazel
---- a/googleapis/cloud/osconfig/agentendpoint/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/osconfig/agentendpoint/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/osconfig/agentendpoint/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6714,7 +6565,7 @@ diff -urN a/googleapis/cloud/osconfig/agentendpoint/v1/BUILD.bazel b/googleapis/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/osconfig/agentendpoint/v1beta/BUILD.bazel b/googleapis/cloud/osconfig/agentendpoint/v1beta/BUILD.bazel
---- a/googleapis/cloud/osconfig/agentendpoint/v1beta/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/osconfig/agentendpoint/v1beta/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/osconfig/agentendpoint/v1beta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6736,7 +6587,7 @@ diff -urN a/googleapis/cloud/osconfig/agentendpoint/v1beta/BUILD.bazel b/googlea
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/osconfig/logging/BUILD.bazel b/googleapis/cloud/osconfig/logging/BUILD.bazel
---- a/googleapis/cloud/osconfig/logging/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/osconfig/logging/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/osconfig/logging/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6759,7 +6610,7 @@ diff -urN a/googleapis/cloud/osconfig/logging/BUILD.bazel b/googleapis/cloud/osc
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/osconfig/v1/BUILD.bazel b/googleapis/cloud/osconfig/v1/BUILD.bazel
---- a/googleapis/cloud/osconfig/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/osconfig/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/osconfig/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6781,7 +6632,7 @@ diff -urN a/googleapis/cloud/osconfig/v1/BUILD.bazel b/googleapis/cloud/osconfig
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/osconfig/v1alpha/BUILD.bazel b/googleapis/cloud/osconfig/v1alpha/BUILD.bazel
---- a/googleapis/cloud/osconfig/v1alpha/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/osconfig/v1alpha/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/osconfig/v1alpha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6803,7 +6654,7 @@ diff -urN a/googleapis/cloud/osconfig/v1alpha/BUILD.bazel b/googleapis/cloud/osc
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/osconfig/v1beta/BUILD.bazel b/googleapis/cloud/osconfig/v1beta/BUILD.bazel
---- a/googleapis/cloud/osconfig/v1beta/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/osconfig/v1beta/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/osconfig/v1beta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6825,7 +6676,7 @@ diff -urN a/googleapis/cloud/osconfig/v1beta/BUILD.bazel b/googleapis/cloud/osco
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/oslogin/common/BUILD.bazel b/googleapis/cloud/oslogin/common/BUILD.bazel
---- a/googleapis/cloud/oslogin/common/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/oslogin/common/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/oslogin/common/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6848,7 +6699,7 @@ diff -urN a/googleapis/cloud/oslogin/common/BUILD.bazel b/googleapis/cloud/oslog
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/oslogin/v1/BUILD.bazel b/googleapis/cloud/oslogin/v1/BUILD.bazel
---- a/googleapis/cloud/oslogin/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/oslogin/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/oslogin/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6870,7 +6721,7 @@ diff -urN a/googleapis/cloud/oslogin/v1/BUILD.bazel b/googleapis/cloud/oslogin/v
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/oslogin/v1alpha/BUILD.bazel b/googleapis/cloud/oslogin/v1alpha/BUILD.bazel
---- a/googleapis/cloud/oslogin/v1alpha/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/oslogin/v1alpha/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/oslogin/v1alpha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6899,7 +6750,7 @@ diff -urN a/googleapis/cloud/oslogin/v1alpha/BUILD.bazel b/googleapis/cloud/oslo
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/oslogin/v1beta/BUILD.bazel b/googleapis/cloud/oslogin/v1beta/BUILD.bazel
---- a/googleapis/cloud/oslogin/v1beta/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/oslogin/v1beta/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/oslogin/v1beta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6921,9 +6772,9 @@ diff -urN a/googleapis/cloud/oslogin/v1beta/BUILD.bazel b/googleapis/cloud/oslog
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/paymentgateway/issuerswitch/v1/BUILD.bazel b/googleapis/cloud/paymentgateway/issuerswitch/v1/BUILD.bazel
---- a/googleapis/cloud/paymentgateway/issuerswitch/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/paymentgateway/issuerswitch/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/paymentgateway/issuerswitch/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -6942,6 +6793,7 @@ diff -urN a/googleapis/cloud/paymentgateway/issuerswitch/v1/BUILD.bazel b/google
 +        "//googleapis/logging/type",
 +        "//googleapis/longrunning",
 +        "//googleapis/type/date",
++        "//googleapis/type/latlng",
 +        "//googleapis/type/money",
 +        "@org_golang_google_grpc//:go_default_library",
 +        "@org_golang_google_grpc//codes:go_default_library",
@@ -6959,7 +6811,7 @@ diff -urN a/googleapis/cloud/paymentgateway/issuerswitch/v1/BUILD.bazel b/google
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/phishingprotection/v1beta1/BUILD.bazel b/googleapis/cloud/phishingprotection/v1beta1/BUILD.bazel
---- a/googleapis/cloud/phishingprotection/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/phishingprotection/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/phishingprotection/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6981,7 +6833,7 @@ diff -urN a/googleapis/cloud/phishingprotection/v1beta1/BUILD.bazel b/googleapis
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/policytroubleshooter/v1/BUILD.bazel b/googleapis/cloud/policytroubleshooter/v1/BUILD.bazel
---- a/googleapis/cloud/policytroubleshooter/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/policytroubleshooter/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/policytroubleshooter/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7003,7 +6855,7 @@ diff -urN a/googleapis/cloud/policytroubleshooter/v1/BUILD.bazel b/googleapis/cl
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/privatecatalog/v1beta1/BUILD.bazel b/googleapis/cloud/privatecatalog/v1beta1/BUILD.bazel
---- a/googleapis/cloud/privatecatalog/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/privatecatalog/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/privatecatalog/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7025,7 +6877,7 @@ diff -urN a/googleapis/cloud/privatecatalog/v1beta1/BUILD.bazel b/googleapis/clo
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/pubsublite/v1/BUILD.bazel b/googleapis/cloud/pubsublite/v1/BUILD.bazel
---- a/googleapis/cloud/pubsublite/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/pubsublite/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/pubsublite/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7047,7 +6899,7 @@ diff -urN a/googleapis/cloud/pubsublite/v1/BUILD.bazel b/googleapis/cloud/pubsub
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/recaptchaenterprise/v1/BUILD.bazel b/googleapis/cloud/recaptchaenterprise/v1/BUILD.bazel
---- a/googleapis/cloud/recaptchaenterprise/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/recaptchaenterprise/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/recaptchaenterprise/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7069,7 +6921,7 @@ diff -urN a/googleapis/cloud/recaptchaenterprise/v1/BUILD.bazel b/googleapis/clo
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/recaptchaenterprise/v1beta1/BUILD.bazel b/googleapis/cloud/recaptchaenterprise/v1beta1/BUILD.bazel
---- a/googleapis/cloud/recaptchaenterprise/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/recaptchaenterprise/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/recaptchaenterprise/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7091,7 +6943,7 @@ diff -urN a/googleapis/cloud/recaptchaenterprise/v1beta1/BUILD.bazel b/googleapi
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/recommendationengine/v1beta1/BUILD.bazel b/googleapis/cloud/recommendationengine/v1beta1/BUILD.bazel
---- a/googleapis/cloud/recommendationengine/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/recommendationengine/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/recommendationengine/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7113,7 +6965,7 @@ diff -urN a/googleapis/cloud/recommendationengine/v1beta1/BUILD.bazel b/googleap
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/recommender/logging/v1/BUILD.bazel b/googleapis/cloud/recommender/logging/v1/BUILD.bazel
---- a/googleapis/cloud/recommender/logging/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/recommender/logging/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/recommender/logging/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7137,7 +6989,7 @@ diff -urN a/googleapis/cloud/recommender/logging/v1/BUILD.bazel b/googleapis/clo
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/recommender/logging/v1beta1/BUILD.bazel b/googleapis/cloud/recommender/logging/v1beta1/BUILD.bazel
---- a/googleapis/cloud/recommender/logging/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/recommender/logging/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/recommender/logging/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7161,7 +7013,7 @@ diff -urN a/googleapis/cloud/recommender/logging/v1beta1/BUILD.bazel b/googleapi
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/recommender/v1/BUILD.bazel b/googleapis/cloud/recommender/v1/BUILD.bazel
---- a/googleapis/cloud/recommender/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/recommender/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/recommender/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7183,7 +7035,7 @@ diff -urN a/googleapis/cloud/recommender/v1/BUILD.bazel b/googleapis/cloud/recom
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/recommender/v1beta1/BUILD.bazel b/googleapis/cloud/recommender/v1beta1/BUILD.bazel
---- a/googleapis/cloud/recommender/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/recommender/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/recommender/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7205,7 +7057,7 @@ diff -urN a/googleapis/cloud/recommender/v1beta1/BUILD.bazel b/googleapis/cloud/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/redis/v1/BUILD.bazel b/googleapis/cloud/redis/v1/BUILD.bazel
---- a/googleapis/cloud/redis/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/redis/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/redis/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7227,7 +7079,7 @@ diff -urN a/googleapis/cloud/redis/v1/BUILD.bazel b/googleapis/cloud/redis/v1/BU
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/redis/v1beta1/BUILD.bazel b/googleapis/cloud/redis/v1beta1/BUILD.bazel
---- a/googleapis/cloud/redis/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/redis/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/redis/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7249,7 +7101,7 @@ diff -urN a/googleapis/cloud/redis/v1beta1/BUILD.bazel b/googleapis/cloud/redis/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/resourcemanager/v2/BUILD.bazel b/googleapis/cloud/resourcemanager/v2/BUILD.bazel
---- a/googleapis/cloud/resourcemanager/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/resourcemanager/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/resourcemanager/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7271,7 +7123,7 @@ diff -urN a/googleapis/cloud/resourcemanager/v2/BUILD.bazel b/googleapis/cloud/r
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/resourcemanager/v3/BUILD.bazel b/googleapis/cloud/resourcemanager/v3/BUILD.bazel
---- a/googleapis/cloud/resourcemanager/v3/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/resourcemanager/v3/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/resourcemanager/v3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7293,7 +7145,7 @@ diff -urN a/googleapis/cloud/resourcemanager/v3/BUILD.bazel b/googleapis/cloud/r
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/resourcesettings/v1/BUILD.bazel b/googleapis/cloud/resourcesettings/v1/BUILD.bazel
---- a/googleapis/cloud/resourcesettings/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/resourcesettings/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/resourcesettings/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7315,7 +7167,7 @@ diff -urN a/googleapis/cloud/resourcesettings/v1/BUILD.bazel b/googleapis/cloud/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/retail/logging/BUILD.bazel b/googleapis/cloud/retail/logging/BUILD.bazel
---- a/googleapis/cloud/retail/logging/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/retail/logging/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/retail/logging/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7339,7 +7191,7 @@ diff -urN a/googleapis/cloud/retail/logging/BUILD.bazel b/googleapis/cloud/retai
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/retail/v2/BUILD.bazel b/googleapis/cloud/retail/v2/BUILD.bazel
---- a/googleapis/cloud/retail/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/retail/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/retail/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7361,7 +7213,7 @@ diff -urN a/googleapis/cloud/retail/v2/BUILD.bazel b/googleapis/cloud/retail/v2/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/retail/v2alpha/BUILD.bazel b/googleapis/cloud/retail/v2alpha/BUILD.bazel
---- a/googleapis/cloud/retail/v2alpha/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/retail/v2alpha/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/retail/v2alpha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7383,7 +7235,7 @@ diff -urN a/googleapis/cloud/retail/v2alpha/BUILD.bazel b/googleapis/cloud/retai
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/retail/v2beta/BUILD.bazel b/googleapis/cloud/retail/v2beta/BUILD.bazel
---- a/googleapis/cloud/retail/v2beta/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/retail/v2beta/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/retail/v2beta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7405,7 +7257,7 @@ diff -urN a/googleapis/cloud/retail/v2beta/BUILD.bazel b/googleapis/cloud/retail
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/run/v2/BUILD.bazel b/googleapis/cloud/run/v2/BUILD.bazel
---- a/googleapis/cloud/run/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/run/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/run/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7427,7 +7279,7 @@ diff -urN a/googleapis/cloud/run/v2/BUILD.bazel b/googleapis/cloud/run/v2/BUILD.
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/runtimeconfig/v1beta1/BUILD.bazel b/googleapis/cloud/runtimeconfig/v1beta1/BUILD.bazel
---- a/googleapis/cloud/runtimeconfig/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/runtimeconfig/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/runtimeconfig/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7461,7 +7313,7 @@ diff -urN a/googleapis/cloud/runtimeconfig/v1beta1/BUILD.bazel b/googleapis/clou
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/saasaccelerator/management/logs/v1/BUILD.bazel b/googleapis/cloud/saasaccelerator/management/logs/v1/BUILD.bazel
---- a/googleapis/cloud/saasaccelerator/management/logs/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/saasaccelerator/management/logs/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/saasaccelerator/management/logs/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7487,7 +7339,7 @@ diff -urN a/googleapis/cloud/saasaccelerator/management/logs/v1/BUILD.bazel b/go
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/scheduler/v1/BUILD.bazel b/googleapis/cloud/scheduler/v1/BUILD.bazel
---- a/googleapis/cloud/scheduler/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/scheduler/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/scheduler/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7509,7 +7361,7 @@ diff -urN a/googleapis/cloud/scheduler/v1/BUILD.bazel b/googleapis/cloud/schedul
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/scheduler/v1beta1/BUILD.bazel b/googleapis/cloud/scheduler/v1beta1/BUILD.bazel
---- a/googleapis/cloud/scheduler/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/scheduler/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/scheduler/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7531,7 +7383,7 @@ diff -urN a/googleapis/cloud/scheduler/v1beta1/BUILD.bazel b/googleapis/cloud/sc
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/secretmanager/logging/v1/BUILD.bazel b/googleapis/cloud/secretmanager/logging/v1/BUILD.bazel
---- a/googleapis/cloud/secretmanager/logging/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/secretmanager/logging/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/secretmanager/logging/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7553,7 +7405,7 @@ diff -urN a/googleapis/cloud/secretmanager/logging/v1/BUILD.bazel b/googleapis/c
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/secretmanager/v1/BUILD.bazel b/googleapis/cloud/secretmanager/v1/BUILD.bazel
---- a/googleapis/cloud/secretmanager/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/secretmanager/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/secretmanager/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7575,7 +7427,7 @@ diff -urN a/googleapis/cloud/secretmanager/v1/BUILD.bazel b/googleapis/cloud/sec
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/security/privateca/v1/BUILD.bazel b/googleapis/cloud/security/privateca/v1/BUILD.bazel
---- a/googleapis/cloud/security/privateca/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/security/privateca/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/security/privateca/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7596,30 +7448,8 @@ diff -urN a/googleapis/cloud/security/privateca/v1/BUILD.bazel b/googleapis/clou
 +    actual = ":privateca",
 +    visibility = ["//visibility:public"],
 +)
-diff -urN a/googleapis/cloud/security/privateca/v1beta1/BUILD.bazel b/googleapis/cloud/security/privateca/v1beta1/BUILD.bazel
---- a/googleapis/cloud/security/privateca/v1beta1/BUILD.bazel	1969-12-31 16:00:00
-+++ b/googleapis/cloud/security/privateca/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,18 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "v1beta1",
-+    srcs = ["alias.go"],
-+    importpath = "google.golang.org/genproto/googleapis/cloud/security/privateca/v1beta1",
-+    visibility = ["//visibility:public"],
-+    deps = [
-+        "@com_google_cloud_go_security//privateca/apiv1beta1/privatecapb:go_default_library",
-+        "@org_golang_google_grpc//:go_default_library",
-+    ],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":v1beta1",
-+    visibility = ["//visibility:public"],
-+)
 diff -urN a/googleapis/cloud/security/publicca/v1beta1/BUILD.bazel b/googleapis/cloud/security/publicca/v1beta1/BUILD.bazel
---- a/googleapis/cloud/security/publicca/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/security/publicca/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/security/publicca/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7641,7 +7471,7 @@ diff -urN a/googleapis/cloud/security/publicca/v1beta1/BUILD.bazel b/googleapis/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/securitycenter/settings/v1beta1/BUILD.bazel b/googleapis/cloud/securitycenter/settings/v1beta1/BUILD.bazel
---- a/googleapis/cloud/securitycenter/settings/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/securitycenter/settings/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/securitycenter/settings/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7663,7 +7493,7 @@ diff -urN a/googleapis/cloud/securitycenter/settings/v1beta1/BUILD.bazel b/googl
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/securitycenter/v1/BUILD.bazel b/googleapis/cloud/securitycenter/v1/BUILD.bazel
---- a/googleapis/cloud/securitycenter/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/securitycenter/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/securitycenter/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7685,7 +7515,7 @@ diff -urN a/googleapis/cloud/securitycenter/v1/BUILD.bazel b/googleapis/cloud/se
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/securitycenter/v1beta1/BUILD.bazel b/googleapis/cloud/securitycenter/v1beta1/BUILD.bazel
---- a/googleapis/cloud/securitycenter/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/securitycenter/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/securitycenter/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7707,9 +7537,9 @@ diff -urN a/googleapis/cloud/securitycenter/v1beta1/BUILD.bazel b/googleapis/clo
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/securitycenter/v1p1beta1/BUILD.bazel b/googleapis/cloud/securitycenter/v1p1beta1/BUILD.bazel
---- a/googleapis/cloud/securitycenter/v1p1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/securitycenter/v1p1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/securitycenter/v1p1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -7717,7 +7547,10 @@ diff -urN a/googleapis/cloud/securitycenter/v1p1beta1/BUILD.bazel b/googleapis/c
 +    srcs = ["alias.go"],
 +    importpath = "google.golang.org/genproto/googleapis/cloud/securitycenter/v1p1beta1",
 +    visibility = ["//visibility:public"],
-+    deps = ["@org_golang_google_grpc//:go_default_library"],
++    deps = [
++        "@com_google_cloud_go_securitycenter//apiv1p1beta1/securitycenterpb:go_default_library",
++        "@org_golang_google_grpc//:go_default_library",
++    ],
 +)
 +
 +alias(
@@ -7726,7 +7559,7 @@ diff -urN a/googleapis/cloud/securitycenter/v1p1beta1/BUILD.bazel b/googleapis/c
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/sensitiveaction/logging/v1/BUILD.bazel b/googleapis/cloud/sensitiveaction/logging/v1/BUILD.bazel
---- a/googleapis/cloud/sensitiveaction/logging/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/sensitiveaction/logging/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/sensitiveaction/logging/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7750,7 +7583,7 @@ diff -urN a/googleapis/cloud/sensitiveaction/logging/v1/BUILD.bazel b/googleapis
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/servicedirectory/v1/BUILD.bazel b/googleapis/cloud/servicedirectory/v1/BUILD.bazel
---- a/googleapis/cloud/servicedirectory/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/servicedirectory/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/servicedirectory/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7772,7 +7605,7 @@ diff -urN a/googleapis/cloud/servicedirectory/v1/BUILD.bazel b/googleapis/cloud/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/servicedirectory/v1beta1/BUILD.bazel b/googleapis/cloud/servicedirectory/v1beta1/BUILD.bazel
---- a/googleapis/cloud/servicedirectory/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/servicedirectory/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/servicedirectory/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7794,7 +7627,7 @@ diff -urN a/googleapis/cloud/servicedirectory/v1beta1/BUILD.bazel b/googleapis/c
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/shell/v1/BUILD.bazel b/googleapis/cloud/shell/v1/BUILD.bazel
---- a/googleapis/cloud/shell/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/shell/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/shell/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7816,7 +7649,7 @@ diff -urN a/googleapis/cloud/shell/v1/BUILD.bazel b/googleapis/cloud/shell/v1/BU
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/speech/v1/BUILD.bazel b/googleapis/cloud/speech/v1/BUILD.bazel
---- a/googleapis/cloud/speech/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/speech/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/speech/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7838,7 +7671,7 @@ diff -urN a/googleapis/cloud/speech/v1/BUILD.bazel b/googleapis/cloud/speech/v1/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/speech/v1p1beta1/BUILD.bazel b/googleapis/cloud/speech/v1p1beta1/BUILD.bazel
---- a/googleapis/cloud/speech/v1p1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/speech/v1p1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/speech/v1p1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7860,7 +7693,7 @@ diff -urN a/googleapis/cloud/speech/v1p1beta1/BUILD.bazel b/googleapis/cloud/spe
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/speech/v2/BUILD.bazel b/googleapis/cloud/speech/v2/BUILD.bazel
---- a/googleapis/cloud/speech/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/speech/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/speech/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7882,7 +7715,7 @@ diff -urN a/googleapis/cloud/speech/v2/BUILD.bazel b/googleapis/cloud/speech/v2/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/sql/v1/BUILD.bazel b/googleapis/cloud/sql/v1/BUILD.bazel
---- a/googleapis/cloud/sql/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/sql/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/sql/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7922,7 +7755,7 @@ diff -urN a/googleapis/cloud/sql/v1/BUILD.bazel b/googleapis/cloud/sql/v1/BUILD.
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/sql/v1beta4/BUILD.bazel b/googleapis/cloud/sql/v1beta4/BUILD.bazel
---- a/googleapis/cloud/sql/v1beta4/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/sql/v1beta4/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/sql/v1beta4/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7957,7 +7790,7 @@ diff -urN a/googleapis/cloud/sql/v1beta4/BUILD.bazel b/googleapis/cloud/sql/v1be
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/storageinsights/v1/BUILD.bazel b/googleapis/cloud/storageinsights/v1/BUILD.bazel
---- a/googleapis/cloud/storageinsights/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/storageinsights/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/storageinsights/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7989,7 +7822,7 @@ diff -urN a/googleapis/cloud/storageinsights/v1/BUILD.bazel b/googleapis/cloud/s
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/stream/logging/v1/BUILD.bazel b/googleapis/cloud/stream/logging/v1/BUILD.bazel
---- a/googleapis/cloud/stream/logging/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/stream/logging/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/stream/logging/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8012,7 +7845,7 @@ diff -urN a/googleapis/cloud/stream/logging/v1/BUILD.bazel b/googleapis/cloud/st
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/support/common/BUILD.bazel b/googleapis/cloud/support/common/BUILD.bazel
---- a/googleapis/cloud/support/common/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/support/common/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/support/common/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8036,7 +7869,7 @@ diff -urN a/googleapis/cloud/support/common/BUILD.bazel b/googleapis/cloud/suppo
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/support/v1alpha1/BUILD.bazel b/googleapis/cloud/support/v1alpha1/BUILD.bazel
---- a/googleapis/cloud/support/v1alpha1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/support/v1alpha1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/support/v1alpha1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8065,7 +7898,7 @@ diff -urN a/googleapis/cloud/support/v1alpha1/BUILD.bazel b/googleapis/cloud/sup
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/talent/v4/BUILD.bazel b/googleapis/cloud/talent/v4/BUILD.bazel
---- a/googleapis/cloud/talent/v4/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/talent/v4/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/talent/v4/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8087,7 +7920,7 @@ diff -urN a/googleapis/cloud/talent/v4/BUILD.bazel b/googleapis/cloud/talent/v4/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/talent/v4beta1/BUILD.bazel b/googleapis/cloud/talent/v4beta1/BUILD.bazel
---- a/googleapis/cloud/talent/v4beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/talent/v4beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/talent/v4beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8109,7 +7942,7 @@ diff -urN a/googleapis/cloud/talent/v4beta1/BUILD.bazel b/googleapis/cloud/talen
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/tasks/v2/BUILD.bazel b/googleapis/cloud/tasks/v2/BUILD.bazel
---- a/googleapis/cloud/tasks/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/tasks/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/tasks/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8131,7 +7964,7 @@ diff -urN a/googleapis/cloud/tasks/v2/BUILD.bazel b/googleapis/cloud/tasks/v2/BU
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/tasks/v2beta2/BUILD.bazel b/googleapis/cloud/tasks/v2beta2/BUILD.bazel
---- a/googleapis/cloud/tasks/v2beta2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/tasks/v2beta2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/tasks/v2beta2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8153,7 +7986,7 @@ diff -urN a/googleapis/cloud/tasks/v2beta2/BUILD.bazel b/googleapis/cloud/tasks/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/tasks/v2beta3/BUILD.bazel b/googleapis/cloud/tasks/v2beta3/BUILD.bazel
---- a/googleapis/cloud/tasks/v2beta3/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/tasks/v2beta3/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/tasks/v2beta3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8175,7 +8008,7 @@ diff -urN a/googleapis/cloud/tasks/v2beta3/BUILD.bazel b/googleapis/cloud/tasks/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/texttospeech/v1/BUILD.bazel b/googleapis/cloud/texttospeech/v1/BUILD.bazel
---- a/googleapis/cloud/texttospeech/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/texttospeech/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/texttospeech/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8197,7 +8030,7 @@ diff -urN a/googleapis/cloud/texttospeech/v1/BUILD.bazel b/googleapis/cloud/text
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/texttospeech/v1beta1/BUILD.bazel b/googleapis/cloud/texttospeech/v1beta1/BUILD.bazel
---- a/googleapis/cloud/texttospeech/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/texttospeech/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/texttospeech/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8228,7 +8061,7 @@ diff -urN a/googleapis/cloud/texttospeech/v1beta1/BUILD.bazel b/googleapis/cloud
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/timeseriesinsights/v1/BUILD.bazel b/googleapis/cloud/timeseriesinsights/v1/BUILD.bazel
---- a/googleapis/cloud/timeseriesinsights/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/timeseriesinsights/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/timeseriesinsights/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8258,7 +8091,7 @@ diff -urN a/googleapis/cloud/timeseriesinsights/v1/BUILD.bazel b/googleapis/clou
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/tpu/v1/BUILD.bazel b/googleapis/cloud/tpu/v1/BUILD.bazel
---- a/googleapis/cloud/tpu/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/tpu/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/tpu/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8280,7 +8113,7 @@ diff -urN a/googleapis/cloud/tpu/v1/BUILD.bazel b/googleapis/cloud/tpu/v1/BUILD.
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/tpu/v2/BUILD.bazel b/googleapis/cloud/tpu/v2/BUILD.bazel
---- a/googleapis/cloud/tpu/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/tpu/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/tpu/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8309,7 +8142,7 @@ diff -urN a/googleapis/cloud/tpu/v2/BUILD.bazel b/googleapis/cloud/tpu/v2/BUILD.
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/tpu/v2alpha1/BUILD.bazel b/googleapis/cloud/tpu/v2alpha1/BUILD.bazel
---- a/googleapis/cloud/tpu/v2alpha1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/tpu/v2alpha1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/tpu/v2alpha1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8341,7 +8174,7 @@ diff -urN a/googleapis/cloud/tpu/v2alpha1/BUILD.bazel b/googleapis/cloud/tpu/v2a
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/translate/v3/BUILD.bazel b/googleapis/cloud/translate/v3/BUILD.bazel
---- a/googleapis/cloud/translate/v3/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/translate/v3/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/translate/v3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8363,7 +8196,7 @@ diff -urN a/googleapis/cloud/translate/v3/BUILD.bazel b/googleapis/cloud/transla
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/translate/v3beta1/BUILD.bazel b/googleapis/cloud/translate/v3beta1/BUILD.bazel
---- a/googleapis/cloud/translate/v3beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/translate/v3beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/translate/v3beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8391,7 +8224,7 @@ diff -urN a/googleapis/cloud/translate/v3beta1/BUILD.bazel b/googleapis/cloud/tr
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/video/livestream/logging/v1/BUILD.bazel b/googleapis/cloud/video/livestream/logging/v1/BUILD.bazel
---- a/googleapis/cloud/video/livestream/logging/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/video/livestream/logging/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/video/livestream/logging/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8415,7 +8248,7 @@ diff -urN a/googleapis/cloud/video/livestream/logging/v1/BUILD.bazel b/googleapi
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/video/livestream/v1/BUILD.bazel b/googleapis/cloud/video/livestream/v1/BUILD.bazel
---- a/googleapis/cloud/video/livestream/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/video/livestream/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/video/livestream/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8437,7 +8270,7 @@ diff -urN a/googleapis/cloud/video/livestream/v1/BUILD.bazel b/googleapis/cloud/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/video/stitcher/v1/BUILD.bazel b/googleapis/cloud/video/stitcher/v1/BUILD.bazel
---- a/googleapis/cloud/video/stitcher/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/video/stitcher/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/video/stitcher/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8459,7 +8292,7 @@ diff -urN a/googleapis/cloud/video/stitcher/v1/BUILD.bazel b/googleapis/cloud/vi
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/video/transcoder/v1/BUILD.bazel b/googleapis/cloud/video/transcoder/v1/BUILD.bazel
---- a/googleapis/cloud/video/transcoder/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/video/transcoder/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/video/transcoder/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8481,7 +8314,7 @@ diff -urN a/googleapis/cloud/video/transcoder/v1/BUILD.bazel b/googleapis/cloud/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/videointelligence/v1/BUILD.bazel b/googleapis/cloud/videointelligence/v1/BUILD.bazel
---- a/googleapis/cloud/videointelligence/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/videointelligence/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/videointelligence/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8503,7 +8336,7 @@ diff -urN a/googleapis/cloud/videointelligence/v1/BUILD.bazel b/googleapis/cloud
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/videointelligence/v1beta2/BUILD.bazel b/googleapis/cloud/videointelligence/v1beta2/BUILD.bazel
---- a/googleapis/cloud/videointelligence/v1beta2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/videointelligence/v1beta2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/videointelligence/v1beta2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8525,7 +8358,7 @@ diff -urN a/googleapis/cloud/videointelligence/v1beta2/BUILD.bazel b/googleapis/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/videointelligence/v1p1beta1/BUILD.bazel b/googleapis/cloud/videointelligence/v1p1beta1/BUILD.bazel
---- a/googleapis/cloud/videointelligence/v1p1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/videointelligence/v1p1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/videointelligence/v1p1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8555,7 +8388,7 @@ diff -urN a/googleapis/cloud/videointelligence/v1p1beta1/BUILD.bazel b/googleapi
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/videointelligence/v1p2beta1/BUILD.bazel b/googleapis/cloud/videointelligence/v1p2beta1/BUILD.bazel
---- a/googleapis/cloud/videointelligence/v1p2beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/videointelligence/v1p2beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/videointelligence/v1p2beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8585,7 +8418,7 @@ diff -urN a/googleapis/cloud/videointelligence/v1p2beta1/BUILD.bazel b/googleapi
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/videointelligence/v1p3beta1/BUILD.bazel b/googleapis/cloud/videointelligence/v1p3beta1/BUILD.bazel
---- a/googleapis/cloud/videointelligence/v1p3beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/videointelligence/v1p3beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/videointelligence/v1p3beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8607,7 +8440,7 @@ diff -urN a/googleapis/cloud/videointelligence/v1p3beta1/BUILD.bazel b/googleapi
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/vision/v1/BUILD.bazel b/googleapis/cloud/vision/v1/BUILD.bazel
---- a/googleapis/cloud/vision/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/vision/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/vision/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8629,7 +8462,7 @@ diff -urN a/googleapis/cloud/vision/v1/BUILD.bazel b/googleapis/cloud/vision/v1/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/vision/v1p1beta1/BUILD.bazel b/googleapis/cloud/vision/v1p1beta1/BUILD.bazel
---- a/googleapis/cloud/vision/v1p1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/vision/v1p1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/vision/v1p1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8651,7 +8484,7 @@ diff -urN a/googleapis/cloud/vision/v1p1beta1/BUILD.bazel b/googleapis/cloud/vis
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/vision/v1p2beta1/BUILD.bazel b/googleapis/cloud/vision/v1p2beta1/BUILD.bazel
---- a/googleapis/cloud/vision/v1p2beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/vision/v1p2beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/vision/v1p2beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,32 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8687,7 +8520,7 @@ diff -urN a/googleapis/cloud/vision/v1p2beta1/BUILD.bazel b/googleapis/cloud/vis
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/vision/v1p3beta1/BUILD.bazel b/googleapis/cloud/vision/v1p3beta1/BUILD.bazel
---- a/googleapis/cloud/vision/v1p3beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/vision/v1p3beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/vision/v1p3beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8727,7 +8560,7 @@ diff -urN a/googleapis/cloud/vision/v1p3beta1/BUILD.bazel b/googleapis/cloud/vis
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/vision/v1p4beta1/BUILD.bazel b/googleapis/cloud/vision/v1p4beta1/BUILD.bazel
---- a/googleapis/cloud/vision/v1p4beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/vision/v1p4beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/vision/v1p4beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,37 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8768,7 +8601,7 @@ diff -urN a/googleapis/cloud/vision/v1p4beta1/BUILD.bazel b/googleapis/cloud/vis
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/visionai/v1/BUILD.bazel b/googleapis/cloud/visionai/v1/BUILD.bazel
---- a/googleapis/cloud/visionai/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/visionai/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/visionai/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,43 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8815,7 +8648,7 @@ diff -urN a/googleapis/cloud/visionai/v1/BUILD.bazel b/googleapis/cloud/visionai
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/visionai/v1alpha1/BUILD.bazel b/googleapis/cloud/visionai/v1alpha1/BUILD.bazel
---- a/googleapis/cloud/visionai/v1alpha1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/visionai/v1alpha1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/visionai/v1alpha1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,43 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8862,7 +8695,7 @@ diff -urN a/googleapis/cloud/visionai/v1alpha1/BUILD.bazel b/googleapis/cloud/vi
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/visualinspection/v1beta1/BUILD.bazel b/googleapis/cloud/visualinspection/v1beta1/BUILD.bazel
---- a/googleapis/cloud/visualinspection/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/visualinspection/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/visualinspection/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,46 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8912,7 +8745,7 @@ diff -urN a/googleapis/cloud/visualinspection/v1beta1/BUILD.bazel b/googleapis/c
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/vmmigration/v1/BUILD.bazel b/googleapis/cloud/vmmigration/v1/BUILD.bazel
---- a/googleapis/cloud/vmmigration/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/vmmigration/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/vmmigration/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8934,7 +8767,7 @@ diff -urN a/googleapis/cloud/vmmigration/v1/BUILD.bazel b/googleapis/cloud/vmmig
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/vmwareengine/v1/BUILD.bazel b/googleapis/cloud/vmwareengine/v1/BUILD.bazel
---- a/googleapis/cloud/vmwareengine/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/vmwareengine/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/vmwareengine/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8956,7 +8789,7 @@ diff -urN a/googleapis/cloud/vmwareengine/v1/BUILD.bazel b/googleapis/cloud/vmwa
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/vpcaccess/v1/BUILD.bazel b/googleapis/cloud/vpcaccess/v1/BUILD.bazel
---- a/googleapis/cloud/vpcaccess/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/vpcaccess/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/vpcaccess/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8978,7 +8811,7 @@ diff -urN a/googleapis/cloud/vpcaccess/v1/BUILD.bazel b/googleapis/cloud/vpcacce
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/webrisk/v1/BUILD.bazel b/googleapis/cloud/webrisk/v1/BUILD.bazel
---- a/googleapis/cloud/webrisk/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/webrisk/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/webrisk/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9000,7 +8833,7 @@ diff -urN a/googleapis/cloud/webrisk/v1/BUILD.bazel b/googleapis/cloud/webrisk/v
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/webrisk/v1beta1/BUILD.bazel b/googleapis/cloud/webrisk/v1beta1/BUILD.bazel
---- a/googleapis/cloud/webrisk/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/webrisk/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/webrisk/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9022,7 +8855,7 @@ diff -urN a/googleapis/cloud/webrisk/v1beta1/BUILD.bazel b/googleapis/cloud/webr
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/websecurityscanner/v1/BUILD.bazel b/googleapis/cloud/websecurityscanner/v1/BUILD.bazel
---- a/googleapis/cloud/websecurityscanner/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/websecurityscanner/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/websecurityscanner/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9044,7 +8877,7 @@ diff -urN a/googleapis/cloud/websecurityscanner/v1/BUILD.bazel b/googleapis/clou
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/websecurityscanner/v1alpha/BUILD.bazel b/googleapis/cloud/websecurityscanner/v1alpha/BUILD.bazel
---- a/googleapis/cloud/websecurityscanner/v1alpha/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/websecurityscanner/v1alpha/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/websecurityscanner/v1alpha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9081,7 +8914,7 @@ diff -urN a/googleapis/cloud/websecurityscanner/v1alpha/BUILD.bazel b/googleapis
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/websecurityscanner/v1beta/BUILD.bazel b/googleapis/cloud/websecurityscanner/v1beta/BUILD.bazel
---- a/googleapis/cloud/websecurityscanner/v1beta/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/websecurityscanner/v1beta/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/websecurityscanner/v1beta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9121,7 +8954,7 @@ diff -urN a/googleapis/cloud/websecurityscanner/v1beta/BUILD.bazel b/googleapis/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/workflows/executions/v1/BUILD.bazel b/googleapis/cloud/workflows/executions/v1/BUILD.bazel
---- a/googleapis/cloud/workflows/executions/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/workflows/executions/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/workflows/executions/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9143,7 +8976,7 @@ diff -urN a/googleapis/cloud/workflows/executions/v1/BUILD.bazel b/googleapis/cl
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/workflows/executions/v1beta/BUILD.bazel b/googleapis/cloud/workflows/executions/v1beta/BUILD.bazel
---- a/googleapis/cloud/workflows/executions/v1beta/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/workflows/executions/v1beta/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/workflows/executions/v1beta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9165,7 +8998,7 @@ diff -urN a/googleapis/cloud/workflows/executions/v1beta/BUILD.bazel b/googleapi
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/workflows/type/BUILD.bazel b/googleapis/cloud/workflows/type/BUILD.bazel
---- a/googleapis/cloud/workflows/type/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/workflows/type/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/workflows/type/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9192,7 +9025,7 @@ diff -urN a/googleapis/cloud/workflows/type/BUILD.bazel b/googleapis/cloud/workf
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/workflows/v1/BUILD.bazel b/googleapis/cloud/workflows/v1/BUILD.bazel
---- a/googleapis/cloud/workflows/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/workflows/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/workflows/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9214,7 +9047,7 @@ diff -urN a/googleapis/cloud/workflows/v1/BUILD.bazel b/googleapis/cloud/workflo
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/cloud/workflows/v1beta/BUILD.bazel b/googleapis/cloud/workflows/v1beta/BUILD.bazel
---- a/googleapis/cloud/workflows/v1beta/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/cloud/workflows/v1beta/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/workflows/v1beta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9235,39 +9068,8 @@ diff -urN a/googleapis/cloud/workflows/v1beta/BUILD.bazel b/googleapis/cloud/wor
 +    actual = ":v1beta",
 +    visibility = ["//visibility:public"],
 +)
-diff -urN a/googleapis/cloud/workstations/v1beta/BUILD.bazel b/googleapis/cloud/workstations/v1beta/BUILD.bazel
---- a/googleapis/cloud/workstations/v1beta/BUILD.bazel	1969-12-31 16:00:00
-+++ b/googleapis/cloud/workstations/v1beta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,27 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "v1beta",
-+    srcs = ["workstations.pb.go"],
-+    importpath = "google.golang.org/genproto/googleapis/cloud/workstations/v1beta",
-+    visibility = ["//visibility:public"],
-+    deps = [
-+        "//googleapis/api/annotations",
-+        "//googleapis/longrunning",
-+        "//googleapis/rpc/status",
-+        "@org_golang_google_grpc//:go_default_library",
-+        "@org_golang_google_grpc//codes:go_default_library",
-+        "@org_golang_google_grpc//status:go_default_library",
-+        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
-+        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
-+        "@org_golang_google_protobuf//types/known/durationpb:go_default_library",
-+        "@org_golang_google_protobuf//types/known/fieldmaskpb:go_default_library",
-+        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
-+    ],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":v1beta",
-+    visibility = ["//visibility:public"],
-+)
 diff -urN a/googleapis/container/v1/BUILD.bazel b/googleapis/container/v1/BUILD.bazel
---- a/googleapis/container/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/container/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/container/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9289,7 +9091,7 @@ diff -urN a/googleapis/container/v1/BUILD.bazel b/googleapis/container/v1/BUILD.
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/container/v1alpha1/BUILD.bazel b/googleapis/container/v1alpha1/BUILD.bazel
---- a/googleapis/container/v1alpha1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/container/v1alpha1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/container/v1alpha1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9316,7 +9118,7 @@ diff -urN a/googleapis/container/v1alpha1/BUILD.bazel b/googleapis/container/v1a
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/container/v1beta1/BUILD.bazel b/googleapis/container/v1beta1/BUILD.bazel
---- a/googleapis/container/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/container/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/container/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,29 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9349,7 +9151,7 @@ diff -urN a/googleapis/container/v1beta1/BUILD.bazel b/googleapis/container/v1be
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/dataflow/v1beta3/BUILD.bazel b/googleapis/dataflow/v1beta3/BUILD.bazel
---- a/googleapis/dataflow/v1beta3/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/dataflow/v1beta3/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/dataflow/v1beta3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9371,7 +9173,7 @@ diff -urN a/googleapis/dataflow/v1beta3/BUILD.bazel b/googleapis/dataflow/v1beta
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/datastore/admin/v1/BUILD.bazel b/googleapis/datastore/admin/v1/BUILD.bazel
---- a/googleapis/datastore/admin/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/datastore/admin/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/datastore/admin/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9393,7 +9195,7 @@ diff -urN a/googleapis/datastore/admin/v1/BUILD.bazel b/googleapis/datastore/adm
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/datastore/admin/v1beta1/BUILD.bazel b/googleapis/datastore/admin/v1beta1/BUILD.bazel
---- a/googleapis/datastore/admin/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/datastore/admin/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/datastore/admin/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9421,7 +9223,7 @@ diff -urN a/googleapis/datastore/admin/v1beta1/BUILD.bazel b/googleapis/datastor
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/datastore/v1/BUILD.bazel b/googleapis/datastore/v1/BUILD.bazel
---- a/googleapis/datastore/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/datastore/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/datastore/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9456,7 +9258,7 @@ diff -urN a/googleapis/datastore/v1/BUILD.bazel b/googleapis/datastore/v1/BUILD.
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/datastore/v1beta3/BUILD.bazel b/googleapis/datastore/v1beta3/BUILD.bazel
---- a/googleapis/datastore/v1beta3/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/datastore/v1beta3/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/datastore/v1beta3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9490,7 +9292,7 @@ diff -urN a/googleapis/datastore/v1beta3/BUILD.bazel b/googleapis/datastore/v1be
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/devtools/artifactregistry/v1/BUILD.bazel b/googleapis/devtools/artifactregistry/v1/BUILD.bazel
---- a/googleapis/devtools/artifactregistry/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/artifactregistry/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/artifactregistry/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9512,7 +9314,7 @@ diff -urN a/googleapis/devtools/artifactregistry/v1/BUILD.bazel b/googleapis/dev
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/devtools/artifactregistry/v1beta2/BUILD.bazel b/googleapis/devtools/artifactregistry/v1beta2/BUILD.bazel
---- a/googleapis/devtools/artifactregistry/v1beta2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/artifactregistry/v1beta2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/artifactregistry/v1beta2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9534,7 +9336,7 @@ diff -urN a/googleapis/devtools/artifactregistry/v1beta2/BUILD.bazel b/googleapi
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/devtools/build/v1/BUILD.bazel b/googleapis/devtools/build/v1/BUILD.bazel
---- a/googleapis/devtools/build/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/build/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/build/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9569,7 +9371,7 @@ diff -urN a/googleapis/devtools/build/v1/BUILD.bazel b/googleapis/devtools/build
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/devtools/cloudbuild/v1/BUILD.bazel b/googleapis/devtools/cloudbuild/v1/BUILD.bazel
---- a/googleapis/devtools/cloudbuild/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/cloudbuild/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/cloudbuild/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9591,7 +9393,7 @@ diff -urN a/googleapis/devtools/cloudbuild/v1/BUILD.bazel b/googleapis/devtools/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/devtools/clouddebugger/v2/BUILD.bazel b/googleapis/devtools/clouddebugger/v2/BUILD.bazel
---- a/googleapis/devtools/clouddebugger/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/clouddebugger/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/clouddebugger/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9613,7 +9415,7 @@ diff -urN a/googleapis/devtools/clouddebugger/v2/BUILD.bazel b/googleapis/devtoo
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/devtools/clouderrorreporting/v1beta1/BUILD.bazel b/googleapis/devtools/clouderrorreporting/v1beta1/BUILD.bazel
---- a/googleapis/devtools/clouderrorreporting/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/clouderrorreporting/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/clouderrorreporting/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9635,7 +9437,7 @@ diff -urN a/googleapis/devtools/clouderrorreporting/v1beta1/BUILD.bazel b/google
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/devtools/cloudprofiler/v2/BUILD.bazel b/googleapis/devtools/cloudprofiler/v2/BUILD.bazel
---- a/googleapis/devtools/cloudprofiler/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/cloudprofiler/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/cloudprofiler/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9663,7 +9465,7 @@ diff -urN a/googleapis/devtools/cloudprofiler/v2/BUILD.bazel b/googleapis/devtoo
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/devtools/cloudtrace/v1/BUILD.bazel b/googleapis/devtools/cloudtrace/v1/BUILD.bazel
---- a/googleapis/devtools/cloudtrace/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/cloudtrace/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/cloudtrace/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9685,7 +9487,7 @@ diff -urN a/googleapis/devtools/cloudtrace/v1/BUILD.bazel b/googleapis/devtools/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/devtools/cloudtrace/v2/BUILD.bazel b/googleapis/devtools/cloudtrace/v2/BUILD.bazel
---- a/googleapis/devtools/cloudtrace/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/cloudtrace/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/cloudtrace/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9707,7 +9509,7 @@ diff -urN a/googleapis/devtools/cloudtrace/v2/BUILD.bazel b/googleapis/devtools/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/devtools/containeranalysis/v1/BUILD.bazel b/googleapis/devtools/containeranalysis/v1/BUILD.bazel
---- a/googleapis/devtools/containeranalysis/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/containeranalysis/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/containeranalysis/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9735,9 +9537,9 @@ diff -urN a/googleapis/devtools/containeranalysis/v1/BUILD.bazel b/googleapis/de
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/devtools/containeranalysis/v1alpha1/BUILD.bazel b/googleapis/devtools/containeranalysis/v1alpha1/BUILD.bazel
---- a/googleapis/devtools/containeranalysis/v1alpha1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/containeranalysis/v1alpha1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/containeranalysis/v1alpha1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -9759,6 +9561,7 @@ diff -urN a/googleapis/devtools/containeranalysis/v1alpha1/BUILD.bazel b/googlea
 +        "//googleapis/rpc/status",
 +        "//protobuf/field_mask",
 +        "@com_github_golang_protobuf//proto:go_default_library",
++        "@com_github_golang_protobuf//ptypes/any:go_default_library",
 +        "@com_github_golang_protobuf//ptypes/empty:go_default_library",
 +        "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
 +        "@org_golang_google_grpc//:go_default_library",
@@ -9772,30 +9575,8 @@ diff -urN a/googleapis/devtools/containeranalysis/v1alpha1/BUILD.bazel b/googlea
 +    actual = ":v1alpha1",
 +    visibility = ["//visibility:public"],
 +)
-diff -urN a/googleapis/devtools/containeranalysis/v1beta1/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/BUILD.bazel
---- a/googleapis/devtools/containeranalysis/v1beta1/BUILD.bazel	1969-12-31 16:00:00
-+++ b/googleapis/devtools/containeranalysis/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,18 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "v1beta1",
-+    srcs = ["alias.go"],
-+    importpath = "google.golang.org/genproto/googleapis/devtools/containeranalysis/v1beta1",
-+    visibility = ["//visibility:public"],
-+    deps = [
-+        "@com_google_cloud_go_containeranalysis//apiv1beta1/containeranalysispb:go_default_library",
-+        "@org_golang_google_grpc//:go_default_library",
-+    ],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":v1beta1",
-+    visibility = ["//visibility:public"],
-+)
 diff -urN a/googleapis/devtools/containeranalysis/v1beta1/attestation/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/attestation/BUILD.bazel
---- a/googleapis/devtools/containeranalysis/v1beta1/attestation/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/containeranalysis/v1beta1/attestation/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/containeranalysis/v1beta1/attestation/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9818,7 +9599,7 @@ diff -urN a/googleapis/devtools/containeranalysis/v1beta1/attestation/BUILD.baze
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/devtools/containeranalysis/v1beta1/build/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/build/BUILD.bazel
---- a/googleapis/devtools/containeranalysis/v1beta1/build/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/containeranalysis/v1beta1/build/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/containeranalysis/v1beta1/build/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9840,8 +9621,30 @@ diff -urN a/googleapis/devtools/containeranalysis/v1beta1/build/BUILD.bazel b/go
 +    actual = ":build",
 +    visibility = ["//visibility:public"],
 +)
+diff -urN a/googleapis/devtools/containeranalysis/v1beta1/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/BUILD.bazel
+--- a/googleapis/devtools/containeranalysis/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/googleapis/devtools/containeranalysis/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,18 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "v1beta1",
++    srcs = ["alias.go"],
++    importpath = "google.golang.org/genproto/googleapis/devtools/containeranalysis/v1beta1",
++    visibility = ["//visibility:public"],
++    deps = [
++        "@com_google_cloud_go_containeranalysis//apiv1beta1/containeranalysispb:go_default_library",
++        "@org_golang_google_grpc//:go_default_library",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":v1beta1",
++    visibility = ["//visibility:public"],
++)
 diff -urN a/googleapis/devtools/containeranalysis/v1beta1/common/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/common/BUILD.bazel
---- a/googleapis/devtools/containeranalysis/v1beta1/common/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/containeranalysis/v1beta1/common/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/containeranalysis/v1beta1/common/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9863,7 +9666,7 @@ diff -urN a/googleapis/devtools/containeranalysis/v1beta1/common/BUILD.bazel b/g
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/devtools/containeranalysis/v1beta1/cvss/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/cvss/BUILD.bazel
---- a/googleapis/devtools/containeranalysis/v1beta1/cvss/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/containeranalysis/v1beta1/cvss/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/containeranalysis/v1beta1/cvss/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9885,7 +9688,7 @@ diff -urN a/googleapis/devtools/containeranalysis/v1beta1/cvss/BUILD.bazel b/goo
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/devtools/containeranalysis/v1beta1/deployment/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/deployment/BUILD.bazel
---- a/googleapis/devtools/containeranalysis/v1beta1/deployment/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/containeranalysis/v1beta1/deployment/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/containeranalysis/v1beta1/deployment/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9908,7 +9711,7 @@ diff -urN a/googleapis/devtools/containeranalysis/v1beta1/deployment/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/devtools/containeranalysis/v1beta1/discovery/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/discovery/BUILD.bazel
---- a/googleapis/devtools/containeranalysis/v1beta1/discovery/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/containeranalysis/v1beta1/discovery/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/containeranalysis/v1beta1/discovery/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9933,7 +9736,7 @@ diff -urN a/googleapis/devtools/containeranalysis/v1beta1/discovery/BUILD.bazel 
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/devtools/containeranalysis/v1beta1/grafeas/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/grafeas/BUILD.bazel
---- a/googleapis/devtools/containeranalysis/v1beta1/grafeas/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/containeranalysis/v1beta1/grafeas/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/containeranalysis/v1beta1/grafeas/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9955,7 +9758,7 @@ diff -urN a/googleapis/devtools/containeranalysis/v1beta1/grafeas/BUILD.bazel b/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/devtools/containeranalysis/v1beta1/image/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/image/BUILD.bazel
---- a/googleapis/devtools/containeranalysis/v1beta1/image/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/containeranalysis/v1beta1/image/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/containeranalysis/v1beta1/image/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9977,7 +9780,7 @@ diff -urN a/googleapis/devtools/containeranalysis/v1beta1/image/BUILD.bazel b/go
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/devtools/containeranalysis/v1beta1/package/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/package/BUILD.bazel
---- a/googleapis/devtools/containeranalysis/v1beta1/package/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/containeranalysis/v1beta1/package/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/containeranalysis/v1beta1/package/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9999,7 +9802,7 @@ diff -urN a/googleapis/devtools/containeranalysis/v1beta1/package/BUILD.bazel b/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/devtools/containeranalysis/v1beta1/provenance/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/provenance/BUILD.bazel
---- a/googleapis/devtools/containeranalysis/v1beta1/provenance/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/containeranalysis/v1beta1/provenance/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/containeranalysis/v1beta1/provenance/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10023,7 +9826,7 @@ diff -urN a/googleapis/devtools/containeranalysis/v1beta1/provenance/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/devtools/containeranalysis/v1beta1/source/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/source/BUILD.bazel
---- a/googleapis/devtools/containeranalysis/v1beta1/source/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/containeranalysis/v1beta1/source/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/containeranalysis/v1beta1/source/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10045,7 +9848,7 @@ diff -urN a/googleapis/devtools/containeranalysis/v1beta1/source/BUILD.bazel b/g
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/devtools/containeranalysis/v1beta1/vulnerability/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/vulnerability/BUILD.bazel
---- a/googleapis/devtools/containeranalysis/v1beta1/vulnerability/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/containeranalysis/v1beta1/vulnerability/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/containeranalysis/v1beta1/vulnerability/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10071,9 +9874,9 @@ diff -urN a/googleapis/devtools/containeranalysis/v1beta1/vulnerability/BUILD.ba
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/devtools/remoteworkers/v1test2/BUILD.bazel b/googleapis/devtools/remoteworkers/v1test2/BUILD.bazel
---- a/googleapis/devtools/remoteworkers/v1test2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/remoteworkers/v1test2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/remoteworkers/v1test2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -10091,6 +9894,7 @@ diff -urN a/googleapis/devtools/remoteworkers/v1test2/BUILD.bazel b/googleapis/d
 +        "//googleapis/rpc/status",
 +        "//protobuf/field_mask",
 +        "@com_github_golang_protobuf//proto:go_default_library",
++        "@com_github_golang_protobuf//ptypes/any:go_default_library",
 +        "@org_golang_google_grpc//:go_default_library",
 +        "@org_golang_google_grpc//codes:go_default_library",
 +        "@org_golang_google_grpc//status:go_default_library",
@@ -10109,7 +9913,7 @@ diff -urN a/googleapis/devtools/remoteworkers/v1test2/BUILD.bazel b/googleapis/d
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/devtools/resultstore/v2/BUILD.bazel b/googleapis/devtools/resultstore/v2/BUILD.bazel
---- a/googleapis/devtools/resultstore/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/resultstore/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/resultstore/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,45 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10158,7 +9962,7 @@ diff -urN a/googleapis/devtools/resultstore/v2/BUILD.bazel b/googleapis/devtools
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/devtools/source/v1/BUILD.bazel b/googleapis/devtools/source/v1/BUILD.bazel
---- a/googleapis/devtools/source/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/source/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/source/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10180,7 +9984,7 @@ diff -urN a/googleapis/devtools/source/v1/BUILD.bazel b/googleapis/devtools/sour
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/devtools/sourcerepo/v1/BUILD.bazel b/googleapis/devtools/sourcerepo/v1/BUILD.bazel
---- a/googleapis/devtools/sourcerepo/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/sourcerepo/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/sourcerepo/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10208,7 +10012,7 @@ diff -urN a/googleapis/devtools/sourcerepo/v1/BUILD.bazel b/googleapis/devtools/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/devtools/testing/v1/BUILD.bazel b/googleapis/devtools/testing/v1/BUILD.bazel
---- a/googleapis/devtools/testing/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/devtools/testing/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/testing/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,29 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10241,7 +10045,7 @@ diff -urN a/googleapis/devtools/testing/v1/BUILD.bazel b/googleapis/devtools/tes
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/example/library/v1/BUILD.bazel b/googleapis/example/library/v1/BUILD.bazel
---- a/googleapis/example/library/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/example/library/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/example/library/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10269,7 +10073,7 @@ diff -urN a/googleapis/example/library/v1/BUILD.bazel b/googleapis/example/libra
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/firebase/fcm/connection/v1alpha1/BUILD.bazel b/googleapis/firebase/fcm/connection/v1alpha1/BUILD.bazel
---- a/googleapis/firebase/fcm/connection/v1alpha1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/firebase/fcm/connection/v1alpha1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/firebase/fcm/connection/v1alpha1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10296,7 +10100,7 @@ diff -urN a/googleapis/firebase/fcm/connection/v1alpha1/BUILD.bazel b/googleapis
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/firestore/admin/v1/BUILD.bazel b/googleapis/firestore/admin/v1/BUILD.bazel
---- a/googleapis/firestore/admin/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/firestore/admin/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/firestore/admin/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10318,7 +10122,7 @@ diff -urN a/googleapis/firestore/admin/v1/BUILD.bazel b/googleapis/firestore/adm
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/firestore/admin/v1beta1/BUILD.bazel b/googleapis/firestore/admin/v1beta1/BUILD.bazel
---- a/googleapis/firestore/admin/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/firestore/admin/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/firestore/admin/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10352,7 +10156,7 @@ diff -urN a/googleapis/firestore/admin/v1beta1/BUILD.bazel b/googleapis/firestor
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/firestore/admin/v1beta2/BUILD.bazel b/googleapis/firestore/admin/v1beta2/BUILD.bazel
---- a/googleapis/firestore/admin/v1beta2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/firestore/admin/v1beta2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/firestore/admin/v1beta2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10387,7 +10191,7 @@ diff -urN a/googleapis/firestore/admin/v1beta2/BUILD.bazel b/googleapis/firestor
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/firestore/v1/BUILD.bazel b/googleapis/firestore/v1/BUILD.bazel
---- a/googleapis/firestore/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/firestore/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/firestore/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10409,7 +10213,7 @@ diff -urN a/googleapis/firestore/v1/BUILD.bazel b/googleapis/firestore/v1/BUILD.
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/firestore/v1beta1/BUILD.bazel b/googleapis/firestore/v1beta1/BUILD.bazel
---- a/googleapis/firestore/v1beta1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/firestore/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/firestore/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,34 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10447,7 +10251,7 @@ diff -urN a/googleapis/firestore/v1beta1/BUILD.bazel b/googleapis/firestore/v1be
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/gapic/metadata/BUILD.bazel b/googleapis/gapic/metadata/BUILD.bazel
---- a/googleapis/gapic/metadata/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/gapic/metadata/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/gapic/metadata/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10469,7 +10273,7 @@ diff -urN a/googleapis/gapic/metadata/BUILD.bazel b/googleapis/gapic/metadata/BU
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/genomics/v1/BUILD.bazel b/googleapis/genomics/v1/BUILD.bazel
---- a/googleapis/genomics/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/genomics/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/genomics/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,44 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10517,7 +10321,7 @@ diff -urN a/googleapis/genomics/v1/BUILD.bazel b/googleapis/genomics/v1/BUILD.ba
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/genomics/v1alpha2/BUILD.bazel b/googleapis/genomics/v1alpha2/BUILD.bazel
---- a/googleapis/genomics/v1alpha2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/genomics/v1alpha2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/genomics/v1alpha2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10548,7 +10352,7 @@ diff -urN a/googleapis/genomics/v1alpha2/BUILD.bazel b/googleapis/genomics/v1alp
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/geo/type/viewport/BUILD.bazel b/googleapis/geo/type/viewport/BUILD.bazel
---- a/googleapis/geo/type/viewport/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/geo/type/viewport/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/geo/type/viewport/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10571,9 +10375,9 @@ diff -urN a/googleapis/geo/type/viewport/BUILD.bazel b/googleapis/geo/type/viewp
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/grafeas/v1/BUILD.bazel b/googleapis/grafeas/v1/BUILD.bazel
---- a/googleapis/grafeas/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/grafeas/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/grafeas/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,48 @@
+@@ -0,0 +1,49 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -10597,6 +10401,7 @@ diff -urN a/googleapis/grafeas/v1/BUILD.bazel b/googleapis/grafeas/v1/BUILD.baze
 +        "slsa_provenance.pb.go",
 +        "slsa_provenance_zero_two.pb.go",
 +        "upgrade.pb.go",
++        "vex.pb.go",
 +        "vulnerability.pb.go",
 +    ],
 +    importpath = "google.golang.org/genproto/googleapis/grafeas/v1",
@@ -10623,7 +10428,7 @@ diff -urN a/googleapis/grafeas/v1/BUILD.bazel b/googleapis/grafeas/v1/BUILD.baze
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/home/enterprise/sdm/v1/BUILD.bazel b/googleapis/home/enterprise/sdm/v1/BUILD.bazel
---- a/googleapis/home/enterprise/sdm/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/home/enterprise/sdm/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/home/enterprise/sdm/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10654,7 +10459,7 @@ diff -urN a/googleapis/home/enterprise/sdm/v1/BUILD.bazel b/googleapis/home/ente
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/home/graph/v1/BUILD.bazel b/googleapis/home/graph/v1/BUILD.bazel
---- a/googleapis/home/graph/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/home/graph/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/home/graph/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10685,7 +10490,7 @@ diff -urN a/googleapis/home/graph/v1/BUILD.bazel b/googleapis/home/graph/v1/BUIL
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/iam/admin/v1/BUILD.bazel b/googleapis/iam/admin/v1/BUILD.bazel
---- a/googleapis/iam/admin/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/iam/admin/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/iam/admin/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10707,7 +10512,7 @@ diff -urN a/googleapis/iam/admin/v1/BUILD.bazel b/googleapis/iam/admin/v1/BUILD.
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/iam/credentials/v1/BUILD.bazel b/googleapis/iam/credentials/v1/BUILD.bazel
---- a/googleapis/iam/credentials/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/iam/credentials/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/iam/credentials/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10729,7 +10534,7 @@ diff -urN a/googleapis/iam/credentials/v1/BUILD.bazel b/googleapis/iam/credentia
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/iam/v1/BUILD.bazel b/googleapis/iam/v1/BUILD.bazel
---- a/googleapis/iam/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/iam/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/iam/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10751,7 +10556,7 @@ diff -urN a/googleapis/iam/v1/BUILD.bazel b/googleapis/iam/v1/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/iam/v1/logging/BUILD.bazel b/googleapis/iam/v1/logging/BUILD.bazel
---- a/googleapis/iam/v1/logging/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/iam/v1/logging/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/iam/v1/logging/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10774,7 +10579,7 @@ diff -urN a/googleapis/iam/v1/logging/BUILD.bazel b/googleapis/iam/v1/logging/BU
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/iam/v1beta/BUILD.bazel b/googleapis/iam/v1beta/BUILD.bazel
---- a/googleapis/iam/v1beta/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/iam/v1beta/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/iam/v1beta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10802,29 +10607,19 @@ diff -urN a/googleapis/iam/v1beta/BUILD.bazel b/googleapis/iam/v1beta/BUILD.baze
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/iam/v2/BUILD.bazel b/googleapis/iam/v2/BUILD.bazel
---- a/googleapis/iam/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/iam/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/iam/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,28 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
 +    name = "iam",
-+    srcs = [
-+        "deny.pb.go",
-+        "policy.pb.go",
-+    ],
++    srcs = ["alias.go"],
 +    importpath = "google.golang.org/genproto/googleapis/iam/v2",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "//googleapis/api/annotations",
-+        "//googleapis/longrunning",
-+        "//googleapis/type/expr",
++        "@com_google_cloud_go_iam//apiv2/iampb:go_default_library",
 +        "@org_golang_google_grpc//:go_default_library",
-+        "@org_golang_google_grpc//codes:go_default_library",
-+        "@org_golang_google_grpc//status:go_default_library",
-+        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
-+        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
-+        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
 +    ],
 +)
 +
@@ -10834,7 +10629,7 @@ diff -urN a/googleapis/iam/v2/BUILD.bazel b/googleapis/iam/v2/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/iam/v2beta/BUILD.bazel b/googleapis/iam/v2beta/BUILD.bazel
---- a/googleapis/iam/v2beta/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/iam/v2beta/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/iam/v2beta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10866,7 +10661,7 @@ diff -urN a/googleapis/iam/v2beta/BUILD.bazel b/googleapis/iam/v2beta/BUILD.baze
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/identity/accesscontextmanager/type/BUILD.bazel b/googleapis/identity/accesscontextmanager/type/BUILD.bazel
---- a/googleapis/identity/accesscontextmanager/type/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/identity/accesscontextmanager/type/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/identity/accesscontextmanager/type/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10888,7 +10683,7 @@ diff -urN a/googleapis/identity/accesscontextmanager/type/BUILD.bazel b/googleap
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/identity/accesscontextmanager/v1/BUILD.bazel b/googleapis/identity/accesscontextmanager/v1/BUILD.bazel
---- a/googleapis/identity/accesscontextmanager/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/identity/accesscontextmanager/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/identity/accesscontextmanager/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10910,7 +10705,7 @@ diff -urN a/googleapis/identity/accesscontextmanager/v1/BUILD.bazel b/googleapis
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/logging/type/BUILD.bazel b/googleapis/logging/type/BUILD.bazel
---- a/googleapis/logging/type/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/logging/type/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/logging/type/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10936,7 +10731,7 @@ diff -urN a/googleapis/logging/type/BUILD.bazel b/googleapis/logging/type/BUILD.
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/logging/v2/BUILD.bazel b/googleapis/logging/v2/BUILD.bazel
---- a/googleapis/logging/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/logging/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/logging/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10958,7 +10753,7 @@ diff -urN a/googleapis/logging/v2/BUILD.bazel b/googleapis/logging/v2/BUILD.baze
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/longrunning/BUILD.bazel b/googleapis/longrunning/BUILD.bazel
---- a/googleapis/longrunning/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/longrunning/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/longrunning/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10980,7 +10775,7 @@ diff -urN a/googleapis/longrunning/BUILD.bazel b/googleapis/longrunning/BUILD.ba
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/maps/addressvalidation/v1/BUILD.bazel b/googleapis/maps/addressvalidation/v1/BUILD.bazel
---- a/googleapis/maps/addressvalidation/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/maps/addressvalidation/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/maps/addressvalidation/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11002,9 +10797,9 @@ diff -urN a/googleapis/maps/addressvalidation/v1/BUILD.bazel b/googleapis/maps/a
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/maps/fleetengine/delivery/v1/BUILD.bazel b/googleapis/maps/fleetengine/delivery/v1/BUILD.bazel
---- a/googleapis/maps/fleetengine/delivery/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/maps/fleetengine/delivery/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/maps/fleetengine/delivery/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -11014,6 +10809,7 @@ diff -urN a/googleapis/maps/fleetengine/delivery/v1/BUILD.bazel b/googleapis/map
 +        "delivery_api.pb.go",
 +        "delivery_vehicles.pb.go",
 +        "header.pb.go",
++        "task_tracking_info.pb.go",
 +        "tasks.pb.go",
 +    ],
 +    importpath = "google.golang.org/genproto/googleapis/maps/fleetengine/delivery/v1",
@@ -11040,7 +10836,7 @@ diff -urN a/googleapis/maps/fleetengine/delivery/v1/BUILD.bazel b/googleapis/map
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/maps/fleetengine/v1/BUILD.bazel b/googleapis/maps/fleetengine/v1/BUILD.bazel
---- a/googleapis/maps/fleetengine/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/maps/fleetengine/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/maps/fleetengine/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11079,42 +10875,8 @@ diff -urN a/googleapis/maps/fleetengine/v1/BUILD.bazel b/googleapis/maps/fleeten
 +    actual = ":fleetengine",
 +    visibility = ["//visibility:public"],
 +)
-diff -urN a/googleapis/maps/mapsplatformdatasets/v1alpha/BUILD.bazel b/googleapis/maps/mapsplatformdatasets/v1alpha/BUILD.bazel
---- a/googleapis/maps/mapsplatformdatasets/v1alpha/BUILD.bazel	1969-12-31 16:00:00
-+++ b/googleapis/maps/mapsplatformdatasets/v1alpha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,30 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "v1alpha",
-+    srcs = [
-+        "data_source.pb.go",
-+        "dataset.pb.go",
-+        "maps_platform_datasets.pb.go",
-+        "maps_platform_datasets_alpha_service.pb.go",
-+    ],
-+    importpath = "google.golang.org/genproto/googleapis/maps/mapsplatformdatasets/v1alpha",
-+    visibility = ["//visibility:public"],
-+    deps = [
-+        "//googleapis/api/annotations",
-+        "@org_golang_google_grpc//:go_default_library",
-+        "@org_golang_google_grpc//codes:go_default_library",
-+        "@org_golang_google_grpc//status:go_default_library",
-+        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
-+        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
-+        "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
-+        "@org_golang_google_protobuf//types/known/fieldmaskpb:go_default_library",
-+        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
-+    ],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":v1alpha",
-+    visibility = ["//visibility:public"],
-+)
 diff -urN a/googleapis/maps/playablelocations/v3/BUILD.bazel b/googleapis/maps/playablelocations/v3/BUILD.bazel
---- a/googleapis/maps/playablelocations/v3/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/maps/playablelocations/v3/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/maps/playablelocations/v3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11146,7 +10908,7 @@ diff -urN a/googleapis/maps/playablelocations/v3/BUILD.bazel b/googleapis/maps/p
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/maps/playablelocations/v3/sample/BUILD.bazel b/googleapis/maps/playablelocations/v3/sample/BUILD.bazel
---- a/googleapis/maps/playablelocations/v3/sample/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/maps/playablelocations/v3/sample/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/maps/playablelocations/v3/sample/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11171,7 +10933,7 @@ diff -urN a/googleapis/maps/playablelocations/v3/sample/BUILD.bazel b/googleapis
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/maps/regionlookup/v1alpha/BUILD.bazel b/googleapis/maps/regionlookup/v1alpha/BUILD.bazel
---- a/googleapis/maps/regionlookup/v1alpha/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/maps/regionlookup/v1alpha/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/maps/regionlookup/v1alpha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11203,7 +10965,7 @@ diff -urN a/googleapis/maps/regionlookup/v1alpha/BUILD.bazel b/googleapis/maps/r
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/maps/roads/v1op/BUILD.bazel b/googleapis/maps/roads/v1op/BUILD.bazel
---- a/googleapis/maps/roads/v1op/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/maps/roads/v1op/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/maps/roads/v1op/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11231,7 +10993,7 @@ diff -urN a/googleapis/maps/roads/v1op/BUILD.bazel b/googleapis/maps/roads/v1op/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/maps/routes/v1/BUILD.bazel b/googleapis/maps/routes/v1/BUILD.bazel
---- a/googleapis/maps/routes/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/maps/routes/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/maps/routes/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,45 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11280,7 +11042,7 @@ diff -urN a/googleapis/maps/routes/v1/BUILD.bazel b/googleapis/maps/routes/v1/BU
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/maps/routes/v1alpha/BUILD.bazel b/googleapis/maps/routes/v1alpha/BUILD.bazel
---- a/googleapis/maps/routes/v1alpha/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/maps/routes/v1alpha/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/maps/routes/v1alpha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11307,7 +11069,7 @@ diff -urN a/googleapis/maps/routes/v1alpha/BUILD.bazel b/googleapis/maps/routes/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/maps/routing/v2/BUILD.bazel b/googleapis/maps/routing/v2/BUILD.bazel
---- a/googleapis/maps/routing/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/maps/routing/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/maps/routing/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11329,7 +11091,7 @@ diff -urN a/googleapis/maps/routing/v2/BUILD.bazel b/googleapis/maps/routing/v2/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/maps/unity/BUILD.bazel b/googleapis/maps/unity/BUILD.bazel
---- a/googleapis/maps/unity/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/maps/unity/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/maps/unity/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11351,7 +11113,7 @@ diff -urN a/googleapis/maps/unity/BUILD.bazel b/googleapis/maps/unity/BUILD.baze
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/monitoring/dashboard/v1/BUILD.bazel b/googleapis/monitoring/dashboard/v1/BUILD.bazel
---- a/googleapis/monitoring/dashboard/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/monitoring/dashboard/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/monitoring/dashboard/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11373,7 +11135,7 @@ diff -urN a/googleapis/monitoring/dashboard/v1/BUILD.bazel b/googleapis/monitori
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/monitoring/metricsscope/v1/BUILD.bazel b/googleapis/monitoring/metricsscope/v1/BUILD.bazel
---- a/googleapis/monitoring/metricsscope/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/monitoring/metricsscope/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/monitoring/metricsscope/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11395,7 +11157,7 @@ diff -urN a/googleapis/monitoring/metricsscope/v1/BUILD.bazel b/googleapis/monit
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/monitoring/v3/BUILD.bazel b/googleapis/monitoring/v3/BUILD.bazel
---- a/googleapis/monitoring/v3/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/monitoring/v3/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/monitoring/v3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11417,7 +11179,7 @@ diff -urN a/googleapis/monitoring/v3/BUILD.bazel b/googleapis/monitoring/v3/BUIL
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/networking/trafficdirector/type/BUILD.bazel b/googleapis/networking/trafficdirector/type/BUILD.bazel
---- a/googleapis/networking/trafficdirector/type/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/networking/trafficdirector/type/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/networking/trafficdirector/type/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11439,7 +11201,7 @@ diff -urN a/googleapis/networking/trafficdirector/type/BUILD.bazel b/googleapis/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/partner/aistreams/v1alpha1/BUILD.bazel b/googleapis/partner/aistreams/v1alpha1/BUILD.bazel
---- a/googleapis/partner/aistreams/v1alpha1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/partner/aistreams/v1alpha1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/partner/aistreams/v1alpha1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11468,7 +11230,7 @@ diff -urN a/googleapis/partner/aistreams/v1alpha1/BUILD.bazel b/googleapis/partn
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/privacy/dlp/v2/BUILD.bazel b/googleapis/privacy/dlp/v2/BUILD.bazel
---- a/googleapis/privacy/dlp/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/privacy/dlp/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/privacy/dlp/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11490,7 +11252,7 @@ diff -urN a/googleapis/privacy/dlp/v2/BUILD.bazel b/googleapis/privacy/dlp/v2/BU
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/pubsub/v1/BUILD.bazel b/googleapis/pubsub/v1/BUILD.bazel
---- a/googleapis/pubsub/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/pubsub/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/pubsub/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11512,7 +11274,7 @@ diff -urN a/googleapis/pubsub/v1/BUILD.bazel b/googleapis/pubsub/v1/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/pubsub/v1beta2/BUILD.bazel b/googleapis/pubsub/v1beta2/BUILD.bazel
---- a/googleapis/pubsub/v1beta2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/pubsub/v1beta2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/pubsub/v1beta2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11538,7 +11300,7 @@ diff -urN a/googleapis/pubsub/v1beta2/BUILD.bazel b/googleapis/pubsub/v1beta2/BU
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/rpc/code/BUILD.bazel b/googleapis/rpc/code/BUILD.bazel
---- a/googleapis/rpc/code/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/rpc/code/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/rpc/code/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11559,31 +11321,8 @@ diff -urN a/googleapis/rpc/code/BUILD.bazel b/googleapis/rpc/code/BUILD.bazel
 +    actual = ":code",
 +    visibility = ["//visibility:public"],
 +)
-diff -urN a/googleapis/rpc/context/BUILD.bazel b/googleapis/rpc/context/BUILD.bazel
---- a/googleapis/rpc/context/BUILD.bazel	1969-12-31 16:00:00
-+++ b/googleapis/rpc/context/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,19 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "context",
-+    srcs = ["audit_context.pb.go"],
-+    importpath = "google.golang.org/genproto/googleapis/rpc/context",
-+    visibility = ["//visibility:public"],
-+    deps = [
-+        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
-+        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
-+        "@org_golang_google_protobuf//types/known/structpb:go_default_library",
-+    ],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":context",
-+    visibility = ["//visibility:public"],
-+)
 diff -urN a/googleapis/rpc/context/attribute_context/BUILD.bazel b/googleapis/rpc/context/attribute_context/BUILD.bazel
---- a/googleapis/rpc/context/attribute_context/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/rpc/context/attribute_context/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/rpc/context/attribute_context/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11608,8 +11347,31 @@ diff -urN a/googleapis/rpc/context/attribute_context/BUILD.bazel b/googleapis/rp
 +    actual = ":attribute_context",
 +    visibility = ["//visibility:public"],
 +)
+diff -urN a/googleapis/rpc/context/BUILD.bazel b/googleapis/rpc/context/BUILD.bazel
+--- a/googleapis/rpc/context/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/googleapis/rpc/context/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "context",
++    srcs = ["audit_context.pb.go"],
++    importpath = "google.golang.org/genproto/googleapis/rpc/context",
++    visibility = ["//visibility:public"],
++    deps = [
++        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
++        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
++        "@org_golang_google_protobuf//types/known/structpb:go_default_library",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":context",
++    visibility = ["//visibility:public"],
++)
 diff -urN a/googleapis/rpc/errdetails/BUILD.bazel b/googleapis/rpc/errdetails/BUILD.bazel
---- a/googleapis/rpc/errdetails/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/rpc/errdetails/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/rpc/errdetails/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11632,7 +11394,7 @@ diff -urN a/googleapis/rpc/errdetails/BUILD.bazel b/googleapis/rpc/errdetails/BU
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/rpc/http/BUILD.bazel b/googleapis/rpc/http/BUILD.bazel
---- a/googleapis/rpc/http/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/rpc/http/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/rpc/http/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11654,7 +11416,7 @@ diff -urN a/googleapis/rpc/http/BUILD.bazel b/googleapis/rpc/http/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/rpc/status/BUILD.bazel b/googleapis/rpc/status/BUILD.bazel
---- a/googleapis/rpc/status/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/rpc/status/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/rpc/status/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11677,7 +11439,7 @@ diff -urN a/googleapis/rpc/status/BUILD.bazel b/googleapis/rpc/status/BUILD.baze
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/search/partnerdataingestion/logging/v1/BUILD.bazel b/googleapis/search/partnerdataingestion/logging/v1/BUILD.bazel
---- a/googleapis/search/partnerdataingestion/logging/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/search/partnerdataingestion/logging/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/search/partnerdataingestion/logging/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11699,7 +11461,7 @@ diff -urN a/googleapis/search/partnerdataingestion/logging/v1/BUILD.bazel b/goog
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/spanner/admin/database/v1/BUILD.bazel b/googleapis/spanner/admin/database/v1/BUILD.bazel
---- a/googleapis/spanner/admin/database/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/spanner/admin/database/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/spanner/admin/database/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11721,7 +11483,7 @@ diff -urN a/googleapis/spanner/admin/database/v1/BUILD.bazel b/googleapis/spanne
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/spanner/admin/instance/v1/BUILD.bazel b/googleapis/spanner/admin/instance/v1/BUILD.bazel
---- a/googleapis/spanner/admin/instance/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/spanner/admin/instance/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/spanner/admin/instance/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11743,7 +11505,7 @@ diff -urN a/googleapis/spanner/admin/instance/v1/BUILD.bazel b/googleapis/spanne
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/spanner/v1/BUILD.bazel b/googleapis/spanner/v1/BUILD.bazel
---- a/googleapis/spanner/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/spanner/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/spanner/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11765,7 +11527,7 @@ diff -urN a/googleapis/spanner/v1/BUILD.bazel b/googleapis/spanner/v1/BUILD.baze
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/storage/clouddms/logging/v1/BUILD.bazel b/googleapis/storage/clouddms/logging/v1/BUILD.bazel
---- a/googleapis/storage/clouddms/logging/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/storage/clouddms/logging/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/storage/clouddms/logging/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11790,7 +11552,7 @@ diff -urN a/googleapis/storage/clouddms/logging/v1/BUILD.bazel b/googleapis/stor
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/storage/v1/BUILD.bazel b/googleapis/storage/v1/BUILD.bazel
---- a/googleapis/storage/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/storage/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/storage/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11824,7 +11586,7 @@ diff -urN a/googleapis/storage/v1/BUILD.bazel b/googleapis/storage/v1/BUILD.baze
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/storage/v2/BUILD.bazel b/googleapis/storage/v2/BUILD.bazel
---- a/googleapis/storage/v2/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/storage/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/storage/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11858,7 +11620,7 @@ diff -urN a/googleapis/storage/v2/BUILD.bazel b/googleapis/storage/v2/BUILD.baze
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/storagetransfer/logging/BUILD.bazel b/googleapis/storagetransfer/logging/BUILD.bazel
---- a/googleapis/storagetransfer/logging/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/storagetransfer/logging/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/storagetransfer/logging/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11882,7 +11644,7 @@ diff -urN a/googleapis/storagetransfer/logging/BUILD.bazel b/googleapis/storaget
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/storagetransfer/v1/BUILD.bazel b/googleapis/storagetransfer/v1/BUILD.bazel
---- a/googleapis/storagetransfer/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/storagetransfer/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/storagetransfer/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11904,7 +11666,7 @@ diff -urN a/googleapis/storagetransfer/v1/BUILD.bazel b/googleapis/storagetransf
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/streetview/publish/v1/BUILD.bazel b/googleapis/streetview/publish/v1/BUILD.bazel
---- a/googleapis/streetview/publish/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/streetview/publish/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/streetview/publish/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11941,7 +11703,7 @@ diff -urN a/googleapis/streetview/publish/v1/BUILD.bazel b/googleapis/streetview
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/type/calendarperiod/BUILD.bazel b/googleapis/type/calendarperiod/BUILD.bazel
---- a/googleapis/type/calendarperiod/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/type/calendarperiod/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/type/calendarperiod/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11963,7 +11725,7 @@ diff -urN a/googleapis/type/calendarperiod/BUILD.bazel b/googleapis/type/calenda
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/type/color/BUILD.bazel b/googleapis/type/color/BUILD.bazel
---- a/googleapis/type/color/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/type/color/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/type/color/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -11986,7 +11748,7 @@ diff -urN a/googleapis/type/color/BUILD.bazel b/googleapis/type/color/BUILD.baze
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/type/date/BUILD.bazel b/googleapis/type/date/BUILD.bazel
---- a/googleapis/type/date/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/type/date/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/type/date/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -12008,7 +11770,7 @@ diff -urN a/googleapis/type/date/BUILD.bazel b/googleapis/type/date/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/type/date_range/BUILD.bazel b/googleapis/type/date_range/BUILD.bazel
---- a/googleapis/type/date_range/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/type/date_range/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/type/date_range/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -12030,31 +11792,8 @@ diff -urN a/googleapis/type/date_range/BUILD.bazel b/googleapis/type/date_range/
 +    actual = ":date_range",
 +    visibility = ["//visibility:public"],
 +)
-diff -urN a/googleapis/type/date_time_range/BUILD.bazel b/googleapis/type/date_time_range/BUILD.bazel
---- a/googleapis/type/date_time_range/BUILD.bazel	1969-12-31 16:00:00
-+++ b/googleapis/type/date_time_range/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,19 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "date_time_range",
-+    srcs = ["datetime_range.pb.go"],
-+    importpath = "google.golang.org/genproto/googleapis/type/date_time_range",
-+    visibility = ["//visibility:public"],
-+    deps = [
-+        "//googleapis/type/datetime",
-+        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
-+        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
-+    ],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":date_time_range",
-+    visibility = ["//visibility:public"],
-+)
 diff -urN a/googleapis/type/datetime/BUILD.bazel b/googleapis/type/datetime/BUILD.bazel
---- a/googleapis/type/datetime/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/type/datetime/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/type/datetime/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -12076,8 +11815,31 @@ diff -urN a/googleapis/type/datetime/BUILD.bazel b/googleapis/type/datetime/BUIL
 +    actual = ":datetime",
 +    visibility = ["//visibility:public"],
 +)
+diff -urN a/googleapis/type/date_time_range/BUILD.bazel b/googleapis/type/date_time_range/BUILD.bazel
+--- a/googleapis/type/date_time_range/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/googleapis/type/date_time_range/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "date_time_range",
++    srcs = ["datetime_range.pb.go"],
++    importpath = "google.golang.org/genproto/googleapis/type/date_time_range",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//googleapis/type/datetime",
++        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
++        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":date_time_range",
++    visibility = ["//visibility:public"],
++)
 diff -urN a/googleapis/type/dayofweek/BUILD.bazel b/googleapis/type/dayofweek/BUILD.bazel
---- a/googleapis/type/dayofweek/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/type/dayofweek/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/type/dayofweek/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -12099,7 +11861,7 @@ diff -urN a/googleapis/type/dayofweek/BUILD.bazel b/googleapis/type/dayofweek/BU
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/type/decimal/BUILD.bazel b/googleapis/type/decimal/BUILD.bazel
---- a/googleapis/type/decimal/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/type/decimal/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/type/decimal/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -12121,7 +11883,7 @@ diff -urN a/googleapis/type/decimal/BUILD.bazel b/googleapis/type/decimal/BUILD.
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/type/expr/BUILD.bazel b/googleapis/type/expr/BUILD.bazel
---- a/googleapis/type/expr/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/type/expr/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/type/expr/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -12143,7 +11905,7 @@ diff -urN a/googleapis/type/expr/BUILD.bazel b/googleapis/type/expr/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/type/fraction/BUILD.bazel b/googleapis/type/fraction/BUILD.bazel
---- a/googleapis/type/fraction/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/type/fraction/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/type/fraction/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -12165,7 +11927,7 @@ diff -urN a/googleapis/type/fraction/BUILD.bazel b/googleapis/type/fraction/BUIL
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/type/interval/BUILD.bazel b/googleapis/type/interval/BUILD.bazel
---- a/googleapis/type/interval/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/type/interval/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/type/interval/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -12188,7 +11950,7 @@ diff -urN a/googleapis/type/interval/BUILD.bazel b/googleapis/type/interval/BUIL
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/type/latlng/BUILD.bazel b/googleapis/type/latlng/BUILD.bazel
---- a/googleapis/type/latlng/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/type/latlng/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/type/latlng/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -12210,7 +11972,7 @@ diff -urN a/googleapis/type/latlng/BUILD.bazel b/googleapis/type/latlng/BUILD.ba
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/type/localized_text/BUILD.bazel b/googleapis/type/localized_text/BUILD.bazel
---- a/googleapis/type/localized_text/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/type/localized_text/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/type/localized_text/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -12232,7 +11994,7 @@ diff -urN a/googleapis/type/localized_text/BUILD.bazel b/googleapis/type/localiz
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/type/money/BUILD.bazel b/googleapis/type/money/BUILD.bazel
---- a/googleapis/type/money/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/type/money/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/type/money/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -12254,7 +12016,7 @@ diff -urN a/googleapis/type/money/BUILD.bazel b/googleapis/type/money/BUILD.baze
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/type/month/BUILD.bazel b/googleapis/type/month/BUILD.bazel
---- a/googleapis/type/month/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/type/month/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/type/month/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -12276,7 +12038,7 @@ diff -urN a/googleapis/type/month/BUILD.bazel b/googleapis/type/month/BUILD.baze
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/type/phone_number/BUILD.bazel b/googleapis/type/phone_number/BUILD.bazel
---- a/googleapis/type/phone_number/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/type/phone_number/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/type/phone_number/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -12298,7 +12060,7 @@ diff -urN a/googleapis/type/phone_number/BUILD.bazel b/googleapis/type/phone_num
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/type/postaladdress/BUILD.bazel b/googleapis/type/postaladdress/BUILD.bazel
---- a/googleapis/type/postaladdress/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/type/postaladdress/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/type/postaladdress/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -12320,7 +12082,7 @@ diff -urN a/googleapis/type/postaladdress/BUILD.bazel b/googleapis/type/postalad
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/type/quaternion/BUILD.bazel b/googleapis/type/quaternion/BUILD.bazel
---- a/googleapis/type/quaternion/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/type/quaternion/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/type/quaternion/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -12342,7 +12104,7 @@ diff -urN a/googleapis/type/quaternion/BUILD.bazel b/googleapis/type/quaternion/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/type/timeofday/BUILD.bazel b/googleapis/type/timeofday/BUILD.bazel
---- a/googleapis/type/timeofday/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/type/timeofday/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/type/timeofday/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -12364,7 +12126,7 @@ diff -urN a/googleapis/type/timeofday/BUILD.bazel b/googleapis/type/timeofday/BU
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/watcher/v1/BUILD.bazel b/googleapis/watcher/v1/BUILD.bazel
---- a/googleapis/watcher/v1/BUILD.bazel	1969-12-31 16:00:00
+--- a/googleapis/watcher/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/watcher/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -12392,7 +12154,7 @@ diff -urN a/googleapis/watcher/v1/BUILD.bazel b/googleapis/watcher/v1/BUILD.baze
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protobuf/api/BUILD.bazel b/protobuf/api/BUILD.bazel
---- a/protobuf/api/BUILD.bazel	1969-12-31 16:00:00
+--- a/protobuf/api/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protobuf/api/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -12411,7 +12173,7 @@ diff -urN a/protobuf/api/BUILD.bazel b/protobuf/api/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protobuf/field_mask/BUILD.bazel b/protobuf/field_mask/BUILD.bazel
---- a/protobuf/field_mask/BUILD.bazel	1969-12-31 16:00:00
+--- a/protobuf/field_mask/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protobuf/field_mask/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -12430,7 +12192,7 @@ diff -urN a/protobuf/field_mask/BUILD.bazel b/protobuf/field_mask/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protobuf/ptype/BUILD.bazel b/protobuf/ptype/BUILD.bazel
---- a/protobuf/ptype/BUILD.bazel	1969-12-31 16:00:00
+--- a/protobuf/ptype/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protobuf/ptype/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -12449,7 +12211,7 @@ diff -urN a/protobuf/ptype/BUILD.bazel b/protobuf/ptype/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/protobuf/source_context/BUILD.bazel b/protobuf/source_context/BUILD.bazel
---- a/protobuf/source_context/BUILD.bazel	1969-12-31 16:00:00
+--- a/protobuf/source_context/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/protobuf/source_context/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")

--- a/third_party/org_golang_google_protobuf-gazelle.patch
+++ b/third_party/org_golang_google_protobuf-gazelle.patch
@@ -1,7 +1,7 @@
 diff -urN a/cmd/protoc-gen-go/BUILD.bazel b/cmd/protoc-gen-go/BUILD.bazel
---- a/cmd/protoc-gen-go/BUILD.bazel	1969-12-31 16:00:00
+--- a/cmd/protoc-gen-go/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cmd/protoc-gen-go/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,31 @@
+@@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 +
 +go_library(
@@ -24,19 +24,24 @@ diff -urN a/cmd/protoc-gen-go/BUILD.bazel b/cmd/protoc-gen-go/BUILD.bazel
 +
 +go_test(
 +    name = "protoc-gen-go_test",
-+    srcs = ["annotation_test.go"],
++    srcs = [
++        "annotation_test.go",
++        "retention_test.go",
++    ],
 +    embed = [":protoc-gen-go_lib"],
 +    deps = [
++        "//cmd/protoc-gen-go/testdata/retention",
 +        "//encoding/prototext",
 +        "//internal/genid",
 +        "//proto",
++        "//reflect/protoreflect",
 +        "//types/descriptorpb",
 +    ],
 +)
 diff -urN a/cmd/protoc-gen-go/internal_gengo/BUILD.bazel b/cmd/protoc-gen-go/internal_gengo/BUILD.bazel
---- a/cmd/protoc-gen-go/internal_gengo/BUILD.bazel	1969-12-31 16:00:00
+--- a/cmd/protoc-gen-go/internal_gengo/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cmd/protoc-gen-go/internal_gengo/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,31 @@
+@@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -56,6 +61,8 @@ diff -urN a/cmd/protoc-gen-go/internal_gengo/BUILD.bazel b/cmd/protoc-gen-go/int
 +        "//internal/genid",
 +        "//internal/version",
 +        "//proto",
++        "//reflect/protopath",
++        "//reflect/protorange",
 +        "//reflect/protoreflect",
 +        "//runtime/protoimpl",
 +        "//types/descriptorpb",
@@ -68,10 +75,32 @@ diff -urN a/cmd/protoc-gen-go/internal_gengo/BUILD.bazel b/cmd/protoc-gen-go/int
 +    actual = ":internal_gengo",
 +    visibility = ["//visibility:public"],
 +)
+diff -urN a/cmd/protoc-gen-go/testdata/annotations/BUILD.bazel b/cmd/protoc-gen-go/testdata/annotations/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/annotations/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/cmd/protoc-gen-go/testdata/annotations/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,18 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "annotations",
++    srcs = ["annotations.pb.go"],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/annotations",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":annotations",
++    visibility = ["//visibility:public"],
++)
 diff -urN a/cmd/protoc-gen-go/testdata/BUILD.bazel b/cmd/protoc-gen-go/testdata/BUILD.bazel
---- a/cmd/protoc-gen-go/testdata/BUILD.bazel	1969-12-31 16:00:00
+--- a/cmd/protoc-gen-go/testdata/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cmd/protoc-gen-go/testdata/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,33 @@
+@@ -0,0 +1,34 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_test")
 +
 +go_test(
@@ -100,35 +129,14 @@ diff -urN a/cmd/protoc-gen-go/testdata/BUILD.bazel b/cmd/protoc-gen-go/testdata/
 +        "//cmd/protoc-gen-go/testdata/nopackage",
 +        "//cmd/protoc-gen-go/testdata/proto2",
 +        "//cmd/protoc-gen-go/testdata/proto3",
++        "//cmd/protoc-gen-go/testdata/retention",
 +        "//internal/filedesc",
 +        "//reflect/protoreflect",
 +        "//reflect/protoregistry",
 +    ],
 +)
-diff -urN a/cmd/protoc-gen-go/testdata/annotations/BUILD.bazel b/cmd/protoc-gen-go/testdata/annotations/BUILD.bazel
---- a/cmd/protoc-gen-go/testdata/annotations/BUILD.bazel	1969-12-31 16:00:00
-+++ b/cmd/protoc-gen-go/testdata/annotations/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,18 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "annotations",
-+    srcs = ["annotations.pb.go"],
-+    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/annotations",
-+    visibility = ["//visibility:public"],
-+    deps = [
-+        "//reflect/protoreflect",
-+        "//runtime/protoimpl",
-+    ],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":annotations",
-+    visibility = ["//visibility:public"],
-+)
 diff -urN a/cmd/protoc-gen-go/testdata/comments/BUILD.bazel b/cmd/protoc-gen-go/testdata/comments/BUILD.bazel
---- a/cmd/protoc-gen-go/testdata/comments/BUILD.bazel	1969-12-31 16:00:00
+--- a/cmd/protoc-gen-go/testdata/comments/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cmd/protoc-gen-go/testdata/comments/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -153,7 +161,7 @@ diff -urN a/cmd/protoc-gen-go/testdata/comments/BUILD.bazel b/cmd/protoc-gen-go/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/cmd/protoc-gen-go/testdata/extensions/base/BUILD.bazel b/cmd/protoc-gen-go/testdata/extensions/base/BUILD.bazel
---- a/cmd/protoc-gen-go/testdata/extensions/base/BUILD.bazel	1969-12-31 16:00:00
+--- a/cmd/protoc-gen-go/testdata/extensions/base/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cmd/protoc-gen-go/testdata/extensions/base/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -175,7 +183,7 @@ diff -urN a/cmd/protoc-gen-go/testdata/extensions/base/BUILD.bazel b/cmd/protoc-
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/cmd/protoc-gen-go/testdata/extensions/ext/BUILD.bazel b/cmd/protoc-gen-go/testdata/extensions/ext/BUILD.bazel
---- a/cmd/protoc-gen-go/testdata/extensions/ext/BUILD.bazel	1969-12-31 16:00:00
+--- a/cmd/protoc-gen-go/testdata/extensions/ext/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cmd/protoc-gen-go/testdata/extensions/ext/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -199,7 +207,7 @@ diff -urN a/cmd/protoc-gen-go/testdata/extensions/ext/BUILD.bazel b/cmd/protoc-g
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/cmd/protoc-gen-go/testdata/extensions/extra/BUILD.bazel b/cmd/protoc-gen-go/testdata/extensions/extra/BUILD.bazel
---- a/cmd/protoc-gen-go/testdata/extensions/extra/BUILD.bazel	1969-12-31 16:00:00
+--- a/cmd/protoc-gen-go/testdata/extensions/extra/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cmd/protoc-gen-go/testdata/extensions/extra/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -221,7 +229,7 @@ diff -urN a/cmd/protoc-gen-go/testdata/extensions/extra/BUILD.bazel b/cmd/protoc
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/cmd/protoc-gen-go/testdata/extensions/proto3/BUILD.bazel b/cmd/protoc-gen-go/testdata/extensions/proto3/BUILD.bazel
---- a/cmd/protoc-gen-go/testdata/extensions/proto3/BUILD.bazel	1969-12-31 16:00:00
+--- a/cmd/protoc-gen-go/testdata/extensions/proto3/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cmd/protoc-gen-go/testdata/extensions/proto3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -244,7 +252,7 @@ diff -urN a/cmd/protoc-gen-go/testdata/extensions/proto3/BUILD.bazel b/cmd/proto
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/cmd/protoc-gen-go/testdata/fieldnames/BUILD.bazel b/cmd/protoc-gen-go/testdata/fieldnames/BUILD.bazel
---- a/cmd/protoc-gen-go/testdata/fieldnames/BUILD.bazel	1969-12-31 16:00:00
+--- a/cmd/protoc-gen-go/testdata/fieldnames/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cmd/protoc-gen-go/testdata/fieldnames/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -266,7 +274,7 @@ diff -urN a/cmd/protoc-gen-go/testdata/fieldnames/BUILD.bazel b/cmd/protoc-gen-g
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/cmd/protoc-gen-go/testdata/import_public/BUILD.bazel b/cmd/protoc-gen-go/testdata/import_public/BUILD.bazel
---- a/cmd/protoc-gen-go/testdata/import_public/BUILD.bazel	1969-12-31 16:00:00
+--- a/cmd/protoc-gen-go/testdata/import_public/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cmd/protoc-gen-go/testdata/import_public/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -294,7 +302,7 @@ diff -urN a/cmd/protoc-gen-go/testdata/import_public/BUILD.bazel b/cmd/protoc-ge
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/cmd/protoc-gen-go/testdata/import_public/sub/BUILD.bazel b/cmd/protoc-gen-go/testdata/import_public/sub/BUILD.bazel
---- a/cmd/protoc-gen-go/testdata/import_public/sub/BUILD.bazel	1969-12-31 16:00:00
+--- a/cmd/protoc-gen-go/testdata/import_public/sub/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cmd/protoc-gen-go/testdata/import_public/sub/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -320,7 +328,7 @@ diff -urN a/cmd/protoc-gen-go/testdata/import_public/sub/BUILD.bazel b/cmd/proto
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/cmd/protoc-gen-go/testdata/import_public/sub2/BUILD.bazel b/cmd/protoc-gen-go/testdata/import_public/sub2/BUILD.bazel
---- a/cmd/protoc-gen-go/testdata/import_public/sub2/BUILD.bazel	1969-12-31 16:00:00
+--- a/cmd/protoc-gen-go/testdata/import_public/sub2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cmd/protoc-gen-go/testdata/import_public/sub2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -342,7 +350,7 @@ diff -urN a/cmd/protoc-gen-go/testdata/import_public/sub2/BUILD.bazel b/cmd/prot
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/cmd/protoc-gen-go/testdata/imports/BUILD.bazel b/cmd/protoc-gen-go/testdata/imports/BUILD.bazel
---- a/cmd/protoc-gen-go/testdata/imports/BUILD.bazel	1969-12-31 16:00:00
+--- a/cmd/protoc-gen-go/testdata/imports/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cmd/protoc-gen-go/testdata/imports/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -372,7 +380,7 @@ diff -urN a/cmd/protoc-gen-go/testdata/imports/BUILD.bazel b/cmd/protoc-gen-go/t
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/cmd/protoc-gen-go/testdata/imports/fmt/BUILD.bazel b/cmd/protoc-gen-go/testdata/imports/fmt/BUILD.bazel
---- a/cmd/protoc-gen-go/testdata/imports/fmt/BUILD.bazel	1969-12-31 16:00:00
+--- a/cmd/protoc-gen-go/testdata/imports/fmt/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cmd/protoc-gen-go/testdata/imports/fmt/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -394,7 +402,7 @@ diff -urN a/cmd/protoc-gen-go/testdata/imports/fmt/BUILD.bazel b/cmd/protoc-gen-
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/cmd/protoc-gen-go/testdata/imports/test_a_1/BUILD.bazel b/cmd/protoc-gen-go/testdata/imports/test_a_1/BUILD.bazel
---- a/cmd/protoc-gen-go/testdata/imports/test_a_1/BUILD.bazel	1969-12-31 16:00:00
+--- a/cmd/protoc-gen-go/testdata/imports/test_a_1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cmd/protoc-gen-go/testdata/imports/test_a_1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -419,7 +427,7 @@ diff -urN a/cmd/protoc-gen-go/testdata/imports/test_a_1/BUILD.bazel b/cmd/protoc
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/cmd/protoc-gen-go/testdata/imports/test_a_2/BUILD.bazel b/cmd/protoc-gen-go/testdata/imports/test_a_2/BUILD.bazel
---- a/cmd/protoc-gen-go/testdata/imports/test_a_2/BUILD.bazel	1969-12-31 16:00:00
+--- a/cmd/protoc-gen-go/testdata/imports/test_a_2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cmd/protoc-gen-go/testdata/imports/test_a_2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -444,7 +452,7 @@ diff -urN a/cmd/protoc-gen-go/testdata/imports/test_a_2/BUILD.bazel b/cmd/protoc
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/cmd/protoc-gen-go/testdata/imports/test_b_1/BUILD.bazel b/cmd/protoc-gen-go/testdata/imports/test_b_1/BUILD.bazel
---- a/cmd/protoc-gen-go/testdata/imports/test_b_1/BUILD.bazel	1969-12-31 16:00:00
+--- a/cmd/protoc-gen-go/testdata/imports/test_b_1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cmd/protoc-gen-go/testdata/imports/test_b_1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -469,7 +477,7 @@ diff -urN a/cmd/protoc-gen-go/testdata/imports/test_b_1/BUILD.bazel b/cmd/protoc
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/cmd/protoc-gen-go/testdata/issue780_oneof_conflict/BUILD.bazel b/cmd/protoc-gen-go/testdata/issue780_oneof_conflict/BUILD.bazel
---- a/cmd/protoc-gen-go/testdata/issue780_oneof_conflict/BUILD.bazel	1969-12-31 16:00:00
+--- a/cmd/protoc-gen-go/testdata/issue780_oneof_conflict/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cmd/protoc-gen-go/testdata/issue780_oneof_conflict/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -491,7 +499,7 @@ diff -urN a/cmd/protoc-gen-go/testdata/issue780_oneof_conflict/BUILD.bazel b/cmd
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/cmd/protoc-gen-go/testdata/nopackage/BUILD.bazel b/cmd/protoc-gen-go/testdata/nopackage/BUILD.bazel
---- a/cmd/protoc-gen-go/testdata/nopackage/BUILD.bazel	1969-12-31 16:00:00
+--- a/cmd/protoc-gen-go/testdata/nopackage/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cmd/protoc-gen-go/testdata/nopackage/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -513,7 +521,7 @@ diff -urN a/cmd/protoc-gen-go/testdata/nopackage/BUILD.bazel b/cmd/protoc-gen-go
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/cmd/protoc-gen-go/testdata/proto2/BUILD.bazel b/cmd/protoc-gen-go/testdata/proto2/BUILD.bazel
---- a/cmd/protoc-gen-go/testdata/proto2/BUILD.bazel	1969-12-31 16:00:00
+--- a/cmd/protoc-gen-go/testdata/proto2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cmd/protoc-gen-go/testdata/proto2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -540,7 +548,7 @@ diff -urN a/cmd/protoc-gen-go/testdata/proto2/BUILD.bazel b/cmd/protoc-gen-go/te
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/cmd/protoc-gen-go/testdata/proto3/BUILD.bazel b/cmd/protoc-gen-go/testdata/proto3/BUILD.bazel
---- a/cmd/protoc-gen-go/testdata/proto3/BUILD.bazel	1969-12-31 16:00:00
+--- a/cmd/protoc-gen-go/testdata/proto3/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cmd/protoc-gen-go/testdata/proto3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -564,10 +572,36 @@ diff -urN a/cmd/protoc-gen-go/testdata/proto3/BUILD.bazel b/cmd/protoc-gen-go/te
 +    actual = ":proto3",
 +    visibility = ["//visibility:public"],
 +)
+diff -urN a/cmd/protoc-gen-go/testdata/retention/BUILD.bazel b/cmd/protoc-gen-go/testdata/retention/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/retention/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/cmd/protoc-gen-go/testdata/retention/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,22 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "retention",
++    srcs = [
++        "options_message.pb.go",
++        "retention.pb.go",
++    ],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/retention",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++        "//types/descriptorpb",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":retention",
++    visibility = ["//visibility:public"],
++)
 diff -urN a/compiler/protogen/BUILD.bazel b/compiler/protogen/BUILD.bazel
---- a/compiler/protogen/BUILD.bazel	1969-12-31 16:00:00
+--- a/compiler/protogen/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/compiler/protogen/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,38 @@
+@@ -0,0 +1,39 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -584,6 +618,7 @@ diff -urN a/compiler/protogen/BUILD.bazel b/compiler/protogen/BUILD.bazel
 +        "//reflect/protoreflect",
 +        "//reflect/protoregistry",
 +        "//types/descriptorpb",
++        "//types/dynamicpb",
 +        "//types/pluginpb",
 +    ],
 +)
@@ -607,7 +642,7 @@ diff -urN a/compiler/protogen/BUILD.bazel b/compiler/protogen/BUILD.bazel
 +    ],
 +)
 diff -urN a/encoding/BUILD.bazel b/encoding/BUILD.bazel
---- a/encoding/BUILD.bazel	1969-12-31 16:00:00
+--- a/encoding/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/encoding/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,12 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_test")
@@ -622,8 +657,43 @@ diff -urN a/encoding/BUILD.bazel b/encoding/BUILD.bazel
 +        "//reflect/protoreflect",
 +    ],
 +)
+diff -urN a/encoding/protodelim/BUILD.bazel b/encoding/protodelim/BUILD.bazel
+--- a/encoding/protodelim/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/encoding/protodelim/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,31 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "protodelim",
++    srcs = ["protodelim.go"],
++    importpath = "google.golang.org/protobuf/encoding/protodelim",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//encoding/protowire",
++        "//internal/errors",
++        "//proto",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":protodelim",
++    visibility = ["//visibility:public"],
++)
++
++go_test(
++    name = "protodelim_test",
++    srcs = ["protodelim_test.go"],
++    deps = [
++        ":protodelim",
++        "//encoding/protowire",
++        "//internal/testprotos/test3",
++        "//testing/protocmp",
++        "@com_github_google_go_cmp//cmp:go_default_library",
++    ],
++)
 diff -urN a/encoding/protojson/BUILD.bazel b/encoding/protojson/BUILD.bazel
---- a/encoding/protojson/BUILD.bazel	1969-12-31 16:00:00
+--- a/encoding/protojson/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/encoding/protojson/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,64 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -691,7 +761,7 @@ diff -urN a/encoding/protojson/BUILD.bazel b/encoding/protojson/BUILD.bazel
 +    ],
 +)
 diff -urN a/encoding/prototext/BUILD.bazel b/encoding/prototext/BUILD.bazel
---- a/encoding/prototext/BUILD.bazel	1969-12-31 16:00:00
+--- a/encoding/prototext/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/encoding/prototext/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,61 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -756,7 +826,7 @@ diff -urN a/encoding/prototext/BUILD.bazel b/encoding/prototext/BUILD.bazel
 +    ],
 +)
 diff -urN a/encoding/protowire/BUILD.bazel b/encoding/protowire/BUILD.bazel
---- a/encoding/protowire/BUILD.bazel	1969-12-31 16:00:00
+--- a/encoding/protowire/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/encoding/protowire/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -781,7 +851,7 @@ diff -urN a/encoding/protowire/BUILD.bazel b/encoding/protowire/BUILD.bazel
 +    embed = [":protowire"],
 +)
 diff -urN a/internal/benchmarks/BUILD.bazel b/internal/benchmarks/BUILD.bazel
---- a/internal/benchmarks/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/benchmarks/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/benchmarks/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_test")
@@ -804,7 +874,7 @@ diff -urN a/internal/benchmarks/BUILD.bazel b/internal/benchmarks/BUILD.bazel
 +    ],
 +)
 diff -urN a/internal/benchmarks/micro/BUILD.bazel b/internal/benchmarks/micro/BUILD.bazel
---- a/internal/benchmarks/micro/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/benchmarks/micro/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/benchmarks/micro/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_test")
@@ -822,7 +892,7 @@ diff -urN a/internal/benchmarks/micro/BUILD.bazel b/internal/benchmarks/micro/BU
 +    ],
 +)
 diff -urN a/internal/cmd/generate-corpus/BUILD.bazel b/internal/cmd/generate-corpus/BUILD.bazel
---- a/internal/cmd/generate-corpus/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/cmd/generate-corpus/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/cmd/generate-corpus/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -847,7 +917,7 @@ diff -urN a/internal/cmd/generate-corpus/BUILD.bazel b/internal/cmd/generate-cor
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/cmd/generate-protos/BUILD.bazel b/internal/cmd/generate-protos/BUILD.bazel
---- a/internal/cmd/generate-protos/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/cmd/generate-protos/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/cmd/generate-protos/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -870,7 +940,7 @@ diff -urN a/internal/cmd/generate-protos/BUILD.bazel b/internal/cmd/generate-pro
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/cmd/generate-types/BUILD.bazel b/internal/cmd/generate-types/BUILD.bazel
---- a/internal/cmd/generate-types/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/cmd/generate-types/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/cmd/generate-types/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -892,7 +962,7 @@ diff -urN a/internal/cmd/generate-types/BUILD.bazel b/internal/cmd/generate-type
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/cmd/pbdump/BUILD.bazel b/internal/cmd/pbdump/BUILD.bazel
---- a/internal/cmd/pbdump/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/cmd/pbdump/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/cmd/pbdump/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
@@ -931,7 +1001,7 @@ diff -urN a/internal/cmd/pbdump/BUILD.bazel b/internal/cmd/pbdump/BUILD.bazel
 +    ],
 +)
 diff -urN a/internal/conformance/BUILD.bazel b/internal/conformance/BUILD.bazel
---- a/internal/conformance/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/conformance/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/conformance/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,12 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_test")
@@ -947,7 +1017,7 @@ diff -urN a/internal/conformance/BUILD.bazel b/internal/conformance/BUILD.bazel
 +    ],
 +)
 diff -urN a/internal/descfmt/BUILD.bazel b/internal/descfmt/BUILD.bazel
---- a/internal/descfmt/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/descfmt/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/descfmt/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -976,7 +1046,7 @@ diff -urN a/internal/descfmt/BUILD.bazel b/internal/descfmt/BUILD.bazel
 +    embed = [":descfmt"],
 +)
 diff -urN a/internal/descopts/BUILD.bazel b/internal/descopts/BUILD.bazel
---- a/internal/descopts/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/descopts/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/descopts/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -995,7 +1065,7 @@ diff -urN a/internal/descopts/BUILD.bazel b/internal/descopts/BUILD.bazel
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/detrand/BUILD.bazel b/internal/detrand/BUILD.bazel
---- a/internal/detrand/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/detrand/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/detrand/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1019,7 +1089,7 @@ diff -urN a/internal/detrand/BUILD.bazel b/internal/detrand/BUILD.bazel
 +    embed = [":detrand"],
 +)
 diff -urN a/internal/encoding/defval/BUILD.bazel b/internal/encoding/defval/BUILD.bazel
---- a/internal/encoding/defval/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/encoding/defval/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/encoding/defval/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,29 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1052,7 +1122,7 @@ diff -urN a/internal/encoding/defval/BUILD.bazel b/internal/encoding/defval/BUIL
 +    ],
 +)
 diff -urN a/internal/encoding/json/BUILD.bazel b/internal/encoding/json/BUILD.bazel
---- a/internal/encoding/json/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/encoding/json/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/encoding/json/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,40 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1096,7 +1166,7 @@ diff -urN a/internal/encoding/json/BUILD.bazel b/internal/encoding/json/BUILD.ba
 +    ],
 +)
 diff -urN a/internal/encoding/messageset/BUILD.bazel b/internal/encoding/messageset/BUILD.bazel
---- a/internal/encoding/messageset/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/encoding/messageset/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/encoding/messageset/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1119,7 +1189,7 @@ diff -urN a/internal/encoding/messageset/BUILD.bazel b/internal/encoding/message
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/encoding/tag/BUILD.bazel b/internal/encoding/tag/BUILD.bazel
---- a/internal/encoding/tag/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/encoding/tag/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/encoding/tag/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,32 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1155,7 +1225,7 @@ diff -urN a/internal/encoding/tag/BUILD.bazel b/internal/encoding/tag/BUILD.baze
 +    ],
 +)
 diff -urN a/internal/encoding/text/BUILD.bazel b/internal/encoding/text/BUILD.bazel
---- a/internal/encoding/text/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/encoding/text/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/encoding/text/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,41 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1200,7 +1270,7 @@ diff -urN a/internal/encoding/text/BUILD.bazel b/internal/encoding/text/BUILD.ba
 +    ],
 +)
 diff -urN a/internal/errors/BUILD.bazel b/internal/errors/BUILD.bazel
---- a/internal/errors/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/errors/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/errors/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1229,7 +1299,7 @@ diff -urN a/internal/errors/BUILD.bazel b/internal/errors/BUILD.bazel
 +    embed = [":errors"],
 +)
 diff -urN a/internal/filedesc/BUILD.bazel b/internal/filedesc/BUILD.bazel
---- a/internal/filedesc/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/filedesc/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/filedesc/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,55 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1288,7 +1358,7 @@ diff -urN a/internal/filedesc/BUILD.bazel b/internal/filedesc/BUILD.bazel
 +    ],
 +)
 diff -urN a/internal/filetype/BUILD.bazel b/internal/filetype/BUILD.bazel
---- a/internal/filetype/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/filetype/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/filetype/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1313,7 +1383,7 @@ diff -urN a/internal/filetype/BUILD.bazel b/internal/filetype/BUILD.bazel
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/flags/BUILD.bazel b/internal/flags/BUILD.bazel
---- a/internal/flags/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/flags/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/flags/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1334,7 +1404,7 @@ diff -urN a/internal/flags/BUILD.bazel b/internal/flags/BUILD.bazel
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/fuzz/jsonfuzz/BUILD.bazel b/internal/fuzz/jsonfuzz/BUILD.bazel
---- a/internal/fuzz/jsonfuzz/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/fuzz/jsonfuzz/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/fuzz/jsonfuzz/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1364,7 +1434,7 @@ diff -urN a/internal/fuzz/jsonfuzz/BUILD.bazel b/internal/fuzz/jsonfuzz/BUILD.ba
 +    deps = ["//internal/fuzztest"],
 +)
 diff -urN a/internal/fuzz/textfuzz/BUILD.bazel b/internal/fuzz/textfuzz/BUILD.bazel
---- a/internal/fuzz/textfuzz/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/fuzz/textfuzz/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/fuzz/textfuzz/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1394,7 +1464,7 @@ diff -urN a/internal/fuzz/textfuzz/BUILD.bazel b/internal/fuzz/textfuzz/BUILD.ba
 +    deps = ["//internal/fuzztest"],
 +)
 diff -urN a/internal/fuzz/wirefuzz/BUILD.bazel b/internal/fuzz/wirefuzz/BUILD.bazel
---- a/internal/fuzz/wirefuzz/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/fuzz/wirefuzz/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/fuzz/wirefuzz/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1426,7 +1496,7 @@ diff -urN a/internal/fuzz/wirefuzz/BUILD.bazel b/internal/fuzz/wirefuzz/BUILD.ba
 +    deps = ["//internal/fuzztest"],
 +)
 diff -urN a/internal/fuzztest/BUILD.bazel b/internal/fuzztest/BUILD.bazel
---- a/internal/fuzztest/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/fuzztest/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/fuzztest/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1444,7 +1514,7 @@ diff -urN a/internal/fuzztest/BUILD.bazel b/internal/fuzztest/BUILD.bazel
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/genid/BUILD.bazel b/internal/genid/BUILD.bazel
---- a/internal/genid/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/genid/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/genid/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1479,7 +1549,7 @@ diff -urN a/internal/genid/BUILD.bazel b/internal/genid/BUILD.bazel
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/impl/BUILD.bazel b/internal/impl/BUILD.bazel
---- a/internal/impl/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/impl/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/impl/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,111 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1594,7 +1664,7 @@ diff -urN a/internal/impl/BUILD.bazel b/internal/impl/BUILD.bazel
 +    ],
 +)
 diff -urN a/internal/msgfmt/BUILD.bazel b/internal/msgfmt/BUILD.bazel
---- a/internal/msgfmt/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/msgfmt/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/msgfmt/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,43 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1641,7 +1711,7 @@ diff -urN a/internal/msgfmt/BUILD.bazel b/internal/msgfmt/BUILD.bazel
 +    ],
 +)
 diff -urN a/internal/order/BUILD.bazel b/internal/order/BUILD.bazel
---- a/internal/order/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/order/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/order/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1673,7 +1743,7 @@ diff -urN a/internal/order/BUILD.bazel b/internal/order/BUILD.bazel
 +    ],
 +)
 diff -urN a/internal/pragma/BUILD.bazel b/internal/pragma/BUILD.bazel
---- a/internal/pragma/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/pragma/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/pragma/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1691,7 +1761,7 @@ diff -urN a/internal/pragma/BUILD.bazel b/internal/pragma/BUILD.bazel
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/protobuild/BUILD.bazel b/internal/protobuild/BUILD.bazel
---- a/internal/protobuild/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/protobuild/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/protobuild/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1713,7 +1783,7 @@ diff -urN a/internal/protobuild/BUILD.bazel b/internal/protobuild/BUILD.bazel
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/protolegacy/BUILD.bazel b/internal/protolegacy/BUILD.bazel
---- a/internal/protolegacy/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/protolegacy/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/protolegacy/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1737,7 +1807,7 @@ diff -urN a/internal/protolegacy/BUILD.bazel b/internal/protolegacy/BUILD.bazel
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/set/BUILD.bazel b/internal/set/BUILD.bazel
---- a/internal/set/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/set/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/set/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1761,7 +1831,7 @@ diff -urN a/internal/set/BUILD.bazel b/internal/set/BUILD.bazel
 +    embed = [":set"],
 +)
 diff -urN a/internal/strs/BUILD.bazel b/internal/strs/BUILD.bazel
---- a/internal/strs/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/strs/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/strs/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1792,7 +1862,7 @@ diff -urN a/internal/strs/BUILD.bazel b/internal/strs/BUILD.bazel
 +    embed = [":strs"],
 +)
 diff -urN a/internal/testprotos/annotation/BUILD.bazel b/internal/testprotos/annotation/BUILD.bazel
---- a/internal/testprotos/annotation/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/annotation/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/annotation/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1815,7 +1885,7 @@ diff -urN a/internal/testprotos/annotation/BUILD.bazel b/internal/testprotos/ann
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/benchmarks/BUILD.bazel b/internal/testprotos/benchmarks/BUILD.bazel
---- a/internal/testprotos/benchmarks/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/benchmarks/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/benchmarks/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1837,7 +1907,7 @@ diff -urN a/internal/testprotos/benchmarks/BUILD.bazel b/internal/testprotos/ben
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/benchmarks/datasets/google_message1/proto2/BUILD.bazel b/internal/testprotos/benchmarks/datasets/google_message1/proto2/BUILD.bazel
---- a/internal/testprotos/benchmarks/datasets/google_message1/proto2/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/benchmarks/datasets/google_message1/proto2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/benchmarks/datasets/google_message1/proto2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1859,7 +1929,7 @@ diff -urN a/internal/testprotos/benchmarks/datasets/google_message1/proto2/BUILD
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/benchmarks/datasets/google_message1/proto3/BUILD.bazel b/internal/testprotos/benchmarks/datasets/google_message1/proto3/BUILD.bazel
---- a/internal/testprotos/benchmarks/datasets/google_message1/proto3/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/benchmarks/datasets/google_message1/proto3/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/benchmarks/datasets/google_message1/proto3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1881,7 +1951,7 @@ diff -urN a/internal/testprotos/benchmarks/datasets/google_message1/proto3/BUILD
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/benchmarks/datasets/google_message2/BUILD.bazel b/internal/testprotos/benchmarks/datasets/google_message2/BUILD.bazel
---- a/internal/testprotos/benchmarks/datasets/google_message2/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/benchmarks/datasets/google_message2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/benchmarks/datasets/google_message2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1903,7 +1973,7 @@ diff -urN a/internal/testprotos/benchmarks/datasets/google_message2/BUILD.bazel 
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/benchmarks/datasets/google_message3/BUILD.bazel b/internal/testprotos/benchmarks/datasets/google_message3/BUILD.bazel
---- a/internal/testprotos/benchmarks/datasets/google_message3/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/benchmarks/datasets/google_message3/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/benchmarks/datasets/google_message3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1935,7 +2005,7 @@ diff -urN a/internal/testprotos/benchmarks/datasets/google_message3/BUILD.bazel 
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/benchmarks/datasets/google_message4/BUILD.bazel b/internal/testprotos/benchmarks/datasets/google_message4/BUILD.bazel
---- a/internal/testprotos/benchmarks/datasets/google_message4/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/benchmarks/datasets/google_message4/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/benchmarks/datasets/google_message4/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1962,7 +2032,7 @@ diff -urN a/internal/testprotos/benchmarks/datasets/google_message4/BUILD.bazel 
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/benchmarks/micro/BUILD.bazel b/internal/testprotos/benchmarks/micro/BUILD.bazel
---- a/internal/testprotos/benchmarks/micro/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/benchmarks/micro/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/benchmarks/micro/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1984,7 +2054,7 @@ diff -urN a/internal/testprotos/benchmarks/micro/BUILD.bazel b/internal/testprot
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/conformance/BUILD.bazel b/internal/testprotos/conformance/BUILD.bazel
---- a/internal/testprotos/conformance/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/conformance/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/conformance/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2016,7 +2086,7 @@ diff -urN a/internal/testprotos/conformance/BUILD.bazel b/internal/testprotos/co
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/enums/BUILD.bazel b/internal/testprotos/enums/BUILD.bazel
---- a/internal/testprotos/enums/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/enums/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/enums/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2038,7 +2108,7 @@ diff -urN a/internal/testprotos/enums/BUILD.bazel b/internal/testprotos/enums/BU
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/fieldtrack/BUILD.bazel b/internal/testprotos/fieldtrack/BUILD.bazel
---- a/internal/testprotos/fieldtrack/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/fieldtrack/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/fieldtrack/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2063,7 +2133,7 @@ diff -urN a/internal/testprotos/fieldtrack/BUILD.bazel b/internal/testprotos/fie
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/fuzz/BUILD.bazel b/internal/testprotos/fuzz/BUILD.bazel
---- a/internal/testprotos/fuzz/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/fuzz/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/fuzz/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2087,7 +2157,7 @@ diff -urN a/internal/testprotos/fuzz/BUILD.bazel b/internal/testprotos/fuzz/BUIL
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/irregular/BUILD.bazel b/internal/testprotos/irregular/BUILD.bazel
---- a/internal/testprotos/irregular/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/irregular/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/irregular/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2115,8 +2185,36 @@ diff -urN a/internal/testprotos/irregular/BUILD.bazel b/internal/testprotos/irre
 +    actual = ":irregular",
 +    visibility = ["//:__subpackages__"],
 +)
+diff -urN a/internal/testprotos/legacy/bug1052/BUILD.bazel b/internal/testprotos/legacy/bug1052/BUILD.bazel
+--- a/internal/testprotos/legacy/bug1052/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/testprotos/legacy/bug1052/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,24 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "bug1052",
++    srcs = ["bug1052.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/legacy/bug1052",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//internal/protolegacy",
++        "//types/descriptorpb",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":bug1052",
++    visibility = ["//:__subpackages__"],
++)
++
++go_test(
++    name = "bug1052_test",
++    srcs = ["bug1052_test.go"],
++    deps = [":bug1052"],
++)
 diff -urN a/internal/testprotos/legacy/BUILD.bazel b/internal/testprotos/legacy/BUILD.bazel
---- a/internal/testprotos/legacy/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/legacy/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/legacy/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2149,36 +2247,8 @@ diff -urN a/internal/testprotos/legacy/BUILD.bazel b/internal/testprotos/legacy/
 +    actual = ":legacy",
 +    visibility = ["//:__subpackages__"],
 +)
-diff -urN a/internal/testprotos/legacy/bug1052/BUILD.bazel b/internal/testprotos/legacy/bug1052/BUILD.bazel
---- a/internal/testprotos/legacy/bug1052/BUILD.bazel	1969-12-31 16:00:00
-+++ b/internal/testprotos/legacy/bug1052/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,24 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-+
-+go_library(
-+    name = "bug1052",
-+    srcs = ["bug1052.pb.go"],
-+    importpath = "google.golang.org/protobuf/internal/testprotos/legacy/bug1052",
-+    visibility = ["//:__subpackages__"],
-+    deps = [
-+        "//internal/protolegacy",
-+        "//types/descriptorpb",
-+    ],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":bug1052",
-+    visibility = ["//:__subpackages__"],
-+)
-+
-+go_test(
-+    name = "bug1052_test",
-+    srcs = ["bug1052_test.go"],
-+    deps = [":bug1052"],
-+)
 diff -urN a/internal/testprotos/legacy/proto2_20160225_2fc053c5/BUILD.bazel b/internal/testprotos/legacy/proto2_20160225_2fc053c5/BUILD.bazel
---- a/internal/testprotos/legacy/proto2_20160225_2fc053c5/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/legacy/proto2_20160225_2fc053c5/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/legacy/proto2_20160225_2fc053c5/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2197,7 +2267,7 @@ diff -urN a/internal/testprotos/legacy/proto2_20160225_2fc053c5/BUILD.bazel b/in
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/legacy/proto2_20160519_a4ab9ec5/BUILD.bazel b/internal/testprotos/legacy/proto2_20160519_a4ab9ec5/BUILD.bazel
---- a/internal/testprotos/legacy/proto2_20160519_a4ab9ec5/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/legacy/proto2_20160519_a4ab9ec5/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/legacy/proto2_20160519_a4ab9ec5/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2216,7 +2286,7 @@ diff -urN a/internal/testprotos/legacy/proto2_20160519_a4ab9ec5/BUILD.bazel b/in
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/legacy/proto2_20180125_92554152/BUILD.bazel b/internal/testprotos/legacy/proto2_20180125_92554152/BUILD.bazel
---- a/internal/testprotos/legacy/proto2_20180125_92554152/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/legacy/proto2_20180125_92554152/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/legacy/proto2_20180125_92554152/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2235,7 +2305,7 @@ diff -urN a/internal/testprotos/legacy/proto2_20180125_92554152/BUILD.bazel b/in
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/legacy/proto2_20180430_b4deda09/BUILD.bazel b/internal/testprotos/legacy/proto2_20180430_b4deda09/BUILD.bazel
---- a/internal/testprotos/legacy/proto2_20180430_b4deda09/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/legacy/proto2_20180430_b4deda09/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/legacy/proto2_20180430_b4deda09/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2254,7 +2324,7 @@ diff -urN a/internal/testprotos/legacy/proto2_20180430_b4deda09/BUILD.bazel b/in
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/legacy/proto2_20180814_aa810b61/BUILD.bazel b/internal/testprotos/legacy/proto2_20180814_aa810b61/BUILD.bazel
---- a/internal/testprotos/legacy/proto2_20180814_aa810b61/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/legacy/proto2_20180814_aa810b61/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/legacy/proto2_20180814_aa810b61/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2273,7 +2343,7 @@ diff -urN a/internal/testprotos/legacy/proto2_20180814_aa810b61/BUILD.bazel b/in
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/legacy/proto2_20190205_c823c79e/BUILD.bazel b/internal/testprotos/legacy/proto2_20190205_c823c79e/BUILD.bazel
---- a/internal/testprotos/legacy/proto2_20190205_c823c79e/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/legacy/proto2_20190205_c823c79e/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/legacy/proto2_20190205_c823c79e/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2292,7 +2362,7 @@ diff -urN a/internal/testprotos/legacy/proto2_20190205_c823c79e/BUILD.bazel b/in
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/legacy/proto3_20160225_2fc053c5/BUILD.bazel b/internal/testprotos/legacy/proto3_20160225_2fc053c5/BUILD.bazel
---- a/internal/testprotos/legacy/proto3_20160225_2fc053c5/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/legacy/proto3_20160225_2fc053c5/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/legacy/proto3_20160225_2fc053c5/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2311,7 +2381,7 @@ diff -urN a/internal/testprotos/legacy/proto3_20160225_2fc053c5/BUILD.bazel b/in
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/legacy/proto3_20160519_a4ab9ec5/BUILD.bazel b/internal/testprotos/legacy/proto3_20160519_a4ab9ec5/BUILD.bazel
---- a/internal/testprotos/legacy/proto3_20160519_a4ab9ec5/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/legacy/proto3_20160519_a4ab9ec5/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/legacy/proto3_20160519_a4ab9ec5/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2330,7 +2400,7 @@ diff -urN a/internal/testprotos/legacy/proto3_20160519_a4ab9ec5/BUILD.bazel b/in
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/legacy/proto3_20180125_92554152/BUILD.bazel b/internal/testprotos/legacy/proto3_20180125_92554152/BUILD.bazel
---- a/internal/testprotos/legacy/proto3_20180125_92554152/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/legacy/proto3_20180125_92554152/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/legacy/proto3_20180125_92554152/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2349,7 +2419,7 @@ diff -urN a/internal/testprotos/legacy/proto3_20180125_92554152/BUILD.bazel b/in
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/legacy/proto3_20180430_b4deda09/BUILD.bazel b/internal/testprotos/legacy/proto3_20180430_b4deda09/BUILD.bazel
---- a/internal/testprotos/legacy/proto3_20180430_b4deda09/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/legacy/proto3_20180430_b4deda09/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/legacy/proto3_20180430_b4deda09/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2368,7 +2438,7 @@ diff -urN a/internal/testprotos/legacy/proto3_20180430_b4deda09/BUILD.bazel b/in
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/legacy/proto3_20180814_aa810b61/BUILD.bazel b/internal/testprotos/legacy/proto3_20180814_aa810b61/BUILD.bazel
---- a/internal/testprotos/legacy/proto3_20180814_aa810b61/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/legacy/proto3_20180814_aa810b61/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/legacy/proto3_20180814_aa810b61/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2387,7 +2457,7 @@ diff -urN a/internal/testprotos/legacy/proto3_20180814_aa810b61/BUILD.bazel b/in
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/legacy/proto3_20190205_c823c79e/BUILD.bazel b/internal/testprotos/legacy/proto3_20190205_c823c79e/BUILD.bazel
---- a/internal/testprotos/legacy/proto3_20190205_c823c79e/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/legacy/proto3_20190205_c823c79e/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/legacy/proto3_20190205_c823c79e/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2406,7 +2476,7 @@ diff -urN a/internal/testprotos/legacy/proto3_20190205_c823c79e/BUILD.bazel b/in
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/messageset/messagesetpb/BUILD.bazel b/internal/testprotos/messageset/messagesetpb/BUILD.bazel
---- a/internal/testprotos/messageset/messagesetpb/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/messageset/messagesetpb/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/messageset/messagesetpb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2428,7 +2498,7 @@ diff -urN a/internal/testprotos/messageset/messagesetpb/BUILD.bazel b/internal/t
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/messageset/msetextpb/BUILD.bazel b/internal/testprotos/messageset/msetextpb/BUILD.bazel
---- a/internal/testprotos/messageset/msetextpb/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/messageset/msetextpb/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/messageset/msetextpb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2451,7 +2521,7 @@ diff -urN a/internal/testprotos/messageset/msetextpb/BUILD.bazel b/internal/test
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/news/BUILD.bazel b/internal/testprotos/news/BUILD.bazel
---- a/internal/testprotos/news/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/news/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/news/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2475,7 +2545,7 @@ diff -urN a/internal/testprotos/news/BUILD.bazel b/internal/testprotos/news/BUIL
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/nullable/BUILD.bazel b/internal/testprotos/nullable/BUILD.bazel
---- a/internal/testprotos/nullable/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/nullable/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/nullable/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2512,7 +2582,7 @@ diff -urN a/internal/testprotos/nullable/BUILD.bazel b/internal/testprotos/nulla
 +    ],
 +)
 diff -urN a/internal/testprotos/order/BUILD.bazel b/internal/testprotos/order/BUILD.bazel
---- a/internal/testprotos/order/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/order/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/order/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2534,7 +2604,7 @@ diff -urN a/internal/testprotos/order/BUILD.bazel b/internal/testprotos/order/BU
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/registry/BUILD.bazel b/internal/testprotos/registry/BUILD.bazel
---- a/internal/testprotos/registry/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/registry/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/registry/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2556,7 +2626,7 @@ diff -urN a/internal/testprotos/registry/BUILD.bazel b/internal/testprotos/regis
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/required/BUILD.bazel b/internal/testprotos/required/BUILD.bazel
---- a/internal/testprotos/required/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/required/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/required/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2578,7 +2648,7 @@ diff -urN a/internal/testprotos/required/BUILD.bazel b/internal/testprotos/requi
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/test/BUILD.bazel b/internal/testprotos/test/BUILD.bazel
---- a/internal/testprotos/test/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/test/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/test/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2607,7 +2677,7 @@ diff -urN a/internal/testprotos/test/BUILD.bazel b/internal/testprotos/test/BUIL
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/test/weak1/BUILD.bazel b/internal/testprotos/test/weak1/BUILD.bazel
---- a/internal/testprotos/test/weak1/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/test/weak1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/test/weak1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2629,7 +2699,7 @@ diff -urN a/internal/testprotos/test/weak1/BUILD.bazel b/internal/testprotos/tes
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/test/weak2/BUILD.bazel b/internal/testprotos/test/weak2/BUILD.bazel
---- a/internal/testprotos/test/weak2/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/test/weak2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/test/weak2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2651,7 +2721,7 @@ diff -urN a/internal/testprotos/test/weak2/BUILD.bazel b/internal/testprotos/tes
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/test3/BUILD.bazel b/internal/testprotos/test3/BUILD.bazel
---- a/internal/testprotos/test3/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/test3/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/test3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2678,7 +2748,7 @@ diff -urN a/internal/testprotos/test3/BUILD.bazel b/internal/testprotos/test3/BU
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/textpb2/BUILD.bazel b/internal/testprotos/textpb2/BUILD.bazel
---- a/internal/testprotos/textpb2/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/textpb2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/textpb2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2707,7 +2777,7 @@ diff -urN a/internal/testprotos/textpb2/BUILD.bazel b/internal/testprotos/textpb
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/textpb3/BUILD.bazel b/internal/testprotos/textpb3/BUILD.bazel
---- a/internal/testprotos/textpb3/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/testprotos/textpb3/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/textpb3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2729,7 +2799,7 @@ diff -urN a/internal/testprotos/textpb3/BUILD.bazel b/internal/testprotos/textpb
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/version/BUILD.bazel b/internal/version/BUILD.bazel
---- a/internal/version/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/version/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/version/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2747,7 +2817,7 @@ diff -urN a/internal/version/BUILD.bazel b/internal/version/BUILD.bazel
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/weakdeps/BUILD.bazel b/internal/weakdeps/BUILD.bazel
---- a/internal/weakdeps/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/weakdeps/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/weakdeps/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2765,7 +2835,7 @@ diff -urN a/internal/weakdeps/BUILD.bazel b/internal/weakdeps/BUILD.bazel
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/proto/BUILD.bazel b/proto/BUILD.bazel
---- a/proto/BUILD.bazel	1969-12-31 16:00:00
+--- a/proto/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/proto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,95 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2863,8 +2933,31 @@ diff -urN a/proto/BUILD.bazel b/proto/BUILD.bazel
 +        "@com_github_google_go_cmp//cmp:go_default_library",
 +    ],
 +)
+diff -urN a/protoadapt/BUILD.bazel b/protoadapt/BUILD.bazel
+--- a/protoadapt/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/protoadapt/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "protoadapt",
++    srcs = ["convert.go"],
++    importpath = "google.golang.org/protobuf/protoadapt",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//proto",
++        "//runtime/protoiface",
++        "//runtime/protoimpl",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":protoadapt",
++    visibility = ["//visibility:public"],
++)
 diff -urN a/reflect/protodesc/BUILD.bazel b/reflect/protodesc/BUILD.bazel
---- a/reflect/protodesc/BUILD.bazel	1969-12-31 16:00:00
+--- a/reflect/protodesc/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/reflect/protodesc/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,48 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2916,7 +3009,7 @@ diff -urN a/reflect/protodesc/BUILD.bazel b/reflect/protodesc/BUILD.bazel
 +    ],
 +)
 diff -urN a/reflect/protopath/BUILD.bazel b/reflect/protopath/BUILD.bazel
---- a/reflect/protopath/BUILD.bazel	1969-12-31 16:00:00
+--- a/reflect/protopath/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/reflect/protopath/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2942,7 +3035,7 @@ diff -urN a/reflect/protopath/BUILD.bazel b/reflect/protopath/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/reflect/protorange/BUILD.bazel b/reflect/protorange/BUILD.bazel
---- a/reflect/protorange/BUILD.bazel	1969-12-31 16:00:00
+--- a/reflect/protorange/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/reflect/protorange/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,46 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2992,9 +3085,9 @@ diff -urN a/reflect/protorange/BUILD.bazel b/reflect/protorange/BUILD.bazel
 +    ],
 +)
 diff -urN a/reflect/protoreflect/BUILD.bazel b/reflect/protoreflect/BUILD.bazel
---- a/reflect/protoreflect/BUILD.bazel	1969-12-31 16:00:00
+--- a/reflect/protoreflect/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/reflect/protoreflect/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,37 @@
+@@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -3006,6 +3099,7 @@ diff -urN a/reflect/protoreflect/BUILD.bazel b/reflect/protoreflect/BUILD.bazel
 +        "source_gen.go",
 +        "type.go",
 +        "value.go",
++        "value_equal.go",
 +        "value_union.go",
 +        "value_unsafe.go",
 +    ],
@@ -3033,7 +3127,7 @@ diff -urN a/reflect/protoreflect/BUILD.bazel b/reflect/protoreflect/BUILD.bazel
 +    embed = [":protoreflect"],
 +)
 diff -urN a/reflect/protoregistry/BUILD.bazel b/reflect/protoregistry/BUILD.bazel
---- a/reflect/protoregistry/BUILD.bazel	1969-12-31 16:00:00
+--- a/reflect/protoregistry/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/reflect/protoregistry/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3073,7 +3167,7 @@ diff -urN a/reflect/protoregistry/BUILD.bazel b/reflect/protoregistry/BUILD.baze
 +    ],
 +)
 diff -urN a/runtime/protoiface/BUILD.bazel b/runtime/protoiface/BUILD.bazel
---- a/runtime/protoiface/BUILD.bazel	1969-12-31 16:00:00
+--- a/runtime/protoiface/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/runtime/protoiface/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3098,7 +3192,7 @@ diff -urN a/runtime/protoiface/BUILD.bazel b/runtime/protoiface/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/runtime/protoimpl/BUILD.bazel b/runtime/protoimpl/BUILD.bazel
---- a/runtime/protoimpl/BUILD.bazel	1969-12-31 16:00:00
+--- a/runtime/protoimpl/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/runtime/protoimpl/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3125,7 +3219,7 @@ diff -urN a/runtime/protoimpl/BUILD.bazel b/runtime/protoimpl/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/testing/protocmp/BUILD.bazel b/testing/protocmp/BUILD.bazel
---- a/testing/protocmp/BUILD.bazel	1969-12-31 16:00:00
+--- a/testing/protocmp/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/testing/protocmp/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,52 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3181,7 +3275,7 @@ diff -urN a/testing/protocmp/BUILD.bazel b/testing/protocmp/BUILD.bazel
 +    ],
 +)
 diff -urN a/testing/protopack/BUILD.bazel b/testing/protopack/BUILD.bazel
---- a/testing/protopack/BUILD.bazel	1969-12-31 16:00:00
+--- a/testing/protopack/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/testing/protopack/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3216,7 +3310,7 @@ diff -urN a/testing/protopack/BUILD.bazel b/testing/protopack/BUILD.bazel
 +    ],
 +)
 diff -urN a/testing/prototest/BUILD.bazel b/testing/prototest/BUILD.bazel
---- a/testing/prototest/BUILD.bazel	1969-12-31 16:00:00
+--- a/testing/prototest/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/testing/prototest/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,42 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3262,7 +3356,7 @@ diff -urN a/testing/prototest/BUILD.bazel b/testing/prototest/BUILD.bazel
 +    ],
 +)
 diff -urN a/types/descriptorpb/BUILD.bazel b/types/descriptorpb/BUILD.bazel
---- a/types/descriptorpb/BUILD.bazel	1969-12-31 16:00:00
+--- a/types/descriptorpb/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/types/descriptorpb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3284,7 +3378,7 @@ diff -urN a/types/descriptorpb/BUILD.bazel b/types/descriptorpb/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/types/dynamicpb/BUILD.bazel b/types/dynamicpb/BUILD.bazel
---- a/types/dynamicpb/BUILD.bazel	1969-12-31 16:00:00
+--- a/types/dynamicpb/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/types/dynamicpb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,34 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3322,7 +3416,7 @@ diff -urN a/types/dynamicpb/BUILD.bazel b/types/dynamicpb/BUILD.bazel
 +    ],
 +)
 diff -urN a/types/known/anypb/BUILD.bazel b/types/known/anypb/BUILD.bazel
---- a/types/known/anypb/BUILD.bazel	1969-12-31 16:00:00
+--- a/types/known/anypb/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/types/known/anypb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3361,7 +3455,7 @@ diff -urN a/types/known/anypb/BUILD.bazel b/types/known/anypb/BUILD.bazel
 +    ],
 +)
 diff -urN a/types/known/apipb/BUILD.bazel b/types/known/apipb/BUILD.bazel
---- a/types/known/apipb/BUILD.bazel	1969-12-31 16:00:00
+--- a/types/known/apipb/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/types/known/apipb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3385,7 +3479,7 @@ diff -urN a/types/known/apipb/BUILD.bazel b/types/known/apipb/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/types/known/durationpb/BUILD.bazel b/types/known/durationpb/BUILD.bazel
---- a/types/known/durationpb/BUILD.bazel	1969-12-31 16:00:00
+--- a/types/known/durationpb/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/types/known/durationpb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3419,7 +3513,7 @@ diff -urN a/types/known/durationpb/BUILD.bazel b/types/known/durationpb/BUILD.ba
 +    ],
 +)
 diff -urN a/types/known/emptypb/BUILD.bazel b/types/known/emptypb/BUILD.bazel
---- a/types/known/emptypb/BUILD.bazel	1969-12-31 16:00:00
+--- a/types/known/emptypb/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/types/known/emptypb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3441,7 +3535,7 @@ diff -urN a/types/known/emptypb/BUILD.bazel b/types/known/emptypb/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/types/known/fieldmaskpb/BUILD.bazel b/types/known/fieldmaskpb/BUILD.bazel
---- a/types/known/fieldmaskpb/BUILD.bazel	1969-12-31 16:00:00
+--- a/types/known/fieldmaskpb/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/types/known/fieldmaskpb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3476,7 +3570,7 @@ diff -urN a/types/known/fieldmaskpb/BUILD.bazel b/types/known/fieldmaskpb/BUILD.
 +    ],
 +)
 diff -urN a/types/known/sourcecontextpb/BUILD.bazel b/types/known/sourcecontextpb/BUILD.bazel
---- a/types/known/sourcecontextpb/BUILD.bazel	1969-12-31 16:00:00
+--- a/types/known/sourcecontextpb/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/types/known/sourcecontextpb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3498,7 +3592,7 @@ diff -urN a/types/known/sourcecontextpb/BUILD.bazel b/types/known/sourcecontextp
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/types/known/structpb/BUILD.bazel b/types/known/structpb/BUILD.bazel
---- a/types/known/structpb/BUILD.bazel	1969-12-31 16:00:00
+--- a/types/known/structpb/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/types/known/structpb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3533,7 +3627,7 @@ diff -urN a/types/known/structpb/BUILD.bazel b/types/known/structpb/BUILD.bazel
 +    ],
 +)
 diff -urN a/types/known/timestamppb/BUILD.bazel b/types/known/timestamppb/BUILD.bazel
---- a/types/known/timestamppb/BUILD.bazel	1969-12-31 16:00:00
+--- a/types/known/timestamppb/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/types/known/timestamppb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3567,7 +3661,7 @@ diff -urN a/types/known/timestamppb/BUILD.bazel b/types/known/timestamppb/BUILD.
 +    ],
 +)
 diff -urN a/types/known/typepb/BUILD.bazel b/types/known/typepb/BUILD.bazel
---- a/types/known/typepb/BUILD.bazel	1969-12-31 16:00:00
+--- a/types/known/typepb/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/types/known/typepb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3591,7 +3685,7 @@ diff -urN a/types/known/typepb/BUILD.bazel b/types/known/typepb/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/types/known/wrapperspb/BUILD.bazel b/types/known/wrapperspb/BUILD.bazel
---- a/types/known/wrapperspb/BUILD.bazel	1969-12-31 16:00:00
+--- a/types/known/wrapperspb/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/types/known/wrapperspb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3613,7 +3707,7 @@ diff -urN a/types/known/wrapperspb/BUILD.bazel b/types/known/wrapperspb/BUILD.ba
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/types/pluginpb/BUILD.bazel b/types/pluginpb/BUILD.bazel
---- a/types/pluginpb/BUILD.bazel	1969-12-31 16:00:00
+--- a/types/pluginpb/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/types/pluginpb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")

--- a/third_party/org_golang_x_sys-gazelle.patch
+++ b/third_party/org_golang_x_sys-gazelle.patch
@@ -1,7 +1,7 @@
 diff -urN a/cpu/BUILD.bazel b/cpu/BUILD.bazel
---- a/cpu/BUILD.bazel	1969-12-31 16:00:00
+--- a/cpu/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cpu/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,62 @@
+@@ -0,0 +1,67 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -40,9 +40,13 @@ diff -urN a/cpu/BUILD.bazel b/cpu/BUILD.bazel
 +        "cpu_x86.s",
 +        "cpu_zos.go",
 +        "cpu_zos_s390x.go",
++        "endian_big.go",
++        "endian_little.go",
 +        "hwcap_linux.go",
 +        "parse.go",
 +        "proc_cpuinfo_linux.go",
++        "runtime_auxv.go",
++        "runtime_auxv_go121.go",
 +        "syscall_aix_ppc64_gc.go",
 +    ],
 +    importpath = "golang.org/x/sys/cpu",
@@ -61,11 +65,12 @@ diff -urN a/cpu/BUILD.bazel b/cpu/BUILD.bazel
 +        "cpu_s390x_test.go",
 +        "cpu_test.go",
 +        "parse_test.go",
++        "runtime_auxv_go121_test.go",
 +    ],
 +    embed = [":cpu"],
 +)
 diff -urN a/execabs/BUILD.bazel b/execabs/BUILD.bazel
---- a/execabs/BUILD.bazel	1969-12-31 16:00:00
+--- a/execabs/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/execabs/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -93,7 +98,7 @@ diff -urN a/execabs/BUILD.bazel b/execabs/BUILD.bazel
 +    embed = [":execabs"],
 +)
 diff -urN a/internal/unsafeheader/BUILD.bazel b/internal/unsafeheader/BUILD.bazel
---- a/internal/unsafeheader/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/unsafeheader/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/unsafeheader/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -117,7 +122,7 @@ diff -urN a/internal/unsafeheader/BUILD.bazel b/internal/unsafeheader/BUILD.baze
 +    deps = [":unsafeheader"],
 +)
 diff -urN a/plan9/BUILD.bazel b/plan9/BUILD.bazel
---- a/plan9/BUILD.bazel	1969-12-31 16:00:00
+--- a/plan9/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/plan9/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,45 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -166,9 +171,9 @@ diff -urN a/plan9/BUILD.bazel b/plan9/BUILD.bazel
 +    }),
 +)
 diff -urN a/unix/BUILD.bazel b/unix/BUILD.bazel
---- a/unix/BUILD.bazel	1969-12-31 16:00:00
+--- a/unix/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/unix/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,295 @@
+@@ -0,0 +1,296 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -432,6 +437,7 @@ diff -urN a/unix/BUILD.bazel b/unix/BUILD.bazel
 +        "darwin_test.go",
 +        "dev_linux_test.go",
 +        "dirent_test.go",
++        "dup3_test.go",
 +        "example_exec_test.go",
 +        "example_flock_test.go",
 +        "example_sysvshm_test.go",
@@ -465,7 +471,7 @@ diff -urN a/unix/BUILD.bazel b/unix/BUILD.bazel
 +    embed = [":unix"],
 +)
 diff -urN a/unix/internal/mkmerge/BUILD.bazel b/unix/internal/mkmerge/BUILD.bazel
---- a/unix/internal/mkmerge/BUILD.bazel	1969-12-31 16:00:00
+--- a/unix/internal/mkmerge/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/unix/internal/mkmerge/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
@@ -489,7 +495,7 @@ diff -urN a/unix/internal/mkmerge/BUILD.bazel b/unix/internal/mkmerge/BUILD.baze
 +    embed = [":mkmerge_lib"],
 +)
 diff -urN a/windows/BUILD.bazel b/windows/BUILD.bazel
---- a/windows/BUILD.bazel	1969-12-31 16:00:00
+--- a/windows/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/windows/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,59 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -552,10 +558,10 @@ diff -urN a/windows/BUILD.bazel b/windows/BUILD.bazel
 +    }),
 +)
 diff -urN a/windows/mkwinsyscall/BUILD.bazel b/windows/mkwinsyscall/BUILD.bazel
---- a/windows/mkwinsyscall/BUILD.bazel	1969-12-31 16:00:00
+--- a/windows/mkwinsyscall/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/windows/mkwinsyscall/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,14 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+@@ -0,0 +1,20 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 +
 +go_library(
 +    name = "mkwinsyscall_lib",
@@ -569,8 +575,14 @@ diff -urN a/windows/mkwinsyscall/BUILD.bazel b/windows/mkwinsyscall/BUILD.bazel
 +    embed = [":mkwinsyscall_lib"],
 +    visibility = ["//visibility:public"],
 +)
++
++go_test(
++    name = "mkwinsyscall_test",
++    srcs = ["mkwinsyscall_test.go"],
++    embed = [":mkwinsyscall_lib"],
++)
 diff -urN a/windows/registry/BUILD.bazel b/windows/registry/BUILD.bazel
---- a/windows/registry/BUILD.bazel	1969-12-31 16:00:00
+--- a/windows/registry/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/windows/registry/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,34 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -608,7 +620,7 @@ diff -urN a/windows/registry/BUILD.bazel b/windows/registry/BUILD.bazel
 +    embed = [":registry"],
 +)
 diff -urN a/windows/svc/BUILD.bazel b/windows/svc/BUILD.bazel
---- a/windows/svc/BUILD.bazel	1969-12-31 16:00:00
+--- a/windows/svc/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/windows/svc/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -648,7 +660,7 @@ diff -urN a/windows/svc/BUILD.bazel b/windows/svc/BUILD.bazel
 +    }),
 +)
 diff -urN a/windows/svc/debug/BUILD.bazel b/windows/svc/debug/BUILD.bazel
---- a/windows/svc/debug/BUILD.bazel	1969-12-31 16:00:00
+--- a/windows/svc/debug/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/windows/svc/debug/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -675,7 +687,7 @@ diff -urN a/windows/svc/debug/BUILD.bazel b/windows/svc/debug/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/windows/svc/eventlog/BUILD.bazel b/windows/svc/eventlog/BUILD.bazel
---- a/windows/svc/eventlog/BUILD.bazel	1969-12-31 16:00:00
+--- a/windows/svc/eventlog/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/windows/svc/eventlog/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -714,7 +726,7 @@ diff -urN a/windows/svc/eventlog/BUILD.bazel b/windows/svc/eventlog/BUILD.bazel
 +    }),
 +)
 diff -urN a/windows/svc/example/BUILD.bazel b/windows/svc/example/BUILD.bazel
---- a/windows/svc/example/BUILD.bazel	1969-12-31 16:00:00
+--- a/windows/svc/example/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/windows/svc/example/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,29 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -747,7 +759,7 @@ diff -urN a/windows/svc/example/BUILD.bazel b/windows/svc/example/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/windows/svc/mgr/BUILD.bazel b/windows/svc/mgr/BUILD.bazel
---- a/windows/svc/mgr/BUILD.bazel	1969-12-31 16:00:00
+--- a/windows/svc/mgr/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/windows/svc/mgr/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")

--- a/third_party/org_golang_x_xerrors-gazelle.patch
+++ b/third_party/org_golang_x_xerrors-gazelle.patch
@@ -1,5 +1,5 @@
 diff -urN a/BUILD.bazel b/BUILD.bazel
---- a/BUILD.bazel	1969-12-31 16:00:00
+--- a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,40 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -43,7 +43,7 @@ diff -urN a/BUILD.bazel b/BUILD.bazel
 +    deps = ["//internal"],
 +)
 diff -urN a/internal/BUILD.bazel b/internal/BUILD.bazel
---- a/internal/BUILD.bazel	1969-12-31 16:00:00
+--- a/internal/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")


### PR DESCRIPTION
Prepare lease 0.39

This diff updates all dependencies in go/private/repositories.bzl **_except_** for `@go_googleapis`

This is because of issues relating to https://github.com/bazelbuild/bazel-gazelle/issues/1422

When tested downstream, many build failures arise from this upgrade. Therefore, we are keeping the version of this dependency stagnant while a better solution to these dependencies is explored. 

This PR was accomplished by running:
```
bazel run //go/tools/releaser -- upgrade-dep -mirror=false all      
```
And then reverting the changes to `@go_googleapis` and its patches.

This change was tested downstream in Uber's Go Monorepo