### PR TITLE
Fix hermetic toolchain linking before Go 1.21

### DIFF
--- a/go/private/mode.bzl
+++ b/go/private/mode.bzl
@@ -241,7 +241,9 @@ def extld_from_cc_toolchain(go):
     if not go.cgo_tools:
         return []
     elif go.mode.link in (LINKMODE_SHARED, LINKMODE_PLUGIN, LINKMODE_C_SHARED, LINKMODE_PIE):
-        return ["-extld", go.cgo_tools.ld_dynamic_lib_path]
+        # NOTE: Use '=' to help distinguish between `extld` and `extldflags` in
+        # cgoAbsLinkFlags.
+        return ["-extld=" + go.cgo_tools.ld_dynamic_lib_path]
     elif go.mode.link == LINKMODE_C_ARCHIVE:
         if go.mode.goos in ["darwin", "ios"]:
             # TODO(jayconrod): on macOS, set -extar. At this time, wrapped_ar is
@@ -255,4 +257,6 @@ def extld_from_cc_toolchain(go):
         # on macOS, Bazel returns wrapped_ar, which is not executable.
         # /usr/bin/ar (the default) should be visible though, and we have a
         # hack in link.go to strip out non-reproducible stuff.
-        return ["-extld", go.cgo_tools.ld_executable_path]
+        # NOTE: Use '=' to help distinguish between `extld` and `extldflags` in
+        # cgoAbsLinkFlags.
+        return ["-extld=" + go.cgo_tools.ld_executable_path]

--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -35,6 +35,11 @@ var (
 	cgoEnvVars = []string{"CGO_CFLAGS", "CGO_CXXFLAGS", "CGO_CPPFLAGS", "CGO_LDFLAGS"}
 	// cgoAbsEnvFlags are all the flags that need absolute path in cgoEnvVars
 	cgoAbsEnvFlags = []string{"-I", "-L", "-isysroot", "-isystem", "-iquote", "-include", "-gcc-toolchain", "--sysroot", "-resource-dir", "-fsanitize-blacklist", "-fsanitize-ignorelist"}
+	// cgoAbsLinkFlags are all the flags in the generated link command that need absolute paths.
+	// Need absolute path for -extld because of https://github.com/golang/go/issues/59952.
+	// Can be reverted after dropping support for Go versions older than 1.21.0.
+	// Also see note for `-extld=` vs `-extld` in go/private/mode.bzl.
+	cgoAbsLinkFlags = []string{"-extld="}
 )
 
 // env holds a small amount of Go environment and toolchain information

--- a/go/tools/builders/link.go
+++ b/go/tools/builders/link.go
@@ -36,6 +36,7 @@ func link(args []string) error {
 	if err != nil {
 		return err
 	}
+	absArgs(args, cgoAbsLinkFlags)
 	builderArgs, toolArgs := splitArgs(args)
 	stamps := multiFlag{}
 	xdefs := multiFlag{}


### PR DESCRIPTION
Go toolchain checks which linker flags are available by running the
linker on a temporary file. Before Go 1.21, this command was run in a
temporary directory, but this has now been fixed upstream.
https://github.com/golang/go/issues/59952

This change will not be needed for Go versions 1.21 and above, but will
be beneficial for users on lower versions and using a hermetic
toolchain.

See https://github.com/grailbio/bazel-toolchain/issues/183 for some more
context.
