### PR TITLE
Fix bazel query scope not being used

### DIFF
--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -125,12 +125,12 @@ func (b *BazelJSONBuilder) queryFromRequests(requests ...string) string {
 		if strings.HasSuffix(request, ".go") {
 			f := strings.TrimPrefix(request, "file=")
 			result = b.fileQuery(f)
+		} else if bazelQueryScope != "" {
+			result = b.packageQuery(request)
 		} else if isLocalPattern(request) {
 			result = b.localQuery(request)
 		} else if request == "builtin" || request == "std" {
 			result = fmt.Sprintf(RulesGoStdlibLabel)
-		} else if bazelQueryScope != "" {
-			result = b.packageQuery(request)
 		}
 
 		if result != "" {


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->
**What type of PR is this?**

Bug fix


**What does this PR do? Why is it needed?**

Addresses an issue with Gopackagesdriver not using bazelQueryScope.

The packageQuery currently returns a bazel query formatted to find dependencies by import path (line 116, `kind("%s", attr(importpath, "%s", deps(%s)))`), so even if localQuery was restricted to the bazelQueryScope, it would not produce the same required output. It seems this behavior change happened after commit b84cd75.

**Which issues(s) does this PR fix?**

Fixes #3687 

**Other notes for review**
