### PR TITLE
Drop coverage linker flags from stdlib build

### DIFF
--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 load(
+    "//go/private:common.bzl",
+    "COVERAGE_OPTIONS_DENYLIST",
+)
+load(
     "//go/private:providers.bzl",
     "GoStdLib",
 )
@@ -98,10 +102,12 @@ def _build_stdlib(go):
     else:
         # NOTE(#2545): avoid unnecessary dynamic link
         # go std library doesn't use C++, so should not have -lstdc++
+        # Also drop coverage flags as nothing in the stdlib is compiled with
+        # coverage - we disable it for all CGo code anyway.
         ldflags = [
             option
             for option in extldflags_from_cc_toolchain(go)
-            if option not in ("-lstdc++", "-lc++")
+            if option not in ("-lstdc++", "-lc++") and option not in COVERAGE_OPTIONS_DENYLIST
         ]
         env.update({
             "CGO_ENABLED": "1",

--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -243,3 +243,12 @@ def count_group_matches(v, prefix, suffix):
         count = count + 1
 
     return count
+
+# C/C++ compiler and linker options related to coverage instrumentation.
+COVERAGE_OPTIONS_DENYLIST = {
+    "--coverage": None,
+    "-ftest-coverage": None,
+    "-fprofile-arcs": None,
+    "-fprofile-instr-generate": None,
+    "-fcoverage-mapping": None,
+}

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -105,6 +105,8 @@ _COMPILER_OPTIONS_DENYLIST = {
     "--coverage": None,
     "-ftest-coverage": None,
     "-fprofile-arcs": None,
+    "-fprofile-instr-generate": None,
+    "-fcoverage-mapping": None,
 }
 
 _LINKER_OPTIONS_DENYLIST = {

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -51,6 +51,7 @@ load(
 )
 load(
     ":common.bzl",
+    "COVERAGE_OPTIONS_DENYLIST",
     "as_iterable",
     "goos_to_extension",
     "goos_to_shared_extension",
@@ -86,7 +87,7 @@ _UNSUPPORTED_C_COMPILERS = {
     "clang-cl": None,
 }
 
-_COMPILER_OPTIONS_DENYLIST = {
+_COMPILER_OPTIONS_DENYLIST = dict({
     # cgo parses the error messages from the compiler.  It can't handle colors.
     # Ignore both variants of the diagnostics color flag.
     "-fcolor-diagnostics": None,
@@ -107,7 +108,7 @@ _COMPILER_OPTIONS_DENYLIST = {
     "-fprofile-arcs": None,
     "-fprofile-instr-generate": None,
     "-fcoverage-mapping": None,
-}
+}, **COVERAGE_OPTIONS_DENYLIST)
 
 _LINKER_OPTIONS_DENYLIST = {
     "-Wl,--gc-sections": None,


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

We never compile CGo with coverage instrumentation and the stdlib contains no user-provided C/C++ code, so linking coverage runtimes is never needed.

**Which issues(s) does this PR fix?**

Work towards #3472 

(fixing the issue requires a change to Bazel)

**Other notes for review**
