### PR TITLE
releaser: turn off upload to mirror by default

### DIFF
--- a/go/tools/releaser/file.go
+++ b/go/tools/releaser/file.go
@@ -286,16 +286,8 @@ func sha256SumFile(name string) (string, error) {
 // copyFileToMirror uploads a file to the GCS bucket backing mirror.bazel.build.
 // gsutil must be installed, and the user must be authenticated with
 // 'gcloud auth login' and be allowed to write files to the bucket.
+//
+// Deprecated: To mirror, please file a request to Bazel's Github Issue
 func copyFileToMirror(ctx context.Context, path, fileName string) (err error) {
-	dest := "gs://bazel-mirror/" + path
-	defer func() {
-		if err != nil {
-			err = fmt.Errorf("copying file %s to %s: %w", fileName, dest, err)
-		}
-	}()
-
-	// This function shells out to gsutil instead of using
-	// cloud.google.com/go/storage because that package has a million
-	// dependencies.
-	return runForError(ctx, ".", "gsutil", "cp", "-n", fileName, dest)
+	return nil
 }

--- a/go/tools/releaser/prepare.go
+++ b/go/tools/releaser/prepare.go
@@ -73,7 +73,7 @@ func runPrepare(ctx context.Context, stderr io.Writer, args []string) error {
 	var githubToken githubTokenFlag
 	var uploadToMirror bool
 	flags.Var(&githubToken, "githubtoken", "GitHub personal access token or path to a file containing it")
-	flags.BoolVar(&uploadToMirror, "mirror", true, "whether to upload dependency archives to mirror.bazel.build")
+	flags.BoolVar(&uploadToMirror, "mirror", false, "whether to upload dependency archives to mirror.bazel.build")
 	flags.StringVar(&rnotesPath, "rnotes", "", "Name of file containing release notes in Markdown")
 	flags.StringVar(&version, "version", "", "Version to release")
 	if err := flags.Parse(args); err != nil {

--- a/go/tools/releaser/upgradedep.go
+++ b/go/tools/releaser/upgradedep.go
@@ -130,7 +130,7 @@ func runUpgradeDep(ctx context.Context, stderr io.Writer, args []string) error {
 	if err != nil {
 		return err
 	}
-	for _, tool := range []string{"diff", "gazelle", "gsutil", "patch"} {
+	for _, tool := range []string{"diff", "gazelle", "patch"} {
 		if _, err := exec.LookPath(tool); err != nil {
 			return fmt.Errorf("%s must be installed in PATH", tool)
 		}


### PR DESCRIPTION
Most rules_go maintainers do not have direct access to Bazel team's
GSC bucket to upload this mirror. Let's disable it by default for
eventually removal.

Mirroring should be done by filing a requests in Bazel.git's Github
issues.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix
> Feature
> Documentation
> Other

**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
