### PR TITLE
allow data input to go_proto_compiler

### DIFF
--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -117,13 +117,14 @@ def go_proto_compile(go, compiler, protos, imports, importpath):
     args.add_all(imports, before_each = "-import")
     args.add_all(proto_paths.keys())
     args.use_param_file("-param=%s")
+    data = [file for target in compiler.internal.data for file in target.files.to_list()]
     go.actions.run(
         inputs = depset(
             direct = [
                 compiler.internal.go_protoc,
                 compiler.internal.protoc,
                 compiler.internal.plugin,
-            ],
+            ] + data,
             transitive = [transitive_descriptor_sets],
         ),
         outputs = go_srcs,
@@ -176,6 +177,7 @@ def _go_proto_compiler_impl(ctx):
             compile = go_proto_compile,
             valid_archive = ctx.attr.valid_archive,
             internal = struct(
+                data = ctx.attr.data,
                 options = ctx.attr.options,
                 suffix = ctx.attr.suffix,
                 suffixes = ctx.attr.suffixes,
@@ -192,6 +194,7 @@ def _go_proto_compiler_impl(ctx):
 _go_proto_compiler = rule(
     implementation = _go_proto_compiler_impl,
     attrs = {
+        "data": attr.label_list(),
         "deps": attr.label_list(providers = [GoLibrary]),
         "options": attr.string_list(),
         "suffix": attr.string(default = ".pb.go"),


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
Currently the go_proto_compiler rule accepts custom proto compiler executables, but not the ability to pass custom input data in to the compiler runtime.

This change adds a `data` attribute to the `go_proto_compiler` rule. The data files provided are then appended to the input file list in the `go.actions.run` where the proto compiler is executed.

**Which issues(s) does this PR fix?**

Fixes https://github.com/bazelbuild/rules_go/issues/3732

**Other notes for review**
Let me know what you are looking for regarding tests and I would be happy to add.
