### PR TITLE
builder: Make paths absolute for stdliblist (#1357)

### DIFF
--- a/go/tools/builders/stdlib.go
+++ b/go/tools/builders/stdlib.go
@@ -81,7 +81,6 @@ You may need to use the flags --cpu=x64_windows --compiler=mingw-gcc.`)
 	os.Setenv("GO111MODULE", "off")
 
 	// Make sure we have an absolute path to the C compiler.
-	// TODO(#1357): also take absolute paths of includes and other paths in flags.
 	os.Setenv("CC", quotePathIfNeeded(abs(os.Getenv("CC"))))
 
 	// Ensure paths are absolute.
@@ -159,7 +158,7 @@ You may need to use the flags --cpu=x64_windows --compiler=mingw-gcc.`)
 	installArgs = append(installArgs, "-ldflags="+allSlug+strings.Join(ldflags, " "))
 	installArgs = append(installArgs, "-asmflags="+allSlug+strings.Join(asmflags, " "))
 
-	// Modifying CGO flags to use only absolute path
+	// Modify CGO flags to use only absolute path
 	// because go is having its own sandbox, all CGO flags must use absolute path
 	if err := absEnv(cgoEnvVars, cgoAbsEnvFlags); err != nil {
 		return fmt.Errorf("error modifying cgo environment to absolute path: %v", err)

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -251,12 +251,17 @@ func stdliblist(args []string) error {
 
 	cgoEnabled := os.Getenv("CGO_ENABLED") == "1"
 	// Make sure we have an absolute path to the C compiler.
-	// TODO(#1357): also take absolute paths of includes and other paths in flags.
 	ccEnv, ok := os.LookupEnv("CC")
 	if cgoEnabled && !ok {
 		return fmt.Errorf("CC must be set")
 	}
 	os.Setenv("CC", quotePathIfNeeded(abs(ccEnv)))
+
+	// Modify CGO flags to use only absolute path
+	// because go is having its own sandbox, all CGO flags must use absolute path
+	if err := absEnv(cgoEnvVars, cgoAbsEnvFlags); err != nil {
+		return fmt.Errorf("error modifying cgo environment to absolute path: %v", err)
+	}
 
 	// We want to keep the cache around so that the processed files can be used by other tools.
 	absCachePath := abs(*cachePath)


### PR DESCRIPTION
Make the gopackagesdriver work when using a C/C++ toolchain with sysroots. We need to turn the relative in flag like --sysroot into an absolute.

Address the todo by using the code already available in the stdlib.go as part of #1536.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

On a high-level this makes gopls and the gopackagesdriver work again for Go versions without a pre-compiled stdlib and using an external toolchain. This is done by turning a "CGO_CFLAGS='--sysroot=external/sysroot'" into an absolute path like it is done in stdlib.go.

**Which issues(s) does this PR fix?**

Fixes #1357 

**Other notes for review**

I looked at the similarities of stdlib.go and stdliblist.go. We might refactor parts of the environment handling but keeping that separately seems equally justified.  