### PR TITLE
[go_proto_library] File granularity for output groups in OutputGroupInfo 

### DIFF
--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -134,9 +134,9 @@ def _go_proto_library_impl(ctx):
     )
     source = go.library_to_source(go, ctx.attr, library, False)
     providers = [library, source]
-    output_groups = {
-        "go_generated_srcs": go_srcs,
-    }
+    output_groups = {}
+    for go_src in go_srcs:
+        output_groups[go_src.basename] = depset([go_src])
     if valid_archive:
         archive = go.archive(go, source)
         output_groups["compilation_outputs"] = [archive.data.file]

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -134,7 +134,9 @@ def _go_proto_library_impl(ctx):
     )
     source = go.library_to_source(go, ctx.attr, library, False)
     providers = [library, source]
-    output_groups = {}
+    output_groups = {
+        "go_generated_srcs": go_srcs,
+    }
     for go_src in go_srcs:
         output_groups[go_src.basename] = depset([go_src])
     if valid_archive:

--- a/tests/core/go_proto_library/BUILD.bazel
+++ b/tests/core/go_proto_library/BUILD.bazel
@@ -101,14 +101,14 @@ go_proto_library(
 )
 
 filegroup(
-    name = "generated_resources",
+    name = "generated_proxy_a",
     srcs = ["//tests/core/go_proto_library:proxy_go_proto"],
     output_group = "proxy_a.pb.go",
     visibility = ["//visibility:public"],
 )
 
 filegroup(
-    name = "generated_resources_b",
+    name = "generated_proxy_b",
     srcs = ["//tests/core/go_proto_library:proxy_go_proto"],
     output_group = "proxy_b.pb.go",
     visibility = ["//visibility:public"],
@@ -117,8 +117,8 @@ filegroup(
 go_library(
     name = "proxy_go_library",
     srcs = [
-        "//tests/core/go_proto_library:generated_resources",
-        "//tests/core/go_proto_library:generated_resources_b",
+        "//tests/core/go_proto_library:generated_proxy_a",
+        "//tests/core/go_proto_library:generated_proxy_b",
     ],
     importpath = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/proxy",
     deps = [

--- a/tests/core/go_proto_library/BUILD.bazel
+++ b/tests/core/go_proto_library/BUILD.bazel
@@ -100,6 +100,41 @@ go_proto_library(
     proto = ":proxy_proto",
 )
 
+filegroup(
+    name = "generated_resources",
+    srcs = ["//tests/core/go_proto_library:proxy_go_proto"],
+    output_group = "proxy_a.pb.go",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "generated_resources_b",
+    srcs = ["//tests/core/go_proto_library:proxy_go_proto"],
+    output_group = "proxy_b.pb.go",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "proxy_go_library",
+    srcs = [
+        "//tests/core/go_proto_library:generated_resources",
+        "//tests/core/go_proto_library:generated_resources_b",
+    ],
+    importpath = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/proxy",
+    deps = [
+        "@org_golang_google_protobuf//reflect/protoreflect",  # keep
+        "@org_golang_google_protobuf//runtime/protoimpl",  # keep
+    ],
+)
+
+go_test(
+    name = "proxy_test_using_filegroup",
+    srcs = ["proxy_test.go"],
+    deps = [
+        "//tests/core/go_proto_library:proxy_go_library",
+    ],
+)
+
 proto_library(
     name = "proxy_proto",
     deps = [


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

Make OutputGroupInfo more modularized in go_proto_library. This allows us to create filegroups referring to subset of the generated Go files. See tests for examples of only referring to one of the generated files. 

**Which issues(s) does this PR fix?**

Fixes #3664

**Other notes for review**
