### PR TITLE
Fix handling of linkmode from attr and config setting

### DIFF
--- a/go/private/rules/transition.bzl
+++ b/go/private/rules/transition.bzl
@@ -111,8 +111,10 @@ def _go_transition_impl(settings, attr):
     if tags:
         settings["//go/config:tags"] = _deduped_and_sorted(tags)
 
-    linkmode = getattr(attr, "linkmode", "auto")
-    if linkmode != "auto":
+    linkmode = getattr(attr, "linkmode", LINKMODE_NORMAL)
+    if linkmode != LINKMODE_NORMAL:
+        # linkmode takes precedence over //go/config:linkmode,
+        # because it offers a more detailed level of control.
         if linkmode not in LINKMODES:
             fail("linkmode: invalid mode {}; want one of {}".format(linkmode, ", ".join(LINKMODES)))
         settings["//go/config:linkmode"] = linkmode


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This PR enables proper functionality of `go_binary` and `go_test` rules with `--@io_bazel_rules_go//go/config:linkmode=X`, where `X` is considered as `pie` in the context of this text, for simplicity.

Previously, when building `go_binary` and `go_test` rules with `--@io_bazel_rules_go//go/config:linkmode=pie`, the configuration parameter would be disregarded due to the presence of a default value for the `linkmode` attribute in the rules. This default attribute value would always be used during the transition.

With this update, if `--@io_bazel_rules_go//go/config:linkmode=pie` is set, it will be applied to all valid rules through `//go/config:linkmode`. If both the configuration option and the attribute are set, the attribute takes precedence, providing more precise control.

In contrast, if the attribute is explicitly set to "normal", the configuration option will be given priority. To modify this behavior, it might be necessary to update the default value of the `linkmode` attribute to an empty string or use a mechanism (if such exists) that can differentiate between default and user-specified values.

**Which issues(s) does this PR fix?**

Fixes #3614 

**Other notes for review**

Open to testing suggestions.