### PR TITLE
stdlib: Do not pass -static to cgo

### DIFF
--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -78,7 +78,7 @@ def emit_link(
     # Exclude -lstdc++ from link options. We don't want to link against it
     # unless we actually have some C++ code. _cgo_codegen will include it
     # in archives via CGO_LDFLAGS if it's needed.
-    extldflags = [f for f in extldflags_from_cc_toolchain(go) if f not in ("-lstdc++", "-lc++")]
+    extldflags = [f for f in extldflags_from_cc_toolchain(go) if f not in ("-lstdc++", "-lc++", "-static")]
 
     if go.coverage_enabled:
         extldflags.append("--coverage")

--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -94,10 +94,11 @@ def _build_env(go):
     # go std library doesn't use C++, so should not have -lstdc++
     # Also drop coverage flags as nothing in the stdlib is compiled with
     # coverage - we disable it for all CGo code anyway.
+    # NOTE(#3590): avoid forcing static linking.
     ldflags = [
         option
         for option in extldflags_from_cc_toolchain(go)
-        if option not in ("-lstdc++", "-lc++") and option not in COVERAGE_OPTIONS_DENYLIST
+        if option not in ("-lstdc++", "-lc++", "-static") and option not in COVERAGE_OPTIONS_DENYLIST
     ]
     env.update({
         "CGO_ENABLED": "1",


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

For our C/C++ we have used --features=fully_static_link to produce static binaries. Prior to Go 1.20 this setting did not leak into the compiled Go binary (when using cgo). This PR restores the behavior we have seen with Go 1.19. For a go_binary we can individually decide whether or not to link it statically.


**Which issues(s) does this PR fix?**

Fixes #3590

**Other notes for review**
