### PR TITLE
sdk.bzl: include go.env since 1.21.0

### DIFF
--- a/go/private/BUILD.sdk.bazel
+++ b/go/private/BUILD.sdk.bazel
@@ -80,8 +80,10 @@ filegroup(
         "bin/go*",
         "src/**",
         "pkg/**",
-        "go.env*",
-    ]),
+    ]) + glob(
+        ["go.env*"],
+        allow_empty = True,
+    ),
 )
 
 exports_files(

--- a/go/private/BUILD.sdk.bazel
+++ b/go/private/BUILD.sdk.bazel
@@ -80,7 +80,7 @@ filegroup(
         "bin/go*",
         "src/**",
         "pkg/**",
-        {goenv}
+        "go.env*",
     ]),
 )
 

--- a/go/private/BUILD.sdk.bazel
+++ b/go/private/BUILD.sdk.bazel
@@ -80,6 +80,7 @@ filegroup(
         "bin/go*",
         "src/**",
         "pkg/**",
+        {goenv}
     ]),
 )
 

--- a/go/private/BUILD.sdk.bazel
+++ b/go/private/BUILD.sdk.bazel
@@ -80,7 +80,7 @@ filegroup(
         "bin/go*",
         "src/**",
         "pkg/**",
-        "go.env*",
+        {goenv}
     ]),
 )
 

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -478,6 +478,9 @@ def _sdk_build_file(ctx, platform, version, experiments):
         if not "nocoverageredesign" in experiments and not "coverageredesign" in experiments:
             experiments = experiments + ["nocoverageredesign"]
 
+    # TODO(sluongng): Remove this once we drop support for Go 1.20
+    include_go_env = pv[1] >= 21
+
     ctx.template(
         "BUILD.bazel",
         ctx.path(ctx.attr._sdk_build_file),
@@ -488,6 +491,7 @@ def _sdk_build_file(ctx, platform, version, experiments):
             "{exe}": ".exe" if goos == "windows" else "",
             "{version}": version,
             "{experiments}": repr(experiments),
+            "{goenv}": "\"go.env\"," if include_go_env else "",
         },
     )
 

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -478,9 +478,6 @@ def _sdk_build_file(ctx, platform, version, experiments):
         if not "nocoverageredesign" in experiments and not "coverageredesign" in experiments:
             experiments = experiments + ["nocoverageredesign"]
 
-    # TODO(sluongng): Remove this once we drop support for Go 1.20
-    include_go_env = pv[1] >= 21
-
     ctx.template(
         "BUILD.bazel",
         ctx.path(ctx.attr._sdk_build_file),
@@ -491,7 +488,6 @@ def _sdk_build_file(ctx, platform, version, experiments):
             "{exe}": ".exe" if goos == "windows" else "",
             "{version}": version,
             "{experiments}": repr(experiments),
-            "{goenv}": "\"go.env\"," if include_go_env else "",
         },
     )
 


### PR DESCRIPTION
Include go.env file in the root of the sdk repo starting from Go 1.21.0.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->


Fixes #3665
