### PR TITLE
Move CI flags to .bazelrc and fix BwoB build

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -11,11 +11,6 @@ tasks:
     bazel: 5.4.0 # test minimum supported version of bazel
     shell_commands:
       - tests/core/cgo/generate_imported_dylib.sh
-    build_flags:
-      # Temporary rollback to fix //tests/core/go_path builds
-      # https://github.com/bazelbuild/continuous-integration/commit/a95a916098d3015bb4ea20b7e33bc7d27d00bffc
-      - "--remote_download_outputs=all"
-      - "--build_runfile_links"
     build_targets:
     - "//..."
     test_flags:
@@ -57,20 +52,12 @@ tasks:
       - "--apple_crosstool_top=@local_config_apple_cc//:toolchain"
       - "--crosstool_top=@local_config_apple_cc//:toolchain"
       - "--host_crosstool_top=@local_config_apple_cc//:toolchain"
-      # Temporary rollback to fix //tests/core/cgo:versioned_dylib_test
-      # https://github.com/bazelbuild/continuous-integration/commit/a95a916098d3015bb4ea20b7e33bc7d27d00bffc
-      - "--remote_download_outputs=all"
-      - "--build_runfile_links"
     build_targets:
     - "//..."
     test_flags:
       - "--apple_crosstool_top=@local_config_apple_cc//:toolchain"
       - "--crosstool_top=@local_config_apple_cc//:toolchain"
       - "--host_crosstool_top=@local_config_apple_cc//:toolchain"
-      # Temporary rollback to fix //tests/core/cgo:versioned_dylib_test
-      # https://github.com/bazelbuild/continuous-integration/commit/a95a916098d3015bb4ea20b7e33bc7d27d00bffc
-      - "--remote_download_outputs=all"
-      - "--build_runfile_links"
     test_targets:
     - "//..."
   rbe_ubuntu1604:
@@ -94,17 +81,7 @@ tasks:
     - "-//tests/core/stdlib:buildid_test"
   windows:
     build_flags:
-    # Go requires a C toolchain that accepts options and emits errors like
-    # gcc or clang. The Go SDK does not support MSVC.
-    - "--cpu=x64_windows"
-    - "--compiler=mingw-gcc"
     - '--action_env=PATH=C:\tools\msys64\usr\bin;C:\tools\msys64\bin;C:\tools\msys64\mingw64\bin;C:\python3\Scripts\;C:\python3;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0;C:\Windows\System32\OpenSSH;C:\ProgramData\GooGet;C:\Program Files\Google\Compute Engine\metadata_scripts;C:\Program Files (x86)\Google\Cloud SDK\google-cloud-sdk\bin;C:\Program Files\Google\Compute Engine\sysprep;C:\ProgramData\chocolatey\bin;C:\Program Files\Git\cmd;C:\tools\msys64\usr\bin;c:\openjdk\bin;C:\Program Files (x86)\Windows Kits\8.1\Windows Performance Toolkit\;C:\Program Files\CMake\bin;c:\ninja;c:\bazel;c:\buildkite'
-    # NOTE(bazelbuild/bazel#10529): bazel doesn't register the mingw toolchain automatically.
-    # We also need the host and target platforms to have the mingw constraint value.
-    - "--extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows_mingw"
-    - "--host_platform=@io_bazel_rules_go//go/toolchain:windows_amd64_cgo"
-    - "--platforms=@io_bazel_rules_go//go/toolchain:windows_amd64_cgo"
-    - "--incompatible_enable_cc_toolchain_resolution"
     build_targets:
     # BUG(bazelbuild/bazel#6485): Bazel 0.18.0 crashes when loading
     # @com_google_protobuf//:protobuf. We have to exclude everything that
@@ -279,15 +256,7 @@ tasks:
     - "-//tests/legacy/test_rundir:go_default_test"
     - "-//tests/legacy/transitive_data:go_default_test"
     test_flags:
-    # Go requires a C toolchain that accepts options and emits errors like
-    # gcc or clang. The Go SDK does not support MSVC.
-    - "--cpu=x64_windows"
-    - "--compiler=mingw-gcc"
     - '--action_env=PATH=C:\tools\msys64\usr\bin;C:\tools\msys64\bin;C:\tools\msys64\mingw64\bin;C:\python3\Scripts\;C:\python3;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0;C:\Windows\System32\OpenSSH;C:\ProgramData\GooGet;C:\Program Files\Google\Compute Engine\metadata_scripts;C:\Program Files (x86)\Google\Cloud SDK\google-cloud-sdk\bin;C:\Program Files\Google\Compute Engine\sysprep;C:\ProgramData\chocolatey\bin;C:\Program Files\Git\cmd;C:\tools\msys64\usr\bin;c:\openjdk\bin;C:\Program Files (x86)\Windows Kits\8.1\Windows Performance Toolkit\;C:\Program Files\CMake\bin;c:\ninja;c:\bazel;c:\buildkite'
-    - "--extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows_mingw"
-    - "--host_platform=@io_bazel_rules_go//go/toolchain:windows_amd64_cgo"
-    - "--platforms=@io_bazel_rules_go//go/toolchain:windows_amd64_cgo"
-    - "--incompatible_enable_cc_toolchain_resolution"
     # On Windows CI, bazel (bazelisk) needs %LocalAppData% to find the cache directory.
     # We invoke bazel in tests, so the tests need this, too.
     - "--test_env=LOCALAPPDATA"

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,21 @@
+common --enable_platform_specific_config
+
+# //tests/core/go_path is incompatible with BwoB, which is enabled in Bazel CI.
+# https://github.com/bazelbuild/continuous-integration/commit/a95a916098d3015bb4ea20b7e33bc7d27d00bffc
+build --remote_download_outputs=all
+build --build_runfile_links
+build --experimental_remote_download_regex=.*tests/core/go_path/.*
+
+# Go requires a C toolchain that accepts options and emits errors like
+# gcc or clang. The Go SDK does not support MSVC.
 build:windows --cpu=x64_windows
 build:windows --compiler=mingw-gcc
+# NOTE(bazelbuild/bazel#10529): bazel doesn't register the mingw toolchain automatically.
+# We also need the host and target platforms to have the mingw constraint value.
+build:windows --extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows_mingw
+build:windows --host_platform=@io_bazel_rules_go//go/toolchain:windows_amd64_cgo
+build:windows --platforms=@io_bazel_rules_go//go/toolchain:windows_amd64_cgo
+build:windows --incompatible_enable_cc_toolchain_resolution
 
 build:check --all_incompatible_changes
 


### PR DESCRIPTION
This simplifies the CI config and also ensures that the recent BwoB flip in CI is disabled in all runs.