### PR TITLE
Use `go_default_sdk` in `.bcr/presubmit.yml`

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -26,6 +26,6 @@ bcr_test_module:
       platform: ${{ platform }}
       build_targets:
         - //...
-        - '@go_sdk//...'
+        - '@go_default_sdk//...'
       test_targets:
         - //...


### PR DESCRIPTION
Context: https://github.com/bazelbuild/bazel-central-registry/pull/547
