### PR TITLE
Migrate `exec_tools` to `tools` on `genrule`

### DIFF
--- a/tests/core/transition/hermeticity_test.go
+++ b/tests/core/transition/hermeticity_test.go
@@ -85,14 +85,14 @@ cc_library(
 genrule(
     name = "gen_go",
     outs = ["gen.go"],
-    exec_tools = [":helper"],
+    tools = [":helper"],
     cmd = "# Not needed for bazel cquery",
 )
 
 genrule(
     name = "gen_indirect_go",
     outs = ["gen_indirect.go"],
-    exec_tools = [":indirect_helper"],
+    tools = [":indirect_helper"],
     cmd = "# Not needed for bazel cquery",
 )
 


### PR DESCRIPTION
`exec_tools` is a deprecated alias for `tools` with Bazel 6 and higher and may soon be removed from Bazel.

See https://github.com/bazelbuild/rules_go/issues/3597#issuecomment-1658009675