### PR TITLE
Remove LLVM coverage flags for CGo

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -105,6 +105,8 @@ _COMPILER_OPTIONS_DENYLIST = {
     "--coverage": None,
     "-ftest-coverage": None,
     "-fprofile-arcs": None,
+    "-fprofile-instr-generate": None,
+    "-fcoverage-mapping": None,
 }
 
 _LINKER_OPTIONS_DENYLIST = {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

We already remove the GCC variants of these flags.

