### PR TITLE
Work around Bazel@HEAD bug breaking `hermeticity_test`

### DIFF
--- a/tests/core/transition/hermeticity_test.go
+++ b/tests/core/transition/hermeticity_test.go
@@ -27,6 +27,9 @@ import (
 func TestMain(m *testing.M) {
 	bazel_testing.TestMain(m, bazel_testing.Args{
 		Main: `
+-- .bazelrc --
+# TODO: Remove this once https://github.com/bazelbuild/bazel/issues/19823 is fixed at HEAD.
+common --noexperimental_enable_bzlmod
 -- BUILD.bazel --
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")

--- a/tests/core/transition/hermeticity_test.go
+++ b/tests/core/transition/hermeticity_test.go
@@ -30,6 +30,7 @@ func TestMain(m *testing.M) {
 -- .bazelrc --
 # TODO: Remove this once https://github.com/bazelbuild/bazel/issues/19823 is fixed at HEAD.
 common --noexperimental_enable_bzlmod
+common --noincompatible_enable_cc_toolchain_resolution
 -- BUILD.bazel --
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")


### PR DESCRIPTION
`bazel config` doesn't work correctly with Bzlmod, which is enabled by default with Bazel@HEAD.

Fixes https://github.com/bazelbuild/rules_go/issues/3597
See https://github.com/bazelbuild/bazel/issues/19823