### PR TITLE
add netrc support to go_download_sdk

### DIFF
--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -15,7 +15,7 @@
 load("//go/private:common.bzl", "executable_path")
 load("//go/private:nogo.bzl", "go_register_nogo")
 load("//go/private/skylib/lib:versions.bzl", "versions")
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "patch")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "patch", "read_user_netrc", "use_netrc")
 
 MIN_SUPPORTED_VERSION = (1, 14, 0)
 
@@ -423,6 +423,8 @@ def _remote_sdk(ctx, urls, strip_prefix, sha256):
 
     ctx.report_progress("Downloading and extracting Go toolchain")
 
+    auth = use_netrc(read_user_netrc(ctx), ctx.attr.urls, {})
+
     # TODO(#2771): After bazelbuild/bazel#18448 is merged and available in
     # the minimum supported version of Bazel, remove the workarounds below.
     #
@@ -446,6 +448,7 @@ def _remote_sdk(ctx, urls, strip_prefix, sha256):
             url = urls,
             sha256 = sha256,
             output = "go_sdk.tar.gz",
+            auth = auth
         )
         res = ctx.execute(["tar", "-xf", "go_sdk.tar.gz", "--strip-components=1"])
         if res.return_code:
@@ -464,12 +467,14 @@ def _remote_sdk(ctx, urls, strip_prefix, sha256):
                 "go/test/fixedbugs/issue27836.dir/\336foo.go": "go/test/fixedbugs/issue27836.dir/thfoo.go",
                 "go/test/fixedbugs/issue27836.dir/\336main.go": "go/test/fixedbugs/issue27836.dir/thmain.go",
             },
+            auth = auth
         )
     else:
         ctx.download_and_extract(
             url = urls,
             stripPrefix = strip_prefix,
             sha256 = sha256,
+            auth = auth
         )
 
 def _local_sdk(ctx, path):

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -448,7 +448,7 @@ def _remote_sdk(ctx, urls, strip_prefix, sha256):
             url = urls,
             sha256 = sha256,
             output = "go_sdk.tar.gz",
-            auth = auth
+            auth = auth,
         )
         res = ctx.execute(["tar", "-xf", "go_sdk.tar.gz", "--strip-components=1"])
         if res.return_code:
@@ -467,14 +467,14 @@ def _remote_sdk(ctx, urls, strip_prefix, sha256):
                 "go/test/fixedbugs/issue27836.dir/\336foo.go": "go/test/fixedbugs/issue27836.dir/thfoo.go",
                 "go/test/fixedbugs/issue27836.dir/\336main.go": "go/test/fixedbugs/issue27836.dir/thmain.go",
             },
-            auth = auth
+            auth = auth,
         )
     else:
         ctx.download_and_extract(
             url = urls,
             stripPrefix = strip_prefix,
             sha256 = sha256,
-            auth = auth
+            auth = auth,
         )
 
 def _local_sdk(ctx, path):


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**
We want to use go_download_sdk, but it gets an unauthorized failure, so this adds netrc support to go_download_sdk. Our use case only requires using the default netrc, but if desired I can cover more cases like how it's done in [http_archive](https://github.com/bazelbuild/bazel/blob/master/tools/build_defs/repo/http.bzl#L116C10-L116C10)

**Which issues(s) does this PR fix?**
https://github.com/bazelbuild/rules_go/issues/2560

Fixes #

**Other notes for review**
