### PR TITLE
Fix Ubuntu CI after --remote_download_toplevel flip in Bazel CI 

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -11,8 +11,18 @@ tasks:
     bazel: 5.4.0 # test minimum supported version of bazel
     shell_commands:
       - tests/core/cgo/generate_imported_dylib.sh
+    build_flags:
+      # Temporary rollback to fix //tests/core/go_path builds
+      # https://github.com/bazelbuild/continuous-integration/commit/a95a916098d3015bb4ea20b7e33bc7d27d00bffc
+      - "--remote_download_outputs=all"
+      - "--build_runfile_links"
     build_targets:
     - "//..."
+    test_flags:
+      # Temporary rollback to fix //tests/core/go_path builds
+      # https://github.com/bazelbuild/continuous-integration/commit/a95a916098d3015bb4ea20b7e33bc7d27d00bffc
+      - "--remote_download_outputs=all"
+      - "--build_runfile_links"
     test_targets:
     - "//..."
   ubuntu2004:


### PR DESCRIPTION
Fixes failures such as:
https://buildkite.com/bazel/rules-go-golang/builds/5066#01878f4b-c637-4080-b1df-47ff2e0e5f63/276-300
caused by https://github.com/bazelbuild/continuous-integration/pull/1585.