### PR TITLE
Add go_cross_binary to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,7 @@ Go rules for Bazel_
 .. _go_rules_dependencies: go/dependencies.rst#go_rules_dependencies
 .. _go_source: docs/go/core/rules.md#go_source
 .. _go_test: docs/go/core/rules.md#go_test
+.. _go_cross_binary: docs/go/core/rules.md#go_cross_binary
 .. _go_toolchain: go/toolchains.rst#go_toolchain
 .. _go_wrap_sdk: go/toolchains.rst#go_wrap_sdk
 
@@ -161,6 +162,7 @@ Documentation
   * `go_test`_
   * `go_source`_
   * `go_path`_
+  * `go_cross_binary`_
 
 * `Proto rules`_
 
@@ -674,9 +676,13 @@ dependencies with ``select`` expressions (Gazelle does this automatically).
       }),
   )
 
-To build a specific `go_binary`_ or `go_test`_ target for a target platform,
-set the ``goos`` and ``goarch`` attributes on that rule. This is useful for
-producing multiple binaries for different platforms in a single build.
+To build a specific `go_binary`_ target for a target platform, use the
+`go_cross_binary`_ rule. This is useful for producing multiple binaries
+for different platforms in a single build.
+
+To build a specific `go_test`_ target for a target platform, set the
+``goos`` and ``goarch`` attributes on that rule.
+
 You can equivalently depend on a `go_binary`_ or `go_test`_ rule through
 a Bazel `configuration transition`_ on ``//command_line_option:platforms``
 (there are problems with this approach prior to rules_go 0.23.0).

--- a/README.rst
+++ b/README.rst
@@ -676,9 +676,9 @@ dependencies with ``select`` expressions (Gazelle does this automatically).
       }),
   )
 
-To build a specific `go_binary`_ target for a target platform, use the
-`go_cross_binary`_ rule. This is useful for producing multiple binaries
-for different platforms in a single build.
+To build a specific `go_binary`_ target for a target platform or using a
+specific golang SDK version, use the `go_cross_binary`_ rule. This is useful
+for producing multiple binaries for different platforms in a single build.
 
 To build a specific `go_test`_ target for a target platform, set the
 ``goos`` and ``goarch`` attributes on that rule.


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Documentation

**What does this PR do? Why is it needed?**
It's hard to find `go_cross_binary` unless you already know it exists. This adds it to the relevant sections in the README.

**Other notes for review**
Related thread on Bazel slack: https://bazelbuild.slack.com/archives/CDBP88Z0D/p1698892575577309