### PR TITLE
Ignore pre-compiled stdlib only on 1.19 with experiments

### DIFF
--- a/go/private/actions/BUILD.bazel
+++ b/go/private/actions/BUILD.bazel
@@ -65,5 +65,6 @@ bzl_library(
     deps = [
         "//go/private:mode",
         "//go/private:providers",
+        "//go/private:sdk",
     ],
 )

--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -44,13 +44,14 @@ def _stdlib_library_to_source(go, _attr, source, _merge):
         source["stdlib"] = _build_stdlib(go)
 
 def _should_use_sdk_stdlib(go):
+    if go.sdk.version.startswith("1.19") and "boringcrypto" in go.sdk.experiments:
+        return False
     return (go.sdk.libs and  # go.sdk.libs is non-empty if sdk ships with precompiled .a files
             go.mode.goos == go.sdk.goos and
             go.mode.goarch == go.sdk.goarch and
             not go.mode.race and  # TODO(jayconrod): use precompiled race
             not go.mode.msan and
             not go.mode.pure and
-            not go.sdk.experiments and
             go.mode.link == LINKMODE_NORMAL)
 
 def _build_stdlib_list_json(go):

--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -44,7 +44,9 @@ def _stdlib_library_to_source(go, _attr, source, _merge):
         source["stdlib"] = _build_stdlib(go)
 
 def _should_use_sdk_stdlib(go):
-    if go.sdk.version.startswith("1.19") and "boringcrypto" in go.sdk.experiments:
+    major, minor, _ = go.sdk.version.split(".", 3)
+    if int(major) <= 1 and int(minor) <= 19 and go.sdk.experiments:
+        # The precompiled stdlib shipped with 1.19 or below doesn't have experiments
         return False
     return (go.sdk.libs and  # go.sdk.libs is non-empty if sdk ships with precompiled .a files
             go.mode.goos == go.sdk.goos and

--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -22,6 +22,7 @@ load(
     "extldflags_from_cc_toolchain",
     "link_mode_args",
 )
+load("//go/private:sdk.bzl", "parse_version")
 
 def emit_stdlib(go):
     """Returns a standard library for the target configuration.
@@ -44,8 +45,8 @@ def _stdlib_library_to_source(go, _attr, source, _merge):
         source["stdlib"] = _build_stdlib(go)
 
 def _should_use_sdk_stdlib(go):
-    major, minor, _ = go.sdk.version.split(".", 3)
-    if int(major) <= 1 and int(minor) <= 19 and go.sdk.experiments:
+    version = parse_version(go.sdk.version)
+    if version and version[0] <= 1 and version[1] <= 19 and go.sdk.experiments:
         # The precompiled stdlib shipped with 1.19 or below doesn't have experiments
         return False
     return (go.sdk.libs and  # go.sdk.libs is non-empty if sdk ships with precompiled .a files

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -95,7 +95,7 @@ def _go_download_sdk_impl(ctx):
         if not version:
             highest_version = None
             for v in sdks_by_version.keys():
-                pv = _parse_version(v)
+                pv = parse_version(v)
                 if not pv or _version_is_prerelease(pv):
                     # skip parse errors and pre-release versions
                     continue
@@ -149,7 +149,7 @@ go_download_sdk_rule = repository_rule(
 )
 
 def _define_version_constants(version, prefix = ""):
-    pv = _parse_version(version)
+    pv = parse_version(version)
     if pv == None or len(pv) < 3:
         fail("error parsing sdk version: " + version)
     major, minor, patch = pv[0], pv[1], pv[2]
@@ -439,7 +439,7 @@ def _sdk_build_file(ctx, platform, version, experiments):
     ctx.file("ROOT")
     goos, _, goarch = platform.partition("_")
 
-    pv = _parse_version(version)
+    pv = parse_version(version)
     if pv != None and pv[1] >= 20:
         # Turn off coverageredesign GOEXPERIMENT on 1.20+
         # until rules_go is updated to work with the
@@ -541,7 +541,7 @@ def _detect_sdk_version(ctx, goroot):
         version = output_parts[3][len("go"):]
     else:
         fail("Could not parse SDK version from '%s version' output: %s" % (go_binary_path, result.stdout))
-    if _parse_version(version) == None:
+    if parse_version(version) == None:
         fail("Could not parse SDK version from '%s version' output: %s" % (go_binary_path, result.stdout))
     if ctx.attr.version and ctx.attr.version != version:
         fail("SDK is version %s, but version %s was expected" % (version, ctx.attr.version))
@@ -573,7 +573,7 @@ def _parse_versions_json(data):
         for sdk in sdks
     }
 
-def _parse_version(version):
+def parse_version(version):
     """Parses a version string like "1.15.5" and returns a tuple of numbers or None"""
     l, r = 0, 0
     parsed = []
@@ -654,7 +654,7 @@ def go_register_toolchains(version = None, nogo = None, go_version = None, exper
         elif version == "host":
             go_host_sdk(name = "go_sdk", experiments = experiments)
         else:
-            pv = _parse_version(version)
+            pv = parse_version(version)
             if not pv:
                 fail('go_register_toolchains: version must be a string like "1.15.5" or "host"')
             if _version_less(pv, MIN_SUPPORTED_VERSION):


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
#3398 allowed people to use boringcrypto on 1.19 by ignoring the pre-compile stdlib when boringcrypto is request. However, #3401 over generalized the intention by ignore pre-compile stdlib for all experimental flags for all Go versions. In addition, rules_go add a "nocoverageredesign" experimental flag for Go 1.20. This means rules_go always ignores pre-compiled stdlib that users provide, even it's compiled correctly.

This restore the intention of #3398 by only ignoring pre-compiled stdlib on Go 1.19 with experiments. This allows people to add precompiled stdlib on 1.20+ to improve build performance.

**Other notes for review**
