### PR TITLE
compilepkg: cgo assembly uses the C compiler

### DIFF
--- a/tests/core/cgo/asm/BUILD.bazel
+++ b/tests/core/cgo/asm/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test", "go_library")
+
+go_library(
+    name = "asm",
+    srcs = [
+        "asm_amd64.S",
+        "asm_arm64.S",
+        "cgoasm.go",
+    ],
+    cgo = True,
+    importpath = "github.com/bazelbuild/rules_go/tests/cgo/asm"
+)
+
+go_test(
+    name = "asm_test",
+    srcs = [
+        "cgoasm_test.go",
+    ],
+    embed = [":asm"],
+)

--- a/tests/core/cgo/asm/BUILD.bazel
+++ b/tests/core/cgo/asm/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "asm",
@@ -8,7 +8,7 @@ go_library(
         "cgoasm.go",
     ],
     cgo = True,
-    importpath = "github.com/bazelbuild/rules_go/tests/cgo/asm"
+    importpath = "github.com/bazelbuild/rules_go/tests/core/cgo/asm",
 )
 
 go_test(

--- a/tests/core/cgo/asm/asm_amd64.S
+++ b/tests/core/cgo/asm/asm_amd64.S
@@ -1,0 +1,14 @@
+/*
+https://stackoverflow.com/questions/73435637/how-can-i-fix-usr-bin-ld-warning-trap-o-missing-note-gnu-stack-section-imp
+*/
+.section .note.GNU-stack,"",@progbits
+
+.global example_asm_func
+.text
+example_asm_func:
+    mov $42, %rax
+    ret
+
+#if NOT_DEFINED
+#error "should not fail
+#endif

--- a/tests/core/cgo/asm/asm_amd64.S
+++ b/tests/core/cgo/asm/asm_amd64.S
@@ -1,7 +1,9 @@
 /*
 https://stackoverflow.com/questions/73435637/how-can-i-fix-usr-bin-ld-warning-trap-o-missing-note-gnu-stack-section-imp
 */
+#if defined(__ELF__) && defined(__GNUC__)
 .section .note.GNU-stack,"",@progbits
+#endif
 
 .global example_asm_func
 .text
@@ -10,5 +12,5 @@ example_asm_func:
     ret
 
 #if NOT_DEFINED
-#error "should not fail
+#error "should not fail"
 #endif

--- a/tests/core/cgo/asm/asm_amd64.S
+++ b/tests/core/cgo/asm/asm_amd64.S
@@ -5,9 +5,15 @@ https://stackoverflow.com/questions/73435637/how-can-i-fix-usr-bin-ld-warning-tr
 .section .note.GNU-stack,"",@progbits
 #endif
 
+/*
+define this symbol both with and without underscore.
+It seems like Mac OS X wants the underscore, but Linux does not.
+*/
 .global example_asm_func
+.global _example_asm_func
 .text
 example_asm_func:
+_example_asm_func:
     mov $42, %rax
     ret
 

--- a/tests/core/cgo/asm/asm_arm64.S
+++ b/tests/core/cgo/asm/asm_arm64.S
@@ -1,5 +1,11 @@
+/*
+define this symbol both with and without underscore.
+It seems like Mac OS X wants the underscore, but Linux does not.
+*/
+.global example_asm_func
 .global _example_asm_func
 .p2align 2 /* ld: warning: arm64 function not 4-byte aligned */
+example_asm_func:
 _example_asm_func:
     mov x0, #44
     ret

--- a/tests/core/cgo/asm/asm_arm64.S
+++ b/tests/core/cgo/asm/asm_arm64.S
@@ -5,5 +5,5 @@ _example_asm_func:
     ret
 
 #if NOT_DEFINED
-#error "should not fail
+#error "should not fail"
 #endif

--- a/tests/core/cgo/asm/asm_arm64.S
+++ b/tests/core/cgo/asm/asm_arm64.S
@@ -1,0 +1,9 @@
+.global _example_asm_func
+.p2align 2 /* ld: warning: arm64 function not 4-byte aligned */
+_example_asm_func:
+    mov x0, #44
+    ret
+
+#if NOT_DEFINED
+#error "should not fail
+#endif

--- a/tests/core/cgo/asm/cgoasm.go
+++ b/tests/core/cgo/asm/cgoasm.go
@@ -1,0 +1,10 @@
+package asm
+
+/*
+extern int example_asm_func();
+*/
+import "C"
+
+func callAssembly() int {
+	return int(C.example_asm_func())
+}

--- a/tests/core/cgo/asm/cgoasm.go
+++ b/tests/core/cgo/asm/cgoasm.go
@@ -1,4 +1,4 @@
-//go:build unix && (amd64 || arm64)
+//go:build amd64 || arm64
 
 package asm
 

--- a/tests/core/cgo/asm/cgoasm.go
+++ b/tests/core/cgo/asm/cgoasm.go
@@ -1,3 +1,5 @@
+//go:build unix && (amd64 || arm64)
+
 package asm
 
 /*

--- a/tests/core/cgo/asm/cgoasm_test.go
+++ b/tests/core/cgo/asm/cgoasm_test.go
@@ -1,4 +1,4 @@
-//go:build unix && (amd64 || arm64)
+//go:build amd64 || arm64
 
 package asm
 

--- a/tests/core/cgo/asm/cgoasm_test.go
+++ b/tests/core/cgo/asm/cgoasm_test.go
@@ -1,8 +1,10 @@
+//go:build unix && (amd64 || arm64)
+
 package asm
 
 import (
-	"testing"
 	"runtime"
+	"testing"
 )
 
 func TestNativeAssembly(t *testing.T) {

--- a/tests/core/cgo/asm/cgoasm_test.go
+++ b/tests/core/cgo/asm/cgoasm_test.go
@@ -1,0 +1,21 @@
+package asm
+
+import (
+	"testing"
+	"runtime"
+)
+
+func TestNativeAssembly(t *testing.T) {
+	expectedGOARCH := map[string]int{
+		"amd64": 42,
+		"arm64": 44,
+	}
+	expected := expectedGOARCH[runtime.GOARCH]
+	if expected == 0 {
+		t.Fatalf("expected=0 for GOARCH=%s; missing value?", runtime.GOARCH)
+	}
+	actual := callAssembly()
+	if actual != expected {
+		t.Errorf("callAssembly()=%d; expected=%d", actual, expected)
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
Bug fix


**What does this PR do? Why is it needed?**

This changes compilepkg to use the C compiler for .S and .s files to use the C compiler, like go build does. Previously it would use the Go assembler, which is used for pure Go packages. This should help fix issue: https://github.com/bazelbuild/rules_go/issues/3411

I have added a cgo test for this issue that is intended to work with both arm64 and amd64 machines. I have only tested it on Linux amd64 and Darwin arm64. Without this change it fails to build with the following output. This fails to parse the assembly file because it uses the Go assembler.

```
ERROR: rules_go/tests/core/cgo/asm/BUILD.bazel:3:11: GoCompilePkg tests/core/cgo/asm/asm.a failed: (Exit 1): builder failed: error executing command (from target //tests/core/cgo/asm:asm) bazel-out/k8-opt-exec-2B5CBBC6/bin/external/go_sdk/builder_reset/builder compilepkg -sdk external/go_sdk -installsuffix linux_amd64 -src tests/core/cgo/asm/cgoasm.go -src tests/core/cgo/asm/asm_amd64.S ...

tests/core/cgo/asm/asm_amd64.S:4: expected identifier, found "."
asm: assembly of tests/core/cgo/asm/asm_amd64.S failed
compilepkg: error running subcommand external/go_sdk/pkg/tool/linux_amd64/asm: exit status 1
```

**Which issues(s) does this PR fix?**

Fixes # https://github.com/bazelbuild/rules_go/issues/3411

**Other notes for review**

This seems to pass `bazelisk test //tests/core/...` on my machine.