### PR TITLE
bug fix: parse embeds in files that contain the double quote rune

### DIFF
--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -9,6 +9,13 @@ go_test(
         "filter.go",
         "filter_test.go",
         "read.go",
+        "read_test.go",
+    ],
+    data = [
+        "read_test_fixture.go",
+    ],
+    deps = [
+        "//go/runfiles",
     ],
 )
 

--- a/go/tools/builders/read.go
+++ b/go/tools/builders/read.go
@@ -198,6 +198,28 @@ func (r *importReader) findEmbed(first bool) bool {
 		case ' ', '\t':
 			// leave startLine alone
 
+		case '\'':
+			startLine = false
+			for r.err == nil {
+				if r.eof {
+					r.syntaxError()
+				}
+				c = r.readByteNoBuf()
+				if c == '\\' {
+					_ = r.readByteNoBuf()
+					if r.err != nil {
+						r.syntaxError()
+						return false
+					}
+					continue
+				}
+				if c == '\'' {
+					c = r.readByteNoBuf()
+					goto Reswitch
+				}
+			}
+			goto Reswitch
+
 		case '"':
 			startLine = false
 			for r.err == nil {
@@ -206,7 +228,7 @@ func (r *importReader) findEmbed(first bool) bool {
 				}
 				c = r.readByteNoBuf()
 				if c == '\\' {
-					r.readByteNoBuf()
+					_ = r.readByteNoBuf()
 					if r.err != nil {
 						r.syntaxError()
 						return false

--- a/go/tools/builders/read_test.go
+++ b/go/tools/builders/read_test.go
@@ -1,0 +1,45 @@
+/* Copyright 2016 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"go/build"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/runfiles"
+)
+
+func TestReadFileInfoEmbeds(t *testing.T) {
+	rf, err := runfiles.New()
+	if err != nil {
+		t.Fatalf("Error creating runfiles: %v", err)
+	}
+
+	f, err := rf.Rlocation("io_bazel_rules_go/go/tools/builders/read_test_fixture.go")
+	if err != nil {
+		t.Fatalf("Unable to get test file: %v", err)
+	}
+
+	fileInfo, err := readFileInfo(build.Default, f)
+	if err != nil {
+		t.Fatalf("readFileInfo: %v", err)
+	}
+
+	numExpectedEmbeds := 2
+	if len(fileInfo.embeds) != numExpectedEmbeds {
+		t.Fatalf("did not find expected number of file embeds! found %d got %d", len(fileInfo.embeds), numExpectedEmbeds)
+	}
+}

--- a/go/tools/builders/read_test_fixture.go
+++ b/go/tools/builders/read_test_fixture.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	_ "embed"
+)
+
+//go:embed before.sql
+var beforeDoubleQuoteRune string
+
+func doubleQuoteRune() {
+	rune := '"'
+}
+
+//go:embed after.sql
+var afterDoubleQuoteRune string


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Updates the embed parser to parse between single quotes. As it stands, the double quote rune `'"'` effectively halts embed parsing for a given file.

**Which issues(s) does this PR fix?**

**Other notes for review**

In the first commit, I've added a failing test using a fixture file with the double quote rune. The second commit resolves the failure and fixes the bug.
