### PR TITLE
Fix: update gomock.bzl by poping incompatible argument

### DIFF
--- a/extras/gomock.bzl
+++ b/extras/gomock.bzl
@@ -202,10 +202,7 @@ def gomock(name, library, out, source = None, interfaces = [], package = "", sel
 
 def _gomock_reflect(name, library, out, mockgen_tool, **kwargs):
     interfaces = kwargs.pop("interfaces", None)
-
-    mockgen_model_lib = _MOCKGEN_MODEL_LIB
-    if kwargs.get("mockgen_model_library", None):
-        mockgen_model_lib = kwargs["mockgen_model_library"]
+    mockgen_model_lib = kwargs.pop("mockgen_model_library", _MOCKGEN_MODEL_LIB)
 
     prog_src = name + "_gomock_prog"
     prog_src_out = prog_src + ".go"


### PR DESCRIPTION
Poping argument "mockgen_model_library" from kwarg before passing in to _gomock_prog_exec rule.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
For fixing error described in #3673

**Which issues(s) does this PR fix?**

Fixes #3673 
