### PR TITLE
use carved out module for x/tools/go/vcs

### DIFF
--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -82,6 +82,25 @@ def go_rules_dependencies(force = False):
         patch_args = ["-p1"],
     )
 
+    # Needed for go/tools/fetch_repo
+    # releaser:upgrade-dep golang tools
+    wrapper(
+        http_archive,
+        name = "org_golang_x_tools_go_vcs",
+        # v0.12.0, latest as of 2023-08-12
+        urls = [
+            "https://mirror.bazel.build/github.com/golang/tools/archive/refs/tags/go/vcs/v0.1.0-deprecated.zip",
+            "https://github.com/golang/tools/archive/refs/tags/go/vcs/v0.1.0-deprecated.zip",
+        ],
+        sha256 = "1b389268d126467105305ae4482df0189cc80a13aaab28d0946192b4ad0737a8",
+        strip_prefix = "tools-go-vcs-v0.1.0-deprecated/go/vcs",
+        patches = [
+            # releaser:patch-cmd gazelle -repo_root . -go_prefix golang.org/x/tools/go/vcs -go_naming_convention import_alias
+            Label("//third_party:org_golang_x_tools_go_vcs-gazelle.patch"),
+        ],
+        patch_args = ["-p1"],
+    )
+
     # releaser:upgrade-dep golang sys
     wrapper(
         http_archive,

--- a/go/tools/fetch_repo/BUILD.bazel
+++ b/go/tools/fetch_repo/BUILD.bazel
@@ -11,7 +11,7 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/bazelbuild/rules_go/go/tools/fetch_repo",
     visibility = ["//visibility:private"],
-    deps = ["@org_golang_x_tools//go/vcs:go_default_library"],
+    deps = ["@org_golang_x_tools_go_vcs//:go_default_library"],
 )
 
 go_test(
@@ -19,5 +19,5 @@ go_test(
     size = "small",
     srcs = ["fetch_repo_test.go"],
     embed = [":go_default_library"],
-    deps = ["@org_golang_x_tools//go/vcs:go_default_library"],
+    deps = ["@org_golang_x_tools_go_vcs//:go_default_library"],
 )

--- a/third_party/org_golang_x_tools_go_vcs-gazelle.patch
+++ b/third_party/org_golang_x_tools_go_vcs-gazelle.patch
@@ -1,0 +1,30 @@
+diff -urN a/BUILD.bazel b/BUILD.bazel
+--- a/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
++++ b/BUILD.bazel	2023-08-12 19:21:03.606016940 +0200
+@@ -0,0 +1,26 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "vcs",
++    srcs = [
++        "discovery.go",
++        "env.go",
++        "http.go",
++        "vcs.go",
++    ],
++    importpath = "golang.org/x/tools/go/vcs",
++    visibility = ["//visibility:public"],
++    deps = ["@org_golang_x_sys//execabs:go_default_library"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":vcs",
++    visibility = ["//visibility:public"],
++)
++
++go_test(
++    name = "vcs_test",
++    srcs = ["vcs_test.go"],
++    embed = [":vcs"],
++)


### PR DESCRIPTION
This is a part of #3654 that was carved out to make it smaller and easier to understand. 
The vcs part of golang.org/x/tools was removed from tools. The vcs code is still available in a separate module with a version marked as "deprecated". Let's use it for now.


<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

- Use deprecated module golang.org/x/tools/go/vcs (the package was removed from golang.org/x/tools)

**Which issues(s) does this PR fix?**

You can now upgrade golang.org/x/tools and rules_go will no longer try to use the vcs package from that module.
Note however, that updating golang.org/x/tools still triggers #3640.
To fix this, we need to update `golang.org/x/tools` in rules_go and use the new function signature (as shown in https://github.com/bazelbuild/rules_go/pull/3654/commits/d09bc19a2a4b8d726d2ddc5f097ac7b1e4129de3).

**Other notes for review**

We should probably vendor this code in the long term.