### PR TITLE
Symlink all SDK files with `go_local_sdk`

### DIFF
--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -473,8 +473,10 @@ def _remote_sdk(ctx, urls, strip_prefix, sha256):
         )
 
 def _local_sdk(ctx, path):
-    for entry in ["src", "pkg", "bin", "lib", "misc"]:
-        ctx.symlink(path + "/" + entry, entry)
+    for entry in ctx.path(path).readdir():
+        if ctx.path(entry.basename).exists:
+            continue
+        ctx.symlink(entry, entry.basename)
 
 def _sdk_build_file(ctx, platform, version, experiments):
     ctx.file("ROOT")


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This is required with Go 1.21.1 as the `go` tool reads the `go.env` at the root of the SDK. Instead of explicitly symlinking that file, symlink all files except for the ones that already exist, e.g. because they were added by another SDK rule wrapped with `go_wrap_sdk`.

