### PR TITLE
Pass `-trimpath` to `cgo` in `stdlib` action

### DIFF
--- a/go/tools/builders/stdlib.go
+++ b/go/tools/builders/stdlib.go
@@ -120,6 +120,15 @@ You may need to use the flags --cpu=x64_windows --compiler=mingw-gcc.`)
 	// creating reproducible builds because the build ids are hashed from
 	// CGO_CFLAGS, which frequently contains absolute paths. As a workaround,
 	// we strip the build ids, since they won't be used after this.
+	//
+	// We also use filterbuildid to add -trimpath to all invocations of cgo as
+	// there is no "CGOFLAGS" environment variable we could use for that
+	// purpose.
+	execRoot, err := bazelExecRoot()
+	if err != nil {
+		return err
+	}
+	os.Setenv("BAZEL_EXECROOT", execRoot)
 	installArgs := goenv.goCmd("install", "-toolexec", abs(os.Args[0])+" filterbuildid")
 	if len(build.Default.BuildTags) > 0 {
 		installArgs = append(installArgs, "-tags", strings.Join(build.Default.BuildTags, ","))


### PR DESCRIPTION
When `go install` invokes `cgo`, we need to pass `-trimpath`, but there doesn't seem to be a way to influence the command line. Instead, use `filterbuildid` to inject the argument.

This resolves one source of non-hermeticity when building the stdlib with the hermetic C++ toolchain, but another one remains.