### PR TITLE
bzlmod: Fix repo name used by gopackagesdriver

### DIFF
--- a/go/tools/gopackagesdriver/BUILD.bazel
+++ b/go/tools/gopackagesdriver/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//go:def.bzl", "go_binary", "go_library")
+load(":aspect.bzl", "bazel_supports_canonical_label_literals")
 
 go_library(
     name = "gopackagesdriver_lib",
@@ -20,5 +21,19 @@ go_library(
 go_binary(
     name = "gopackagesdriver",
     embed = [":gopackagesdriver_lib"],
+    x_defs = {
+        # Determine the name of the rules_go repository as we need to specify it when invoking the
+        # aspect.
+        # If canonical label literals are supported, we can use a canonical label literal (starting
+        # with @@) to pass the repository_name() through repo mapping unchanged.
+        # If canonical label literals are not supported, then bzlmod is certainly not enabled and
+        # we can assume that the repository name is not affected by repo mappings.
+        # If run in the rules_go repo itself, repository_name() returns "@", which is equivalent to
+        # "@io_bazel_rules_go" since Bazel 6:
+        # https://github.com/bazelbuild/bazel/commit/7694cf75e6366b92e3905c2ad60234cda57627ee
+        # TODO: Once we drop support for Bazel 5, we can remove the feature detection logic and
+        #       use "@" + repository_name().
+        "rulesGoRepositoryName": "@" + repository_name() if bazel_supports_canonical_label_literals() else repository_name(),
+    },
     visibility = ["//visibility:public"],
 )

--- a/go/tools/gopackagesdriver/aspect.bzl
+++ b/go/tools/gopackagesdriver/aspect.bzl
@@ -34,6 +34,9 @@ PROTO_COMPILER_ATTRS = [
     "compilers",
 ]
 
+def bazel_supports_canonical_label_literals():
+    return str(Label("//:bogus")).startswith("@@")
+
 def is_file_external(f):
     return f.owner.workspace_root != ""
 

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -31,9 +31,7 @@ type BazelJSONBuilder struct {
 	requests []string
 }
 
-const (
-	RulesGoStdlibLabel = "@io_bazel_rules_go//:stdlib"
-)
+var RulesGoStdlibLabel = rulesGoRepositoryName + "//:stdlib"
 
 var _defaultKinds = []string{"go_library", "go_test", "go_binary"}
 

--- a/go/tools/gopackagesdriver/main.go
+++ b/go/tools/gopackagesdriver/main.go
@@ -49,9 +49,9 @@ type driverResponse struct {
 }
 
 var (
-	// It seems https://github.com/bazelbuild/bazel/issues/3115 isn't fixed when specifying
-	// the aspect from the command line. Use this trick in the mean time.
-	rulesGoRepositoryName = getenvDefault("GOPACKAGESDRIVER_RULES_GO_REPOSITORY_NAME", "@io_bazel_rules_go")
+	// Injected via x_defs.
+
+	rulesGoRepositoryName string
 	goDefaultAspect       = rulesGoRepositoryName + "//go/tools/gopackagesdriver:aspect.bzl%go_pkg_info_aspect"
 	bazelBin              = getenvDefault("GOPACKAGESDRIVER_BAZEL", "bazel")
 	bazelStartupFlags     = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_FLAGS"))

--- a/tools/gopackagesdriver.sh
+++ b/tools/gopackagesdriver.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
-export GOPACKAGESDRIVER_RULES_GO_REPOSITORY_NAME=
 exec bazel run --tool_tag=gopackagesdriver -- //go/tools/gopackagesdriver "${@}"


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Ensure that we always specify the correct repo name when invoking the aspect by injecting it via `x_defs`. This works even with Bzlmod (where users usually refer to rules_go as `@rules_go`, not `@io_bazel_rules_go`, but could choose any apparent repository name for it).

Also replace one instance of a hardcoded repo name (thanks @bricedp).

**Which issues(s) does this PR fix?**

#3515 

Fixes #

**Other notes for review**
