### PR TITLE
go_download_sdk: allow patching to stdlib

### DIFF
--- a/go/toolchains.rst
+++ b/go/toolchains.rst
@@ -313,6 +313,27 @@ This downloads a Go SDK for use in toolchains.
 | Go distribution (with a different SHA-256 sum) or a version of Go                                          |
 | not supported by rules_go (for example, a beta or release candidate).                                      |
 +--------------------------------+-----------------------------+---------------------------------------------+
+| :param:`patches`               | :type:`label_list`          | :value:`[]`                                 |
++--------------------------------+-----------------------------+---------------------------------------------+
+| A list of files that are to be applied to go sdk. By default, it uses the Bazel-native patch               |
+| implementation which doesn't support fuzz match and binary patch, but Bazel will fall back to use          |
+| patch command line tool if `patch_tool` attribute is specified.                                            |
++--------------------------------+-----------------------------+---------------------------------------------+
+| :param:`remote_patches`        | :type:`string_dict`         | :value:`{}`                                 |
++--------------------------------+-----------------------------+---------------------------------------------+
+| A map of patch file URL to its integrity value, they are applied before applying patch files               |
+| from the `patches` attribute. It uses the Bazel-native patch implementation, you can specify               |
+| the patch strip number with `remote_patch_strip`.                                                          |
++--------------------------------+-----------------------------+---------------------------------------------+
+| :param:`remote_patch_strip`    | :type:`int`                 | :value:`0`                                  |
++--------------------------------+-----------------------------+---------------------------------------------+
+| The number of leading slashes to be stripped from the file name in the remote patches.                     |
++--------------------------------+-----------------------------+---------------------------------------------+
+| :param:`patch_strip`           | :type:`int`                 | :value:`0`                                  |
++--------------------------------+-----------------------------+---------------------------------------------+
+| The number of leading slashes to be stripped from the file name in thepatches.                             |
++--------------------------------+-----------------------------+---------------------------------------------+
+
 
 **Example**:
 
@@ -343,6 +364,10 @@ This downloads a Go SDK for use in toolchains.
             "linux_amd64": ("go1.18.1.linux-amd64.tar.gz", "b3b815f47ababac13810fc6021eb73d65478e0b2db4b09d348eefad9581a2334"),
             "darwin_amd64": ("go1.18.1.darwin-amd64.tar.gz", "3703e9a0db1000f18c0c7b524f3d378aac71219b4715a6a4c5683eb639f41a4d"),
         },
+        patch_strip = 1,
+        patches = [
+            "//patches:cgo_issue_fix.patch",
+        ]
     )
 
     go_rules_dependencies()

--- a/tests/core/go_download_sdk/go_download_sdk_test.go
+++ b/tests/core/go_download_sdk/go_download_sdk_test.go
@@ -16,7 +16,7 @@ package go_download_sdk_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
@@ -25,12 +25,26 @@ import (
 func TestMain(m *testing.M) {
 	bazel_testing.TestMain(m, bazel_testing.Args{
 		Main: `
+-- go.patch --
+--- src/runtime/extern.go	1969-12-31 16:00:00
++++ src/runtime/extern.go	2000-01-01 00:00:00.000000000 -0000
+@@ -244,7 +244,7 @@
+ // It is either the commit hash and date at the time of the build or,
+ // when possible, a release tag like "go1.3".
+ func Version() string {
+-	return sys.TheVersion
++	return "go100.0"
+ }
+
+ // GOOS is the running program's operating system target:
+
 -- BUILD.bazel --
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "version_test",
     srcs = ["version_test.go"],
+    pure = "on",
 )
 
 go_test(
@@ -77,6 +91,20 @@ func Test(t *testing.T) {
 		optToWantVersion map[string]string
 		fetchOnly        string
 	}{
+		{
+			desc: "patch",
+			rule: `
+load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk")
+
+go_download_sdk(
+    name = "go_sdk_patch",
+    version = "1.16",
+    patches = ["//:go.patch"],
+)
+
+`,
+			optToWantVersion: map[string]string{"": "go100.0"},
+		},
 		{
 			desc: "version",
 			rule: `
@@ -151,7 +179,7 @@ go_download_sdk(
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
-			origWorkspaceData, err := ioutil.ReadFile("WORKSPACE")
+			origWorkspaceData, err := os.ReadFile("WORKSPACE")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -169,11 +197,11 @@ go_rules_dependencies()
 
 go_register_toolchains()
 `)
-			if err := ioutil.WriteFile("WORKSPACE", buf.Bytes(), 0666); err != nil {
+			if err := os.WriteFile("WORKSPACE", buf.Bytes(), 0666); err != nil {
 				t.Fatal(err)
 			}
 			defer func() {
-				if err := ioutil.WriteFile("WORKSPACE", origWorkspaceData, 0666); err != nil {
+				if err := os.WriteFile("WORKSPACE", origWorkspaceData, 0666); err != nil {
 					t.Errorf("error restoring WORKSPACE: %v", err)
 				}
 			}()
@@ -205,7 +233,7 @@ go_register_toolchains()
 }
 
 func TestPatch(t *testing.T) {
-	origWorkspaceData, err := ioutil.ReadFile("WORKSPACE")
+	origWorkspaceData, err := os.ReadFile("WORKSPACE")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -231,7 +259,7 @@ go_rules_dependencies()
 
 go_register_toolchains()
 `)
-	if err := ioutil.WriteFile("WORKSPACE", buf.Bytes(), 0666); err != nil {
+	if err := os.WriteFile("WORKSPACE", buf.Bytes(), 0666); err != nil {
 		t.Fatal(err)
 	}
 
@@ -250,11 +278,11 @@ index 5306bcb..d110a19 100644
  // by Lstat, in directory order. Subsequent calls on the same file will yield
 `)
 
-	if err := ioutil.WriteFile("test.patch", patchContent, 0666); err != nil {
+	if err := os.WriteFile("test.patch", patchContent, 0666); err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		if err := ioutil.WriteFile("WORKSPACE", origWorkspaceData, 0666); err != nil {
+		if err := os.WriteFile("WORKSPACE", origWorkspaceData, 0666); err != nil {
 			t.Errorf("error restoring WORKSPACE: %v", err)
 		}
 	}()


### PR DESCRIPTION
This commit merges the features from https://github.com/bazelbuild/rules_go/pull/3670 and https://github.com/bazelbuild/rules_go/pull/3684

We should be as restrictive as possible since we will need to maintain all uses in the long term.

The signature of the allowed patch arguments allows for `patch_strip` rather than `patch_args` to prevent misuse of the patch args. This design decision was also taken by Bzlmod.

`go_local_sdk` and `go_wrap_sdk` also do not allow patching, since these directories/repositories can be modified with patches before being registered as a Go SDK. Allowing these features again is risky as it gives users unnecessary additional control. 

