### PR TITLE
Include `go.env` in `//go` runfiles

### DIFF
--- a/go/private/BUILD.sdk.bazel
+++ b/go/private/BUILD.sdk.bazel
@@ -31,7 +31,17 @@ filegroup(
     srcs = glob([
         "pkg/tool/**",
         "bin/gofmt*",
-    ]),
+    ]) + [
+        ":config",
+    ],
+)
+
+filegroup(
+    name = "config",
+    srcs = glob(
+        ["go.env*"],
+        allow_empty = True,
+    ),
 )
 
 go_sdk(
@@ -82,10 +92,9 @@ filegroup(
         "bin/go*",
         "src/**",
         "pkg/**",
-    ]) + glob(
-        ["go.env*"],
-        allow_empty = True,
-    ),
+    ]) + [
+        ":config",
+    ],
 )
 
 exports_files(


### PR DESCRIPTION
Speculative fix for user reports of this error message showing up when using `//go`, which indicates that `go.env` is missing:

```
GOPROXY list is not the empty string, but contains no entries
```

Adding `go.env` to the `tools` files of the SDK rather than creating a new field on `GoSDK` for it may end up fixing latent bugs.

https://bazelbuild.slack.com/archives/CDBP88Z0D/p1696892815685419