### PR TITLE
update rules_go to 0.42.0 in go/def.bzl

### DIFF
--- a/go/def.bzl
+++ b/go/def.bzl
@@ -119,7 +119,7 @@ TOOLS_NOGO = [
 
 # Current version or next version to be tagged. Gazelle and other tools may
 # check this to determine compatibility.
-RULES_GO_VERSION = "0.41.0"
+RULES_GO_VERSION = "0.42.0"
 
 go_context = _go_context
 gomock = _gomock


### PR DESCRIPTION
This was accidentally left out of https://github.com/bazelbuild/rules_go/pull/3697