### PR TITLE
Fix typo in load statement for bzlmod docs

### DIFF
--- a/docs/go/core/bzlmod.md
+++ b/docs/go/core/bzlmod.md
@@ -78,7 +78,7 @@ If you have a use case that would require this, please explain it in an issue.
 Add the following to your top-level BUILD file, including your Go module's path in a [Gazelle directive](https://github.com/bazelbuild/bazel-gazelle#directives):
 
 ```starlark
-load("@gazelle//:defs.bzl", "gazelle")
+load("@gazelle//:def.bzl", "gazelle")
 
 # gazelle:prefix github.com/example/project
 gazelle(name = "gazelle")


### PR DESCRIPTION
**What type of PR is this?**
- Documentation

**What does this PR do? Why is it needed?**

- This PR fixes a typo that made the docs incorrect. There is no defs.bzl, only [def.bzl](https://github.com/bazelbuild/bazel-gazelle/blob/master/def.bzl). 
