### PR TITLE
Add support for `xtest` packages in Go Packages Driver

### DIFF
--- a/go/tools/bazel_testing/bazel_testing.go
+++ b/go/tools/bazel_testing/bazel_testing.go
@@ -206,7 +206,8 @@ func RunBazel(args ...string) error {
 // If the command starts but exits with a non-zero status, a *StderrExitError
 // will be returned which wraps the original *exec.ExitError.
 func BazelOutput(args ...string) ([]byte, error) {
-	return BazelOutputWithInput(nil, args...)
+	stdout, _, err := BazelOutputWithInput(nil, args...)
+	return stdout, err
 }
 
 // BazelOutputWithInput invokes a bazel command with a list of arguments and
@@ -214,7 +215,7 @@ func BazelOutput(args ...string) ([]byte, error) {
 //
 // If the command starts but exits with a non-zero status, a *StderrExitError
 // will be returned which wraps the original *exec.ExitError.
-func BazelOutputWithInput(stdin io.Reader, args ...string) ([]byte, error) {
+func BazelOutputWithInput(stdin io.Reader, args ...string) ([]byte, []byte, error) {
 	cmd := BazelCmd(args...)
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
@@ -228,7 +229,7 @@ func BazelOutputWithInput(stdin io.Reader, args ...string) ([]byte, error) {
 		eErr.Stderr = stderr.Bytes()
 		err = &StderrExitError{Err: eErr}
 	}
-	return stdout.Bytes(), err
+	return stdout.Bytes(), stderr.Bytes(), err
 }
 
 // StderrExitError wraps *exec.ExitError and prints the complete stderr output

--- a/go/tools/gopackagesdriver/packageregistry.go
+++ b/go/tools/gopackagesdriver/packageregistry.go
@@ -71,6 +71,10 @@ func (pr *PackageRegistry) ResolveImports() error {
 		if err := pkg.ResolveImports(resolve); err != nil {
 			return err
 		}
+		testFp := pkg.MoveTestFiles()
+		if testFp != nil {
+			pr.packagesByID[testFp.ID] = testFp
+		}
 	}
 
 	return nil
@@ -108,6 +112,10 @@ func (pr *PackageRegistry) Match(labels []string) ([]string, []*FlatPackage) {
 			}
 		} else {
 			roots[label] = struct{}{}
+			// If an xtest package exists for this package add it to the roots
+			if _, ok := pr.packagesByID[label+"_xtest"]; ok {
+				roots[label+"_xtest"] = struct{}{}
+			}
 		}
 	}
 

--- a/tests/integration/gopackagesdriver/gopackagesdriver_test.go
+++ b/tests/integration/gopackagesdriver/gopackagesdriver_test.go
@@ -19,13 +19,22 @@ func TestMain(m *testing.M) {
 	bazel_testing.TestMain(m, bazel_testing.Args{
 		Main: `
 -- BUILD.bazel --
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "hello",
     srcs = ["hello.go"],
     importpath = "example.com/hello",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+	name = "hello_test",
+	srcs = [
+		"hello_test.go",
+		"hello_external_test.go",
+	],
+	embed = [":hello"],
 )
 
 -- hello.go --
@@ -36,6 +45,20 @@ import "os"
 func main() {
 	fmt.Fprintln(os.Stderr, "Hello World!")
 }
+
+-- hello_test.go --
+package hello
+
+import "testing"
+
+func TestHelloInternal(t *testing.T) {}
+
+-- hello_external_test.go --
+package hello_test
+
+import "testing"
+
+func TestHelloExternal(t *testing.T) {}
 		`,
 	})
 }
@@ -46,7 +69,7 @@ const (
 
 func TestBaseFileLookup(t *testing.T) {
 	reader := strings.NewReader("{}")
-	out, err := bazel_testing.BazelOutputWithInput(reader, "run", "@io_bazel_rules_go//go/tools/gopackagesdriver", "--", "file=hello.go")
+	out, _, err := bazel_testing.BazelOutputWithInput(reader, "run", "@io_bazel_rules_go//go/tools/gopackagesdriver", "--", "file=hello.go")
 	if err != nil {
 		t.Errorf("Unexpected error: %w", err.Error())
 		return
@@ -123,4 +146,38 @@ func TestBaseFileLookup(t *testing.T) {
 			return
 		}
 	})
+}
+
+func TestExternalTests(t *testing.T) {
+	reader := strings.NewReader("{}")
+	out, _, err := bazel_testing.BazelOutputWithInput(reader, "run", "@io_bazel_rules_go//go/tools/gopackagesdriver", "--", "file=hello_external_test.go")
+	if err != nil {
+		t.Errorf("Unexpected error: %w", err.Error())
+	}
+	var resp response
+	err = json.Unmarshal(out, &resp)
+	if err != nil {
+		t.Errorf("Failed to unmarshal packages driver response: %w\n%w", err.Error(), out)
+	}
+
+	if len(resp.Roots) != 2 {
+		t.Errorf("Expected exactly two roots for package: %+v", resp.Roots)
+	}
+
+	var testId, xTestId string
+	for _, id := range resp.Roots {
+		if strings.HasSuffix(id, "_xtest") {
+			xTestId = id
+		} else {
+			testId = id
+		}
+	}
+
+	for _, p := range resp.Packages {
+		if p.ID == xTestId && !strings.HasSuffix(p.GoFiles[0], "external_test.go") {
+			t.Errorf("Expected only one file in _xtest pkg, got %+v", p.GoFiles)
+		} else if p.ID == testId && len(p.GoFiles) != 2 {
+			t.Errorf("Expected only 2 files in _test pkg, got %+v", p.GoFiles)
+		}
+	}
 }

--- a/tests/integration/gopackagesdriver/gopackagesdriver_test.go
+++ b/tests/integration/gopackagesdriver/gopackagesdriver_test.go
@@ -174,8 +174,8 @@ func TestExternalTests(t *testing.T) {
 	}
 
 	for _, p := range resp.Packages {
-		if p.ID == xTestId && len(p.GoFiles) == 1 && !strings.HasSuffix(p.GoFiles[0], "external_test.go") {
-			t.Errorf("Expected only one file in _xtest pkg, got %+v", p.GoFiles)
+		if p.ID == xTestId {
+			assertSuffixesInList(t, p.GoFiles, "/hello_external_test.go")
 		} else if p.ID == testId {
 			assertSuffixesInList(t, p.GoFiles, "/hello.go", "/hello_test.go")
 		}


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

xtests, also named external tests, are test cases that validate the public facing API of a package, even though the files are still located in the same package.

A sample folder structure:

> code.go -> `package code` -> has both public and private methods/interfaces of things
> code_test.go -> `package code` -> tests the private logic
> code_ext_test.go -> `package code_test` -> tests the public API

From what I gather, the go compiler is happy to handle this since the package names are different, but when the Go packages driver runs its aspect, we'll get all of this in one FlatPackage (since they're part of the `go_test` rule) with the same package ID. This causes Go internally to mark the `package code_test` as inconsistent with the `package code` of the other test files.

The solution:

- Read the package id field from any file that has an `_test.go` suffix, if it doesn't match the package id provided by the FlatPackage, separate it out into a list of external test files.
- If we see that we have more than 0 xtestfiles, we create a new xtest package to add to the registry.
- Finally, we need to ensure that this xtest package gets added to the roots if we created one. We do this unconditionally, since if you're trying to resolve the tests of a package, you'd likely also want the external tests.