### PR TITLE
Implement //nolint parsing similar to golangci-lint

### DIFF
--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -37,6 +37,15 @@ go_test(
     rundir = ".",
 )
 
+go_test(
+    name = "nolint_test",
+    size = "small",
+    srcs = [
+        "nolint.go",
+        "nolint_test.go",
+    ],
+)
+
 filegroup(
     name = "builder_srcs",
     srcs = [
@@ -82,6 +91,7 @@ go_source(
         "nogo_main.go",
         "nogo_typeparams_go117.go",
         "nogo_typeparams_go118.go",
+        "nolint.go",
         "pack.go",
     ],
     # //go/tools/builders:nogo_srcs is considered a different target by

--- a/go/tools/builders/nolint.go
+++ b/go/tools/builders/nolint.go
@@ -1,0 +1,52 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "strings"
+
+type Linters []string
+
+func (l Linters) Contains(s string) bool {
+	if len(l) == 0 {
+		return true
+	}
+	for _, name := range l {
+		if s == name {
+			return true
+		}
+	}
+	return false
+}
+
+// From a comment like '//nolint:foo,bar' returns [foo, bar], true. If no
+// comment is found, returns nil, false. For 'nolint:all' or 'nolint', returns
+// nil, true.
+func parseNolint(text string) (Linters, bool) {
+	text = strings.TrimLeft(text, "/ ")
+	if !strings.HasPrefix(text, "nolint") {
+		return nil, false
+	}
+	parts := strings.Split(text, ":")
+	if len(parts) == 1 {
+		return nil, true
+	}
+	linters := strings.Split(parts[1], ",")
+	for _, linter := range linters {
+		if strings.EqualFold(linter, "all") {
+			return nil, true
+		}
+	}
+	return Linters(linters), true
+}

--- a/go/tools/builders/nolint.go
+++ b/go/tools/builders/nolint.go
@@ -16,24 +16,9 @@ package main
 
 import "strings"
 
-type Linters []string
-
-func (l Linters) Contains(s string) bool {
-	if len(l) == 0 {
-		return true
-	}
-	for _, name := range l {
-		if s == name {
-			return true
-		}
-	}
-	return false
-}
-
-// From a comment like '//nolint:foo,bar' returns [foo, bar], true. If no
-// comment is found, returns nil, false. For 'nolint:all' or 'nolint', returns
-// nil, true.
-func parseNolint(text string) (Linters, bool) {
+// Parse nolint directives and return the applicable linters. If all linters
+// apply, returns (nil, true).
+func parseNolint(text string) (map[string]bool, bool) {
 	text = strings.TrimLeft(text, "/ ")
 	if !strings.HasPrefix(text, "nolint") {
 		return nil, false
@@ -43,10 +28,12 @@ func parseNolint(text string) (Linters, bool) {
 		return nil, true
 	}
 	linters := strings.Split(parts[1], ",")
+	result := map[string]bool{}
 	for _, linter := range linters {
 		if strings.EqualFold(linter, "all") {
 			return nil, true
 		}
+		result[linter] = true
 	}
-	return Linters(linters), true
+	return result, true
 }

--- a/go/tools/builders/nolint_test.go
+++ b/go/tools/builders/nolint_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestParseNolint(t *testing.T) {
-	assert := func(text string, linters Linters, valid bool) {
+	assert := func(text string, linters map[string]bool, valid bool) {
 		result, ok := parseNolint(text)
 		if valid != ok {
 			t.Fatalf("parseNolint expect %t got %t", valid, ok)
@@ -34,20 +34,14 @@ func TestParseNolint(t *testing.T) {
 	assert("// comment", nil, false)
 	assert("//nolint", nil, true)
 	assert("//nolint:all", nil, true)
-	assert("// nolint:foo", Linters{"foo"}, true)
-	assert("// nolint:foo,bar,baz", Linters{"foo", "bar", "baz"}, true)
-}
-
-func TestLintersContains(t *testing.T) {
-	var linters Linters
-	if !linters.Contains("any") {
-		t.Fatalf("expected nil to contain any linter")
-	}
-	linters = Linters{"bools"}
-	if linters.Contains("any") {
-		t.Fatalf("unexpected match of linter")
-	}
-	if !linters.Contains("bools") {
-		t.Fatalf("expected linters to match")
-	}
+	assert("// nolint:foo", map[string]bool{"foo": true}, true)
+	assert(
+		"// nolint:foo,bar,baz",
+		map[string]bool{
+			"foo": true,
+			"bar": true,
+			"baz": true,
+		},
+		true,
+	)
 }

--- a/go/tools/builders/nolint_test.go
+++ b/go/tools/builders/nolint_test.go
@@ -1,0 +1,53 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseNolint(t *testing.T) {
+	assert := func(text string, linters Linters, valid bool) {
+		result, ok := parseNolint(text)
+		if valid != ok {
+			t.Fatalf("parseNolint expect %t got %t", valid, ok)
+		}
+		if !reflect.DeepEqual(result, linters) {
+			t.Fatalf("parseNolint expect %v got %v", linters, result)
+		}
+	}
+
+	assert("not a comment", nil, false)
+	assert("// comment", nil, false)
+	assert("//nolint", nil, true)
+	assert("//nolint:all", nil, true)
+	assert("// nolint:foo", Linters{"foo"}, true)
+	assert("// nolint:foo,bar,baz", Linters{"foo", "bar", "baz"}, true)
+}
+
+func TestLintersContains(t *testing.T) {
+	var linters Linters
+	if !linters.Contains("any") {
+		t.Fatalf("expected nil to contain any linter")
+	}
+	linters = Linters{"bools"}
+	if linters.Contains("any") {
+		t.Fatalf("unexpected match of linter")
+	}
+	if !linters.Contains("bools") {
+		t.Fatalf("expected linters to match")
+	}
+}

--- a/tests/core/nogo/nolint/BUILD.bazel
+++ b/tests/core/nogo/nolint/BUILD.bazel
@@ -1,0 +1,6 @@
+load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
+
+go_bazel_test(
+    name = "nolint_test",
+    srcs = ["nolint_test.go"],
+)

--- a/tests/core/nogo/nolint/README.rst
+++ b/tests/core/nogo/nolint/README.rst
@@ -1,0 +1,14 @@
+Nolint check
+=========
+
+.. _go_library: /docs/go/core/rules.md#_go_library
+
+Tests to ensure that errors found by nogo and annotated with //nolint are
+ignored.
+
+.. contents::
+
+nolint_test
+--------
+Verified that errors emitted by ``nogo`` are ignored when `//nolint` appears as
+a comment.

--- a/tests/core/nogo/nolint/nolint_test.go
+++ b/tests/core/nogo/nolint/nolint_test.go
@@ -1,0 +1,112 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nolint_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: `
+-- BUILD.bazel --
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_tool_library", "nogo")
+
+nogo(
+    name = "nogo",
+    vet = True,
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "has_errors",
+    srcs = ["has_errors.go"],
+    importpath = "haserrors",
+)
+
+-- has_errors.go --
+package haserrors
+
+//nolint:buildtag
+// +build build_tags_error
+
+import (
+	"fmt"
+	"sync/atomic"
+)
+
+func F() {}
+
+func Foo() bool {
+	x := uint64(1)
+	_ = atomic.AddUint64(&x, 1)
+	if F == nil { //nolint:all
+		return false
+	}
+	fmt.Printf("%b", "hi", true || true) //nolint:printf,bools
+	return true || true //nolint
+}
+
+func InlineComment() {
+	s := "hello" // nolint
+	fmt.Printf("%d", s)
+}
+
+func LinterMatch() bool {
+	return true || true //nolint:printf
+}
+`,
+	})
+}
+
+func Test(t *testing.T) {
+	customRegister := `go_register_toolchains(nogo = "@//:nogo")`
+	if err := replaceInFile("WORKSPACE", "go_register_toolchains()", customRegister); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := bazel_testing.BazelCmd("build", "//:has_errors")
+	stderr := &bytes.Buffer{}
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err == nil {
+		t.Fatal("unexpected success")
+	}
+
+	expected := []string{
+		"has_errors.go:25:2: fmt.Printf format %d has arg s of wrong type string (printf)",
+		"has_errors.go:29:9: redundant or: true || true (bools)",
+	}
+
+	output := stderr.String()
+	for _, ex := range expected {
+		if !strings.Contains(output, ex) {
+			t.Errorf("output did not match expected: %s", ex)
+		}
+	}
+}
+
+func replaceInFile(path, old, new string) error {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	data = bytes.ReplaceAll(data, []byte(old), []byte(new))
+	return ioutil.WriteFile(path, data, 0666)
+}


### PR DESCRIPTION
https://github.com/bazelbuild/rules_go/issues/3561

Look for nolint comments and collect the ranges of where they apply. If a node immediately follows a range with the same column, expand the range to include the node.

Add tests that verify errors are filtered out.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Parses `//nolint` comments and filters out errors from nogo.

**Which issues(s) does this PR fix?**

Fixes #3561 

**Other notes for review**
