### PR TITLE
Fix matching between Starlark and query labels in gopackagesdriver

### DIFF
--- a/go/private/BUILD.sdk.bazel
+++ b/go/private/BUILD.sdk.bazel
@@ -1,6 +1,7 @@
 load("@io_bazel_rules_go//go/private/rules:binary.bzl", "go_tool_binary")
 load("@io_bazel_rules_go//go/private/rules:sdk.bzl", "package_list")
 load("@io_bazel_rules_go//go/private/rules:transition.bzl", "non_go_reset_target")
+load("@io_bazel_rules_go//go/private:common.bzl", "RULES_GO_STDLIB_PREFIX")
 load("@io_bazel_rules_go//go/private:go_toolchain.bzl", "declare_go_toolchains")
 load("@io_bazel_rules_go//go:def.bzl", "go_sdk")
 
@@ -51,6 +52,7 @@ go_sdk(
 go_tool_binary(
     name = "builder",
     srcs = ["@io_bazel_rules_go//go/tools/builders:builder_srcs"],
+    ldflags = "-X main.rulesGoStdlibPrefix={}".format(RULES_GO_STDLIB_PREFIX),
     sdk = ":go_sdk",
 )
 

--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -252,3 +252,10 @@ COVERAGE_OPTIONS_DENYLIST = {
     "-fprofile-instr-generate": None,
     "-fcoverage-mapping": None,
 }
+
+_RULES_GO_RAW_REPO_NAME = str(Label("//:unused"))[:-len("//:unused")]
+
+# When rules_go is the main repository and Bazel < 6 is used, the repo name does
+# not start with a "@", so we need to add it.
+RULES_GO_REPO_NAME = _RULES_GO_RAW_REPO_NAME if _RULES_GO_RAW_REPO_NAME.startswith("@") else "@" + _RULES_GO_RAW_REPO_NAME
+RULES_GO_STDLIB_PREFIX = RULES_GO_REPO_NAME + "//stdlib:"

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -1,5 +1,6 @@
 load("//go:def.bzl", "go_binary", "go_source", "go_test")
 load("//go/private/rules:transition.bzl", "go_reset_target")
+load("//go/private:common.bzl", "RULES_GO_STDLIB_PREFIX")
 
 go_test(
     name = "filter_test",
@@ -35,6 +36,9 @@ go_test(
     ],
     data = ["@go_sdk//:files"],
     rundir = ".",
+    x_defs = {
+        "rulesGoStdlibPrefix": RULES_GO_STDLIB_PREFIX,
+    },
 )
 
 go_test(

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -106,8 +106,16 @@ type goListPackage struct {
 	DepsErrors []*flatPackagesError // errors loading dependencies
 }
 
+var rulesGoStdlibPrefix string
+
+func init() {
+	if rulesGoStdlibPrefix == "" {
+		panic("rulesGoStdlibPrefix should have been set via -X")
+	}
+}
+
 func stdlibPackageID(importPath string) string {
-	return "@io_bazel_rules_go//stdlib:" + importPath
+	return rulesGoStdlibPrefix + importPath
 }
 
 // outputBasePath replace the cloneBase with output base label
@@ -280,7 +288,7 @@ func stdliblist(args []string) error {
 
 	encoder := json.NewEncoder(jsonFile)
 	decoder := json.NewDecoder(jsonData)
-	pathReplaceFn := func (s string) string {
+	pathReplaceFn := func(s string) string {
 		if strings.HasPrefix(s, absCachePath) {
 			return strings.Replace(s, absCachePath, filepath.Join("__BAZEL_EXECROOT__", *cachePath), 1)
 		}

--- a/go/tools/builders/stdliblist_test.go
+++ b/go/tools/builders/stdliblist_test.go
@@ -33,8 +33,8 @@ func Test_stdliblist(t *testing.T) {
 			t.Errorf("unable to decode output json: %v\n", err)
 		}
 
-		if !strings.HasPrefix(result.ID, "@io_bazel_rules_go//stdlib") {
-			t.Errorf("ID should be prefixed with @io_bazel_rules_go//stdlib :%v", result)
+		if !strings.HasPrefix(result.ID, "@//stdlib:") {
+			t.Errorf("ID should be prefixed with @//stdlib: :%v", result)
 		}
 		if !strings.HasPrefix(result.ExportFile, "__BAZEL_OUTPUT_BASE__") {
 			t.Errorf("export file should be prefixed with __BAZEL_OUTPUT_BASE__ :%v", result)

--- a/go/tools/gopackagesdriver/BUILD.bazel
+++ b/go/tools/gopackagesdriver/BUILD.bazel
@@ -1,5 +1,6 @@
 load("//go:def.bzl", "go_binary", "go_library")
 load(":aspect.bzl", "bazel_supports_canonical_label_literals")
+load("//go/private:common.bzl", "RULES_GO_REPO_NAME")
 
 go_library(
     name = "gopackagesdriver_lib",
@@ -21,19 +22,10 @@ go_library(
 go_binary(
     name = "gopackagesdriver",
     embed = [":gopackagesdriver_lib"],
-    x_defs = {
-        # Determine the name of the rules_go repository as we need to specify it when invoking the
-        # aspect.
-        # If canonical label literals are supported, we can use a canonical label literal (starting
-        # with @@) to pass the repository_name() through repo mapping unchanged.
-        # If canonical label literals are not supported, then bzlmod is certainly not enabled and
-        # we can assume that the repository name is not affected by repo mappings.
-        # If run in the rules_go repo itself, repository_name() returns "@", which is equivalent to
-        # "@io_bazel_rules_go" since Bazel 6:
-        # https://github.com/bazelbuild/bazel/commit/7694cf75e6366b92e3905c2ad60234cda57627ee
-        # TODO: Once we drop support for Bazel 5, we can remove the feature detection logic and
-        #       use "@" + repository_name().
-        "rulesGoRepositoryName": "@" + repository_name() if bazel_supports_canonical_label_literals() else repository_name(),
-    },
     visibility = ["//visibility:public"],
+    x_defs = {
+        # Determine the repository part of labels pointing into the rules_go repo. This is needed
+        # both to specify the aspect and to match labels in query output.
+        "rulesGoRepositoryName": RULES_GO_REPO_NAME,
+    },
 )

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -159,7 +159,12 @@ func (b *BazelJSONBuilder) outputGroupsForMode(mode LoadMode) string {
 }
 
 func (b *BazelJSONBuilder) query(ctx context.Context, query string) ([]string, error) {
-	queryArgs := concatStringsArrays(bazelQueryFlags, []string{
+	var bzlmodQueryFlags []string
+	if strings.HasPrefix(rulesGoRepositoryName, "@@") {
+		// Requires Bazel 6.4.0.
+		bzlmodQueryFlags = []string{"--consistent_labels"}
+	}
+	queryArgs := concatStringsArrays(bazelQueryFlags, bzlmodQueryFlags, []string{
 		"--ui_event_filters=-info,-stderr",
 		"--noshow_progress",
 		"--order_output=no",


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Makes gopackagesdriver work under Bzlmod by relying on the query flag `--consistent_labels`, which is available in Bazel 6.4.0.

**Which issues(s) does this PR fix?**

Fixes #3604 
Fixes #3659

**Other notes for review**
