### PR TITLE
config: make strip a bool_flag

### DIFF
--- a/go/config/BUILD.bazel
+++ b/go/config/BUILD.bazel
@@ -1,7 +1,6 @@
 load(
     "@bazel_skylib//rules:common_settings.bzl",
     "bool_flag",
-    "bool_setting",
     "string_flag",
     "string_list_flag",
 )
@@ -34,7 +33,7 @@ bool_flag(
     visibility = ["//visibility:public"],
 )
 
-bool_setting(
+bool_flag(
     name = "strip",
     build_setting_default = False,
     visibility = ["//visibility:public"],


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
Bug fix
> Feature
> Documentation
> Other

**What does this PR do? Why is it needed?**

Allows specifying the `strip` config setting via a flag. This allows configuration of the strip setting via a bazel command line flag and makes it easier to switch between stripped and non-stripped builds.

**Which issues(s) does this PR fix?**

Fixes #3325

**Other notes for review**

As far as I can tell, changing this setting to be a bool_flag just works. It does perform stripping as expected[^1]. I couldn't find any reason as to why the strip setting is handled differently from the rest. If there was a reason, please state it and we can close this.

Edit: This is one possible resolution. See also #3527 for an alternative solution that respects the global bazel strip setting.

[^1]: running `file` on a resulting binary when using the flag shows `ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=redacted, not stripped`, while it shows `ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=redacted, with debug_info, not stripped` without the flag. This seems to be consistent with what the docs say about this flag (it is equivalent to `-w` on the `go build` options). I was expecting this to also set `-s` for the go build options which would change the last part of the output to say `stripped`, but this is a separate issue.