### PR TITLE
Fix stdlib file outputs pointing to processwrapper

### DIFF
--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -65,11 +65,11 @@ def _should_use_sdk_stdlib(go):
 
 def _build_stdlib_list_json(go):
     out = go.declare_file(go, "stdlib.pkg.json")
-    cachepath = go.declare_directory(go, "stdlib.pkg.json.gocache")
+    cache_dir = go.declare_directory(go, "gocache")
     args = go.builder_args(go, "stdliblist")
     args.add("-sdk", go.sdk.root_file.dirname)
     args.add("-out", out)
-    args.add("-cachepath", cachepath.path)
+    args.add("-cache", cache_dir.path)
 
     inputs = go.sdk_files
     if not go.mode.pure:
@@ -77,7 +77,7 @@ def _build_stdlib_list_json(go):
 
     go.actions.run(
         inputs = inputs,
-        outputs = [out, cachepath],
+        outputs = [out, cache_dir],
         mnemonic = "GoStdlibList",
         executable = go.toolchain._builder,
         arguments = [args],

--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -65,9 +65,11 @@ def _should_use_sdk_stdlib(go):
 
 def _build_stdlib_list_json(go):
     out = go.declare_file(go, "stdlib.pkg.json")
+    cachepath = go.declare_directory(go, "stdlib.pkg.json.gocache")
     args = go.builder_args(go, "stdliblist")
     args.add("-sdk", go.sdk.root_file.dirname)
     args.add("-out", out)
+    args.add("-cachepath", cachepath.path)
 
     inputs = go.sdk_files
     if not go.mode.pure:
@@ -75,7 +77,7 @@ def _build_stdlib_list_json(go):
 
     go.actions.run(
         inputs = inputs,
-        outputs = [out],
+        outputs = [out, cachepath],
         mnemonic = "GoStdlibList",
         executable = go.toolchain._builder,
         arguments = [args],

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -194,7 +194,7 @@ func stdliblist(args []string) error {
 	flags := flag.NewFlagSet("stdliblist", flag.ExitOnError)
 	goenv := envFlags(flags)
 	out := flags.String("out", "", "Path to output go list json")
-	cachePath := flags.String("cachepath", "", "Path to use for GOCACHE")
+	cachePath := flags.String("cache", "", "Path to use for GOCACHE")
 	if err := flags.Parse(args); err != nil {
 		return err
 	}

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -139,18 +139,18 @@ func absoluteSourcesPaths(cloneBase, pkgDir string, srcs []string) []string {
 // extension (which are from the cache). This is a work around for
 // https://golang.org/issue/28749: cmd/go puts assembly, C, and C++ files in
 // CompiledGoFiles.
-func filterGoFiles(srcs []string) []string {
+func filterGoFiles(srcs []string, pathReplaceFn func(p string) string) []string {
 	ret := make([]string, 0, len(srcs))
 	for _, f := range srcs {
 		if ext := filepath.Ext(f); ext == ".go" || ext == "" {
-			ret = append(ret, f)
+			ret = append(ret, pathReplaceFn(f))
 		}
 	}
 
 	return ret
 }
 
-func flatPackageForStd(cloneBase string, pkg *goListPackage) *flatPackage {
+func flatPackageForStd(cloneBase string, pkg *goListPackage, pathReplaceFn func(p string) string) *flatPackage {
 	goFiles := absoluteSourcesPaths(cloneBase, pkg.Dir, pkg.GoFiles)
 	compiledGoFiles := absoluteSourcesPaths(cloneBase, pkg.Dir, pkg.CompiledGoFiles)
 
@@ -162,7 +162,7 @@ func flatPackageForStd(cloneBase string, pkg *goListPackage) *flatPackage {
 		Imports:         map[string]string{},
 		Standard:        pkg.Standard,
 		GoFiles:         goFiles,
-		CompiledGoFiles: filterGoFiles(compiledGoFiles),
+		CompiledGoFiles: filterGoFiles(compiledGoFiles, pathReplaceFn),
 	}
 
 	// imports
@@ -194,6 +194,7 @@ func stdliblist(args []string) error {
 	flags := flag.NewFlagSet("stdliblist", flag.ExitOnError)
 	goenv := envFlags(flags)
 	out := flags.String("out", "", "Path to output go list json")
+	cachePath := flags.String("cachepath", "", "Path to use for GOCACHE")
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
@@ -250,10 +251,10 @@ func stdliblist(args []string) error {
 	os.Setenv("CC", quotePathIfNeeded(abs(ccEnv)))
 
 	// We want to keep the cache around so that the processed files can be used by other tools.
-	cachePath := abs(*out + ".gocache")
-	os.Setenv("GOCACHE", cachePath)
-	os.Setenv("GOMODCACHE", cachePath)
-	os.Setenv("GOPATH", cachePath)
+	absCachePath := abs(*cachePath)
+	os.Setenv("GOCACHE", absCachePath)
+	os.Setenv("GOMODCACHE", absCachePath)
+	os.Setenv("GOPATH", absCachePath)
 
 	listArgs := goenv.goCmd("list")
 	if len(build.Default.BuildTags) > 0 {
@@ -279,12 +280,19 @@ func stdliblist(args []string) error {
 
 	encoder := json.NewEncoder(jsonFile)
 	decoder := json.NewDecoder(jsonData)
+	pathReplaceFn := func (s string) string {
+		if strings.HasPrefix(s, absCachePath) {
+			return strings.Replace(s, absCachePath, filepath.Join("__BAZEL_EXECROOT__", *cachePath), 1)
+		}
+
+		return s
+	}
 	for decoder.More() {
 		var pkg *goListPackage
 		if err := decoder.Decode(&pkg); err != nil {
 			return err
 		}
-		if err := encoder.Encode(flatPackageForStd(cloneBase, pkg)); err != nil {
+		if err := encoder.Encode(flatPackageForStd(cloneBase, pkg, pathReplaceFn)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Defines an output_directory so the generated files get copied to execroot.
Make sure the path passed to GOCACHE are absolute and reverse the path back to execroot after getting the go list output

**Which issues(s) does this PR fix?**

Fixes #3607

**Other notes for review**
