### PR TITLE
Temporarily disable Bzlmod explicitly

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,9 @@
 common --enable_platform_specific_config
 # TODO: Temporarily disable while rules_go migrates to Bzlmod for its dev build.
 # https://github.com/bazelbuild/bazel/issues/18958
-common --noenable_bzlmod
+build --noenable_bzlmod
+query --noenable_bzlmod
+fetch --noenable_bzlmod
 test --test_output=errors
 
 # Go requires a C toolchain that accepts options and emits errors like

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,7 @@
 common --enable_platform_specific_config
+# TODO: Temporarily disable while rules_go migrates to Bzlmod for its dev build.
+# https://github.com/bazelbuild/bazel/issues/18958
+common --noenable_bzlmod
 test --test_output=errors
 
 # Go requires a C toolchain that accepts options and emits errors like

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,9 +1,7 @@
 common --enable_platform_specific_config
 # TODO: Temporarily disable while rules_go migrates to Bzlmod for its dev build.
 # https://github.com/bazelbuild/bazel/issues/18958
-build --noenable_bzlmod
-query --noenable_bzlmod
-fetch --noenable_bzlmod
+common --noexperimental_enable_bzlmod
 test --test_output=errors
 
 # Go requires a C toolchain that accepts options and emits errors like


### PR DESCRIPTION
Fixes downstream failures of https://github.com/bazelbuild/bazel/issues/18958 until we complete the migration.