### PR TITLE
Revert "Re-enable go_path_test on RBE (#3539)"

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -77,6 +77,7 @@ tasks:
     test_targets:
     - "--"
     - "//..."
+    - "-//tests/core/go_path:go_path_test"
     - "-//tests/core/stdlib:buildid_test"
   windows:
     build_flags:


### PR DESCRIPTION
This reverts commit f6be5e045c95a681989749a6e054c0c2fa91746e.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
Bug fix
> Feature
> Documentation
> Other

**What does this PR do? Why is it needed?**

Disable go_path test on CI.

It seems that current way Bazel CI setup make it hard for symlink tests to work

**Which issues(s) does this PR fix?**

**Other notes for review**
