### PR TITLE
strip_test: fix expected stack trace for 1.21.0

### DIFF
--- a/tests/core/strip/strip_test.go
+++ b/tests/core/strip/strip_test.go
@@ -250,7 +250,7 @@ var wantStackTrace = []string{
 	`^	GOROOT/src/runtime/debug/stack\.go:\d+ \+0x[0-9a-f]+$`,
 	`^main\.panicAndRecover\.func1\(\)$`,
 	`^	strip\.go:\d+ \+0x[0-9a-f]+$`,
-	`^panic\({0x[0-9a-f]+, 0x[0-9a-f]+}\)$`,
+	`^panic\({0x[0-9a-f]+\?*, 0x[0-9a-f]+\?*}\)$`,
 	`^	GOROOT/src/runtime/panic\.go:\d+ \+0x[0-9a-f]+$`,
 	`^main\.panicAndRecover\(\)$`,
 	`^	strip\.go:\d+ \+0x[0-9a-f]+$`,


### PR DESCRIPTION
In Go 1.21.0, the stack trace contains a question mark `?` for
references.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix
> Feature
> Documentation
> Other

**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
