### PR TITLE
Fix `goexperiment.*` build tags

### DIFF
--- a/go/private/actions/compilepkg.bzl
+++ b/go/private/actions/compilepkg.bzl
@@ -117,7 +117,6 @@ def emit_compilepkg(
         outputs.append(out_cgo_export_h)
     if testfilter:
         args.add("-testfilter", testfilter)
-    args.add_all(go.sdk.experiments, before_each = "-experiment")
 
     gc_flags = list(gc_goopts)
     gc_flags.extend(go.mode.gc_goopts)

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -176,7 +176,6 @@ def emit_link(
     builder_args.add("-p", archive.data.importmap)
     tool_args.add_all(gc_linkopts)
     tool_args.add_all(go.toolchain.flags.link)
-    builder_args.add_all(go.sdk.experiments, before_each = "-experiment")
 
     # Do not remove, somehow this is needed when building for darwin/arm only.
     tool_args.add("-buildid=redacted")

--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -121,7 +121,6 @@ def _build_stdlib(go):
     args.add("-out", pkg.dirname)
     if go.mode.race:
         args.add("-race")
-    args.add_all(go.sdk.experiments, before_each = "-experiment")
     args.add("-package", "std")
     if not go.mode.pure:
         args.add("-package", "runtime/cgo")

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -437,6 +437,7 @@ def go_context(ctx, attr = None):
     env = {
         "GOARCH": mode.goarch,
         "GOOS": mode.goos,
+        "GOEXPERIMENT": ",".join(toolchain.sdk.experiments),
         "GOROOT": goroot,
         "GOROOT_FINAL": "GOROOT",
         "CGO_ENABLED": "0" if mode.pure else "1",

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -56,7 +56,6 @@ func compilePkg(args []string) error {
 	var testFilter string
 	var gcFlags, asmFlags, cppFlags, cFlags, cxxFlags, objcFlags, objcxxFlags, ldFlags quoteMultiFlag
 	var coverFormat string
-	var experiments multiFlag
 	fs.Var(&unfilteredSrcs, "src", ".go, .c, .cc, .m, .mm, .s, or .S file to be filtered and compiled")
 	fs.Var(&coverSrcs, "cover", ".go file that should be instrumented for coverage (must also be a -src)")
 	fs.Var(&embedSrcs, "embedsrc", "file that may be compiled into the package with a //go:embed directive")
@@ -72,7 +71,6 @@ func compilePkg(args []string) error {
 	fs.Var(&cxxFlags, "cxxflags", "C++ compiler flags")
 	fs.Var(&objcFlags, "objcflags", "Objective-C compiler flags")
 	fs.Var(&objcxxFlags, "objcxxflags", "Objective-C++ compiler flags")
-	fs.Var(&experiments, "experiment", "Go experiments to enable via GOEXPERIMENT")
 	fs.Var(&ldFlags, "ldflags", "C linker flags")
 	fs.StringVar(&nogoPath, "nogo", "", "The nogo binary. If unset, nogo will not be run.")
 	fs.StringVar(&packageListPath, "package_list", "", "The file containing the list of standard library packages")
@@ -131,10 +129,6 @@ func compilePkg(args []string) error {
 		srcs.goSrcs = libSrcs
 	default:
 		return fmt.Errorf("invalid test filter %q", testFilter)
-	}
-
-	if len(experiments) > 0 {
-		os.Setenv("GOEXPERIMENT", strings.Join(experiments, ","))
 	}
 
 	return compileArchive(

--- a/go/tools/builders/link.go
+++ b/go/tools/builders/link.go
@@ -39,7 +39,6 @@ func link(args []string) error {
 	builderArgs, toolArgs := splitArgs(args)
 	stamps := multiFlag{}
 	xdefs := multiFlag{}
-	experiments := multiFlag{}
 	archives := archiveMultiFlag{}
 	flags := flag.NewFlagSet("link", flag.ExitOnError)
 	goenv := envFlags(flags)
@@ -51,7 +50,6 @@ func link(args []string) error {
 	buildmode := flags.String("buildmode", "", "Build mode used.")
 	flags.Var(&xdefs, "X", "A string variable to replace in the linked binary (repeated).")
 	flags.Var(&stamps, "stamp", "The name of a file with stamping values.")
-	flags.Var(&experiments, "experiment", "Go experiments to enable via GOEXPERIMENT")
 	conflictErrMsg := flags.String("conflict_err", "", "Error message about conflicts to report if there's a link error.")
 	if err := flags.Parse(builderArgs); err != nil {
 		return err
@@ -147,10 +145,6 @@ func link(args []string) error {
 		goargs = append(goargs, "-buildmode", *buildmode)
 	}
 	goargs = append(goargs, "-o", *outFile)
-
-	if len(experiments) > 0 {
-		os.Setenv("GOEXPERIMENT", strings.Join(experiments, ","))
-	}
 
 	// add in the unprocess pass through options
 	goargs = append(goargs, toolArgs...)

--- a/go/tools/builders/stdlib.go
+++ b/go/tools/builders/stdlib.go
@@ -35,8 +35,6 @@ func stdlib(args []string) error {
 	dynlink := flags.Bool("dynlink", false, "Build in dynlink mode")
 	var packages multiFlag
 	flags.Var(&packages, "package", "Packages to build")
-	var experiments multiFlag
-	flags.Var(&experiments, "experiment", "Go experiments to enable via GOEXPERIMENT")
 	var gcflags quoteMultiFlag
 	flags.Var(&gcflags, "gcflags", "Go compiler flags")
 	if err := flags.Parse(args); err != nil {
@@ -115,10 +113,6 @@ You may need to use the flags --cpu=x64_windows --compiler=mingw-gcc.`)
 	}
 	os.Setenv("CGO_LDFLAGS_ALLOW", b.String())
 	os.Setenv("GODEBUG", "installgoroot=all")
-
-	if len(experiments) > 0 {
-		os.Setenv("GOEXPERIMENT", strings.Join(experiments, ","))
-	}
 
 	// Build the commands needed to build the std library in the right mode
 	// NOTE: the go command stamps compiled .a files with build ids, which are

--- a/tests/core/boringcrypto/boringcrypto_test.go
+++ b/tests/core/boringcrypto/boringcrypto_test.go
@@ -43,6 +43,8 @@ go_library(
 	importpath = "example.com/library"
 )
 -- main.go --
+//go:build goexperiment.boringcrypto
+
 package main
 
 import "example.com/library"


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The environment variable `GOEXPERIMENT` must be defined at the execution of the builder.
Without that, the default build context `build.Default` used in the builder to filter files using build constraints will not be able to filter on a `goexperiment.x` build tag.

**Which issues(s) does this PR fix?**

Fixes #3555 