### PR TITLE
fix indeterminism with cgo during coverage collection

### DIFF
--- a/go/tools/builders/cgo2.go
+++ b/go/tools/builders/cgo2.go
@@ -318,6 +318,10 @@ func defaultCFlags(workDir string) []string {
 	flags := []string{
 		"-fdebug-prefix-map=" + abs(".") + "=.",
 		"-fdebug-prefix-map=" + workDir + "=.",
+		"-fcoverage-prefix-map=" + abs(".") + "=.",
+		"-fcoverage-prefix-map=" + workDir + "=.",
+		"-fmacro-prefix-map=" + abs(".") + "=.",
+		"-fmacro-prefix-map=" + workDir + "=.",
 	}
 	goos, goarch := os.Getenv("GOOS"), os.Getenv("GOARCH")
 	switch {


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix


**What does this PR do? Why is it needed?**

Archives including cgo with coverage instrumentation are indeterministic. 

**Which issues(s) does this PR fix?**

When compiling c files with --collect_code_coverage, the intermediate .o files contain absolute paths  that include the temp dir prefix which leads to indeterminism. Tell the compiler to strip this temp dir prefix. 


**Other notes for review**

I am using https://github.com/grailbio/bazel-toolchain as my underlying toolchain, which may change this behavior, but I am not certain. 