### PR TITLE
detect_sdk_version: Support 1.21's new VERSION file format

### DIFF
--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -545,7 +545,8 @@ def _detect_sdk_version(ctx, goroot):
     version_file_path = goroot + "/VERSION"
     if ctx.path(version_file_path).exists:
         # VERSION file has version prefixed by go, eg. go1.18.3
-        version = ctx.read(version_file_path)[2:]
+        # 1.21: The version is the first line
+        version = ctx.read(version_file_path)[2:].splitlines()[0]
         if ctx.attr.version and ctx.attr.version != version:
             fail("SDK is version %s, but version %s was expected" % (version, ctx.attr.version))
         return version


### PR DESCRIPTION
Go 1.21 changes VERSION to have the Go version on the first line, then include additional key/value pairs on subsequent lines. Right now it only has a "time" key, but may contain others in the future. This changes detect_sdk_version to only take the first line in the file, rather than the entire file. This is necessary to support Go 1.21. I tested this by changing WORKSPACE to use "go1.21rc2".

Fixes:

```
ERROR: .../rules_go/WORKSPACE:8:23: fetching go_download_sdk_rule rule //external:go_sdk: Traceback (most recent call last):
  File ".../rules_go/go/private/sdk.bzl", line 120, column 43, in _go_download_sdk_impl
    detected_version = _detect_sdk_version(ctx, ".")
  File ".../rules_go/go/private/sdk.bzl", line 550, column 17, in _detect_sdk_version
    fail("SDK is version %s, but version %s was expected" % (version, ctx.attr.version))
Error in fail: SDK is version 1.21rc2
time 2023-06-21T02:00:01Z
, but version 1.21rc2 was expected
```
