### PR TITLE
bzlmod: Remove `build_file_proto_mode` attribute

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,12 +26,11 @@ use_repo(go_sdk, "go_toolchains")
 
 register_toolchains("@go_toolchains//:all")
 
-bazel_dep(name = "gazelle", version = "0.27.0")
+bazel_dep(name = "gazelle", version = "0.30.0")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
 go_deps.module(
-    build_file_proto_mode = "disable",
     path = "github.com/gogo/protobuf",
     sum = "h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=",
     version = "v1.3.2",


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

By updating gazelle to a version that maintains a central registry of gazelle overrides, specifying `build_file_proto_mode` on `github.com/gogo/protobuf` is no longer necessary.

This will allow us to get rid of the rules_go exception after the next rules_go release.


**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
