### PR TITLE
Fix `go_sdk` extension failure for unnamed root module

### DIFF
--- a/go/private/extensions.bzl
+++ b/go/private/extensions.bzl
@@ -154,7 +154,8 @@ def _default_go_sdk_name(*, module, multi_version, tag_type, index):
     # Keep the version out of the repository name if possible to prevent unnecessary rebuilds when
     # it changes.
     return "{name}_{version}_{tag_type}_{index}".format(
-        name = module.name,
+        # "main_" is not a valid module name and thus can't collide.
+        name = module.name or "main_",
         version = module.version if multi_version else "",
         tag_type = tag_type,
         index = index,


### PR DESCRIPTION
Fixes failures such as the following if the root module never calls `module`:

```
                 go_download_sdk_rule(
 Error in repository_rule: invalid user-provided repo name '__download_0': valid names may contain only A-Z, a-z, 0-9, '-', '_', '.', and must start with a letter
```