### PR TITLE
[go_sdk download] allow patches to standard library

### DIFF
--- a/docs/doc_helpers.bzl
+++ b/docs/doc_helpers.bzl
@@ -1,3 +1,17 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")

--- a/go/extensions.bzl
+++ b/go/extensions.bzl
@@ -1,3 +1,17 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 load("//go/private:extensions.bzl", _go_sdk = "go_sdk")
 
 go_sdk = _go_sdk

--- a/go/private/BUILD.bazel
+++ b/go/private/BUILD.bazel
@@ -107,6 +107,7 @@ bzl_library(
         "//go/private:nogo",
         "//go/private:platforms",
         "//go/private/skylib/lib:versions",
+        "@bazel_tools//tools/build_defs/repo:utils.bzl",
     ],
 )
 

--- a/go/private/extensions.bzl
+++ b/go/private/extensions.bzl
@@ -1,3 +1,17 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 load("//go/private:sdk.bzl", "detect_host_platform", "go_download_sdk_rule", "go_host_sdk_rule", "go_multiple_toolchains")
 load("//go/private:repositories.bzl", "go_rules_dependencies")
 
@@ -31,6 +45,13 @@ _download_tag = tag_class(
         ),
         "urls": attr.string_list(default = ["https://dl.google.com/go/{}"]),
         "version": attr.string(),
+        "patches": attr.label_list(
+            doc = "A list of patches to apply to the SDK after downloading it",
+        ),
+        "patch_strip": attr.int(
+            default = 0,
+            doc = "The number of leading path segments to be stripped from the file name in the patches.",
+        ),
         "strip_prefix": attr.string(default = "go"),
     },
 )
@@ -93,6 +114,8 @@ def _go_sdk_impl(ctx):
                 goarch = download_tag.goarch,
                 sdks = download_tag.sdks,
                 experiments = download_tag.experiments,
+                patches = download_tag.patches,
+                patch_strip = download_tag.patch_strip,
                 urls = download_tag.urls,
                 version = download_tag.version,
                 strip_prefix = download_tag.strip_prefix,

--- a/tests/bcr/BUILD.bazel
+++ b/tests/bcr/BUILD.bazel
@@ -19,6 +19,11 @@ go_test(
     embed = [":lib"],
 )
 
+go_test(
+    name = "sdk_patch_test",
+    srcs = ["sdk_patch_test.go"],
+)
+
 go_library(
     name = "mockable",
     srcs = [

--- a/tests/bcr/MODULE.bazel
+++ b/tests/bcr/MODULE.bazel
@@ -22,7 +22,13 @@ bazel_dep(name = "gazelle", version = "0.32.0")
 bazel_dep(name = "protobuf", version = "3.19.6")
 
 go_sdk = use_extension("@my_rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.download(version = "1.19.5")
+go_sdk.download(
+    version = "1.21.1",
+    patch_strip = 1,
+    patches = [
+        "//:test_go_sdk.patch",
+    ],
+)
 
 # Request an invalid SDK to verify that it isn't fetched since the first tag takes precedence.
 go_sdk.host(version = "3.0.0")

--- a/tests/bcr/sdk_patch_test.go
+++ b/tests/bcr/sdk_patch_test.go
@@ -1,0 +1,27 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lib
+
+import (
+	"os"
+
+	"testing"
+)
+
+func TestName(t *testing.T) {
+	if os.SayHello != "Hello" {
+		t.Fail()
+	}
+}

--- a/tests/bcr/test_go_sdk.patch
+++ b/tests/bcr/test_go_sdk.patch
@@ -1,0 +1,13 @@
+diff --git a/src/os/dir.go b/src/os/dir.go
+index 5306bcb..d110a19 100644
+--- a/src/os/dir.go
++++ b/src/os/dir.go
+@@ -17,6 +17,8 @@ const (
+ 	readdirFileInfo
+ )
+
++const SayHello = "Hello"
++
+ // Readdir reads the contents of the directory associated with file and
+ // returns a slice of up to n FileInfo values, as would be returned
+ // by Lstat, in directory order. Subsequent calls on the same file will yield

--- a/tests/core/go_download_sdk/go_download_sdk_test.go
+++ b/tests/core/go_download_sdk/go_download_sdk_test.go
@@ -33,6 +33,11 @@ go_test(
     srcs = ["version_test.go"],
 )
 
+go_test(
+    name = "patch_test",
+    srcs = ["patch_test.go"],
+)
+
 -- version_test.go --
 package version_test
 
@@ -47,6 +52,19 @@ var want = flag.String("version", "", "")
 func Test(t *testing.T) {
 	if v := runtime.Version(); v != *want {
 		t.Errorf("got version %q; want %q", v, *want)
+	}
+}
+-- patch_test.go --
+package version_test
+
+import (
+	"os"
+	"testing"
+)
+
+func Test(t *testing.T) {
+	if v := os.SayHello; v != "Hello"{
+		t.Errorf("got version %q; want \"Hello\"", v)
 	}
 }
 `,
@@ -183,5 +201,68 @@ go_register_toolchains()
 				})
 			}
 		})
+	}
+}
+
+func TestPatch(t *testing.T) {
+	origWorkspaceData, err := ioutil.ReadFile("WORKSPACE")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	i := bytes.Index(origWorkspaceData, []byte("go_rules_dependencies()"))
+	if i < 0 {
+		t.Fatal("could not find call to go_rules_dependencies()")
+	}
+
+	buf := &bytes.Buffer{}
+	buf.Write(origWorkspaceData[:i])
+	buf.WriteString(`
+load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk")
+
+go_download_sdk(
+    name = "go_sdk_patched",
+	version = "1.21.1",
+    patch_strip = 1,
+    patches = ["//:test.patch"],
+)
+
+go_rules_dependencies()
+
+go_register_toolchains()
+`)
+	if err := ioutil.WriteFile("WORKSPACE", buf.Bytes(), 0666); err != nil {
+		t.Fatal(err)
+	}
+
+	patchContent := []byte(`diff --git a/src/os/dir.go b/src/os/dir.go
+index 5306bcb..d110a19 100644
+--- a/src/os/dir.go
++++ b/src/os/dir.go
+@@ -17,6 +17,8 @@ const (
+ 	readdirFileInfo
+ )
+
++const SayHello = "Hello"
++
+ // Readdir reads the contents of the directory associated with file and
+ // returns a slice of up to n FileInfo values, as would be returned
+ // by Lstat, in directory order. Subsequent calls on the same file will yield
+`)
+
+	if err := ioutil.WriteFile("test.patch", patchContent, 0666); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := ioutil.WriteFile("WORKSPACE", origWorkspaceData, 0666); err != nil {
+			t.Errorf("error restoring WORKSPACE: %v", err)
+		}
+	}()
+
+	if err := bazel_testing.RunBazel(
+		"test",
+		"//:patch_test",
+	); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Allows users to provide patches to the Go SDK when using the `go_download_sdk` rule or the `go_sdk.download` Bzlmod tag.

This is helpful when some modification is needed to a package in the go standard library, but the user does not want to manage a fork of the standard library itself.

Since we build the standard library from source, the `patches` should apply appropriately across multiple OS and Architectures. However, we should not expect patches to apply correctly across multiple `version`s of the Go toolchain. For that reason, we only allow patches if the version is specified.

**Which issues(s) does this PR fix?**

Fixes #3683 

**Testing**
Added a test to the BCR which patches the `os` package and then runs a test to assert the patch properly applied.

Show that `patches` cannot apply when `version` is not specified:
```
% bazel-6.3.2 test //...
...
ERROR: An error occurred during the fetch of repository 'rules_go~override~go_sdk~rules_go_bcr_tests__download_0':
   Traceback (most recent call last):
        File "/home/user/.cache/bazel/_bazel_tfrench/565e6f63e863d6a7567b33b30501a80c/external/rules_go~override/go/private/sdk.bzl", line 93, column 21, in _go_download_sdk_impl
                fail("version must be specified when patches are specified")
Error in fail: version must be specified when patches are specified
...
ERROR: Couldn't start the build. Unable to run tests
```