### PR TITLE
Implement functionality to skip tests via TESTBRIDGE_TEST_ONLY env

### DIFF
--- a/go/tools/builders/generate_test_main.go
+++ b/go/tools/builders/generate_test_main.go
@@ -99,11 +99,11 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"strings"
 {{if .TestMain}}
 	"reflect"
 {{end}}
 	"strconv"
+	"strings"
 	"testing"
 	"testing/internal/testdeps"
 

--- a/go/tools/builders/generate_test_main.go
+++ b/go/tools/builders/generate_test_main.go
@@ -190,7 +190,11 @@ func main() {
   {{end}}
 
 	if filter := os.Getenv("TESTBRIDGE_TEST_ONLY"); filter != "" {
-		flag.Lookup("test.run").Value.Set(filter)
+		if strings.HasPrefix(filter, "-") {
+			flag.Lookup("test.skip").Value.Set(filter[1:])
+		} else {
+			flag.Lookup("test.run").Value.Set(filter)
+		}
 	}
 
 	if failfast := os.Getenv("TESTBRIDGE_TEST_RUNNER_FAIL_FAST"); failfast != "" {

--- a/go/tools/builders/generate_test_main.go
+++ b/go/tools/builders/generate_test_main.go
@@ -99,6 +99,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strings"
 {{if .TestMain}}
 	"reflect"
 {{end}}

--- a/go/tools/builders/generate_test_main.go
+++ b/go/tools/builders/generate_test_main.go
@@ -189,6 +189,7 @@ func main() {
   {{else}}
 	m := testing.MainStart(testDeps, testsInShard(), benchmarks, examples)
   {{end}}
+
 	if filter := os.Getenv("TESTBRIDGE_TEST_ONLY"); filter != "" {
 		filters := strings.Split(filter, ",")
 		var runTests []string

--- a/go/tools/builders/generate_test_main.go
+++ b/go/tools/builders/generate_test_main.go
@@ -189,11 +189,11 @@ func main() {
   {{else}}
 	m := testing.MainStart(testDeps, testsInShard(), benchmarks, examples)
   {{end}}
-
 	if filter := os.Getenv("TESTBRIDGE_TEST_ONLY"); filter != "" {
 		filters := strings.Split(filter, ",")
 		var runTests []string
 		var skipTests []string
+
 		for _, f := range filters {
 			if strings.HasPrefix(f, "-") {
 				skipTests = append(skipTests, f[1:])
@@ -413,6 +413,7 @@ func genTestMain(args []string) error {
 			}
 		}
 	}
+
 	for name := range importMap {
 		// Set the names for all unused imports to "_"
 		if !pkgs[name] {

--- a/go/tools/builders/generate_test_main.go
+++ b/go/tools/builders/generate_test_main.go
@@ -103,7 +103,6 @@ import (
 	"reflect"
 {{end}}
 	"strconv"
-	"strings"
 	"testing"
 	"testing/internal/testdeps"
 
@@ -191,7 +190,7 @@ func main() {
   {{end}}
 
 	if filter := os.Getenv("TESTBRIDGE_TEST_ONLY"); filter != "" {
-		if strings.HasPrefix(filter, "-") {
+		if filter[0:1] == "-" {
 			flag.Lookup("test.skip").Value.Set(filter[1:])
 		} else {
 			flag.Lookup("test.run").Value.Set(filter)

--- a/tests/core/go_test/BUILD.bazel
+++ b/tests/core/go_test/BUILD.bazel
@@ -259,3 +259,8 @@ go_bazel_test(
     name = "binary_env_test",
     srcs = ["binary_env_test.go"],
 )
+
+go_bazel_test(
+    name = "filter_test_cases_test",
+    srcs = ["filter_test_cases_test.go"],
+)

--- a/tests/core/go_test/filter_test_cases_test.go
+++ b/tests/core/go_test/filter_test_cases_test.go
@@ -1,0 +1,144 @@
+package filter_test_cases_test
+
+import (
+	"encoding/xml"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: `
+-- BUILD.bazel --
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "skip_tests",
+    srcs = ["skip_tests_test.go"],
+	env = {"TESTBRIDGE_TEST_ONLY":"-^TestFoo$,-^TestBaz$"},
+)
+
+go_test(
+	name = "run_only",
+	srcs = ["run_only_test.go"],
+	env = {"TESTBRIDGE_TEST_ONLY":"^TestBar.+"},
+)
+
+go_test(
+	name = "filter_tests",
+	srcs = ["filter_tests_test.go"],
+	env = {"TESTBRIDGE_TEST_ONLY":"^TestTask.+,-^TestTaskB$"},
+)
+-- skip_tests_test.go --
+package filter_test_cases
+
+import "testing"
+
+func TestFoo(t *testing.T) {}
+func TestBar(t *testing.T) {}
+func TestBaz(t *testing.T) {}
+
+-- run_only_test.go --
+package filter_test_cases
+
+import "testing"
+
+func TestFooA(t *testing.T) {}
+func TestBarA(t *testing.T) {}
+func TestBarB(t *testing.T) {}
+
+-- filter_tests_test.go --
+package filter_test_cases
+
+import "testing"
+
+func TestTaskA(t *testing.T) {}
+func TestTaskB(t *testing.T) {}
+func TestTaskC(t *testing.T) {}
+func TestTaskD(t *testing.T) {}
+`,
+	})
+}
+
+// xml test suites to check which test cases were run
+type xmlTestCase struct {
+	XMLName xml.Name `xml:"testcase"`
+	Name    string   `xml:"name,attr"`
+}
+type xmlTestSuite struct {
+	XMLName   xml.Name      `xml:"testsuite"`
+	TestCases []xmlTestCase `xml:"testcase"`
+}
+type xmlTestSuites struct {
+	XMLName xml.Name       `xml:"testsuites"`
+	Suites  []xmlTestSuite `xml:"testsuite"`
+}
+
+func Test(t *testing.T) {
+	tests := []struct {
+		name                  string
+		args                  []string
+		expectedRunTestCases  map[string]bool
+		expectedSkipTestCases map[string]struct{}
+	}{
+		{
+			name:                  "skip_tests",
+			args:                  []string{"test", "//:skip_tests", "--test_env=GO_TEST_WRAP_TESTV=1"},
+			expectedRunTestCases:  map[string]bool{"TestBar": false},
+			expectedSkipTestCases: map[string]struct{}{"TestBaz": {}, "TestFoo": {}},
+		},
+		{
+			name:                  "run_only",
+			args:                  []string{"test", "//:run_only", "--test_env=GO_TEST_WRAP_TESTV=1"},
+			expectedRunTestCases:  map[string]bool{"TestBarA": false, "TestBarB": false},
+			expectedSkipTestCases: map[string]struct{}{"TestFooA": {}},
+		},
+		{
+			name:                  "filter_tests",
+			args:                  []string{"test", "//:filter_tests", "--test_env=GO_TEST_WRAP_TESTV=1"},
+			expectedRunTestCases:  map[string]bool{"TestTaskA": false, "TestTaskC": false, "TestTaskD": false},
+			expectedSkipTestCases: map[string]struct{}{"TestTaskB": {}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := bazel_testing.RunBazel(tt.args...); err != nil {
+				t.Fatal(err)
+			}
+			p, err := bazel_testing.BazelOutput("info", "bazel-testlogs")
+			if err != nil {
+				t.Fatal("could not find testlog root: %s", err)
+			}
+			path := filepath.Join(strings.TrimSpace(string(p)), tt.name, "test.xml")
+			b, err := ioutil.ReadFile(path)
+			if err != nil {
+				t.Fatalf("could not read generated xml file: %s", err)
+			}
+
+			var suites xmlTestSuites
+			if err := xml.Unmarshal(b, &suites); err != nil {
+				t.Fatalf("could not unmarshall generated xml: %s", err)
+			}
+
+			for _, suite := range suites.Suites {
+				for _, tc := range suite.TestCases {
+					if _, ok := tt.expectedRunTestCases[tc.Name]; ok {
+						tt.expectedRunTestCases[tc.Name] = true
+					}
+					if _, ok := tt.expectedSkipTestCases[tc.Name]; ok {
+						t.Fatalf("unexpected test case ran %s", tc.Name)
+					}
+				}
+			}
+			for testCase, found := range tt.expectedRunTestCases {
+				if !found {
+					t.Fatalf("failed to run expecte test case %s", testCase)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**
This PR implements the functionality to skip tests via TESTBRIDGE_TEST_ONLY env field. TESTBRIDGE_TEST_ONLY will expect a comma-separated list of regex expressions. A prefix '-' to the regex specifies to excluded test case matching the filter (similar to [instrumentaion_filter](https://bazel.build/reference/command-line-reference#flag--instrumentation_filter).
For example:
To indicate tests to run all the tests except for TestFQNTaskFiler and TestTargetTaskFiler, provide the environment in go_test:
`env = {"TESTBRIDGE_TEST_ONLY":"-^TestFQNTaskFiler$,-^TestTargetTaskFiler$"}`

This is the opposite behavior of the existing behavior `go test -run`.
This is needed in order to skip flaky test cases in CI.

**Which issues(s) does this PR fix?**

Fixes #2785 

**Other notes for review**
