### PR TITLE
nogo: use bazel validations and don't fail compile

### DIFF
--- a/go/private/actions/compilepkg.bzl
+++ b/go/private/actions/compilepkg.bzl
@@ -54,6 +54,7 @@ def emit_compilepkg(
         clinkopts = [],
         out_lib = None,
         out_export = None,
+        out_nogo_log = None,
         out_cgo_export_h = None,
         gc_goopts = [],
         testfilter = None,  # TODO: remove when test action compiles packages
@@ -112,6 +113,9 @@ def emit_compilepkg(
     if go.nogo:
         args.add("-nogo", go.nogo)
         inputs.append(go.nogo)
+        if out_nogo_log:
+            args.add("-nogo_log", out_nogo_log.path)
+            outputs.append(out_nogo_log)
     if out_cgo_export_h:
         args.add("-cgoexport", out_cgo_export_h)
         outputs.append(out_cgo_export_h)

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -129,6 +129,7 @@ def _go_binary_impl(ctx):
         OutputGroupInfo(
             cgo_exports = archive.cgo_exports,
             compilation_outputs = [archive.data.file],
+            _validation = depset(archive.validations),
         ),
     ]
 

--- a/go/private/rules/library.bzl
+++ b/go/private/rules/library.bzl
@@ -61,6 +61,7 @@ def _go_library_impl(ctx):
         OutputGroupInfo(
             cgo_exports = archive.cgo_exports,
             compilation_outputs = [archive.data.file],
+            _validation = depset(archive.validations),
         ),
     ]
 

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -182,6 +182,7 @@ def _go_test_impl(ctx):
         ),
         OutputGroupInfo(
             compilation_outputs = [internal_archive.data.file],
+            _validation = test_archive.validations,
         ),
         coverage_common.instrumented_files_info(
             ctx,

--- a/go/tools/builders/nogo_main.go
+++ b/go/tools/builders/nogo_main.go
@@ -87,13 +87,13 @@ func run(args []string) error {
 	if err != nil {
 		return fmt.Errorf("error running analyzers: %v", err)
 	}
-	if diagnostics != "" {
-		return fmt.Errorf("errors found by nogo during build-time code analysis:\n%s\n", diagnostics)
-	}
 	if *xPath != "" {
 		if err := ioutil.WriteFile(abs(*xPath), facts, 0o666); err != nil {
 			return fmt.Errorf("error writing facts: %v", err)
 		}
+	}
+	if diagnostics != "" {
+		return fmt.Errorf("errors found by nogo during build-time code analysis:\n%s\n", diagnostics)
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->


**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This PR allows failing nogo findings to be captured as a [Bazel validation action](https://bazel.build/extending/rules#validation_actions) and allow the compilepkg actions to exit 0 even when there are nogo failures. 

This is needed for a couple reasons: 

1. When you flip on a new validation rule, there may be lots of breakages and you would like to see the entire set of violations, as opposed to the only those appearing in the leaf go_libraries in the DAG. This allows go_libraries to propagate their results as to see downstream nogo violations. 
2. When iterating locally, it is _expensive_ to turn off nogo; you currently have to change the nogo registration for the sdk which then requires recompiling the entire chain of dependencies without the nogo check. With this change, you can simply pass --norun_validations and all the nogo output is silenced. 

**Which issues(s) does this PR fix?**

Fixes #3695

**Other notes for review**
