### PR TITLE
go_register_toolchains: update sdk_kinds

### DIFF
--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -639,7 +639,7 @@ def go_register_toolchains(version = None, nogo = None, go_version = None, exper
     if not version:
         version = go_version  # old name
 
-    sdk_kinds = ("_go_download_sdk", "_go_host_sdk", "_go_local_sdk", "_go_wrap_sdk")
+    sdk_kinds = ("go_download_sdk_rule", "_go_host_sdk", "_go_local_sdk", "_go_wrap_sdk")
     existing_rules = native.existing_rules()
     sdk_rules = [r for r in existing_rules.values() if r["kind"] in sdk_kinds]
     if len(sdk_rules) == 0 and "go_sdk" in existing_rules:

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -639,7 +639,7 @@ def go_register_toolchains(version = None, nogo = None, go_version = None, exper
     if not version:
         version = go_version  # old name
 
-    sdk_kinds = ("go_download_sdk_rule", "_go_host_sdk", "_go_local_sdk", "_go_wrap_sdk")
+    sdk_kinds = ("go_download_sdk_rule", "go_host_sdk_rule", "_go_local_sdk", "_go_wrap_sdk")
     existing_rules = native.existing_rules()
     sdk_rules = [r for r in existing_rules.values() if r["kind"] in sdk_kinds]
     if len(sdk_rules) == 0 and "go_sdk" in existing_rules:


### PR DESCRIPTION

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

After 89e3296c36b789e8623e1178a59506547a98419e, we have renamed
_go_download_sdk to go_download_sdk_rule so that we could re-use the
implementation inside the Bazel Module Extension setup.

Update go_register_toolchains to pick up this change.

**Which issues(s) does this PR fix?**

Fixes #3510

**Other notes for review**
