### PR TITLE
Preparing 0.41.0 release

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,7 +25,7 @@ use_repo(go_sdk, "go_toolchains")
 
 register_toolchains("@go_toolchains//:all")
 
-bazel_dep(name = "gazelle", version = "0.32.0")
+bazel_dep(name = "gazelle", version = "0.30.0")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_go",
-    version = "0.40.0",
+    version = "0.41.0",
     compatibility_level = 0,
     repo_name = "io_bazel_rules_go",
 )
@@ -19,13 +19,13 @@ use_repo(
 go_sdk = use_extension("//go:extensions.bzl", "go_sdk")
 go_sdk.download(
     name = "go_default_sdk",
-    version = "1.19.8",
+    version = "1.20.2",
 )
 use_repo(go_sdk, "go_toolchains")
 
 register_toolchains("@go_toolchains//:all")
 
-bazel_dep(name = "gazelle", version = "0.30.0")
+bazel_dep(name = "gazelle", version = "0.32.0")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -123,7 +123,7 @@ TOOLS_NOGO = [
 
 # Current version or next version to be tagged. Gazelle and other tools may
 # check this to determine compatibility.
-RULES_GO_VERSION = "0.40.0"
+RULES_GO_VERSION = "0.41.0"
 
 go_context = _go_context
 go_embed_data = _go_embed_data


### PR DESCRIPTION
Updating version strings for 0.41.0 release. For this release, I intentionally avoid upgrading dependencies, because we just updated them 2 weeks ago and it might bring additional disruption to an already disruptive release.

This release requires next release of Gazelle; and next release of Gazelle requires this release. @fmeum How to release new versions of two Bazel modules that depends on each other at the same time?