### PR TITLE
Pass gc_goopts to stdlib

### DIFF
--- a/go/private/actions/BUILD.bazel
+++ b/go/private/actions/BUILD.bazel
@@ -41,6 +41,7 @@ bzl_library(
     srcs = ["compilepkg.bzl"],
     visibility = ["//go:__subpackages__"],
     deps = [
+        ":utils",
         "//go/private:mode",
         "@bazel_skylib//lib:shell",
     ],
@@ -63,8 +64,14 @@ bzl_library(
     srcs = ["stdlib.bzl"],
     visibility = ["//go:__subpackages__"],
     deps = [
+        ":utils",
         "//go/private:mode",
         "//go/private:providers",
         "//go/private:sdk",
     ],
+)
+
+bzl_library(
+    name = "utils",
+    srcs = ["utils.bzl"],
 )

--- a/go/private/actions/compilepkg.bzl
+++ b/go/private/actions/compilepkg.bzl
@@ -16,10 +16,7 @@ load(
     "//go/private:mode.bzl",
     "link_mode_args",
 )
-load(
-    "@bazel_skylib//lib:shell.bzl",
-    "shell",
-)
+load("//go/private/actions:utils.bzl", "quote_opts")
 
 def _archive(v):
     importpaths = [v.data.importpath]
@@ -134,8 +131,8 @@ def emit_compilepkg(
     gc_flags.extend(go.toolchain.flags.compile)
     gc_flags.extend(link_mode_args(go.mode))
     asm_flags.extend(link_mode_args(go.mode))
-    args.add("-gcflags", _quote_opts(gc_flags))
-    args.add("-asmflags", _quote_opts(asm_flags))
+    args.add("-gcflags", quote_opts(gc_flags))
+    args.add("-asmflags", quote_opts(asm_flags))
 
     env = go.env
     if cgo:
@@ -143,17 +140,17 @@ def emit_compilepkg(
         inputs.extend(go.crosstool)
         env["CC"] = go.cgo_tools.c_compiler_path
         if cppopts:
-            args.add("-cppflags", _quote_opts(cppopts))
+            args.add("-cppflags", quote_opts(cppopts))
         if copts:
-            args.add("-cflags", _quote_opts(copts))
+            args.add("-cflags", quote_opts(copts))
         if cxxopts:
-            args.add("-cxxflags", _quote_opts(cxxopts))
+            args.add("-cxxflags", quote_opts(cxxopts))
         if objcopts:
-            args.add("-objcflags", _quote_opts(objcopts))
+            args.add("-objcflags", quote_opts(objcopts))
         if objcxxopts:
-            args.add("-objcxxflags", _quote_opts(objcxxopts))
+            args.add("-objcxxflags", quote_opts(objcxxopts))
         if clinkopts:
-            args.add("-ldflags", _quote_opts(clinkopts))
+            args.add("-ldflags", quote_opts(clinkopts))
 
     go.actions.run(
         inputs = inputs,
@@ -163,6 +160,3 @@ def emit_compilepkg(
         arguments = [args],
         env = go.env,
     )
-
-def _quote_opts(opts):
-    return " ".join([shell.quote(opt) if " " in opt else opt for opt in opts])

--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -23,6 +23,7 @@ load(
     "link_mode_args",
 )
 load("//go/private:sdk.bzl", "parse_version")
+load("//go/private/actions:utils.bzl", "quote_opts")
 
 def emit_stdlib(go):
     """Returns a standard library for the target configuration.
@@ -55,6 +56,7 @@ def _should_use_sdk_stdlib(go):
             not go.mode.race and  # TODO(jayconrod): use precompiled race
             not go.mode.msan and
             not go.mode.pure and
+            not go.mode.gc_goopts and
             go.mode.link == LINKMODE_NORMAL)
 
 def _build_stdlib_list_json(go):
@@ -107,6 +109,7 @@ def _build_stdlib(go):
             "CGO_CFLAGS": " ".join(go.cgo_tools.c_compile_options),
             "CGO_LDFLAGS": " ".join(ldflags),
         })
+    args.add("-gcflags", quote_opts(go.mode.gc_goopts))
     inputs = (go.sdk.srcs +
               go.sdk.headers +
               go.sdk.tools +

--- a/go/private/actions/utils.bzl
+++ b/go/private/actions/utils.bzl
@@ -1,0 +1,7 @@
+load(
+    "@bazel_skylib//lib:shell.bzl",
+    "shell",
+)
+
+def quote_opts(opts):
+    return " ".join([shell.quote(opt) if " " in opt else opt for opt in opts])

--- a/go/tools/builders/stdlib.go
+++ b/go/tools/builders/stdlib.go
@@ -37,6 +37,8 @@ func stdlib(args []string) error {
 	flags.Var(&packages, "package", "Packages to build")
 	var experiments multiFlag
 	flags.Var(&experiments, "experiment", "Go experiments to enable via GOEXPERIMENT")
+	var gcflags quoteMultiFlag
+	flags.Var(&gcflags, "gcflags", "Go compiler flags")
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
@@ -129,7 +131,6 @@ You may need to use the flags --cpu=x64_windows --compiler=mingw-gcc.`)
 		installArgs = append(installArgs, "-tags", strings.Join(build.Default.BuildTags, ","))
 	}
 
-	gcflags := []string{}
 	ldflags := []string{"-trimpath", sandboxPath}
 	asmflags := []string{"-trimpath", output}
 	if *race {


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
When `//go/config:gc_goopts` is provided by user, we should also pass those flags to `go install` command when we are building stdlib. This PR also ignores the pre-compiled stdlib when `go_goopts` is provided, assuming the pre-compiled stdlib is compiled without any custom `go_goopts`.
