### PR TITLE
Fix compilation_outputs_test on Windows with Bazel@HEAD

### DIFF
--- a/tests/core/output_groups/compilation_outputs_test.go
+++ b/tests/core/output_groups/compilation_outputs_test.go
@@ -22,7 +22,8 @@ func TestCompilationOutputs(t *testing.T) {
 		exe = ".exe"
 	}
 	expectedFiles := map[string]bool{
-		"compilation_outputs_test" + exe: true, // test binary; not relevant
+		"compilation_outputs_test" + exe:                   true, // test binary; not relevant
+		"compilation_outputs_test" + exe + ".repo_mapping": true, // test binary repo mapping; not relevant
 
 		"lib.a":               false, // :lib archive
 		"lib_test.internal.a": false, // :lib_test archive


### PR DESCRIPTION
Bazel now adds the repo mapping manifest to runfiles. It shows up in the output of `ListRunfiles` on Windows, where it should be ignored.

Fixes #3597