### PR TITLE
Fix urls used to get auth in go_download_sdk

### DIFF
--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -423,7 +423,7 @@ def _remote_sdk(ctx, urls, strip_prefix, sha256):
 
     ctx.report_progress("Downloading and extracting Go toolchain")
 
-    auth = use_netrc(read_user_netrc(ctx), ctx.attr.urls, {})
+    auth = use_netrc(read_user_netrc(ctx), urls, {})
 
     # TODO(#2771): After bazelbuild/bazel#18448 is merged and available in
     # the minimum supported version of Bazel, remove the workarounds below.


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
Bug fix

**What does this PR do? Why is it needed?**
Previous [commit](https://github.com/bazelbuild/rules_go/commit/08980b35c1ddee88a33db9382860df86134e4464) introduced a bug because it used ctx.attr.urls which can be unformatted urls. This fixes it by using urls which are the formatted urls.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
