### PR TITLE
go/tools/gopackagesdriver: pass Compiler and Arch in DriverResponse

### DIFF
--- a/go/tools/gopackagesdriver/json_packages_driver.go
+++ b/go/tools/gopackagesdriver/json_packages_driver.go
@@ -52,10 +52,9 @@ func (b *JSONPackagesDriver) GetResponse(labels []string) *driverResponse {
 
 	return &driverResponse{
 		NotHandled: false,
-		// Reviewer: see comment in main.go about the Arch field in the driver response.
-		Compiler: "gc",
-		Arch:     runtime.GOARCH,
-		Roots:    rootPkgs,
-		Packages: packages,
+		Compiler:   "gc",
+		Arch:       runtime.GOARCH,
+		Roots:      rootPkgs,
+		Packages:   packages,
 	}
 }

--- a/go/tools/gopackagesdriver/json_packages_driver.go
+++ b/go/tools/gopackagesdriver/json_packages_driver.go
@@ -16,7 +16,7 @@ package main
 
 import (
 	"fmt"
-	"go/types"
+	"runtime"
 )
 
 type JSONPackagesDriver struct {
@@ -52,8 +52,10 @@ func (b *JSONPackagesDriver) GetResponse(labels []string) *driverResponse {
 
 	return &driverResponse{
 		NotHandled: false,
-		Sizes:      types.SizesFor("gc", "amd64").(*types.StdSizes),
-		Roots:      rootPkgs,
-		Packages:   packages,
+		// Reviewer: see comment in main.go about the Arch field in the driver response.
+		Compiler: "gc",
+		Arch:     runtime.GOARCH,
+		Roots:    rootPkgs,
+		Packages: packages,
 	}
 }

--- a/go/tools/gopackagesdriver/main.go
+++ b/go/tools/gopackagesdriver/main.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"go/types"
 	"os"
+	"runtime"
 	"strings"
 )
 
@@ -31,8 +31,10 @@ type driverResponse struct {
 	// lists of multiple drivers, go/packages will fall back to the next driver.
 	NotHandled bool
 
-	// Sizes, if not nil, is the types.Sizes to use when type checking.
-	Sizes *types.StdSizes
+	// Compiler and Arch are the arguments pass of types.SizesFor
+	// to get a types.Sizes to use when type checking.
+	Compiler string
+	Arch     string
 
 	// Roots is the set of package IDs that make up the root packages.
 	// We have to encode this separately because when we encode a single package
@@ -63,9 +65,14 @@ var (
 	additionalKinds       = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_KINDS"))
 	emptyResponse         = &driverResponse{
 		NotHandled: true,
-		Sizes:      types.SizesFor("gc", "amd64").(*types.StdSizes),
-		Roots:      []string{},
-		Packages:   []*FlatPackage{},
+		// For the reviewer: Does bazel ever use gccgo? I assume bazel can build for other
+		// platforms. If that's the case, how do we find out the actual arch to use here?
+		// Is it reasonable to assume that the configuration that gopackagesdriver is built
+		// with matches the configuration
+		Compiler: "gc",
+		Arch:     runtime.GOARCH,
+		Roots:    []string{},
+		Packages: []*FlatPackage{},
 	}
 )
 

--- a/go/tools/gopackagesdriver/main.go
+++ b/go/tools/gopackagesdriver/main.go
@@ -65,14 +65,10 @@ var (
 	additionalKinds       = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_KINDS"))
 	emptyResponse         = &driverResponse{
 		NotHandled: true,
-		// For the reviewer: Does bazel ever use gccgo? I assume bazel can build for other
-		// platforms. If that's the case, how do we find out the actual arch to use here?
-		// Is it reasonable to assume that the configuration that gopackagesdriver is built
-		// with matches the configuration
-		Compiler: "gc",
-		Arch:     runtime.GOARCH,
-		Roots:    []string{},
-		Packages: []*FlatPackage{},
+		Compiler:   "gc",
+		Arch:       runtime.GOARCH,
+		Roots:      []string{},
+		Packages:   []*FlatPackage{},
 	}
 )
 


### PR DESCRIPTION
go/packages is being changed to expect Compiler and Arch in its DriverResponse (see golang.org/cl/516917) because we can't expect the type of the types.Sizes returned by types.Sizes to be types.StdSizes. (The default it uses when Compiler and Arch aren't set is the set of types for gc,amd64, so there's no change in behavior if those fields aren't set, but we should set them. I'd also like to see if we can correctly provide the arch assuming it's not amd64. I left a question in the code asking about that.

For #3656
