### PR TITLE
feat(gopackagesdriver): add base test case for go packages driver

### DIFF
--- a/go/tools/BUILD.bazel
+++ b/go/tools/BUILD.bazel
@@ -8,6 +8,7 @@ filegroup(
         "//go/tools/bzltestutil:all_files",
         "//go/tools/coverdata:all_files",
         "//go/tools/go_bin_runner:all_files",
+        "//go/tools/gopackagesdriver:all_files",
     ],
     visibility = ["//visibility:public"],
 )

--- a/go/tools/bazel_testing/bazel_testing.go
+++ b/go/tools/bazel_testing/bazel_testing.go
@@ -206,17 +206,7 @@ func RunBazel(args ...string) error {
 // If the command starts but exits with a non-zero status, a *StderrExitError
 // will be returned which wraps the original *exec.ExitError.
 func BazelOutput(args ...string) ([]byte, error) {
-	cmd := BazelCmd(args...)
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-	cmd.Stdout = stdout
-	cmd.Stderr = stderr
-	err := cmd.Run()
-	if eErr, ok := err.(*exec.ExitError); ok {
-		eErr.Stderr = stderr.Bytes()
-		err = &StderrExitError{Err: eErr}
-	}
-	return stdout.Bytes(), err
+	return BazelOutputWithInput(nil, args...)
 }
 
 // BazelOutputWithInput invokes a bazel command with a list of arguments and

--- a/go/tools/gopackagesdriver/BUILD.bazel
+++ b/go/tools/gopackagesdriver/BUILD.bazel
@@ -16,7 +16,9 @@ go_library(
         "utils.go",
     ],
     importpath = "github.com/bazelbuild/rules_go/go/tools/gopackagesdriver",
-    visibility = ["//visibility:private"],
+    visibility = [
+        "//tests/integration/gopackagesdriver:__pkg__",
+    ],
 )
 
 go_binary(
@@ -28,4 +30,11 @@ go_binary(
         # both to specify the aspect and to match labels in query output.
         "rulesGoRepositoryName": RULES_GO_REPO_NAME,
     },
+)
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
 )

--- a/go/tools/gopackagesdriver/BUILD.bazel
+++ b/go/tools/gopackagesdriver/BUILD.bazel
@@ -1,5 +1,4 @@
 load("//go:def.bzl", "go_binary", "go_library")
-load(":aspect.bzl", "bazel_supports_canonical_label_literals")
 load("//go/private:common.bzl", "RULES_GO_REPO_NAME")
 
 go_library(

--- a/go/tools/gopackagesdriver/bazel.go
+++ b/go/tools/gopackagesdriver/bazel.go
@@ -38,6 +38,7 @@ type Bazel struct {
 	workspaceRoot     string
 	bazelStartupFlags []string
 	info              map[string]string
+	version           string
 }
 
 // Minimal BEP structs to access the build outputs
@@ -55,6 +56,7 @@ func NewBazel(ctx context.Context, bazelBin, workspaceRoot string, bazelStartupF
 		bazelBin:          bazelBin,
 		workspaceRoot:     workspaceRoot,
 		bazelStartupFlags: bazelStartupFlags,
+		version:           "6",
 	}
 	if err := b.fillInfo(ctx); err != nil {
 		return nil, fmt.Errorf("unable to query bazel info: %w", err)
@@ -72,6 +74,10 @@ func (b *Bazel) fillInfo(ctx context.Context) error {
 	for scanner.Scan() {
 		parts := strings.SplitN(strings.TrimSpace(scanner.Text()), ":", 2)
 		b.info[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+	}
+	release := strings.Split(b.info["release"], " ")
+	if len(release) == 2 {
+		b.version = release[1]
 	}
 	return nil
 }

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -24,6 +24,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 )
 
@@ -238,7 +239,7 @@ func (b *BazelJSONBuilder) Build(ctx context.Context, labels []string, mode Load
 	ret := []string{}
 	for _, f := range files {
 		if strings.HasSuffix(f, ".pkg.json") {
-			ret = append(ret, f)
+			ret = append(ret, cleanPath(f))
 		}
 	}
 
@@ -252,4 +253,13 @@ func (b *BazelJSONBuilder) PathResolver() PathResolverFunc {
 		p = strings.Replace(p, "__BAZEL_OUTPUT_BASE__", b.bazel.OutputBase(), 1)
 		return p
 	}
+}
+
+func cleanPath(p string) string {
+	// On Windows the paths may contain a starting `\`, this would make them not resolve
+	if runtime.GOOS == "windows" && p[0] == '\\' {
+		return p[1:]
+	}
+
+	return p
 }

--- a/go/tools/gopackagesdriver/json_packages_driver.go
+++ b/go/tools/gopackagesdriver/json_packages_driver.go
@@ -23,9 +23,9 @@ type JSONPackagesDriver struct {
 	registry *PackageRegistry
 }
 
-func NewJSONPackagesDriver(jsonFiles []string, prf PathResolverFunc) (*JSONPackagesDriver, error) {
+func NewJSONPackagesDriver(jsonFiles []string, prf PathResolverFunc, bazelVersion string) (*JSONPackagesDriver, error) {
 	jpd := &JSONPackagesDriver{
-		registry: NewPackageRegistry(),
+		registry: NewPackageRegistry(bazelVersion),
 	}
 
 	for _, f := range jsonFiles {

--- a/go/tools/gopackagesdriver/main.go
+++ b/go/tools/gopackagesdriver/main.go
@@ -103,7 +103,7 @@ func run() (*driverResponse, error) {
 		return emptyResponse, fmt.Errorf("unable to build JSON files: %w", err)
 	}
 
-	driver, err := NewJSONPackagesDriver(jsonFiles, bazelJsonBuilder.PathResolver())
+	driver, err := NewJSONPackagesDriver(jsonFiles, bazelJsonBuilder.PathResolver(), bazel.version)
 	if err != nil {
 		return emptyResponse, fmt.Errorf("unable to load JSON files: %w", err)
 	}

--- a/go/tools/gopackagesdriver/packageregistry.go
+++ b/go/tools/gopackagesdriver/packageregistry.go
@@ -75,13 +75,6 @@ func (pr *PackageRegistry) ResolveImports() error {
 
 func (pr *PackageRegistry) walk(acc map[string]*FlatPackage, root string) {
 	pkg := pr.packagesByID[root]
-	if pkg == nil {
-		str := ""
-		for _, pkg := range pr.packagesByID {
-			str += pkg.ID + "; "
-		}
-		panic("nil package: " + str)
-	}
 
 	acc[pkg.ID] = pkg
 	for _, pkgID := range pkg.Imports {
@@ -95,7 +88,9 @@ func (pr *PackageRegistry) Match(labels []string) ([]string, []*FlatPackage) {
 	roots := map[string]struct{}{}
 
 	for _, label := range labels {
-		if strings.HasPrefix(rulesGoRepositoryName, "@@") && !strings.HasPrefix(label, "@") {
+		// When packagesdriver is ran from rules go, rulesGoRepositoryName will just be @
+		if (strings.HasPrefix(rulesGoRepositoryName, "@@") || rulesGoRepositoryName == "@") &&
+			!strings.HasPrefix(label, "@") {
 			// Canonical labels is only since Bazel 6.0.0
 			label = fmt.Sprintf("@%s", label)
 		}

--- a/go/tools/gopackagesdriver/packageregistry.go
+++ b/go/tools/gopackagesdriver/packageregistry.go
@@ -76,7 +76,11 @@ func (pr *PackageRegistry) ResolveImports() error {
 func (pr *PackageRegistry) walk(acc map[string]*FlatPackage, root string) {
 	pkg := pr.packagesByID[root]
 	if pkg == nil {
-		panic("nil package: " + root)
+		str := ""
+		for _, pkg := range pr.packagesByID {
+			str += pkg.ID + "; "
+		}
+		panic("nil package: " + str)
 	}
 
 	acc[pkg.ID] = pkg

--- a/go/tools/gopackagesdriver/packageregistry.go
+++ b/go/tools/gopackagesdriver/packageregistry.go
@@ -75,6 +75,9 @@ func (pr *PackageRegistry) ResolveImports() error {
 
 func (pr *PackageRegistry) walk(acc map[string]*FlatPackage, root string) {
 	pkg := pr.packagesByID[root]
+	if pkg == nil {
+		panic("nil package: " + root)
+	}
 
 	acc[pkg.ID] = pkg
 	for _, pkgID := range pkg.Imports {

--- a/go/tools/gopackagesdriver/packageregistry.go
+++ b/go/tools/gopackagesdriver/packageregistry.go
@@ -95,7 +95,8 @@ func (pr *PackageRegistry) Match(labels []string) ([]string, []*FlatPackage) {
 	roots := map[string]struct{}{}
 
 	for _, label := range labels {
-		if !strings.HasPrefix(label, "@") {
+		if strings.HasPrefix(rulesGoRepositoryName, "@@") && !strings.HasPrefix(label, "@") {
+			// Canonical labels is only since Bazel 6.0.0
 			label = fmt.Sprintf("@%s", label)
 		}
 

--- a/tests/integration/gopackagesdriver/BUILD.bazel
+++ b/tests/integration/gopackagesdriver/BUILD.bazel
@@ -1,0 +1,13 @@
+load("//go/tools/bazel_testing:def.bzl", "go_bazel_test")
+
+go_bazel_test(
+    name = "gopackagesdriver_test",
+    size = "enormous",
+    srcs = ["gopackagesdriver_test.go"],
+    rule_files = [
+        "//:all_files",
+    ],
+    deps = [
+        "@io_bazel_rules_go//go/tools/gopackagesdriver:gopackagesdriver_lib",
+    ]
+)

--- a/tests/integration/gopackagesdriver/README.rst
+++ b/tests/integration/gopackagesdriver/README.rst
@@ -1,0 +1,8 @@
+Go Packages Driver
+
+gopackagesdriver_test
+--------------------
+Verifies that the output of the go packages driver includes the correct output.
+
+Go x/tools is very sensitive to inaccuracies in the package output, so we should
+validate each added feature against what is expected by x/tools.

--- a/tests/integration/gopackagesdriver/gopackagesdriver_test.go
+++ b/tests/integration/gopackagesdriver/gopackagesdriver_test.go
@@ -64,7 +64,7 @@ func TestBaseFileLookup(t *testing.T) {
 			return
 		}
 
-		if resp.Roots[0] != "@//:hello" {
+		if !strings.HasSuffix(resp.Roots[0], "//:hello") {
 			t.Errorf("Unexpected package id: %q", resp.Roots[0])
 			return
 		}

--- a/tests/integration/gopackagesdriver/gopackagesdriver_test.go
+++ b/tests/integration/gopackagesdriver/gopackagesdriver_test.go
@@ -49,20 +49,24 @@ func TestBaseFileLookup(t *testing.T) {
 	out, err := bazel_testing.BazelOutputWithInput(reader, "run", "@io_bazel_rules_go//go/tools/gopackagesdriver", "--", "file=hello.go")
 	if err != nil {
 		t.Errorf("Unexpected error: %w", err.Error())
+		return
 	}
 	var resp response
 	err = json.Unmarshal(out, &resp)
 	if err != nil {
 		t.Errorf("Failed to unmarshal packages driver response: %w\n%w", err.Error(), out)
+		return
 	}
 
 	t.Run("roots", func(t *testing.T) {
 		if len(resp.Roots) != 1 {
-			t.Errorf("Excpected 1 package root: %+v", resp.Roots)
+			t.Errorf("Expected 1 package root: %+v", resp.Roots)
+			return
 		}
 
 		if resp.Roots[0] != "@//:hello" {
-			t.Errorf("Unecpected package id: %q", resp.Roots[0])
+			t.Errorf("Unexpected package id: %q", resp.Roots[0])
+			return
 		}
 	})
 
@@ -76,23 +80,28 @@ func TestBaseFileLookup(t *testing.T) {
 
 		if pkg == nil {
 			t.Errorf("Expected to find %q in resp.Packages", resp.Roots[0])
+			return
 		}
 
 		if len(pkg.CompiledGoFiles) != 1 || len(pkg.GoFiles) != 1 ||
 			path.Base(pkg.GoFiles[0]) != "hello.go" || path.Base(pkg.CompiledGoFiles[0]) != "hello.go" {
 			t.Errorf("Expected to find 1 file (hello.go) in (Compiled)GoFiles:\n%+v", pkg)
+			return
 		}
 
 		if pkg.Standard {
 			t.Errorf("Expected package to not be Standard:\n%+v", pkg)
+			return
 		}
 
 		if len(pkg.Imports) != 1 {
 			t.Errorf("Expected one import:\n%+v", pkg)
+			return
 		}
 
 		if pkg.Imports["os"] != osPkgID {
 			t.Errorf("Expected os import to map to %q:\n%+v", osPkgID, pkg)
+			return
 		}
 	})
 
@@ -106,10 +115,12 @@ func TestBaseFileLookup(t *testing.T) {
 
 		if osPkg == nil {
 			t.Errorf("Expected os package to be included:\n%+v", osPkg)
+			return
 		}
 
 		if !osPkg.Standard {
 			t.Errorf("Expected os import to be standard:\n%+v", osPkg)
+			return
 		}
 	})
 }

--- a/tests/integration/gopackagesdriver/gopackagesdriver_test.go
+++ b/tests/integration/gopackagesdriver/gopackagesdriver_test.go
@@ -1,0 +1,117 @@
+package gopackagesdriver_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+	gpd "github.com/bazelbuild/rules_go/go/tools/gopackagesdriver"
+)
+
+type response struct {
+	Roots    []string `json:",omitempty"`
+	Packages []*gpd.FlatPackage
+}
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: `
+-- BUILD.bazel --
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "hello",
+    srcs = ["hello.go"],
+    importpath = "example.com/hello",
+    visibility = ["//visibility:public"],
+)
+
+-- hello.go --
+package hello
+
+import "os"
+
+func main() {
+	fmt.Fprintln(os.Stderr, "Hello World!")
+}
+		`,
+	})
+}
+
+const (
+	osPkgID = "@io_bazel_rules_go//stdlib:os"
+)
+
+func TestBaseFileLookup(t *testing.T) {
+	reader := strings.NewReader("{}")
+	out, err := bazel_testing.BazelOutputWithInput(reader, "run", "@io_bazel_rules_go//go/tools/gopackagesdriver", "--", "file=hello.go")
+	if err != nil {
+		t.Errorf("Unexpected error: %w", err.Error())
+	}
+	fmt.Println(string(out))
+	var resp response
+	err = json.Unmarshal(out, &resp)
+	if err != nil {
+		t.Errorf("Failed to unmarshal packages driver response: %w\n%w", err.Error(), out)
+	}
+
+	t.Run("roots", func(t *testing.T) {
+		if len(resp.Roots) != 1 {
+			t.Errorf("Excpected 1 package root: %+v", resp.Roots)
+		}
+
+		if resp.Roots[0] != "@//:hello" {
+			t.Errorf("Unecpected package id: %q", resp.Roots[0])
+		}
+	})
+
+	t.Run("package", func(t *testing.T) {
+		var pkg *gpd.FlatPackage
+		for _, p := range resp.Packages {
+			if p.ID == resp.Roots[0] {
+				pkg = p
+			}
+		}
+
+		if pkg == nil {
+			t.Errorf("Expected to find %q in resp.Packages", resp.Roots[0])
+		}
+
+		if len(pkg.CompiledGoFiles) != 1 || len(pkg.GoFiles) != 1 ||
+			path.Base(pkg.GoFiles[0]) != "hello.go" || path.Base(pkg.CompiledGoFiles[0]) != "hello.go" {
+			t.Errorf("Expected to find 1 file (hello.go) in (Compiled)GoFiles:\n%+v", pkg)
+		}
+
+		if pkg.Standard {
+			t.Errorf("Expected package to not be Standard:\n%+v", pkg)
+		}
+
+		if len(pkg.Imports) != 1 {
+			t.Errorf("Expected one import:\n%+v", pkg)
+		}
+
+		if pkg.Imports["os"] != osPkgID {
+			t.Errorf("Expected os import to map to %q:\n%+v", osPkgID, pkg)
+		}
+	})
+
+	t.Run("dependency", func(t *testing.T) {
+		var osPkg *gpd.FlatPackage
+		for _, p := range resp.Packages {
+			if p.ID == osPkgID {
+				osPkg = p
+			}
+		}
+
+		if osPkg == nil {
+			t.Errorf("Expected os package to be included:\n%+v", osPkg)
+		}
+
+		if !osPkg.Standard {
+			t.Errorf("Expected os import to be standard:\n%+v", osPkg)
+		}
+	})
+}

--- a/tests/integration/gopackagesdriver/gopackagesdriver_test.go
+++ b/tests/integration/gopackagesdriver/gopackagesdriver_test.go
@@ -2,7 +2,6 @@ package gopackagesdriver_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"path"
 	"strings"
 	"testing"
@@ -51,7 +50,6 @@ func TestBaseFileLookup(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %w", err.Error())
 	}
-	fmt.Println(string(out))
 	var resp response
 	err = json.Unmarshal(out, &resp)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

Other - Test cases

**What does this PR do? Why is it needed?**

Validates the basic functionality for the Go Packages Driver, and sets up a framework to add additional tests in the future.

Two major changes were needed to support all testing platforms:
- For bazel <6.0 we need to use the old style labels. Currently it would always prefix with @ and fail the lookup on bazel 5.
- For Windows we need to adjust the paths returned from Bazel. I think because we're running inside MINGW the paths are unix like where everything starts with `\`, but `since` Bazel runs in Java it uses regular Windows paths (eg `C:\<some>\<path>`). So if we see a path like `\C:\<some>\<path>` we have to remove the leading `\` for go to be able tom resolve this path.

This should help contributors validate that changes they make to this functionality and hopefully means less regressions overall.

**Other notes for review**

The goal is to test more scenarios, but wanted to send in the initial approach for review.