### PR TITLE
WIP stdlib: Do not pass -static to cgo

### DIFF
--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -78,7 +78,7 @@ def emit_link(
     # Exclude -lstdc++ from link options. We don't want to link against it
     # unless we actually have some C++ code. _cgo_codegen will include it
     # in archives via CGO_LDFLAGS if it's needed.
-    extldflags = [f for f in extldflags_from_cc_toolchain(go) if f not in ("-lstdc++", "-lc++")]
+    extldflags = [f for f in extldflags_from_cc_toolchain(go) if f not in ("-lstdc++", "-lc++", "-static")]
 
     if go.coverage_enabled:
         extldflags.append("--coverage")

--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -94,10 +94,11 @@ def _build_env(go):
     # go std library doesn't use C++, so should not have -lstdc++
     # Also drop coverage flags as nothing in the stdlib is compiled with
     # coverage - we disable it for all CGo code anyway.
+    # NOTE(#3590): avoid forcing static linking.
     ldflags = [
         option
         for option in extldflags_from_cc_toolchain(go)
-        if option not in ("-lstdc++", "-lc++") and option not in COVERAGE_OPTIONS_DENYLIST
+        if option not in ("-lstdc++", "-lc++", "-static") and option not in COVERAGE_OPTIONS_DENYLIST
     ]
     env.update({
         "CGO_ENABLED": "1",


### PR DESCRIPTION
The CGO_LDFLAGS we pass get embedded as the cgo_ldflag directive. Once we pass -static, any cgo/net/os.user usage will lead to linking statically. Avoid this.

Fixes: #3590

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix
> Feature
> Documentation
> Other

**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
