### PR TITLE
go_sdk extension: create `go_host_compatible_sdk` repository

### DIFF
--- a/go/private/extensions.bzl
+++ b/go/private/extensions.bzl
@@ -4,7 +4,7 @@ load("//go/private:repositories.bzl", "go_rules_dependencies")
 def host_compatible_toolchain_impl(ctx):
     ctx.file("BUILD.bazel")
     ctx.file("defs.bzl", content = """
-host_compatible_sdk = Label({})
+HOST_COMPATIBLE_SDK = Label({})
 """.format(repr(ctx.attr.toolchain)))
 
 host_compatible_toolchain = repository_rule(

--- a/go/private/extensions.bzl
+++ b/go/private/extensions.bzl
@@ -1,5 +1,24 @@
-load("//go/private:sdk.bzl", "go_download_sdk_rule", "go_host_sdk_rule", "go_multiple_toolchains")
+load("//go/private:sdk.bzl", "detect_host_platform", "go_download_sdk_rule", "go_host_sdk_rule", "go_multiple_toolchains")
 load("//go/private:repositories.bzl", "go_rules_dependencies")
+
+def host_compatible_toolchain_impl(ctx):
+    ctx.file("BUILD.bazel")
+    ctx.file("defs.bzl", content = """
+host_compatible_sdk = Label({})
+""".format(repr(ctx.attr.toolchain)))
+
+host_compatible_toolchain = repository_rule(
+    implementation = host_compatible_toolchain_impl,
+    attrs = {
+        # We cannot use attr.label for the `toolchain` attribute since the module extension cannot
+        # refer to the repositories it creates by their apparent repository names.
+        "toolchain": attr.string(
+            doc = "The apparent label of a `ROOT` file in the repository of a host compatible toolchain created by the `go_sdk` extension",
+            mandatory = True,
+        ),
+    },
+    doc = "An external repository to expose the first host compatible toolchain",
+)
 
 _download_tag = tag_class(
     attrs = {
@@ -33,6 +52,11 @@ def _go_sdk_impl(ctx):
         else:
             multi_version_module[module.name] = False
 
+    # We remember the first host compatible toolchain declared by the download and host tags.
+    # The order follows bazel's iteration over modules (the toolchains declared by the root module are considered first).
+    # We know that at least `go_default_sdk` (which is declared by the `rules_go` module itself) is host compatible.
+    first_host_compatible_toolchain = None
+    host_detected_goos, host_detected_goarch = detect_host_platform(ctx)
     toolchains = []
     for module in ctx.modules:
         for index, download_tag in enumerate(module.tags.download):
@@ -65,6 +89,9 @@ def _go_sdk_impl(ctx):
                 urls = download_tag.urls,
                 version = download_tag.version,
             )
+
+            if (not download_tag.goos or download_tag.goos == host_detected_goos) and (not download_tag.goarch or download_tag.goarch == host_detected_goarch):
+                first_host_compatible_toolchain = first_host_compatible_toolchain or "@{}//:ROOT".format(name)
 
             toolchains.append(struct(
                 goos = download_tag.goos,
@@ -99,7 +126,9 @@ def _go_sdk_impl(ctx):
                 sdk_type = "host",
                 sdk_version = host_tag.version,
             ))
+            first_host_compatible_toolchain = first_host_compatible_toolchain or "@{}//:ROOT".format(name)
 
+    host_compatible_toolchain(name = "go_host_compatible_sdk_label", toolchain = first_host_compatible_toolchain)
     if len(toolchains) > _MAX_NUM_TOOLCHAINS:
         fail("more than {} go_sdk tags are not supported".format(_MAX_NUM_TOOLCHAINS))
 

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -59,7 +59,7 @@ def go_host_sdk(name, register_toolchains = True, **kwargs):
 
 def _go_download_sdk_impl(ctx):
     if not ctx.attr.goos and not ctx.attr.goarch:
-        goos, goarch = _detect_host_platform(ctx)
+        goos, goarch = detect_host_platform(ctx)
     else:
         if not ctx.attr.goos:
             fail("goarch set but goos not set")
@@ -173,7 +173,7 @@ def _to_constant_name(s):
 
 def go_toolchains_single_definition(ctx, *, prefix, goos, goarch, sdk_repo, sdk_type, sdk_version):
     if not goos and not goarch:
-        goos, goarch = _detect_host_platform(ctx)
+        goos, goarch = detect_host_platform(ctx)
     else:
         if not goos:
             fail("goarch set but goos not set")
@@ -354,7 +354,7 @@ def _go_wrap_sdk_impl(ctx):
     if ctx.attr.root_file:
         root_file = ctx.attr.root_file
     else:
-        goos, goarch = _detect_host_platform(ctx)
+        goos, goarch = detect_host_platform(ctx)
         platform = goos + "_" + goarch
         if platform not in ctx.attr.root_files:
             fail("unsupported platform {}".format(platform))
@@ -466,7 +466,7 @@ def _sdk_build_file(ctx, platform, version, experiments):
         content = _define_version_constants(version),
     )
 
-def _detect_host_platform(ctx):
+def detect_host_platform(ctx):
     goos = ctx.os.name
     if goos == "mac os x":
         goos = "darwin"

--- a/tests/bcr/MODULE.bazel
+++ b/tests/bcr/MODULE.bazel
@@ -30,6 +30,9 @@ go_sdk.host(version = "3.0.0")
 # Bring the default SDK into scope to verify that it exists.
 use_repo(go_sdk, "go_default_sdk")
 
+# Bring the selected host compatible SDK into scope to verify that it exists.
+use_repo(go_sdk, "go_host_compatible_sdk_label")
+
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.module(
     path = "google.golang.org/grpc",


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**

As discussed in [this issue](https://github.com/bazelbuild/bazel-gazelle/issues/1469), this PR makes the `go_sdk` module extension define a new repository called `go_host_compatible_sdk`.

This repository exposes the label of the first host compatible sdk declared by a module via the `download` or `host` tag (according to bazel's iteration order over modules).

The gazelle module could then rely on this toolchain for bootstrapping instead of always using `go_default_sdk`.

**Which issues(s) does this PR fix?**

This PR is a first step toward closing https://github.com/bazelbuild/bazel-gazelle/issues/1469

**Other notes for review**

- As discussed in the issue, this PR does not yet provide a way do use toolchains declared outside of rules_go. This is left for another PR.
