### PR TITLE
Also take library deps like srcs into account in go context

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -245,6 +245,9 @@ def _library_to_source(go, attr, library, coverage_instrumented):
     generated_srcs = getattr(library, "srcs", [])
     srcs = attr_srcs + generated_srcs
     embedsrcs = [f for t in getattr(attr, "embedsrcs", []) for f in as_iterable(t.files)]
+    attr_deps = getattr(attr, "deps", [])
+    generated_deps = getattr(library, "deps", [])
+    deps = attr_deps + generated_deps
     source = {
         "library": library,
         "mode": go.mode,
@@ -254,7 +257,7 @@ def _library_to_source(go, attr, library, coverage_instrumented):
         "cover": [],
         "embedsrcs": embedsrcs,
         "x_defs": {},
-        "deps": getattr(attr, "deps", []),
+        "deps": deps,
         "gc_goopts": _expand_opts(go, "gc_goopts", getattr(attr, "gc_goopts", [])),
         "runfiles": _collect_runfiles(go, getattr(attr, "data", []), getattr(attr, "deps", [])),
         "cgo": getattr(attr, "cgo", False),


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

Prepare #3706 such that those changes can live solely within `proto/def.bzl`. This also makes it easier to maintain a downstream patch in order to test possible implementations under a real-world setting before upstreaming such a breaking change.

The `srcs` attribute already follows this approach. This PR only expands it to the `deps` attribute. The default behavior doesn't change.