### PR TITLE
go/tools/gopackagesdriver: fix package walk panic if bzlmod enabled

### DIFF
--- a/go/tools/gopackagesdriver/main.go
+++ b/go/tools/gopackagesdriver/main.go
@@ -53,17 +53,18 @@ type driverResponse struct {
 var (
 	// Injected via x_defs.
 
-	rulesGoRepositoryName string
-	goDefaultAspect       = rulesGoRepositoryName + "//go/tools/gopackagesdriver:aspect.bzl%go_pkg_info_aspect"
-	bazelBin              = getenvDefault("GOPACKAGESDRIVER_BAZEL", "bazel")
-	bazelStartupFlags     = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_FLAGS"))
-	bazelQueryFlags       = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_QUERY_FLAGS"))
-	bazelQueryScope       = getenvDefault("GOPACKAGESDRIVER_BAZEL_QUERY_SCOPE", "")
-	bazelBuildFlags       = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_BUILD_FLAGS"))
-	workspaceRoot         = os.Getenv("BUILD_WORKSPACE_DIRECTORY")
-	additionalAspects     = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_ADDTL_ASPECTS"))
-	additionalKinds       = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_KINDS"))
-	emptyResponse         = &driverResponse{
+	rulesGoRepositoryName               string
+	goDefaultAspect                     = rulesGoRepositoryName + "//go/tools/gopackagesdriver:aspect.bzl%go_pkg_info_aspect"
+	bazelSupportsCanonicalLabelLiterals = strings.HasPrefix(rulesGoRepositoryName, "@@")
+	bazelBin                            = getenvDefault("GOPACKAGESDRIVER_BAZEL", "bazel")
+	bazelStartupFlags                   = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_FLAGS"))
+	bazelQueryFlags                     = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_QUERY_FLAGS"))
+	bazelQueryScope                     = getenvDefault("GOPACKAGESDRIVER_BAZEL_QUERY_SCOPE", "")
+	bazelBuildFlags                     = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_BUILD_FLAGS"))
+	workspaceRoot                       = os.Getenv("BUILD_WORKSPACE_DIRECTORY")
+	additionalAspects                   = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_ADDTL_ASPECTS"))
+	additionalKinds                     = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_KINDS"))
+	emptyResponse                       = &driverResponse{
 		NotHandled: true,
 		Compiler:   "gc",
 		Arch:       runtime.GOARCH,

--- a/go/tools/gopackagesdriver/packageregistry.go
+++ b/go/tools/gopackagesdriver/packageregistry.go
@@ -89,10 +89,14 @@ func (pr *PackageRegistry) Match(labels []string) ([]string, []*FlatPackage) {
 
 	for _, label := range labels {
 		if !strings.HasPrefix(label, "@") {
-			label = fmt.Sprintf("@%s", label)
+			if bazelSupportsCanonicalLabelLiterals {
+				label = fmt.Sprintf("@@%s", label)
+			} else {
+				label = fmt.Sprintf("@%s", label)
+			}
 		}
 
-		if label == RulesGoStdlibLabel {
+		if isRulesGoStdlibLabel(label) {
 			// For stdlib, we need to append all the subpackages as roots
 			// since RulesGoStdLibLabel doesn't actually show up in the stdlib pkg.json
 			for _, pkg := range pr.packagesByID {

--- a/go/tools/gopackagesdriver/utils.go
+++ b/go/tools/gopackagesdriver/utils.go
@@ -65,6 +65,18 @@ func isLocalPattern(pattern string) bool {
 	return build.IsLocalImport(pattern) || filepath.IsAbs(pattern)
 }
 
+func isRulesGoStdlibLabel(pattern string) bool {
+	if pattern == RulesGoStdlibLabel {
+		return true
+	} else if pattern == "@io_bazel_rules_go//:stdlib" {
+		// Check also for a static repository name since bazel query does
+		// not return the canonical repository name when bzlmod is enabled.
+		// The static name is also used while building the stdliblist.
+		return true
+	}
+	return false
+}
+
 func packageID(pattern string) string {
 	pattern = path.Clean(pattern)
 	if filepath.IsAbs(pattern) {


### PR DESCRIPTION
❗ **Update:** Fix PR has been abandoned as agreed here https://github.com/bazelbuild/rules_go/pull/3700#issuecomment-1790757985




**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

With bzlmod enabled, gopackagesdriver panics with:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1145c5e]
```

With bzlmod enabled, also canonical repository names are enabled. Thus
labels from the local repository have to be prefixed with two '@' (in
order to refer to the canonical repository name) to match the IDs in
the package registry.
Also, the result of a bazel query does not return the canonical name of
the rules_go repository, but the apparent repository name. Thus, the
query for go targets it will not match the stdlib label as constructed
with the native.repository_name() rule as injected via x_defs.

Since the roots do not match the package IDs, the lookup return `nil` which
leads to a segmentation violation while trying to access attributes from the
structure.

**Which issues(s) does this PR fix?**

Fixes #3604 #3659

**Other notes for review**

Tests: TODO

This fix must be considered as workaround as it leads to a mix of
canonical and apparant repository names in the package lists. Once
bazel query also supports returning the canonincal repository names, a
more correct fix can be applied.