### PR TITLE
Add toolchain param to affected actions

### DIFF
--- a/extras/gomock.bzl
+++ b/extras/gomock.bzl
@@ -23,7 +23,7 @@
 # DO NOT USE IT.
 
 load("//go/private:context.bzl", "go_context")
-load("//go/private:go_toolchain.bzl", "GO_TOOLCHAIN")
+load("//go/private:common.bzl", "GO_TOOLCHAIN")
 load("//go/private/rules:wrappers.bzl", go_binary = "go_binary_macro")
 load("//go/private:providers.bzl", "GoLibrary")
 load("@bazel_skylib//lib:paths.bzl", "paths")

--- a/go/private/actions/compilepkg.bzl
+++ b/go/private/actions/compilepkg.bzl
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//go/private:common.bzl", "GO_TOOLCHAIN")
 load(
     "//go/private:mode.bzl",
     "link_mode_args",
@@ -162,5 +163,5 @@ def emit_compilepkg(
         executable = go.toolchain._builder,
         arguments = [args],
         env = go.env,
-        toolchain = "@io_bazel_rules_go//go:toolchain",
+        toolchain = GO_TOOLCHAIN,
     )

--- a/go/private/actions/compilepkg.bzl
+++ b/go/private/actions/compilepkg.bzl
@@ -162,4 +162,5 @@ def emit_compilepkg(
         executable = go.toolchain._builder,
         arguments = [args],
         env = go.env,
+        toolchain = "@io_bazel_rules_go//go:toolchain",
     )

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -17,6 +17,7 @@ load(
     "as_set",
     "count_group_matches",
     "has_shared_lib_extension",
+    "GO_TOOLCHAIN",
 )
 load(
     "//go/private:mode.bzl",
@@ -209,7 +210,7 @@ def emit_link(
         executable = go.toolchain._builder,
         arguments = [builder_args, "--", tool_args],
         env = go.env,
-        toolchain = "@io_bazel_rules_go//go:toolchain",
+        toolchain = GO_TOOLCHAIN,
     )
 
 def _extract_extldflags(gc_linkopts, extldflags):

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -209,6 +209,7 @@ def emit_link(
         executable = go.toolchain._builder,
         arguments = [builder_args, "--", tool_args],
         env = go.env,
+        toolchain = "@io_bazel_rules_go//go:toolchain",
     )
 
 def _extract_extldflags(gc_linkopts, extldflags):

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -14,10 +14,10 @@
 
 load(
     "//go/private:common.bzl",
+    "GO_TOOLCHAIN",
     "as_set",
     "count_group_matches",
     "has_shared_lib_extension",
-    "GO_TOOLCHAIN",
 )
 load(
     "//go/private:mode.bzl",

--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -82,6 +82,7 @@ def _build_stdlib_list_json(go):
         executable = go.toolchain._builder,
         arguments = [args],
         env = _build_env(go),
+        toolchain = "@io_bazel_rules_go//go:toolchain",
     )
     return out
 
@@ -149,6 +150,7 @@ def _build_stdlib(go):
         executable = go.toolchain._builder,
         arguments = [args],
         env = _build_env(go),
+        toolchain = "@io_bazel_rules_go//go:toolchain",
     )
     return GoStdLib(
         _list_json = _build_stdlib_list_json(go),

--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -15,6 +15,7 @@
 load(
     "//go/private:common.bzl",
     "COVERAGE_OPTIONS_DENYLIST",
+    "GO_TOOLCHAIN",
 )
 load(
     "//go/private:providers.bzl",
@@ -82,7 +83,7 @@ def _build_stdlib_list_json(go):
         executable = go.toolchain._builder,
         arguments = [args],
         env = _build_env(go),
-        toolchain = "@io_bazel_rules_go//go:toolchain",
+        toolchain = GO_TOOLCHAIN,
     )
     return out
 
@@ -150,7 +151,7 @@ def _build_stdlib(go):
         executable = go.toolchain._builder,
         arguments = [args],
         env = _build_env(go),
-        toolchain = "@io_bazel_rules_go//go:toolchain",
+        toolchain = GO_TOOLCHAIN,
     )
     return GoStdLib(
         _list_json = _build_stdlib_list_json(go),

--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+GO_TOOLCHAIN = "@io_bazel_rules_go//go:toolchain"
+
 go_exts = [
     ".go",
 ]

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -27,10 +27,6 @@ load(
     "OBJC_COMPILE_ACTION_NAME",
 )
 load(
-    ":common.bzl",
-    "GO_TOOLCHAIN",
-)
-load(
     ":providers.bzl",
     "CgoContextInfo",
     "EXPLICIT_PATH",
@@ -54,6 +50,7 @@ load(
     "COVERAGE_OPTIONS_DENYLIST",
     "as_iterable",
     "goos_to_extension",
+    "GO_TOOLCHAIN",
     "goos_to_shared_extension",
     "is_struct",
 )

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -27,7 +27,7 @@ load(
     "OBJC_COMPILE_ACTION_NAME",
 )
 load(
-    ":go_toolchain.bzl",
+    ":common.bzl",
     "GO_TOOLCHAIN",
 )
 load(

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -48,9 +48,9 @@ load(
 load(
     ":common.bzl",
     "COVERAGE_OPTIONS_DENYLIST",
+    "GO_TOOLCHAIN",
     "as_iterable",
     "goos_to_extension",
-    "GO_TOOLCHAIN",
     "goos_to_shared_extension",
     "is_struct",
 )

--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -15,6 +15,7 @@
 Toolchain rules used by go.
 """
 
+load("//go/private:common.bzl", "GO_TOOLCHAIN")
 load("//go/private:platforms.bzl", "PLATFORMS")
 load("//go/private:providers.bzl", "GoSDK")
 load("//go/private/actions:archive.bzl", "emit_archive")
@@ -22,8 +23,6 @@ load("//go/private/actions:binary.bzl", "emit_binary")
 load("//go/private/actions:link.bzl", "emit_link")
 load("//go/private/actions:stdlib.bzl", "emit_stdlib")
 load("@bazel_skylib//lib:selects.bzl", "selects")
-
-GO_TOOLCHAIN = "@io_bazel_rules_go//go:toolchain"
 
 def _go_toolchain_impl(ctx):
     sdk = ctx.attr.sdk[GoSDK]

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -21,9 +21,6 @@ load(
     "asm_exts",
     "cgo_exts",
     "go_exts",
-)
-load(
-    "//go/private:go_toolchain.bzl",
     "GO_TOOLCHAIN",
 )
 load(

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -18,10 +18,10 @@ load(
 )
 load(
     "//go/private:common.bzl",
+    "GO_TOOLCHAIN",
     "asm_exts",
     "cgo_exts",
     "go_exts",
-    "GO_TOOLCHAIN",
 )
 load(
     "//go/private:providers.bzl",

--- a/go/private/rules/go_bin_for_host.bzl
+++ b/go/private/rules/go_bin_for_host.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@local_config_platform//:constraints.bzl", "HOST_CONSTRAINTS")
-load("//go/private:go_toolchain.bzl", "GO_TOOLCHAIN")
+load("//go/private:common.bzl", "GO_TOOLCHAIN")
 
 def _ensure_target_cfg(ctx):
     # A target is assumed to be built in the target configuration if it is neither in the exec nor

--- a/go/private/rules/info.bzl
+++ b/go/private/rules/info.bzl
@@ -17,7 +17,7 @@ load(
     "go_context",
 )
 load(
-    "//go/private:go_toolchain.bzl",
+    "//go/private:common.bzl",
     "GO_TOOLCHAIN",
 )
 

--- a/go/private/rules/library.bzl
+++ b/go/private/rules/library.bzl
@@ -14,10 +14,10 @@
 
 load(
     "//go/private:common.bzl",
+    "GO_TOOLCHAIN",
     "asm_exts",
     "cgo_exts",
     "go_exts",
-    "GO_TOOLCHAIN",
 )
 load(
     "//go/private:context.bzl",

--- a/go/private/rules/library.bzl
+++ b/go/private/rules/library.bzl
@@ -17,14 +17,11 @@ load(
     "asm_exts",
     "cgo_exts",
     "go_exts",
+    "GO_TOOLCHAIN",
 )
 load(
     "//go/private:context.bzl",
     "go_context",
-)
-load(
-    "//go/private:go_toolchain.bzl",
-    "GO_TOOLCHAIN",
 )
 load(
     "//go/private:providers.bzl",

--- a/go/private/rules/nogo.bzl
+++ b/go/private/rules/nogo.bzl
@@ -17,7 +17,7 @@ load(
     "go_context",
 )
 load(
-    "//go/private:go_toolchain.bzl",
+    "//go/private:common.bzl",
     "GO_TOOLCHAIN",
 )
 load(

--- a/go/private/rules/source.bzl
+++ b/go/private/rules/source.bzl
@@ -17,7 +17,7 @@ load(
     "go_context",
 )
 load(
-    "//go/private:go_toolchain.bzl",
+    "//go/private:common.bzl",
     "GO_TOOLCHAIN",
 )
 load(

--- a/go/private/rules/stdlib.bzl
+++ b/go/private/rules/stdlib.bzl
@@ -17,7 +17,7 @@ load(
     "go_context",
 )
 load(
-    "//go/private:go_toolchain.bzl",
+    "//go/private:common.bzl",
     "GO_TOOLCHAIN",
 )
 load(

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -18,12 +18,12 @@ load(
 )
 load(
     "//go/private:common.bzl",
+    "GO_TOOLCHAIN",
     "as_list",
     "asm_exts",
     "cgo_exts",
     "go_exts",
     "split_srcs",
-    "GO_TOOLCHAIN",
 )
 load(
     "//go/private/rules:binary.bzl",

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -23,9 +23,6 @@ load(
     "cgo_exts",
     "go_exts",
     "split_srcs",
-)
-load(
-    "//go/private:go_toolchain.bzl",
     "GO_TOOLCHAIN",
 )
 load(

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -22,7 +22,7 @@ load(
     "go_context",
 )
 load(
-    "//go/private:go_toolchain.bzl",
+    "//go/private:common.bzl",
     "GO_TOOLCHAIN",
 )
 load(

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -28,7 +28,7 @@ load(
     "proto_path",
 )
 load(
-    "//go/private:go_toolchain.bzl",
+    "//go/private:common.bzl",
     "GO_TOOLCHAIN",
 )
 load(


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Other - Migration

**What does this PR do? Why is it needed?**
It sets go toolchain type inside affected actions. This is part of the migration of Automatic Exec Groups inside Bazel downstream.

**Which issues(s) does this PR fix?**
Please check https://github.com/bazelbuild/bazel/issues/19981 for additional info.

**Other notes for review**
