### PR TITLE
cgo: Control static linking through rules_go

### DIFF
--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -58,7 +58,10 @@ def cgo_configure(go, srcs, cdeps, cppopts, copts, cxxopts, clinkopts):
     cxxopts = go.cgo_tools.cxx_compile_options + cxxopts
     objcopts = go.cgo_tools.objc_compile_options + copts
     objcxxopts = go.cgo_tools.objcxx_compile_options + cxxopts
-    clinkopts = extldflags_from_cc_toolchain(go) + clinkopts
+    clinkopts = [
+        option for option in extldflags_from_cc_toolchain(go)
+        if option not in ("-static")
+    ] + clinkopts
 
     # NOTE(#2545): avoid unnecessary dynamic link
     if "-static-libstdc++" in clinkopts:


### PR DESCRIPTION
Let the link action of rules_go determine how to link the binary. This aligns the behavior of the stdlib with other cgo code.

A binary can be linked statically by either using `static = "on"` in the go_binary rule or using `--@io_bazel_rules_go//go/config:static`.

Fixes #3601