### PR TITLE
Fix `go_download_sdk` with Bazel dev versions

### DIFF
--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -443,7 +443,9 @@ def _remote_sdk(ctx, urls, strip_prefix, sha256):
         ctx.delete("go_sdk.tar.gz")
     elif (urls[0].endswith(".zip") and
           host_goos != "windows" and
-          versions.is_at_least("6.0.0", versions.get())):
+          # Development versions of Bazel have an empty version string. We assume that they are
+          # more recent than the version that introduced rename_files.
+          versions.is_at_least("6.0.0", versions.get() or "6.0.0")):
         ctx.download_and_extract(
             url = urls,
             stripPrefix = strip_prefix,


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The version check introduced in the previous commit did not take into account that dev versions of Bazel report an empty version string.

**Which issues(s) does this PR fix?**

Fixes #3579 

**Other notes for review**
