### PR TITLE
Reland "Add new darwin CC toolchain for tests (#3460)"

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -43,8 +43,16 @@ tasks:
   macos:
     shell_commands:
       - tests/core/cgo/generate_imported_dylib.sh
+    build_flags:
+      - "--apple_crosstool_top=@local_config_apple_cc//:toolchain"
+      - "--crosstool_top=@local_config_apple_cc//:toolchain"
+      - "--host_crosstool_top=@local_config_apple_cc//:toolchain"
     build_targets:
     - "//..."
+    test_flags:
+      - "--apple_crosstool_top=@local_config_apple_cc//:toolchain"
+      - "--crosstool_top=@local_config_apple_cc//:toolchain"
+      - "--host_crosstool_top=@local_config_apple_cc//:toolchain"
     test_targets:
     - "//..."
   rbe_ubuntu1604:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -165,3 +165,17 @@ http_archive(
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
 
 stardoc_repositories()
+
+# For testing objc_library interop, users should not need to install it
+http_archive(
+    name = "build_bazel_apple_support",
+    sha256 = "77a121a0f5d4cd88824429464ad2bfb54bdc8a3bccdb4d31a6c846003a3f5e44",
+    url = "https://github.com/bazelbuild/apple_support/releases/download/1.4.1/apple_support.1.4.1.tar.gz",
+)
+
+load(
+    "@build_bazel_apple_support//lib:repositories.bzl",
+    "apple_support_dependencies",
+)
+
+apple_support_dependencies()


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This relands cd9817098856f6b993937c2dd794a69850cd90ea, which was reverted by commit 4660427960cde81412031f93a2c2fb9fc6fcffa2.

The Xcode toolchain is now only enabled in tests.

**Which issues(s) does this PR fix?**

Fixes https://github.com/bazelbuild/rules_go/pull/3460