### PR TITLE
upgrade x/tools to 0.15.0

### DIFF
--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -64,13 +64,13 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "org_golang_x_tools",
-        # v0.14.0, latest as of 2023-10-29
+        # v0.15.0, latest as of 2023-11-12
         urls = [
-            "https://mirror.bazel.build/github.com/golang/tools/archive/refs/tags/v0.14.0.zip",
-            "https://github.com/golang/tools/archive/refs/tags/v0.14.0.zip",
+            "https://mirror.bazel.build/github.com/golang/tools/archive/refs/tags/v0.15.0.zip",
+            "https://github.com/golang/tools/archive/refs/tags/v0.15.0.zip",
         ],
-        sha256 = "9c71911c61a791d8b13368ffbc409a0b38859cac80a4b5039487d2a27399e8b9",
-        strip_prefix = "tools-0.14.0",
+        sha256 = "e76a03b11719138502c7fef44d5e1dc4469f8c2fcb2ee4a1d96fb09aaea13362",
+        strip_prefix = "tools-0.15.0",
         patches = [
             # deletegopls removes the gopls subdirectory. It contains a nested
             # module with additional dependencies. It's not needed by rules_go.

--- a/go/tools/builders/nogo_main.go
+++ b/go/tools/builders/nogo_main.go
@@ -234,7 +234,7 @@ func checkPackage(analyzers []*analysis.Analyzer, packagePath string, packageFil
 
 	// Process diagnostics and encode facts for importers of this package.
 	diagnostics := checkAnalysisResults(roots, pkg)
-	facts := pkg.facts.Encode(true/* skipMethodSorting */)
+	facts := pkg.facts.Encode()
 	return diagnostics, facts, nil
 }
 
@@ -396,7 +396,7 @@ func load(packagePath string, imp *importer, filenames []string) (*goPackage, er
 	}
 	pkg.types, pkg.typesInfo = types, info
 
-	pkg.facts, err = facts.NewDecoder(pkg.types).Decode(true/* skipMethodSorting */, imp.readFacts)
+	pkg.facts, err = facts.NewDecoder(pkg.types).Decode(imp.readFacts)
 	if err != nil {
 		return nil, fmt.Errorf("internal error decoding facts: %v", err)
 	}

--- a/tests/integration/popular_repos/BUILD.bazel
+++ b/tests/integration/popular_repos/BUILD.bazel
@@ -186,7 +186,6 @@ test_suite(
         "@org_golang_x_tools//internal/event/export/ocagent:ocagent_test",
         "@org_golang_x_tools//internal/event/export/ocagent/wire:wire_test",
         "@org_golang_x_tools//internal/event/label:label_test",
-        "@org_golang_x_tools//internal/fastwalk:fastwalk_test",
         "@org_golang_x_tools//internal/fuzzy:fuzzy_test",
         "@org_golang_x_tools//internal/gopathwalk:gopathwalk_test",
         "@org_golang_x_tools//internal/jsonrpc2:jsonrpc2_test",

--- a/tests/integration/popular_repos/README.rst
+++ b/tests/integration/popular_repos/README.rst
@@ -184,7 +184,6 @@ This runs tests from the repository `golang.org/x/tools <https://golang.org/x/to
 * @org_golang_x_tools//internal/event/export/ocagent:ocagent_test
 * @org_golang_x_tools//internal/event/export/ocagent/wire:wire_test
 * @org_golang_x_tools//internal/event/label:label_test
-* @org_golang_x_tools//internal/fastwalk:fastwalk_test
 * @org_golang_x_tools//internal/fuzzy:fuzzy_test
 * @org_golang_x_tools//internal/gopathwalk:gopathwalk_test
 * @org_golang_x_tools//internal/jsonrpc2:jsonrpc2_test
@@ -232,5 +231,3 @@ This runs tests from the repository `golang.org/x/mod <https://golang.org/x/mod>
 * @org_golang_x_mod//sumdb/dirhash:dirhash_test
 * @org_golang_x_mod//sumdb/note:note_test
 * @org_golang_x_mod//sumdb/storage:storage_test
-
-

--- a/third_party/org_golang_x_tools-gazelle.patch
+++ b/third_party/org_golang_x_tools-gazelle.patch
@@ -1,5 +1,5 @@
 diff -urN b/benchmark/parse/BUILD.bazel c/benchmark/parse/BUILD.bazel
---- b/benchmark/parse/BUILD.bazel	1970-01-01 08:00:00
+--- b/benchmark/parse/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/benchmark/parse/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -22,8 +22,26 @@ diff -urN b/benchmark/parse/BUILD.bazel c/benchmark/parse/BUILD.bazel
 +    srcs = ["parse_test.go"],
 +    embed = [":parse"],
 +)
+diff -urN b/blog/atom/BUILD.bazel c/blog/atom/BUILD.bazel
+--- b/blog/atom/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ c/blog/atom/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,14 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "atom",
++    srcs = ["atom.go"],
++    importpath = "golang.org/x/tools/blog/atom",
++    visibility = ["//visibility:public"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":atom",
++    visibility = ["//visibility:public"],
++)
 diff -urN b/blog/BUILD.bazel c/blog/BUILD.bazel
---- b/blog/BUILD.bazel	1970-01-01 08:00:00
+--- b/blog/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/blog/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -50,26 +68,8 @@ diff -urN b/blog/BUILD.bazel c/blog/BUILD.bazel
 +    srcs = ["blog_test.go"],
 +    embed = [":blog"],
 +)
-diff -urN b/blog/atom/BUILD.bazel c/blog/atom/BUILD.bazel
---- b/blog/atom/BUILD.bazel	1970-01-01 08:00:00
-+++ c/blog/atom/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,14 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "atom",
-+    srcs = ["atom.go"],
-+    importpath = "golang.org/x/tools/blog/atom",
-+    visibility = ["//visibility:public"],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":atom",
-+    visibility = ["//visibility:public"],
-+)
 diff -urN b/cmd/auth/authtest/BUILD.bazel c/cmd/auth/authtest/BUILD.bazel
---- b/cmd/auth/authtest/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/auth/authtest/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/auth/authtest/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -88,7 +88,7 @@ diff -urN b/cmd/auth/authtest/BUILD.bazel c/cmd/auth/authtest/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/auth/cookieauth/BUILD.bazel c/cmd/auth/cookieauth/BUILD.bazel
---- b/cmd/auth/cookieauth/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/auth/cookieauth/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/auth/cookieauth/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -106,7 +106,7 @@ diff -urN b/cmd/auth/cookieauth/BUILD.bazel c/cmd/auth/cookieauth/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/auth/gitauth/BUILD.bazel c/cmd/auth/gitauth/BUILD.bazel
---- b/cmd/auth/gitauth/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/auth/gitauth/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/auth/gitauth/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -125,7 +125,7 @@ diff -urN b/cmd/auth/gitauth/BUILD.bazel c/cmd/auth/gitauth/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/auth/netrcauth/BUILD.bazel c/cmd/auth/netrcauth/BUILD.bazel
---- b/cmd/auth/netrcauth/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/auth/netrcauth/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/auth/netrcauth/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -143,7 +143,7 @@ diff -urN b/cmd/auth/netrcauth/BUILD.bazel c/cmd/auth/netrcauth/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/benchcmp/BUILD.bazel c/cmd/benchcmp/BUILD.bazel
---- b/cmd/benchcmp/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/benchcmp/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/benchcmp/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,29 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
@@ -176,7 +176,7 @@ diff -urN b/cmd/benchcmp/BUILD.bazel c/cmd/benchcmp/BUILD.bazel
 +    deps = ["//benchmark/parse"],
 +)
 diff -urN b/cmd/bisect/BUILD.bazel c/cmd/bisect/BUILD.bazel
---- b/cmd/bisect/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/bisect/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/bisect/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
@@ -203,7 +203,7 @@ diff -urN b/cmd/bisect/BUILD.bazel c/cmd/bisect/BUILD.bazel
 +go_test(
 +    name = "bisect_test",
 +    srcs = ["main_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
++    data = glob(["testdata/**"]),
 +    embed = [":bisect_lib"],
 +    deps = [
 +        "//internal/bisect",
@@ -213,9 +213,9 @@ diff -urN b/cmd/bisect/BUILD.bazel c/cmd/bisect/BUILD.bazel
 +    ],
 +)
 diff -urN b/cmd/bundle/BUILD.bazel c/cmd/bundle/BUILD.bazel
---- b/cmd/bundle/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/bundle/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/bundle/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,23 @@
+@@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 +
 +go_library(
@@ -235,12 +235,11 @@ diff -urN b/cmd/bundle/BUILD.bazel c/cmd/bundle/BUILD.bazel
 +go_test(
 +    name = "bundle_test",
 +    srcs = ["main_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    embed = [":bundle_lib"],
 +    deps = ["//go/packages/packagestest"],
 +)
 diff -urN b/cmd/bundle/testdata/src/domain.name/importdecl/BUILD.bazel c/cmd/bundle/testdata/src/domain.name/importdecl/BUILD.bazel
---- b/cmd/bundle/testdata/src/domain.name/importdecl/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/bundle/testdata/src/domain.name/importdecl/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/bundle/testdata/src/domain.name/importdecl/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -258,7 +257,7 @@ diff -urN b/cmd/bundle/testdata/src/domain.name/importdecl/BUILD.bazel c/cmd/bun
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/bundle/testdata/src/initial/BUILD.bazel c/cmd/bundle/testdata/src/initial/BUILD.bazel
---- b/cmd/bundle/testdata/src/initial/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/bundle/testdata/src/initial/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/bundle/testdata/src/initial/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -280,9 +279,9 @@ diff -urN b/cmd/bundle/testdata/src/initial/BUILD.bazel c/cmd/bundle/testdata/sr
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/callgraph/BUILD.bazel c/cmd/callgraph/BUILD.bazel
---- b/cmd/callgraph/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/callgraph/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/callgraph/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,74 @@
+@@ -0,0 +1,73 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 +
 +go_library(
@@ -312,7 +311,6 @@ diff -urN b/cmd/callgraph/BUILD.bazel c/cmd/callgraph/BUILD.bazel
 +go_test(
 +    name = "callgraph_test",
 +    srcs = ["main_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    embed = [":callgraph_lib"],
 +    deps = select({
 +        "@io_bazel_rules_go//go/platform:aix": [
@@ -358,7 +356,7 @@ diff -urN b/cmd/callgraph/BUILD.bazel c/cmd/callgraph/BUILD.bazel
 +    }),
 +)
 diff -urN b/cmd/callgraph/testdata/src/pkg/BUILD.bazel c/cmd/callgraph/testdata/src/pkg/BUILD.bazel
---- b/cmd/callgraph/testdata/src/pkg/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/callgraph/testdata/src/pkg/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/callgraph/testdata/src/pkg/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
@@ -382,7 +380,7 @@ diff -urN b/cmd/callgraph/testdata/src/pkg/BUILD.bazel c/cmd/callgraph/testdata/
 +    embed = [":pkg_lib"],
 +)
 diff -urN b/cmd/compilebench/BUILD.bazel c/cmd/compilebench/BUILD.bazel
---- b/cmd/compilebench/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/compilebench/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/compilebench/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -401,7 +399,7 @@ diff -urN b/cmd/compilebench/BUILD.bazel c/cmd/compilebench/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/digraph/BUILD.bazel c/cmd/digraph/BUILD.bazel
---- b/cmd/digraph/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/digraph/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/digraph/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
@@ -429,7 +427,7 @@ diff -urN b/cmd/digraph/BUILD.bazel c/cmd/digraph/BUILD.bazel
 +    embed = [":digraph_lib"],
 +)
 diff -urN b/cmd/eg/BUILD.bazel c/cmd/eg/BUILD.bazel
---- b/cmd/eg/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/eg/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/eg/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -452,7 +450,7 @@ diff -urN b/cmd/eg/BUILD.bazel c/cmd/eg/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/file2fuzz/BUILD.bazel c/cmd/file2fuzz/BUILD.bazel
---- b/cmd/file2fuzz/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/file2fuzz/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/file2fuzz/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
@@ -477,9 +475,9 @@ diff -urN b/cmd/file2fuzz/BUILD.bazel c/cmd/file2fuzz/BUILD.bazel
 +    deps = ["//internal/testenv"],
 +)
 diff -urN b/cmd/fiximports/BUILD.bazel c/cmd/fiximports/BUILD.bazel
---- b/cmd/fiximports/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/fiximports/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/fiximports/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,64 @@
+@@ -0,0 +1,63 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 +
 +go_library(
@@ -499,7 +497,6 @@ diff -urN b/cmd/fiximports/BUILD.bazel c/cmd/fiximports/BUILD.bazel
 +go_test(
 +    name = "fiximports_test",
 +    srcs = ["main_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    embed = [":fiximports_lib"],
 +    deps = select({
 +        "@io_bazel_rules_go//go/platform:aix": [
@@ -545,7 +542,7 @@ diff -urN b/cmd/fiximports/BUILD.bazel c/cmd/fiximports/BUILD.bazel
 +    }),
 +)
 diff -urN b/cmd/fiximports/testdata/src/fruit.io/banana/BUILD.bazel c/cmd/fiximports/testdata/src/fruit.io/banana/BUILD.bazel
---- b/cmd/fiximports/testdata/src/fruit.io/banana/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/fiximports/testdata/src/fruit.io/banana/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/fiximports/testdata/src/fruit.io/banana/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -563,7 +560,7 @@ diff -urN b/cmd/fiximports/testdata/src/fruit.io/banana/BUILD.bazel c/cmd/fiximp
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/fiximports/testdata/src/fruit.io/orange/BUILD.bazel c/cmd/fiximports/testdata/src/fruit.io/orange/BUILD.bazel
---- b/cmd/fiximports/testdata/src/fruit.io/orange/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/fiximports/testdata/src/fruit.io/orange/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/fiximports/testdata/src/fruit.io/orange/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -581,7 +578,7 @@ diff -urN b/cmd/fiximports/testdata/src/fruit.io/orange/BUILD.bazel c/cmd/fiximp
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/fiximports/testdata/src/fruit.io/pear/BUILD.bazel c/cmd/fiximports/testdata/src/fruit.io/pear/BUILD.bazel
---- b/cmd/fiximports/testdata/src/fruit.io/pear/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/fiximports/testdata/src/fruit.io/pear/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/fiximports/testdata/src/fruit.io/pear/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -599,7 +596,7 @@ diff -urN b/cmd/fiximports/testdata/src/fruit.io/pear/BUILD.bazel c/cmd/fiximpor
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/fiximports/testdata/src/new.com/one/BUILD.bazel c/cmd/fiximports/testdata/src/new.com/one/BUILD.bazel
---- b/cmd/fiximports/testdata/src/new.com/one/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/fiximports/testdata/src/new.com/one/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/fiximports/testdata/src/new.com/one/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -617,7 +614,7 @@ diff -urN b/cmd/fiximports/testdata/src/new.com/one/BUILD.bazel c/cmd/fiximports
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/fiximports/testdata/src/old.com/bad/BUILD.bazel c/cmd/fiximports/testdata/src/old.com/bad/BUILD.bazel
---- b/cmd/fiximports/testdata/src/old.com/bad/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/fiximports/testdata/src/old.com/bad/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/fiximports/testdata/src/old.com/bad/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -635,7 +632,7 @@ diff -urN b/cmd/fiximports/testdata/src/old.com/bad/BUILD.bazel c/cmd/fiximports
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/fiximports/testdata/src/old.com/one/BUILD.bazel c/cmd/fiximports/testdata/src/old.com/one/BUILD.bazel
---- b/cmd/fiximports/testdata/src/old.com/one/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/fiximports/testdata/src/old.com/one/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/fiximports/testdata/src/old.com/one/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -653,7 +650,7 @@ diff -urN b/cmd/fiximports/testdata/src/old.com/one/BUILD.bazel c/cmd/fiximports
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/fiximports/testdata/src/titanic.biz/bar/BUILD.bazel c/cmd/fiximports/testdata/src/titanic.biz/bar/BUILD.bazel
---- b/cmd/fiximports/testdata/src/titanic.biz/bar/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/fiximports/testdata/src/titanic.biz/bar/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/fiximports/testdata/src/titanic.biz/bar/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -671,7 +668,7 @@ diff -urN b/cmd/fiximports/testdata/src/titanic.biz/bar/BUILD.bazel c/cmd/fiximp
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/fiximports/testdata/src/titanic.biz/foo/BUILD.bazel c/cmd/fiximports/testdata/src/titanic.biz/foo/BUILD.bazel
---- b/cmd/fiximports/testdata/src/titanic.biz/foo/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/fiximports/testdata/src/titanic.biz/foo/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/fiximports/testdata/src/titanic.biz/foo/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -689,7 +686,7 @@ diff -urN b/cmd/fiximports/testdata/src/titanic.biz/foo/BUILD.bazel c/cmd/fiximp
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/getgo/BUILD.bazel c/cmd/getgo/BUILD.bazel
---- b/cmd/getgo/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/getgo/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/getgo/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,74 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
@@ -767,7 +764,7 @@ diff -urN b/cmd/getgo/BUILD.bazel c/cmd/getgo/BUILD.bazel
 +    embed = [":getgo_lib"],
 +)
 diff -urN b/cmd/getgo/server/BUILD.bazel c/cmd/getgo/server/BUILD.bazel
---- b/cmd/getgo/server/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/getgo/server/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/getgo/server/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -785,7 +782,7 @@ diff -urN b/cmd/getgo/server/BUILD.bazel c/cmd/getgo/server/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/go-contrib-init/BUILD.bazel c/cmd/go-contrib-init/BUILD.bazel
---- b/cmd/go-contrib-init/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/go-contrib-init/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/go-contrib-init/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
@@ -810,7 +807,7 @@ diff -urN b/cmd/go-contrib-init/BUILD.bazel c/cmd/go-contrib-init/BUILD.bazel
 +    embed = [":go-contrib-init_lib"],
 +)
 diff -urN b/cmd/godex/BUILD.bazel c/cmd/godex/BUILD.bazel
---- b/cmd/godex/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/godex/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/godex/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -838,7 +835,7 @@ diff -urN b/cmd/godex/BUILD.bazel c/cmd/godex/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/godoc/BUILD.bazel c/cmd/godoc/BUILD.bazel
---- b/cmd/godoc/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/godoc/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/godoc/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,41 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
@@ -883,7 +880,7 @@ diff -urN b/cmd/godoc/BUILD.bazel c/cmd/godoc/BUILD.bazel
 +    ],
 +)
 diff -urN b/cmd/goimports/BUILD.bazel c/cmd/goimports/BUILD.bazel
---- b/cmd/goimports/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/goimports/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/goimports/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -910,7 +907,7 @@ diff -urN b/cmd/goimports/BUILD.bazel c/cmd/goimports/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/gomvpkg/BUILD.bazel c/cmd/gomvpkg/BUILD.bazel
---- b/cmd/gomvpkg/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/gomvpkg/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/gomvpkg/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -932,9 +929,9 @@ diff -urN b/cmd/gomvpkg/BUILD.bazel c/cmd/gomvpkg/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/gonew/BUILD.bazel c/cmd/gonew/BUILD.bazel
---- b/cmd/gonew/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/gonew/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/gonew/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,30 @@
+@@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 +
 +go_library(
@@ -958,15 +955,16 @@ diff -urN b/cmd/gonew/BUILD.bazel c/cmd/gonew/BUILD.bazel
 +go_test(
 +    name = "gonew_test",
 +    srcs = ["main_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
++    data = glob(["testdata/**"]),
 +    embed = [":gonew_lib"],
 +    deps = [
 +        "//internal/diffp",
++        "//internal/testenv",
 +        "//txtar",
 +    ],
 +)
 diff -urN b/cmd/gorename/BUILD.bazel c/cmd/gorename/BUILD.bazel
---- b/cmd/gorename/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/gorename/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/gorename/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
@@ -994,7 +992,7 @@ diff -urN b/cmd/gorename/BUILD.bazel c/cmd/gorename/BUILD.bazel
 +    deps = ["//internal/testenv"],
 +)
 diff -urN b/cmd/gotype/BUILD.bazel c/cmd/gotype/BUILD.bazel
---- b/cmd/gotype/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/gotype/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/gotype/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -1016,7 +1014,7 @@ diff -urN b/cmd/gotype/BUILD.bazel c/cmd/gotype/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/goyacc/BUILD.bazel c/cmd/goyacc/BUILD.bazel
---- b/cmd/goyacc/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/goyacc/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/goyacc/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -1037,27 +1035,27 @@ diff -urN b/cmd/goyacc/BUILD.bazel c/cmd/goyacc/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/goyacc/testdata/expr/BUILD.bazel c/cmd/goyacc/testdata/expr/BUILD.bazel
---- b/cmd/goyacc/testdata/expr/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/goyacc/testdata/expr/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/goyacc/testdata/expr/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
 +    name = "expr_lib",
 +    srcs = ["main.go"],
 +    importpath = "golang.org/x/tools/cmd/goyacc/testdata/expr",
-+    visibility = ["//visibility:private"],
++    visibility = ["//visibility:public"],
 +)
 +
-+go_binary(
-+    name = "expr",
-+    embed = [":expr_lib"],
++alias(
++    name = "go_default_library",
++    actual = ":expr_lib",
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/guru/BUILD.bazel c/cmd/guru/BUILD.bazel
---- b/cmd/guru/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/guru/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/guru/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,46 @@
+@@ -0,0 +1,45 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 +
 +go_library(
@@ -1100,12 +1098,11 @@ diff -urN b/cmd/guru/BUILD.bazel c/cmd/guru/BUILD.bazel
 +        "guru_test.go",
 +        "unit_test.go",
 +    ],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    embed = [":guru_lib"],
 +    deps = ["//internal/testenv"],
 +)
 diff -urN b/cmd/guru/serial/BUILD.bazel c/cmd/guru/serial/BUILD.bazel
---- b/cmd/guru/serial/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/guru/serial/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/guru/serial/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1123,7 +1120,7 @@ diff -urN b/cmd/guru/serial/BUILD.bazel c/cmd/guru/serial/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/guru/testdata/src/alias/BUILD.bazel c/cmd/guru/testdata/src/alias/BUILD.bazel
---- b/cmd/guru/testdata/src/alias/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/guru/testdata/src/alias/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/guru/testdata/src/alias/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1141,7 +1138,7 @@ diff -urN b/cmd/guru/testdata/src/alias/BUILD.bazel c/cmd/guru/testdata/src/alia
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/guru/testdata/src/definition-json/BUILD.bazel c/cmd/guru/testdata/src/definition-json/BUILD.bazel
---- b/cmd/guru/testdata/src/definition-json/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/guru/testdata/src/definition-json/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/guru/testdata/src/definition-json/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1162,7 +1159,7 @@ diff -urN b/cmd/guru/testdata/src/definition-json/BUILD.bazel c/cmd/guru/testdat
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/guru/testdata/src/describe/BUILD.bazel c/cmd/guru/testdata/src/describe/BUILD.bazel
---- b/cmd/guru/testdata/src/describe/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/guru/testdata/src/describe/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/guru/testdata/src/describe/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1180,7 +1177,7 @@ diff -urN b/cmd/guru/testdata/src/describe/BUILD.bazel c/cmd/guru/testdata/src/d
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/guru/testdata/src/describe-json/BUILD.bazel c/cmd/guru/testdata/src/describe-json/BUILD.bazel
---- b/cmd/guru/testdata/src/describe-json/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/guru/testdata/src/describe-json/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/guru/testdata/src/describe-json/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1198,7 +1195,7 @@ diff -urN b/cmd/guru/testdata/src/describe-json/BUILD.bazel c/cmd/guru/testdata/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/guru/testdata/src/freevars/BUILD.bazel c/cmd/guru/testdata/src/freevars/BUILD.bazel
---- b/cmd/guru/testdata/src/freevars/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/guru/testdata/src/freevars/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/guru/testdata/src/freevars/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -1216,7 +1213,7 @@ diff -urN b/cmd/guru/testdata/src/freevars/BUILD.bazel c/cmd/guru/testdata/src/f
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/guru/testdata/src/implements/BUILD.bazel c/cmd/guru/testdata/src/implements/BUILD.bazel
---- b/cmd/guru/testdata/src/implements/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/guru/testdata/src/implements/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/guru/testdata/src/implements/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -1234,7 +1231,7 @@ diff -urN b/cmd/guru/testdata/src/implements/BUILD.bazel c/cmd/guru/testdata/src
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/guru/testdata/src/implements-json/BUILD.bazel c/cmd/guru/testdata/src/implements-json/BUILD.bazel
---- b/cmd/guru/testdata/src/implements-json/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/guru/testdata/src/implements-json/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/guru/testdata/src/implements-json/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -1252,7 +1249,7 @@ diff -urN b/cmd/guru/testdata/src/implements-json/BUILD.bazel c/cmd/guru/testdat
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/guru/testdata/src/implements-methods/BUILD.bazel c/cmd/guru/testdata/src/implements-methods/BUILD.bazel
---- b/cmd/guru/testdata/src/implements-methods/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/guru/testdata/src/implements-methods/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/guru/testdata/src/implements-methods/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -1270,7 +1267,7 @@ diff -urN b/cmd/guru/testdata/src/implements-methods/BUILD.bazel c/cmd/guru/test
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/guru/testdata/src/implements-methods-json/BUILD.bazel c/cmd/guru/testdata/src/implements-methods-json/BUILD.bazel
---- b/cmd/guru/testdata/src/implements-methods-json/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/guru/testdata/src/implements-methods-json/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/guru/testdata/src/implements-methods-json/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -1288,7 +1285,7 @@ diff -urN b/cmd/guru/testdata/src/implements-methods-json/BUILD.bazel c/cmd/guru
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/guru/testdata/src/imports/BUILD.bazel c/cmd/guru/testdata/src/imports/BUILD.bazel
---- b/cmd/guru/testdata/src/imports/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/guru/testdata/src/imports/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/guru/testdata/src/imports/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -1306,7 +1303,7 @@ diff -urN b/cmd/guru/testdata/src/imports/BUILD.bazel c/cmd/guru/testdata/src/im
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/guru/testdata/src/lib/BUILD.bazel c/cmd/guru/testdata/src/lib/BUILD.bazel
---- b/cmd/guru/testdata/src/lib/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/guru/testdata/src/lib/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/guru/testdata/src/lib/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1324,7 +1321,7 @@ diff -urN b/cmd/guru/testdata/src/lib/BUILD.bazel c/cmd/guru/testdata/src/lib/BU
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/guru/testdata/src/lib/sublib/BUILD.bazel c/cmd/guru/testdata/src/lib/sublib/BUILD.bazel
---- b/cmd/guru/testdata/src/lib/sublib/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/guru/testdata/src/lib/sublib/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/guru/testdata/src/lib/sublib/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -1342,7 +1339,7 @@ diff -urN b/cmd/guru/testdata/src/lib/sublib/BUILD.bazel c/cmd/guru/testdata/src
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/guru/testdata/src/main/BUILD.bazel c/cmd/guru/testdata/src/main/BUILD.bazel
---- b/cmd/guru/testdata/src/main/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/guru/testdata/src/main/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/guru/testdata/src/main/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -1360,7 +1357,7 @@ diff -urN b/cmd/guru/testdata/src/main/BUILD.bazel c/cmd/guru/testdata/src/main/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/guru/testdata/src/referrers/BUILD.bazel c/cmd/guru/testdata/src/referrers/BUILD.bazel
---- b/cmd/guru/testdata/src/referrers/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/guru/testdata/src/referrers/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/guru/testdata/src/referrers/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
@@ -1387,7 +1384,7 @@ diff -urN b/cmd/guru/testdata/src/referrers/BUILD.bazel c/cmd/guru/testdata/src/
 +    embed = [":referrers_lib"],
 +)
 diff -urN b/cmd/guru/testdata/src/referrers-json/BUILD.bazel c/cmd/guru/testdata/src/referrers-json/BUILD.bazel
---- b/cmd/guru/testdata/src/referrers-json/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/guru/testdata/src/referrers-json/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/guru/testdata/src/referrers-json/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -1405,7 +1402,7 @@ diff -urN b/cmd/guru/testdata/src/referrers-json/BUILD.bazel c/cmd/guru/testdata
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/guru/testdata/src/what/BUILD.bazel c/cmd/guru/testdata/src/what/BUILD.bazel
---- b/cmd/guru/testdata/src/what/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/guru/testdata/src/what/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/guru/testdata/src/what/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -1423,7 +1420,7 @@ diff -urN b/cmd/guru/testdata/src/what/BUILD.bazel c/cmd/guru/testdata/src/what/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/guru/testdata/src/what-json/BUILD.bazel c/cmd/guru/testdata/src/what-json/BUILD.bazel
---- b/cmd/guru/testdata/src/what-json/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/guru/testdata/src/what-json/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/guru/testdata/src/what-json/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -1441,7 +1438,7 @@ diff -urN b/cmd/guru/testdata/src/what-json/BUILD.bazel c/cmd/guru/testdata/src/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/html2article/BUILD.bazel c/cmd/html2article/BUILD.bazel
---- b/cmd/html2article/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/html2article/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/html2article/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -1463,7 +1460,7 @@ diff -urN b/cmd/html2article/BUILD.bazel c/cmd/html2article/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/present/BUILD.bazel c/cmd/present/BUILD.bazel
---- b/cmd/present/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/present/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/present/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,42 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -1509,7 +1506,7 @@ diff -urN b/cmd/present/BUILD.bazel c/cmd/present/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/present2md/BUILD.bazel c/cmd/present2md/BUILD.bazel
---- b/cmd/present2md/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/present2md/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/present2md/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -1528,7 +1525,7 @@ diff -urN b/cmd/present2md/BUILD.bazel c/cmd/present2md/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/signature-fuzzer/fuzz-driver/BUILD.bazel c/cmd/signature-fuzzer/fuzz-driver/BUILD.bazel
---- b/cmd/signature-fuzzer/fuzz-driver/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/signature-fuzzer/fuzz-driver/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/signature-fuzzer/fuzz-driver/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
@@ -1554,7 +1551,7 @@ diff -urN b/cmd/signature-fuzzer/fuzz-driver/BUILD.bazel c/cmd/signature-fuzzer/
 +    deps = ["//internal/testenv"],
 +)
 diff -urN b/cmd/signature-fuzzer/fuzz-runner/BUILD.bazel c/cmd/signature-fuzzer/fuzz-runner/BUILD.bazel
---- b/cmd/signature-fuzzer/fuzz-runner/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/signature-fuzzer/fuzz-runner/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/signature-fuzzer/fuzz-runner/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
@@ -1580,7 +1577,7 @@ diff -urN b/cmd/signature-fuzzer/fuzz-runner/BUILD.bazel c/cmd/signature-fuzzer/
 +    deps = ["//internal/testenv"],
 +)
 diff -urN b/cmd/signature-fuzzer/fuzz-runner/testdata/BUILD.bazel c/cmd/signature-fuzzer/fuzz-runner/testdata/BUILD.bazel
---- b/cmd/signature-fuzzer/fuzz-runner/testdata/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/signature-fuzzer/fuzz-runner/testdata/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/signature-fuzzer/fuzz-runner/testdata/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -1598,7 +1595,7 @@ diff -urN b/cmd/signature-fuzzer/fuzz-runner/testdata/BUILD.bazel c/cmd/signatur
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/signature-fuzzer/internal/fuzz-generator/BUILD.bazel c/cmd/signature-fuzzer/internal/fuzz-generator/BUILD.bazel
---- b/cmd/signature-fuzzer/internal/fuzz-generator/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/signature-fuzzer/internal/fuzz-generator/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/signature-fuzzer/internal/fuzz-generator/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,32 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1634,7 +1631,7 @@ diff -urN b/cmd/signature-fuzzer/internal/fuzz-generator/BUILD.bazel c/cmd/signa
 +    deps = ["//internal/testenv"],
 +)
 diff -urN b/cmd/splitdwarf/BUILD.bazel c/cmd/splitdwarf/BUILD.bazel
---- b/cmd/splitdwarf/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/splitdwarf/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/splitdwarf/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,44 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -1682,7 +1679,7 @@ diff -urN b/cmd/splitdwarf/BUILD.bazel c/cmd/splitdwarf/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/splitdwarf/internal/macho/BUILD.bazel c/cmd/splitdwarf/internal/macho/BUILD.bazel
---- b/cmd/splitdwarf/internal/macho/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/splitdwarf/internal/macho/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/splitdwarf/internal/macho/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1709,11 +1706,11 @@ diff -urN b/cmd/splitdwarf/internal/macho/BUILD.bazel c/cmd/splitdwarf/internal/
 +go_test(
 +    name = "macho_test",
 +    srcs = ["file_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
++    data = glob(["testdata/**"]),
 +    embed = [":macho"],
 +)
 diff -urN b/cmd/ssadump/BUILD.bazel c/cmd/ssadump/BUILD.bazel
---- b/cmd/ssadump/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/ssadump/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/ssadump/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -1738,9 +1735,9 @@ diff -urN b/cmd/ssadump/BUILD.bazel c/cmd/ssadump/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/stress/BUILD.bazel c/cmd/stress/BUILD.bazel
---- b/cmd/stress/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/stress/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/stress/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,50 @@
+@@ -0,0 +1,53 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 +
 +go_library(
@@ -1762,6 +1759,9 @@ diff -urN b/cmd/stress/BUILD.bazel c/cmd/stress/BUILD.bazel
 +            "@org_golang_x_sys//execabs:go_default_library",
 +        ],
 +        "@io_bazel_rules_go//go/platform:freebsd": [
++            "@org_golang_x_sys//execabs:go_default_library",
++        ],
++        "@io_bazel_rules_go//go/platform:illumos": [
 +            "@org_golang_x_sys//execabs:go_default_library",
 +        ],
 +        "@io_bazel_rules_go//go/platform:ios": [
@@ -1792,7 +1792,7 @@ diff -urN b/cmd/stress/BUILD.bazel c/cmd/stress/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/stringer/BUILD.bazel c/cmd/stringer/BUILD.bazel
---- b/cmd/stringer/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/stringer/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/stringer/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,69 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
@@ -1865,7 +1865,7 @@ diff -urN b/cmd/stringer/BUILD.bazel c/cmd/stringer/BUILD.bazel
 +    }),
 +)
 diff -urN b/cmd/stringer/testdata/BUILD.bazel c/cmd/stringer/testdata/BUILD.bazel
---- b/cmd/stringer/testdata/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/stringer/testdata/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/stringer/testdata/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -1896,7 +1896,7 @@ diff -urN b/cmd/stringer/testdata/BUILD.bazel c/cmd/stringer/testdata/BUILD.baze
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/stringer/testdata/typeparams/BUILD.bazel c/cmd/stringer/testdata/typeparams/BUILD.bazel
---- b/cmd/stringer/testdata/typeparams/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/stringer/testdata/typeparams/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/stringer/testdata/typeparams/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -1917,7 +1917,7 @@ diff -urN b/cmd/stringer/testdata/typeparams/BUILD.bazel c/cmd/stringer/testdata
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/cmd/toolstash/BUILD.bazel c/cmd/toolstash/BUILD.bazel
---- b/cmd/toolstash/BUILD.bazel	1970-01-01 08:00:00
+--- b/cmd/toolstash/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cmd/toolstash/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -1939,7 +1939,7 @@ diff -urN b/cmd/toolstash/BUILD.bazel c/cmd/toolstash/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/container/intsets/BUILD.bazel c/container/intsets/BUILD.bazel
---- b/container/intsets/BUILD.bazel	1970-01-01 08:00:00
+--- b/container/intsets/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/container/intsets/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1966,7 +1966,7 @@ diff -urN b/container/intsets/BUILD.bazel c/container/intsets/BUILD.bazel
 +    embed = [":intsets"],
 +)
 diff -urN b/copyright/BUILD.bazel c/copyright/BUILD.bazel
---- b/copyright/BUILD.bazel	1970-01-01 08:00:00
+--- b/copyright/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/copyright/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -1990,7 +1990,7 @@ diff -urN b/copyright/BUILD.bazel c/copyright/BUILD.bazel
 +    embed = [":copyright"],
 +)
 diff -urN b/cover/BUILD.bazel c/cover/BUILD.bazel
---- b/cover/BUILD.bazel	1970-01-01 08:00:00
+--- b/cover/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/cover/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2013,37 +2013,8 @@ diff -urN b/cover/BUILD.bazel c/cover/BUILD.bazel
 +    srcs = ["profile_test.go"],
 +    embed = [":cover"],
 +)
-diff -urN b/go/analysis/BUILD.bazel c/go/analysis/BUILD.bazel
---- b/go/analysis/BUILD.bazel	1970-01-01 08:00:00
-+++ c/go/analysis/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,25 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-+
-+go_library(
-+    name = "analysis",
-+    srcs = [
-+        "analysis.go",
-+        "diagnostic.go",
-+        "doc.go",
-+        "validate.go",
-+    ],
-+    importpath = "golang.org/x/tools/go/analysis",
-+    visibility = ["//visibility:public"],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":analysis",
-+    visibility = ["//visibility:public"],
-+)
-+
-+go_test(
-+    name = "analysis_test",
-+    srcs = ["validate_test.go"],
-+    embed = [":analysis"],
-+)
 diff -urN b/go/analysis/analysistest/BUILD.bazel c/go/analysis/analysistest/BUILD.bazel
---- b/go/analysis/analysistest/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/analysistest/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/analysistest/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,32 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2078,8 +2049,37 @@ diff -urN b/go/analysis/analysistest/BUILD.bazel c/go/analysis/analysistest/BUIL
 +        "//internal/testenv",
 +    ],
 +)
+diff -urN b/go/analysis/BUILD.bazel c/go/analysis/BUILD.bazel
+--- b/go/analysis/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ c/go/analysis/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,25 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "analysis",
++    srcs = [
++        "analysis.go",
++        "diagnostic.go",
++        "doc.go",
++        "validate.go",
++    ],
++    importpath = "golang.org/x/tools/go/analysis",
++    visibility = ["//visibility:public"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":analysis",
++    visibility = ["//visibility:public"],
++)
++
++go_test(
++    name = "analysis_test",
++    srcs = ["validate_test.go"],
++    embed = [":analysis"],
++)
 diff -urN b/go/analysis/internal/analysisflags/BUILD.bazel c/go/analysis/internal/analysisflags/BUILD.bazel
---- b/go/analysis/internal/analysisflags/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/internal/analysisflags/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/internal/analysisflags/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2114,7 +2114,7 @@ diff -urN b/go/analysis/internal/analysisflags/BUILD.bazel c/go/analysis/interna
 +    ],
 +)
 diff -urN b/go/analysis/internal/checker/BUILD.bazel c/go/analysis/internal/checker/BUILD.bazel
---- b/go/analysis/internal/checker/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/internal/checker/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/internal/checker/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2156,7 +2156,7 @@ diff -urN b/go/analysis/internal/checker/BUILD.bazel c/go/analysis/internal/chec
 +    ],
 +)
 diff -urN b/go/analysis/internal/versiontest/BUILD.bazel c/go/analysis/internal/versiontest/BUILD.bazel
---- b/go/analysis/internal/versiontest/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/internal/versiontest/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/internal/versiontest/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,13 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_test")
@@ -2173,7 +2173,7 @@ diff -urN b/go/analysis/internal/versiontest/BUILD.bazel c/go/analysis/internal/
 +    ],
 +)
 diff -urN b/go/analysis/multichecker/BUILD.bazel c/go/analysis/multichecker/BUILD.bazel
---- b/go/analysis/multichecker/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/multichecker/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/multichecker/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2208,7 +2208,7 @@ diff -urN b/go/analysis/multichecker/BUILD.bazel c/go/analysis/multichecker/BUIL
 +    ],
 +)
 diff -urN b/go/analysis/passes/appends/BUILD.bazel c/go/analysis/passes/appends/BUILD.bazel
---- b/go/analysis/passes/appends/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/appends/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/appends/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,34 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2227,6 +2227,7 @@ diff -urN b/go/analysis/passes/appends/BUILD.bazel c/go/analysis/passes/appends/
 +        "//go/analysis/passes/inspect",
 +        "//go/analysis/passes/internal/analysisutil",
 +        "//go/ast/inspector",
++        "//go/types/typeutil",
 +    ],
 +)
 +
@@ -2239,14 +2240,13 @@ diff -urN b/go/analysis/passes/appends/BUILD.bazel c/go/analysis/passes/appends/
 +go_test(
 +    name = "appends_test",
 +    srcs = ["appends_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":appends",
 +        "//go/analysis/analysistest",
 +    ],
 +)
 diff -urN b/go/analysis/passes/appends/testdata/src/a/BUILD.bazel c/go/analysis/passes/appends/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/appends/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/appends/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/appends/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2264,7 +2264,7 @@ diff -urN b/go/analysis/passes/appends/testdata/src/a/BUILD.bazel c/go/analysis/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/appends/testdata/src/b/BUILD.bazel c/go/analysis/passes/appends/testdata/src/b/BUILD.bazel
---- b/go/analysis/passes/appends/testdata/src/b/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/appends/testdata/src/b/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/appends/testdata/src/b/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2282,9 +2282,9 @@ diff -urN b/go/analysis/passes/appends/testdata/src/b/BUILD.bazel c/go/analysis/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/asmdecl/BUILD.bazel c/go/analysis/passes/asmdecl/BUILD.bazel
---- b/go/analysis/passes/asmdecl/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/asmdecl/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/asmdecl/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -2311,14 +2311,13 @@ diff -urN b/go/analysis/passes/asmdecl/BUILD.bazel c/go/analysis/passes/asmdecl/
 +go_test(
 +    name = "asmdecl_test",
 +    srcs = ["asmdecl_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":asmdecl",
 +        "//go/analysis/analysistest",
 +    ],
 +)
 diff -urN b/go/analysis/passes/asmdecl/testdata/src/a/BUILD.bazel c/go/analysis/passes/asmdecl/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/asmdecl/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/asmdecl/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/asmdecl/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2348,9 +2347,9 @@ diff -urN b/go/analysis/passes/asmdecl/testdata/src/a/BUILD.bazel c/go/analysis/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/assign/BUILD.bazel c/go/analysis/passes/assign/BUILD.bazel
---- b/go/analysis/passes/assign/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/assign/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/assign/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -2366,6 +2365,7 @@ diff -urN b/go/analysis/passes/assign/BUILD.bazel c/go/analysis/passes/assign/BU
 +        "//go/analysis",
 +        "//go/analysis/passes/inspect",
 +        "//go/analysis/passes/internal/analysisutil",
++        "//go/ast/astutil",
 +        "//go/ast/inspector",
 +    ],
 +)
@@ -2386,7 +2386,7 @@ diff -urN b/go/analysis/passes/assign/BUILD.bazel c/go/analysis/passes/assign/BU
 +    ],
 +)
 diff -urN b/go/analysis/passes/assign/testdata/src/a/BUILD.bazel c/go/analysis/passes/assign/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/assign/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/assign/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/assign/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2404,7 +2404,7 @@ diff -urN b/go/analysis/passes/assign/testdata/src/a/BUILD.bazel c/go/analysis/p
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/assign/testdata/src/typeparams/BUILD.bazel c/go/analysis/passes/assign/testdata/src/typeparams/BUILD.bazel
---- b/go/analysis/passes/assign/testdata/src/typeparams/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/assign/testdata/src/typeparams/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/assign/testdata/src/typeparams/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2422,7 +2422,7 @@ diff -urN b/go/analysis/passes/assign/testdata/src/typeparams/BUILD.bazel c/go/a
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/atomic/BUILD.bazel c/go/analysis/passes/atomic/BUILD.bazel
---- b/go/analysis/passes/atomic/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/atomic/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/atomic/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2441,6 +2441,7 @@ diff -urN b/go/analysis/passes/atomic/BUILD.bazel c/go/analysis/passes/atomic/BU
 +        "//go/analysis/passes/inspect",
 +        "//go/analysis/passes/internal/analysisutil",
 +        "//go/ast/inspector",
++        "//go/types/typeutil",
 +    ],
 +)
 +
@@ -2453,7 +2454,6 @@ diff -urN b/go/analysis/passes/atomic/BUILD.bazel c/go/analysis/passes/atomic/BU
 +go_test(
 +    name = "atomic_test",
 +    srcs = ["atomic_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":atomic",
 +        "//go/analysis/analysistest",
@@ -2461,7 +2461,7 @@ diff -urN b/go/analysis/passes/atomic/BUILD.bazel c/go/analysis/passes/atomic/BU
 +    ],
 +)
 diff -urN b/go/analysis/passes/atomic/testdata/src/a/BUILD.bazel c/go/analysis/passes/atomic/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/atomic/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/atomic/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/atomic/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2479,7 +2479,7 @@ diff -urN b/go/analysis/passes/atomic/testdata/src/a/BUILD.bazel c/go/analysis/p
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/atomic/testdata/src/typeparams/BUILD.bazel c/go/analysis/passes/atomic/testdata/src/typeparams/BUILD.bazel
---- b/go/analysis/passes/atomic/testdata/src/typeparams/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/atomic/testdata/src/typeparams/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/atomic/testdata/src/typeparams/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2497,7 +2497,7 @@ diff -urN b/go/analysis/passes/atomic/testdata/src/typeparams/BUILD.bazel c/go/a
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/atomicalign/BUILD.bazel c/go/analysis/passes/atomicalign/BUILD.bazel
---- b/go/analysis/passes/atomicalign/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/atomicalign/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/atomicalign/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2512,6 +2512,7 @@ diff -urN b/go/analysis/passes/atomicalign/BUILD.bazel c/go/analysis/passes/atom
 +        "//go/analysis/passes/inspect",
 +        "//go/analysis/passes/internal/analysisutil",
 +        "//go/ast/inspector",
++        "//go/types/typeutil",
 +    ],
 +)
 +
@@ -2524,14 +2525,13 @@ diff -urN b/go/analysis/passes/atomicalign/BUILD.bazel c/go/analysis/passes/atom
 +go_test(
 +    name = "atomicalign_test",
 +    srcs = ["atomicalign_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":atomicalign",
 +        "//go/analysis/analysistest",
 +    ],
 +)
 diff -urN b/go/analysis/passes/atomicalign/testdata/src/a/BUILD.bazel c/go/analysis/passes/atomicalign/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/atomicalign/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/atomicalign/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/atomicalign/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2552,7 +2552,7 @@ diff -urN b/go/analysis/passes/atomicalign/testdata/src/a/BUILD.bazel c/go/analy
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/atomicalign/testdata/src/b/BUILD.bazel c/go/analysis/passes/atomicalign/testdata/src/b/BUILD.bazel
---- b/go/analysis/passes/atomicalign/testdata/src/b/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/atomicalign/testdata/src/b/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/atomicalign/testdata/src/b/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2573,7 +2573,7 @@ diff -urN b/go/analysis/passes/atomicalign/testdata/src/b/BUILD.bazel c/go/analy
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/bools/BUILD.bazel c/go/analysis/passes/bools/BUILD.bazel
---- b/go/analysis/passes/bools/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/bools/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/bools/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2587,6 +2587,7 @@ diff -urN b/go/analysis/passes/bools/BUILD.bazel c/go/analysis/passes/bools/BUIL
 +        "//go/analysis",
 +        "//go/analysis/passes/inspect",
 +        "//go/analysis/passes/internal/analysisutil",
++        "//go/ast/astutil",
 +        "//go/ast/inspector",
 +    ],
 +)
@@ -2600,7 +2601,6 @@ diff -urN b/go/analysis/passes/bools/BUILD.bazel c/go/analysis/passes/bools/BUIL
 +go_test(
 +    name = "bools_test",
 +    srcs = ["bools_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":bools",
 +        "//go/analysis/analysistest",
@@ -2608,7 +2608,7 @@ diff -urN b/go/analysis/passes/bools/BUILD.bazel c/go/analysis/passes/bools/BUIL
 +    ],
 +)
 diff -urN b/go/analysis/passes/bools/testdata/src/a/BUILD.bazel c/go/analysis/passes/bools/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/bools/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/bools/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/bools/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2626,7 +2626,7 @@ diff -urN b/go/analysis/passes/bools/testdata/src/a/BUILD.bazel c/go/analysis/pa
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/bools/testdata/src/typeparams/BUILD.bazel c/go/analysis/passes/bools/testdata/src/typeparams/BUILD.bazel
---- b/go/analysis/passes/bools/testdata/src/typeparams/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/bools/testdata/src/typeparams/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/bools/testdata/src/typeparams/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2644,9 +2644,9 @@ diff -urN b/go/analysis/passes/bools/testdata/src/typeparams/BUILD.bazel c/go/an
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/buildssa/BUILD.bazel c/go/analysis/passes/buildssa/BUILD.bazel
---- b/go/analysis/passes/buildssa/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/buildssa/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/buildssa/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -2669,7 +2669,6 @@ diff -urN b/go/analysis/passes/buildssa/BUILD.bazel c/go/analysis/passes/buildss
 +go_test(
 +    name = "buildssa_test",
 +    srcs = ["buildssa_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":buildssa",
 +        "//go/analysis/analysistest",
@@ -2677,7 +2676,7 @@ diff -urN b/go/analysis/passes/buildssa/BUILD.bazel c/go/analysis/passes/buildss
 +    ],
 +)
 diff -urN b/go/analysis/passes/buildssa/testdata/src/a/BUILD.bazel c/go/analysis/passes/buildssa/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/buildssa/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/buildssa/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/buildssa/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2695,7 +2694,7 @@ diff -urN b/go/analysis/passes/buildssa/testdata/src/a/BUILD.bazel c/go/analysis
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/buildssa/testdata/src/b/BUILD.bazel c/go/analysis/passes/buildssa/testdata/src/b/BUILD.bazel
---- b/go/analysis/passes/buildssa/testdata/src/b/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/buildssa/testdata/src/b/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/buildssa/testdata/src/b/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2713,7 +2712,7 @@ diff -urN b/go/analysis/passes/buildssa/testdata/src/b/BUILD.bazel c/go/analysis
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/buildssa/testdata/src/c/BUILD.bazel c/go/analysis/passes/buildssa/testdata/src/c/BUILD.bazel
---- b/go/analysis/passes/buildssa/testdata/src/c/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/buildssa/testdata/src/c/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/buildssa/testdata/src/c/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2731,9 +2730,9 @@ diff -urN b/go/analysis/passes/buildssa/testdata/src/c/BUILD.bazel c/go/analysis
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/buildtag/BUILD.bazel c/go/analysis/passes/buildtag/BUILD.bazel
---- b/go/analysis/passes/buildtag/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/buildtag/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/buildtag/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -2759,7 +2758,6 @@ diff -urN b/go/analysis/passes/buildtag/BUILD.bazel c/go/analysis/passes/buildta
 +go_test(
 +    name = "buildtag_test",
 +    srcs = ["buildtag_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":buildtag",
 +        "//go/analysis",
@@ -2767,7 +2765,7 @@ diff -urN b/go/analysis/passes/buildtag/BUILD.bazel c/go/analysis/passes/buildta
 +    ],
 +)
 diff -urN b/go/analysis/passes/buildtag/testdata/src/a/BUILD.bazel c/go/analysis/passes/buildtag/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/buildtag/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/buildtag/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/buildtag/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2789,7 +2787,7 @@ diff -urN b/go/analysis/passes/buildtag/testdata/src/a/BUILD.bazel c/go/analysis
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/cgocall/BUILD.bazel c/go/analysis/passes/cgocall/BUILD.bazel
---- b/go/analysis/passes/cgocall/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/cgocall/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/cgocall/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2806,6 +2804,7 @@ diff -urN b/go/analysis/passes/cgocall/BUILD.bazel c/go/analysis/passes/cgocall/
 +    deps = [
 +        "//go/analysis",
 +        "//go/analysis/passes/internal/analysisutil",
++        "//go/ast/astutil",
 +    ],
 +)
 +
@@ -2818,7 +2817,6 @@ diff -urN b/go/analysis/passes/cgocall/BUILD.bazel c/go/analysis/passes/cgocall/
 +go_test(
 +    name = "cgocall_test",
 +    srcs = ["cgocall_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":cgocall",
 +        "//go/analysis/analysistest",
@@ -2826,7 +2824,7 @@ diff -urN b/go/analysis/passes/cgocall/BUILD.bazel c/go/analysis/passes/cgocall/
 +    ],
 +)
 diff -urN b/go/analysis/passes/cgocall/testdata/src/a/BUILD.bazel c/go/analysis/passes/cgocall/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/cgocall/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/cgocall/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/cgocall/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2848,7 +2846,7 @@ diff -urN b/go/analysis/passes/cgocall/testdata/src/a/BUILD.bazel c/go/analysis/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/cgocall/testdata/src/b/BUILD.bazel c/go/analysis/passes/cgocall/testdata/src/b/BUILD.bazel
---- b/go/analysis/passes/cgocall/testdata/src/b/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/cgocall/testdata/src/b/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/cgocall/testdata/src/b/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2866,7 +2864,7 @@ diff -urN b/go/analysis/passes/cgocall/testdata/src/b/BUILD.bazel c/go/analysis/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/cgocall/testdata/src/c/BUILD.bazel c/go/analysis/passes/cgocall/testdata/src/c/BUILD.bazel
---- b/go/analysis/passes/cgocall/testdata/src/c/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/cgocall/testdata/src/c/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/cgocall/testdata/src/c/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2884,7 +2882,7 @@ diff -urN b/go/analysis/passes/cgocall/testdata/src/c/BUILD.bazel c/go/analysis/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/cgocall/testdata/src/typeparams/BUILD.bazel c/go/analysis/passes/cgocall/testdata/src/typeparams/BUILD.bazel
---- b/go/analysis/passes/cgocall/testdata/src/typeparams/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/cgocall/testdata/src/typeparams/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/cgocall/testdata/src/typeparams/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2903,9 +2901,9 @@ diff -urN b/go/analysis/passes/cgocall/testdata/src/typeparams/BUILD.bazel c/go/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/composite/BUILD.bazel c/go/analysis/passes/composite/BUILD.bazel
---- b/go/analysis/passes/composite/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/composite/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/composite/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -2933,7 +2931,6 @@ diff -urN b/go/analysis/passes/composite/BUILD.bazel c/go/analysis/passes/compos
 +go_test(
 +    name = "composite_test",
 +    srcs = ["composite_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":composite",
 +        "//go/analysis/analysistest",
@@ -2941,7 +2938,7 @@ diff -urN b/go/analysis/passes/composite/BUILD.bazel c/go/analysis/passes/compos
 +    ],
 +)
 diff -urN b/go/analysis/passes/composite/testdata/src/a/BUILD.bazel c/go/analysis/passes/composite/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/composite/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/composite/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/composite/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -2965,7 +2962,7 @@ diff -urN b/go/analysis/passes/composite/testdata/src/a/BUILD.bazel c/go/analysi
 +    embed = [":a"],
 +)
 diff -urN b/go/analysis/passes/composite/testdata/src/typeparams/BUILD.bazel c/go/analysis/passes/composite/testdata/src/typeparams/BUILD.bazel
---- b/go/analysis/passes/composite/testdata/src/typeparams/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/composite/testdata/src/typeparams/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/composite/testdata/src/typeparams/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -2983,7 +2980,7 @@ diff -urN b/go/analysis/passes/composite/testdata/src/typeparams/BUILD.bazel c/g
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/composite/testdata/src/typeparams/lib/BUILD.bazel c/go/analysis/passes/composite/testdata/src/typeparams/lib/BUILD.bazel
---- b/go/analysis/passes/composite/testdata/src/typeparams/lib/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/composite/testdata/src/typeparams/lib/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/composite/testdata/src/typeparams/lib/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3001,7 +2998,7 @@ diff -urN b/go/analysis/passes/composite/testdata/src/typeparams/lib/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/copylock/BUILD.bazel c/go/analysis/passes/copylock/BUILD.bazel
---- b/go/analysis/passes/copylock/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/copylock/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/copylock/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,32 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3015,6 +3012,7 @@ diff -urN b/go/analysis/passes/copylock/BUILD.bazel c/go/analysis/passes/copyloc
 +        "//go/analysis",
 +        "//go/analysis/passes/inspect",
 +        "//go/analysis/passes/internal/analysisutil",
++        "//go/ast/astutil",
 +        "//go/ast/inspector",
 +        "//internal/typeparams",
 +    ],
@@ -3029,7 +3027,6 @@ diff -urN b/go/analysis/passes/copylock/BUILD.bazel c/go/analysis/passes/copyloc
 +go_test(
 +    name = "copylock_test",
 +    srcs = ["copylock_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":copylock",
 +        "//go/analysis/analysistest",
@@ -3037,7 +3034,7 @@ diff -urN b/go/analysis/passes/copylock/BUILD.bazel c/go/analysis/passes/copyloc
 +    ],
 +)
 diff -urN b/go/analysis/passes/copylock/testdata/src/a/BUILD.bazel c/go/analysis/passes/copylock/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/copylock/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/copylock/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/copylock/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3060,7 +3057,7 @@ diff -urN b/go/analysis/passes/copylock/testdata/src/a/BUILD.bazel c/go/analysis
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/copylock/testdata/src/typeparams/BUILD.bazel c/go/analysis/passes/copylock/testdata/src/typeparams/BUILD.bazel
---- b/go/analysis/passes/copylock/testdata/src/typeparams/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/copylock/testdata/src/typeparams/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/copylock/testdata/src/typeparams/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3078,9 +3075,9 @@ diff -urN b/go/analysis/passes/copylock/testdata/src/typeparams/BUILD.bazel c/go
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/ctrlflow/BUILD.bazel c/go/analysis/passes/ctrlflow/BUILD.bazel
---- b/go/analysis/passes/ctrlflow/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/ctrlflow/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/ctrlflow/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -3106,7 +3103,6 @@ diff -urN b/go/analysis/passes/ctrlflow/BUILD.bazel c/go/analysis/passes/ctrlflo
 +go_test(
 +    name = "ctrlflow_test",
 +    srcs = ["ctrlflow_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":ctrlflow",
 +        "//go/analysis/analysistest",
@@ -3114,7 +3110,7 @@ diff -urN b/go/analysis/passes/ctrlflow/BUILD.bazel c/go/analysis/passes/ctrlflo
 +    ],
 +)
 diff -urN b/go/analysis/passes/ctrlflow/testdata/src/a/BUILD.bazel c/go/analysis/passes/ctrlflow/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/ctrlflow/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/ctrlflow/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/ctrlflow/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3132,7 +3128,7 @@ diff -urN b/go/analysis/passes/ctrlflow/testdata/src/a/BUILD.bazel c/go/analysis
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/ctrlflow/testdata/src/lib/BUILD.bazel c/go/analysis/passes/ctrlflow/testdata/src/lib/BUILD.bazel
---- b/go/analysis/passes/ctrlflow/testdata/src/lib/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/ctrlflow/testdata/src/lib/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/ctrlflow/testdata/src/lib/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3150,7 +3146,7 @@ diff -urN b/go/analysis/passes/ctrlflow/testdata/src/lib/BUILD.bazel c/go/analys
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/ctrlflow/testdata/src/typeparams/BUILD.bazel c/go/analysis/passes/ctrlflow/testdata/src/typeparams/BUILD.bazel
---- b/go/analysis/passes/ctrlflow/testdata/src/typeparams/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/ctrlflow/testdata/src/typeparams/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/ctrlflow/testdata/src/typeparams/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3168,9 +3164,9 @@ diff -urN b/go/analysis/passes/ctrlflow/testdata/src/typeparams/BUILD.bazel c/go
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/deepequalerrors/BUILD.bazel c/go/analysis/passes/deepequalerrors/BUILD.bazel
---- b/go/analysis/passes/deepequalerrors/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/deepequalerrors/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/deepequalerrors/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -3196,7 +3192,6 @@ diff -urN b/go/analysis/passes/deepequalerrors/BUILD.bazel c/go/analysis/passes/
 +go_test(
 +    name = "deepequalerrors_test",
 +    srcs = ["deepequalerrors_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":deepequalerrors",
 +        "//go/analysis/analysistest",
@@ -3204,7 +3199,7 @@ diff -urN b/go/analysis/passes/deepequalerrors/BUILD.bazel c/go/analysis/passes/
 +    ],
 +)
 diff -urN b/go/analysis/passes/deepequalerrors/testdata/src/a/BUILD.bazel c/go/analysis/passes/deepequalerrors/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/deepequalerrors/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/deepequalerrors/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/deepequalerrors/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3222,7 +3217,7 @@ diff -urN b/go/analysis/passes/deepequalerrors/testdata/src/a/BUILD.bazel c/go/a
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/deepequalerrors/testdata/src/typeparams/BUILD.bazel c/go/analysis/passes/deepequalerrors/testdata/src/typeparams/BUILD.bazel
---- b/go/analysis/passes/deepequalerrors/testdata/src/typeparams/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/deepequalerrors/testdata/src/typeparams/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/deepequalerrors/testdata/src/typeparams/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3240,9 +3235,9 @@ diff -urN b/go/analysis/passes/deepequalerrors/testdata/src/typeparams/BUILD.baz
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/defers/BUILD.bazel c/go/analysis/passes/defers/BUILD.bazel
---- b/go/analysis/passes/defers/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/defers/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/defers/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,35 @@
+@@ -0,0 +1,34 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -3272,14 +3267,13 @@ diff -urN b/go/analysis/passes/defers/BUILD.bazel c/go/analysis/passes/defers/BU
 +go_test(
 +    name = "defers_test",
 +    srcs = ["defers_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":defers",
 +        "//go/analysis/analysistest",
 +    ],
 +)
 diff -urN b/go/analysis/passes/defers/cmd/defers/BUILD.bazel c/go/analysis/passes/defers/cmd/defers/BUILD.bazel
---- b/go/analysis/passes/defers/cmd/defers/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/defers/cmd/defers/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/defers/cmd/defers/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -3301,7 +3295,7 @@ diff -urN b/go/analysis/passes/defers/cmd/defers/BUILD.bazel c/go/analysis/passe
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/defers/testdata/src/a/BUILD.bazel c/go/analysis/passes/defers/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/defers/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/defers/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/defers/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3319,9 +3313,9 @@ diff -urN b/go/analysis/passes/defers/testdata/src/a/BUILD.bazel c/go/analysis/p
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/directive/BUILD.bazel c/go/analysis/passes/directive/BUILD.bazel
---- b/go/analysis/passes/directive/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/directive/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/directive/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -3344,7 +3338,6 @@ diff -urN b/go/analysis/passes/directive/BUILD.bazel c/go/analysis/passes/direct
 +go_test(
 +    name = "directive_test",
 +    srcs = ["directive_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":directive",
 +        "//go/analysis",
@@ -3352,7 +3345,7 @@ diff -urN b/go/analysis/passes/directive/BUILD.bazel c/go/analysis/passes/direct
 +    ],
 +)
 diff -urN b/go/analysis/passes/directive/testdata/src/a/BUILD.bazel c/go/analysis/passes/directive/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/directive/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/directive/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/directive/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3378,7 +3371,7 @@ diff -urN b/go/analysis/passes/directive/testdata/src/a/BUILD.bazel c/go/analysi
 +    srcs = ["misplaced_test.go"],
 +)
 diff -urN b/go/analysis/passes/errorsas/BUILD.bazel c/go/analysis/passes/errorsas/BUILD.bazel
---- b/go/analysis/passes/errorsas/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/errorsas/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/errorsas/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3413,7 +3406,7 @@ diff -urN b/go/analysis/passes/errorsas/BUILD.bazel c/go/analysis/passes/errorsa
 +    ],
 +)
 diff -urN b/go/analysis/passes/errorsas/testdata/src/a/BUILD.bazel c/go/analysis/passes/errorsas/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/errorsas/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/errorsas/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/errorsas/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3431,7 +3424,7 @@ diff -urN b/go/analysis/passes/errorsas/testdata/src/a/BUILD.bazel c/go/analysis
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/errorsas/testdata/src/typeparams/BUILD.bazel c/go/analysis/passes/errorsas/testdata/src/typeparams/BUILD.bazel
---- b/go/analysis/passes/errorsas/testdata/src/typeparams/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/errorsas/testdata/src/typeparams/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/errorsas/testdata/src/typeparams/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3449,9 +3442,9 @@ diff -urN b/go/analysis/passes/errorsas/testdata/src/typeparams/BUILD.bazel c/go
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/fieldalignment/BUILD.bazel c/go/analysis/passes/fieldalignment/BUILD.bazel
---- b/go/analysis/passes/fieldalignment/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/fieldalignment/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/fieldalignment/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -3475,14 +3468,13 @@ diff -urN b/go/analysis/passes/fieldalignment/BUILD.bazel c/go/analysis/passes/f
 +go_test(
 +    name = "fieldalignment_test",
 +    srcs = ["fieldalignment_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":fieldalignment",
 +        "//go/analysis/analysistest",
 +    ],
 +)
 diff -urN b/go/analysis/passes/fieldalignment/cmd/fieldalignment/BUILD.bazel c/go/analysis/passes/fieldalignment/cmd/fieldalignment/BUILD.bazel
---- b/go/analysis/passes/fieldalignment/cmd/fieldalignment/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/fieldalignment/cmd/fieldalignment/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/fieldalignment/cmd/fieldalignment/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -3504,7 +3496,7 @@ diff -urN b/go/analysis/passes/fieldalignment/cmd/fieldalignment/BUILD.bazel c/g
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/fieldalignment/testdata/src/a/BUILD.bazel c/go/analysis/passes/fieldalignment/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/fieldalignment/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/fieldalignment/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/fieldalignment/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3526,9 +3518,9 @@ diff -urN b/go/analysis/passes/fieldalignment/testdata/src/a/BUILD.bazel c/go/an
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/findcall/BUILD.bazel c/go/analysis/passes/findcall/BUILD.bazel
---- b/go/analysis/passes/findcall/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/findcall/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/findcall/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,25 @@
+@@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -3548,14 +3540,13 @@ diff -urN b/go/analysis/passes/findcall/BUILD.bazel c/go/analysis/passes/findcal
 +go_test(
 +    name = "findcall_test",
 +    srcs = ["findcall_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":findcall",
 +        "//go/analysis/analysistest",
 +    ],
 +)
 diff -urN b/go/analysis/passes/findcall/cmd/findcall/BUILD.bazel c/go/analysis/passes/findcall/cmd/findcall/BUILD.bazel
---- b/go/analysis/passes/findcall/cmd/findcall/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/findcall/cmd/findcall/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/findcall/cmd/findcall/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -3577,7 +3568,7 @@ diff -urN b/go/analysis/passes/findcall/cmd/findcall/BUILD.bazel c/go/analysis/p
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/findcall/testdata/src/a/BUILD.bazel c/go/analysis/passes/findcall/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/findcall/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/findcall/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/findcall/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -3595,9 +3586,9 @@ diff -urN b/go/analysis/passes/findcall/testdata/src/a/BUILD.bazel c/go/analysis
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/framepointer/BUILD.bazel c/go/analysis/passes/framepointer/BUILD.bazel
---- b/go/analysis/passes/framepointer/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/framepointer/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/framepointer/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,28 @@
+@@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -3620,14 +3611,13 @@ diff -urN b/go/analysis/passes/framepointer/BUILD.bazel c/go/analysis/passes/fra
 +go_test(
 +    name = "framepointer_test",
 +    srcs = ["framepointer_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":framepointer",
 +        "//go/analysis/analysistest",
 +    ],
 +)
 diff -urN b/go/analysis/passes/framepointer/testdata/src/a/BUILD.bazel c/go/analysis/passes/framepointer/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/framepointer/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/framepointer/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/framepointer/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3650,10 +3640,83 @@ diff -urN b/go/analysis/passes/framepointer/testdata/src/a/BUILD.bazel c/go/anal
 +    actual = ":a",
 +    visibility = ["//visibility:public"],
 +)
+diff -urN b/go/analysis/passes/httpmux/BUILD.bazel c/go/analysis/passes/httpmux/BUILD.bazel
+--- b/go/analysis/passes/httpmux/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ c/go/analysis/passes/httpmux/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,29 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "httpmux",
++    srcs = ["httpmux.go"],
++    importpath = "golang.org/x/tools/go/analysis/passes/httpmux",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//go/analysis",
++        "//go/analysis/passes/inspect",
++        "//go/analysis/passes/internal/analysisutil",
++        "//go/ast/inspector",
++        "//go/types/typeutil",
++        "@org_golang_x_mod//semver:go_default_library",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":httpmux",
++    visibility = ["//visibility:public"],
++)
++
++go_test(
++    name = "httpmux_test",
++    srcs = ["httpmux_test.go"],
++    embed = [":httpmux"],
++    deps = ["//go/analysis/analysistest"],
++)
+diff -urN b/go/analysis/passes/httpmux/cmd/httpmux/BUILD.bazel c/go/analysis/passes/httpmux/cmd/httpmux/BUILD.bazel
+--- b/go/analysis/passes/httpmux/cmd/httpmux/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ c/go/analysis/passes/httpmux/cmd/httpmux/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,18 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
++
++go_library(
++    name = "httpmux_lib",
++    srcs = ["main.go"],
++    importpath = "golang.org/x/tools/go/analysis/passes/httpmux/cmd/httpmux",
++    visibility = ["//visibility:private"],
++    deps = [
++        "//go/analysis/passes/httpmux",
++        "//go/analysis/singlechecker",
++    ],
++)
++
++go_binary(
++    name = "httpmux",
++    embed = [":httpmux_lib"],
++    visibility = ["//visibility:public"],
++)
+diff -urN b/go/analysis/passes/httpmux/testdata/src/a/BUILD.bazel c/go/analysis/passes/httpmux/testdata/src/a/BUILD.bazel
+--- b/go/analysis/passes/httpmux/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ c/go/analysis/passes/httpmux/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,14 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "a",
++    srcs = ["a.go"],
++    importpath = "golang.org/x/tools/go/analysis/passes/httpmux/testdata/src/a",
++    visibility = ["//visibility:public"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":a",
++    visibility = ["//visibility:public"],
++)
 diff -urN b/go/analysis/passes/httpresponse/BUILD.bazel c/go/analysis/passes/httpresponse/BUILD.bazel
---- b/go/analysis/passes/httpresponse/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/httpresponse/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/httpresponse/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,31 @@
+@@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -3678,7 +3741,6 @@ diff -urN b/go/analysis/passes/httpresponse/BUILD.bazel c/go/analysis/passes/htt
 +go_test(
 +    name = "httpresponse_test",
 +    srcs = ["httpresponse_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":httpresponse",
 +        "//go/analysis/analysistest",
@@ -3686,7 +3748,7 @@ diff -urN b/go/analysis/passes/httpresponse/BUILD.bazel c/go/analysis/passes/htt
 +    ],
 +)
 diff -urN b/go/analysis/passes/httpresponse/testdata/src/a/BUILD.bazel c/go/analysis/passes/httpresponse/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/httpresponse/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/httpresponse/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/httpresponse/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3704,7 +3766,7 @@ diff -urN b/go/analysis/passes/httpresponse/testdata/src/a/BUILD.bazel c/go/anal
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/httpresponse/testdata/src/typeparams/BUILD.bazel c/go/analysis/passes/httpresponse/testdata/src/typeparams/BUILD.bazel
---- b/go/analysis/passes/httpresponse/testdata/src/typeparams/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/httpresponse/testdata/src/typeparams/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/httpresponse/testdata/src/typeparams/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3722,9 +3784,9 @@ diff -urN b/go/analysis/passes/httpresponse/testdata/src/typeparams/BUILD.bazel 
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/ifaceassert/BUILD.bazel c/go/analysis/passes/ifaceassert/BUILD.bazel
---- b/go/analysis/passes/ifaceassert/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/ifaceassert/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/ifaceassert/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,37 @@
+@@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -3755,7 +3817,6 @@ diff -urN b/go/analysis/passes/ifaceassert/BUILD.bazel c/go/analysis/passes/ifac
 +go_test(
 +    name = "ifaceassert_test",
 +    srcs = ["ifaceassert_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":ifaceassert",
 +        "//go/analysis/analysistest",
@@ -3763,7 +3824,7 @@ diff -urN b/go/analysis/passes/ifaceassert/BUILD.bazel c/go/analysis/passes/ifac
 +    ],
 +)
 diff -urN b/go/analysis/passes/ifaceassert/cmd/ifaceassert/BUILD.bazel c/go/analysis/passes/ifaceassert/cmd/ifaceassert/BUILD.bazel
---- b/go/analysis/passes/ifaceassert/cmd/ifaceassert/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/ifaceassert/cmd/ifaceassert/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/ifaceassert/cmd/ifaceassert/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -3785,7 +3846,7 @@ diff -urN b/go/analysis/passes/ifaceassert/cmd/ifaceassert/BUILD.bazel c/go/anal
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/ifaceassert/testdata/src/a/BUILD.bazel c/go/analysis/passes/ifaceassert/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/ifaceassert/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/ifaceassert/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/ifaceassert/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3803,7 +3864,7 @@ diff -urN b/go/analysis/passes/ifaceassert/testdata/src/a/BUILD.bazel c/go/analy
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/ifaceassert/testdata/src/typeparams/BUILD.bazel c/go/analysis/passes/ifaceassert/testdata/src/typeparams/BUILD.bazel
---- b/go/analysis/passes/ifaceassert/testdata/src/typeparams/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/ifaceassert/testdata/src/typeparams/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/ifaceassert/testdata/src/typeparams/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3821,7 +3882,7 @@ diff -urN b/go/analysis/passes/ifaceassert/testdata/src/typeparams/BUILD.bazel c
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/inspect/BUILD.bazel c/go/analysis/passes/inspect/BUILD.bazel
---- b/go/analysis/passes/inspect/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/inspect/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/inspect/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3843,7 +3904,7 @@ diff -urN b/go/analysis/passes/inspect/BUILD.bazel c/go/analysis/passes/inspect/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/internal/analysisutil/BUILD.bazel c/go/analysis/passes/internal/analysisutil/BUILD.bazel
---- b/go/analysis/passes/internal/analysisutil/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/internal/analysisutil/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/internal/analysisutil/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,29 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -3876,9 +3937,9 @@ diff -urN b/go/analysis/passes/internal/analysisutil/BUILD.bazel c/go/analysis/p
 +    ],
 +)
 diff -urN b/go/analysis/passes/loopclosure/BUILD.bazel c/go/analysis/passes/loopclosure/BUILD.bazel
---- b/go/analysis/passes/loopclosure/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/loopclosure/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/loopclosure/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,36 @@
+@@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -3908,7 +3969,6 @@ diff -urN b/go/analysis/passes/loopclosure/BUILD.bazel c/go/analysis/passes/loop
 +go_test(
 +    name = "loopclosure_test",
 +    srcs = ["loopclosure_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":loopclosure",
 +        "//go/analysis/analysistest",
@@ -3916,7 +3976,7 @@ diff -urN b/go/analysis/passes/loopclosure/BUILD.bazel c/go/analysis/passes/loop
 +    ],
 +)
 diff -urN b/go/analysis/passes/loopclosure/testdata/src/a/BUILD.bazel c/go/analysis/passes/loopclosure/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/loopclosure/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/loopclosure/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/loopclosure/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3938,7 +3998,7 @@ diff -urN b/go/analysis/passes/loopclosure/testdata/src/a/BUILD.bazel c/go/analy
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/loopclosure/testdata/src/golang.org/x/sync/errgroup/BUILD.bazel c/go/analysis/passes/loopclosure/testdata/src/golang.org/x/sync/errgroup/BUILD.bazel
---- b/go/analysis/passes/loopclosure/testdata/src/golang.org/x/sync/errgroup/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/loopclosure/testdata/src/golang.org/x/sync/errgroup/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/loopclosure/testdata/src/golang.org/x/sync/errgroup/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3956,7 +4016,7 @@ diff -urN b/go/analysis/passes/loopclosure/testdata/src/golang.org/x/sync/errgro
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/loopclosure/testdata/src/subtests/BUILD.bazel c/go/analysis/passes/loopclosure/testdata/src/subtests/BUILD.bazel
---- b/go/analysis/passes/loopclosure/testdata/src/subtests/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/loopclosure/testdata/src/subtests/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/loopclosure/testdata/src/subtests/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3974,7 +4034,7 @@ diff -urN b/go/analysis/passes/loopclosure/testdata/src/subtests/BUILD.bazel c/g
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/loopclosure/testdata/src/typeparams/BUILD.bazel c/go/analysis/passes/loopclosure/testdata/src/typeparams/BUILD.bazel
---- b/go/analysis/passes/loopclosure/testdata/src/typeparams/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/loopclosure/testdata/src/typeparams/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/loopclosure/testdata/src/typeparams/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -3993,9 +4053,9 @@ diff -urN b/go/analysis/passes/loopclosure/testdata/src/typeparams/BUILD.bazel c
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/lostcancel/BUILD.bazel c/go/analysis/passes/lostcancel/BUILD.bazel
---- b/go/analysis/passes/lostcancel/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/lostcancel/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/lostcancel/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,37 @@
+@@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -4026,7 +4086,6 @@ diff -urN b/go/analysis/passes/lostcancel/BUILD.bazel c/go/analysis/passes/lostc
 +go_test(
 +    name = "lostcancel_test",
 +    srcs = ["lostcancel_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":lostcancel",
 +        "//go/analysis/analysistest",
@@ -4034,7 +4093,7 @@ diff -urN b/go/analysis/passes/lostcancel/BUILD.bazel c/go/analysis/passes/lostc
 +    ],
 +)
 diff -urN b/go/analysis/passes/lostcancel/cmd/lostcancel/BUILD.bazel c/go/analysis/passes/lostcancel/cmd/lostcancel/BUILD.bazel
---- b/go/analysis/passes/lostcancel/cmd/lostcancel/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/lostcancel/cmd/lostcancel/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/lostcancel/cmd/lostcancel/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -4056,7 +4115,7 @@ diff -urN b/go/analysis/passes/lostcancel/cmd/lostcancel/BUILD.bazel c/go/analys
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/lostcancel/testdata/src/a/BUILD.bazel c/go/analysis/passes/lostcancel/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/lostcancel/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/lostcancel/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/lostcancel/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4074,7 +4133,7 @@ diff -urN b/go/analysis/passes/lostcancel/testdata/src/a/BUILD.bazel c/go/analys
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/lostcancel/testdata/src/b/BUILD.bazel c/go/analysis/passes/lostcancel/testdata/src/b/BUILD.bazel
---- b/go/analysis/passes/lostcancel/testdata/src/b/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/lostcancel/testdata/src/b/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/lostcancel/testdata/src/b/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -4092,7 +4151,7 @@ diff -urN b/go/analysis/passes/lostcancel/testdata/src/b/BUILD.bazel c/go/analys
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/lostcancel/testdata/src/typeparams/BUILD.bazel c/go/analysis/passes/lostcancel/testdata/src/typeparams/BUILD.bazel
---- b/go/analysis/passes/lostcancel/testdata/src/typeparams/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/lostcancel/testdata/src/typeparams/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/lostcancel/testdata/src/typeparams/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4110,7 +4169,7 @@ diff -urN b/go/analysis/passes/lostcancel/testdata/src/typeparams/BUILD.bazel c/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/nilfunc/BUILD.bazel c/go/analysis/passes/nilfunc/BUILD.bazel
---- b/go/analysis/passes/nilfunc/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/nilfunc/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/nilfunc/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4149,7 +4208,7 @@ diff -urN b/go/analysis/passes/nilfunc/BUILD.bazel c/go/analysis/passes/nilfunc/
 +    ],
 +)
 diff -urN b/go/analysis/passes/nilfunc/testdata/src/a/BUILD.bazel c/go/analysis/passes/nilfunc/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/nilfunc/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/nilfunc/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/nilfunc/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4167,7 +4226,7 @@ diff -urN b/go/analysis/passes/nilfunc/testdata/src/a/BUILD.bazel c/go/analysis/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/nilfunc/testdata/src/typeparams/BUILD.bazel c/go/analysis/passes/nilfunc/testdata/src/typeparams/BUILD.bazel
---- b/go/analysis/passes/nilfunc/testdata/src/typeparams/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/nilfunc/testdata/src/typeparams/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/nilfunc/testdata/src/typeparams/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4185,7 +4244,7 @@ diff -urN b/go/analysis/passes/nilfunc/testdata/src/typeparams/BUILD.bazel c/go/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/nilness/BUILD.bazel c/go/analysis/passes/nilness/BUILD.bazel
---- b/go/analysis/passes/nilness/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/nilness/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/nilness/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4227,7 +4286,7 @@ diff -urN b/go/analysis/passes/nilness/BUILD.bazel c/go/analysis/passes/nilness/
 +    ],
 +)
 diff -urN b/go/analysis/passes/nilness/cmd/nilness/BUILD.bazel c/go/analysis/passes/nilness/cmd/nilness/BUILD.bazel
---- b/go/analysis/passes/nilness/cmd/nilness/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/nilness/cmd/nilness/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/nilness/cmd/nilness/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -4249,7 +4308,7 @@ diff -urN b/go/analysis/passes/nilness/cmd/nilness/BUILD.bazel c/go/analysis/pas
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/nilness/testdata/src/a/BUILD.bazel c/go/analysis/passes/nilness/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/nilness/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/nilness/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/nilness/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4267,7 +4326,7 @@ diff -urN b/go/analysis/passes/nilness/testdata/src/a/BUILD.bazel c/go/analysis/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/nilness/testdata/src/b/BUILD.bazel c/go/analysis/passes/nilness/testdata/src/b/BUILD.bazel
---- b/go/analysis/passes/nilness/testdata/src/b/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/nilness/testdata/src/b/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/nilness/testdata/src/b/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4285,7 +4344,7 @@ diff -urN b/go/analysis/passes/nilness/testdata/src/b/BUILD.bazel c/go/analysis/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/nilness/testdata/src/c/BUILD.bazel c/go/analysis/passes/nilness/testdata/src/c/BUILD.bazel
---- b/go/analysis/passes/nilness/testdata/src/c/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/nilness/testdata/src/c/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/nilness/testdata/src/c/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4303,7 +4362,7 @@ diff -urN b/go/analysis/passes/nilness/testdata/src/c/BUILD.bazel c/go/analysis/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/nilness/testdata/src/d/BUILD.bazel c/go/analysis/passes/nilness/testdata/src/d/BUILD.bazel
---- b/go/analysis/passes/nilness/testdata/src/d/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/nilness/testdata/src/d/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/nilness/testdata/src/d/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4321,7 +4380,7 @@ diff -urN b/go/analysis/passes/nilness/testdata/src/d/BUILD.bazel c/go/analysis/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/pkgfact/BUILD.bazel c/go/analysis/passes/pkgfact/BUILD.bazel
---- b/go/analysis/passes/pkgfact/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/pkgfact/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/pkgfact/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4349,7 +4408,7 @@ diff -urN b/go/analysis/passes/pkgfact/BUILD.bazel c/go/analysis/passes/pkgfact/
 +    ],
 +)
 diff -urN b/go/analysis/passes/pkgfact/testdata/src/a/BUILD.bazel c/go/analysis/passes/pkgfact/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/pkgfact/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/pkgfact/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/pkgfact/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4367,7 +4426,7 @@ diff -urN b/go/analysis/passes/pkgfact/testdata/src/a/BUILD.bazel c/go/analysis/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/pkgfact/testdata/src/b/BUILD.bazel c/go/analysis/passes/pkgfact/testdata/src/b/BUILD.bazel
---- b/go/analysis/passes/pkgfact/testdata/src/b/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/pkgfact/testdata/src/b/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/pkgfact/testdata/src/b/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4385,7 +4444,7 @@ diff -urN b/go/analysis/passes/pkgfact/testdata/src/b/BUILD.bazel c/go/analysis/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/pkgfact/testdata/src/c/BUILD.bazel c/go/analysis/passes/pkgfact/testdata/src/c/BUILD.bazel
---- b/go/analysis/passes/pkgfact/testdata/src/c/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/pkgfact/testdata/src/c/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/pkgfact/testdata/src/c/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4403,7 +4462,7 @@ diff -urN b/go/analysis/passes/pkgfact/testdata/src/c/BUILD.bazel c/go/analysis/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/printf/BUILD.bazel c/go/analysis/passes/printf/BUILD.bazel
---- b/go/analysis/passes/printf/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/printf/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/printf/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4445,7 +4504,7 @@ diff -urN b/go/analysis/passes/printf/BUILD.bazel c/go/analysis/passes/printf/BU
 +    ],
 +)
 diff -urN b/go/analysis/passes/printf/testdata/src/a/BUILD.bazel c/go/analysis/passes/printf/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/printf/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/printf/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/printf/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4463,7 +4522,7 @@ diff -urN b/go/analysis/passes/printf/testdata/src/a/BUILD.bazel c/go/analysis/p
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/printf/testdata/src/b/BUILD.bazel c/go/analysis/passes/printf/testdata/src/b/BUILD.bazel
---- b/go/analysis/passes/printf/testdata/src/b/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/printf/testdata/src/b/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/printf/testdata/src/b/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4481,7 +4540,7 @@ diff -urN b/go/analysis/passes/printf/testdata/src/b/BUILD.bazel c/go/analysis/p
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/printf/testdata/src/nofmt/BUILD.bazel c/go/analysis/passes/printf/testdata/src/nofmt/BUILD.bazel
---- b/go/analysis/passes/printf/testdata/src/nofmt/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/printf/testdata/src/nofmt/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/printf/testdata/src/nofmt/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4499,7 +4558,7 @@ diff -urN b/go/analysis/passes/printf/testdata/src/nofmt/BUILD.bazel c/go/analys
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/printf/testdata/src/typeparams/BUILD.bazel c/go/analysis/passes/printf/testdata/src/typeparams/BUILD.bazel
---- b/go/analysis/passes/printf/testdata/src/typeparams/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/printf/testdata/src/typeparams/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/printf/testdata/src/typeparams/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4520,7 +4579,7 @@ diff -urN b/go/analysis/passes/printf/testdata/src/typeparams/BUILD.bazel c/go/a
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/reflectvaluecompare/BUILD.bazel c/go/analysis/passes/reflectvaluecompare/BUILD.bazel
---- b/go/analysis/passes/reflectvaluecompare/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/reflectvaluecompare/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/reflectvaluecompare/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,34 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4558,7 +4617,7 @@ diff -urN b/go/analysis/passes/reflectvaluecompare/BUILD.bazel c/go/analysis/pas
 +    ],
 +)
 diff -urN b/go/analysis/passes/reflectvaluecompare/testdata/src/a/BUILD.bazel c/go/analysis/passes/reflectvaluecompare/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/reflectvaluecompare/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/reflectvaluecompare/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/reflectvaluecompare/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4576,7 +4635,7 @@ diff -urN b/go/analysis/passes/reflectvaluecompare/testdata/src/a/BUILD.bazel c/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/shadow/BUILD.bazel c/go/analysis/passes/shadow/BUILD.bazel
---- b/go/analysis/passes/shadow/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/shadow/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/shadow/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4613,7 +4672,7 @@ diff -urN b/go/analysis/passes/shadow/BUILD.bazel c/go/analysis/passes/shadow/BU
 +    ],
 +)
 diff -urN b/go/analysis/passes/shadow/cmd/shadow/BUILD.bazel c/go/analysis/passes/shadow/cmd/shadow/BUILD.bazel
---- b/go/analysis/passes/shadow/cmd/shadow/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/shadow/cmd/shadow/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/shadow/cmd/shadow/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -4635,7 +4694,7 @@ diff -urN b/go/analysis/passes/shadow/cmd/shadow/BUILD.bazel c/go/analysis/passe
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/shadow/testdata/src/a/BUILD.bazel c/go/analysis/passes/shadow/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/shadow/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/shadow/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/shadow/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4653,7 +4712,7 @@ diff -urN b/go/analysis/passes/shadow/testdata/src/a/BUILD.bazel c/go/analysis/p
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/shift/BUILD.bazel c/go/analysis/passes/shift/BUILD.bazel
---- b/go/analysis/passes/shift/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/shift/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/shift/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,34 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4691,7 +4750,7 @@ diff -urN b/go/analysis/passes/shift/BUILD.bazel c/go/analysis/passes/shift/BUIL
 +    ],
 +)
 diff -urN b/go/analysis/passes/shift/testdata/src/a/BUILD.bazel c/go/analysis/passes/shift/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/shift/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/shift/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/shift/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4709,7 +4768,7 @@ diff -urN b/go/analysis/passes/shift/testdata/src/a/BUILD.bazel c/go/analysis/pa
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/shift/testdata/src/typeparams/BUILD.bazel c/go/analysis/passes/shift/testdata/src/typeparams/BUILD.bazel
---- b/go/analysis/passes/shift/testdata/src/typeparams/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/shift/testdata/src/typeparams/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/shift/testdata/src/typeparams/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4727,7 +4786,7 @@ diff -urN b/go/analysis/passes/shift/testdata/src/typeparams/BUILD.bazel c/go/an
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/sigchanyzer/BUILD.bazel c/go/analysis/passes/sigchanyzer/BUILD.bazel
---- b/go/analysis/passes/sigchanyzer/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/sigchanyzer/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/sigchanyzer/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4764,7 +4823,7 @@ diff -urN b/go/analysis/passes/sigchanyzer/BUILD.bazel c/go/analysis/passes/sigc
 +    ],
 +)
 diff -urN b/go/analysis/passes/sigchanyzer/testdata/src/a/BUILD.bazel c/go/analysis/passes/sigchanyzer/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/sigchanyzer/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/sigchanyzer/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/sigchanyzer/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4782,7 +4841,7 @@ diff -urN b/go/analysis/passes/sigchanyzer/testdata/src/a/BUILD.bazel c/go/analy
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/slog/BUILD.bazel c/go/analysis/passes/slog/BUILD.bazel
---- b/go/analysis/passes/slog/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/slog/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/slog/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4821,7 +4880,7 @@ diff -urN b/go/analysis/passes/slog/BUILD.bazel c/go/analysis/passes/slog/BUILD.
 +    ],
 +)
 diff -urN b/go/analysis/passes/slog/testdata/src/a/BUILD.bazel c/go/analysis/passes/slog/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/slog/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/slog/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/slog/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4839,7 +4898,7 @@ diff -urN b/go/analysis/passes/slog/testdata/src/a/BUILD.bazel c/go/analysis/pas
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/slog/testdata/src/b/BUILD.bazel c/go/analysis/passes/slog/testdata/src/b/BUILD.bazel
---- b/go/analysis/passes/slog/testdata/src/b/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/slog/testdata/src/b/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/slog/testdata/src/b/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4857,7 +4916,7 @@ diff -urN b/go/analysis/passes/slog/testdata/src/b/BUILD.bazel c/go/analysis/pas
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/sortslice/BUILD.bazel c/go/analysis/passes/sortslice/BUILD.bazel
---- b/go/analysis/passes/sortslice/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/sortslice/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/sortslice/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -4891,7 +4950,7 @@ diff -urN b/go/analysis/passes/sortslice/BUILD.bazel c/go/analysis/passes/sortsl
 +    ],
 +)
 diff -urN b/go/analysis/passes/sortslice/testdata/src/a/BUILD.bazel c/go/analysis/passes/sortslice/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/sortslice/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/sortslice/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/sortslice/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4909,9 +4968,9 @@ diff -urN b/go/analysis/passes/sortslice/testdata/src/a/BUILD.bazel c/go/analysi
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/stdmethods/BUILD.bazel c/go/analysis/passes/stdmethods/BUILD.bazel
---- b/go/analysis/passes/stdmethods/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/stdmethods/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/stdmethods/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,35 @@
+@@ -0,0 +1,34 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -4940,7 +4999,6 @@ diff -urN b/go/analysis/passes/stdmethods/BUILD.bazel c/go/analysis/passes/stdme
 +go_test(
 +    name = "stdmethods_test",
 +    srcs = ["stdmethods_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":stdmethods",
 +        "//go/analysis/analysistest",
@@ -4948,7 +5006,7 @@ diff -urN b/go/analysis/passes/stdmethods/BUILD.bazel c/go/analysis/passes/stdme
 +    ],
 +)
 diff -urN b/go/analysis/passes/stdmethods/testdata/src/a/BUILD.bazel c/go/analysis/passes/stdmethods/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/stdmethods/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/stdmethods/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/stdmethods/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4969,7 +5027,7 @@ diff -urN b/go/analysis/passes/stdmethods/testdata/src/a/BUILD.bazel c/go/analys
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/stdmethods/testdata/src/typeparams/BUILD.bazel c/go/analysis/passes/stdmethods/testdata/src/typeparams/BUILD.bazel
---- b/go/analysis/passes/stdmethods/testdata/src/typeparams/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/stdmethods/testdata/src/typeparams/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/stdmethods/testdata/src/typeparams/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -4987,9 +5045,9 @@ diff -urN b/go/analysis/passes/stdmethods/testdata/src/typeparams/BUILD.bazel c/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/stringintconv/BUILD.bazel c/go/analysis/passes/stringintconv/BUILD.bazel
---- b/go/analysis/passes/stringintconv/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/stringintconv/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/stringintconv/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,36 @@
+@@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -5019,7 +5077,6 @@ diff -urN b/go/analysis/passes/stringintconv/BUILD.bazel c/go/analysis/passes/st
 +go_test(
 +    name = "stringintconv_test",
 +    srcs = ["string_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":stringintconv",
 +        "//go/analysis/analysistest",
@@ -5027,7 +5084,7 @@ diff -urN b/go/analysis/passes/stringintconv/BUILD.bazel c/go/analysis/passes/st
 +    ],
 +)
 diff -urN b/go/analysis/passes/stringintconv/cmd/stringintconv/BUILD.bazel c/go/analysis/passes/stringintconv/cmd/stringintconv/BUILD.bazel
---- b/go/analysis/passes/stringintconv/cmd/stringintconv/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/stringintconv/cmd/stringintconv/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/stringintconv/cmd/stringintconv/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -5049,7 +5106,7 @@ diff -urN b/go/analysis/passes/stringintconv/cmd/stringintconv/BUILD.bazel c/go/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/stringintconv/testdata/src/a/BUILD.bazel c/go/analysis/passes/stringintconv/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/stringintconv/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/stringintconv/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/stringintconv/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5067,7 +5124,7 @@ diff -urN b/go/analysis/passes/stringintconv/testdata/src/a/BUILD.bazel c/go/ana
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/stringintconv/testdata/src/typeparams/BUILD.bazel c/go/analysis/passes/stringintconv/testdata/src/typeparams/BUILD.bazel
---- b/go/analysis/passes/stringintconv/testdata/src/typeparams/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/stringintconv/testdata/src/typeparams/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/stringintconv/testdata/src/typeparams/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5085,9 +5142,9 @@ diff -urN b/go/analysis/passes/stringintconv/testdata/src/typeparams/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/structtag/BUILD.bazel c/go/analysis/passes/structtag/BUILD.bazel
---- b/go/analysis/passes/structtag/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/structtag/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/structtag/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -5111,32 +5168,13 @@ diff -urN b/go/analysis/passes/structtag/BUILD.bazel c/go/analysis/passes/struct
 +go_test(
 +    name = "structtag_test",
 +    srcs = ["structtag_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":structtag",
 +        "//go/analysis/analysistest",
 +    ],
 +)
-diff -urN b/go/analysis/passes/structtag/testdata/src/a/BUILD.bazel c/go/analysis/passes/structtag/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/structtag/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
-+++ c/go/analysis/passes/structtag/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,14 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "a",
-+    srcs = ["a.go"],
-+    importpath = "golang.org/x/tools/go/analysis/passes/structtag/testdata/src/a",
-+    visibility = ["//visibility:public"],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":a",
-+    visibility = ["//visibility:public"],
-+)
 diff -urN b/go/analysis/passes/structtag/testdata/src/a/b/BUILD.bazel c/go/analysis/passes/structtag/testdata/src/a/b/BUILD.bazel
---- b/go/analysis/passes/structtag/testdata/src/a/b/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/structtag/testdata/src/a/b/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/structtag/testdata/src/a/b/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5153,10 +5191,28 @@ diff -urN b/go/analysis/passes/structtag/testdata/src/a/b/BUILD.bazel c/go/analy
 +    actual = ":b",
 +    visibility = ["//visibility:public"],
 +)
+diff -urN b/go/analysis/passes/structtag/testdata/src/a/BUILD.bazel c/go/analysis/passes/structtag/testdata/src/a/BUILD.bazel
+--- b/go/analysis/passes/structtag/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ c/go/analysis/passes/structtag/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,14 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "a",
++    srcs = ["a.go"],
++    importpath = "golang.org/x/tools/go/analysis/passes/structtag/testdata/src/a",
++    visibility = ["//visibility:public"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":a",
++    visibility = ["//visibility:public"],
++)
 diff -urN b/go/analysis/passes/testinggoroutine/BUILD.bazel c/go/analysis/passes/testinggoroutine/BUILD.bazel
---- b/go/analysis/passes/testinggoroutine/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/testinggoroutine/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/testinggoroutine/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,36 @@
+@@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -5186,7 +5242,6 @@ diff -urN b/go/analysis/passes/testinggoroutine/BUILD.bazel c/go/analysis/passes
 +go_test(
 +    name = "testinggoroutine_test",
 +    srcs = ["testinggoroutine_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":testinggoroutine",
 +        "//go/analysis/analysistest",
@@ -5194,7 +5249,7 @@ diff -urN b/go/analysis/passes/testinggoroutine/BUILD.bazel c/go/analysis/passes
 +    ],
 +)
 diff -urN b/go/analysis/passes/testinggoroutine/testdata/src/a/BUILD.bazel c/go/analysis/passes/testinggoroutine/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/testinggoroutine/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/testinggoroutine/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/testinggoroutine/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5215,7 +5270,7 @@ diff -urN b/go/analysis/passes/testinggoroutine/testdata/src/a/BUILD.bazel c/go/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/testinggoroutine/testdata/src/typeparams/BUILD.bazel c/go/analysis/passes/testinggoroutine/testdata/src/typeparams/BUILD.bazel
---- b/go/analysis/passes/testinggoroutine/testdata/src/typeparams/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/testinggoroutine/testdata/src/typeparams/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/testinggoroutine/testdata/src/typeparams/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5233,9 +5288,9 @@ diff -urN b/go/analysis/passes/testinggoroutine/testdata/src/typeparams/BUILD.ba
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/tests/BUILD.bazel c/go/analysis/passes/tests/BUILD.bazel
---- b/go/analysis/passes/tests/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/tests/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/tests/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -5263,7 +5318,6 @@ diff -urN b/go/analysis/passes/tests/BUILD.bazel c/go/analysis/passes/tests/BUIL
 +go_test(
 +    name = "tests_test",
 +    srcs = ["tests_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":tests",
 +        "//go/analysis/analysistest",
@@ -5271,7 +5325,7 @@ diff -urN b/go/analysis/passes/tests/BUILD.bazel c/go/analysis/passes/tests/BUIL
 +    ],
 +)
 diff -urN b/go/analysis/passes/tests/testdata/src/a/BUILD.bazel c/go/analysis/passes/tests/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/tests/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/tests/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/tests/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -5299,7 +5353,7 @@ diff -urN b/go/analysis/passes/tests/testdata/src/a/BUILD.bazel c/go/analysis/pa
 +    embed = [":a"],
 +)
 diff -urN b/go/analysis/passes/tests/testdata/src/b/BUILD.bazel c/go/analysis/passes/tests/testdata/src/b/BUILD.bazel
---- b/go/analysis/passes/tests/testdata/src/b/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/tests/testdata/src/b/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/tests/testdata/src/b/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5317,7 +5371,7 @@ diff -urN b/go/analysis/passes/tests/testdata/src/b/BUILD.bazel c/go/analysis/pa
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/tests/testdata/src/b_x_test/BUILD.bazel c/go/analysis/passes/tests/testdata/src/b_x_test/BUILD.bazel
---- b/go/analysis/passes/tests/testdata/src/b_x_test/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/tests/testdata/src/b_x_test/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/tests/testdata/src/b_x_test/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,6 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_test")
@@ -5327,7 +5381,7 @@ diff -urN b/go/analysis/passes/tests/testdata/src/b_x_test/BUILD.bazel c/go/anal
 +    srcs = ["b_test.go"],
 +)
 diff -urN b/go/analysis/passes/tests/testdata/src/divergent/BUILD.bazel c/go/analysis/passes/tests/testdata/src/divergent/BUILD.bazel
---- b/go/analysis/passes/tests/testdata/src/divergent/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/tests/testdata/src/divergent/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/tests/testdata/src/divergent/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -5351,7 +5405,7 @@ diff -urN b/go/analysis/passes/tests/testdata/src/divergent/BUILD.bazel c/go/ana
 +    embed = [":divergent"],
 +)
 diff -urN b/go/analysis/passes/tests/testdata/src/typeparams/BUILD.bazel c/go/analysis/passes/tests/testdata/src/typeparams/BUILD.bazel
---- b/go/analysis/passes/tests/testdata/src/typeparams/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/tests/testdata/src/typeparams/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/tests/testdata/src/typeparams/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -5375,9 +5429,9 @@ diff -urN b/go/analysis/passes/tests/testdata/src/typeparams/BUILD.bazel c/go/an
 +    embed = [":typeparams"],
 +)
 diff -urN b/go/analysis/passes/timeformat/BUILD.bazel c/go/analysis/passes/timeformat/BUILD.bazel
---- b/go/analysis/passes/timeformat/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/timeformat/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/timeformat/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,35 @@
+@@ -0,0 +1,34 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -5407,14 +5461,13 @@ diff -urN b/go/analysis/passes/timeformat/BUILD.bazel c/go/analysis/passes/timef
 +go_test(
 +    name = "timeformat_test",
 +    srcs = ["timeformat_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":timeformat",
 +        "//go/analysis/analysistest",
 +    ],
 +)
 diff -urN b/go/analysis/passes/timeformat/testdata/src/a/BUILD.bazel c/go/analysis/passes/timeformat/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/timeformat/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/timeformat/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/timeformat/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5432,7 +5485,7 @@ diff -urN b/go/analysis/passes/timeformat/testdata/src/a/BUILD.bazel c/go/analys
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/timeformat/testdata/src/b/BUILD.bazel c/go/analysis/passes/timeformat/testdata/src/b/BUILD.bazel
---- b/go/analysis/passes/timeformat/testdata/src/b/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/timeformat/testdata/src/b/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/timeformat/testdata/src/b/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5450,9 +5503,9 @@ diff -urN b/go/analysis/passes/timeformat/testdata/src/b/BUILD.bazel c/go/analys
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/unmarshal/BUILD.bazel c/go/analysis/passes/unmarshal/BUILD.bazel
---- b/go/analysis/passes/unmarshal/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/unmarshal/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/unmarshal/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,37 @@
+@@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -5483,7 +5536,6 @@ diff -urN b/go/analysis/passes/unmarshal/BUILD.bazel c/go/analysis/passes/unmars
 +go_test(
 +    name = "unmarshal_test",
 +    srcs = ["unmarshal_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":unmarshal",
 +        "//go/analysis/analysistest",
@@ -5491,7 +5543,7 @@ diff -urN b/go/analysis/passes/unmarshal/BUILD.bazel c/go/analysis/passes/unmars
 +    ],
 +)
 diff -urN b/go/analysis/passes/unmarshal/cmd/unmarshal/BUILD.bazel c/go/analysis/passes/unmarshal/cmd/unmarshal/BUILD.bazel
---- b/go/analysis/passes/unmarshal/cmd/unmarshal/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/unmarshal/cmd/unmarshal/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/unmarshal/cmd/unmarshal/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -5513,7 +5565,7 @@ diff -urN b/go/analysis/passes/unmarshal/cmd/unmarshal/BUILD.bazel c/go/analysis
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/unmarshal/testdata/src/a/BUILD.bazel c/go/analysis/passes/unmarshal/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/unmarshal/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/unmarshal/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/unmarshal/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5531,7 +5583,7 @@ diff -urN b/go/analysis/passes/unmarshal/testdata/src/a/BUILD.bazel c/go/analysi
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/unmarshal/testdata/src/typeparams/BUILD.bazel c/go/analysis/passes/unmarshal/testdata/src/typeparams/BUILD.bazel
---- b/go/analysis/passes/unmarshal/testdata/src/typeparams/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/unmarshal/testdata/src/typeparams/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/unmarshal/testdata/src/typeparams/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5549,9 +5601,9 @@ diff -urN b/go/analysis/passes/unmarshal/testdata/src/typeparams/BUILD.bazel c/g
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/unreachable/BUILD.bazel c/go/analysis/passes/unreachable/BUILD.bazel
---- b/go/analysis/passes/unreachable/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/unreachable/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/unreachable/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -5580,14 +5632,13 @@ diff -urN b/go/analysis/passes/unreachable/BUILD.bazel c/go/analysis/passes/unre
 +go_test(
 +    name = "unreachable_test",
 +    srcs = ["unreachable_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":unreachable",
 +        "//go/analysis/analysistest",
 +    ],
 +)
 diff -urN b/go/analysis/passes/unreachable/testdata/src/a/BUILD.bazel c/go/analysis/passes/unreachable/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/unreachable/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/unreachable/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/unreachable/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5605,7 +5656,7 @@ diff -urN b/go/analysis/passes/unreachable/testdata/src/a/BUILD.bazel c/go/analy
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/unsafeptr/BUILD.bazel c/go/analysis/passes/unsafeptr/BUILD.bazel
---- b/go/analysis/passes/unsafeptr/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/unsafeptr/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/unsafeptr/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -5623,6 +5674,7 @@ diff -urN b/go/analysis/passes/unsafeptr/BUILD.bazel c/go/analysis/passes/unsafe
 +        "//go/analysis",
 +        "//go/analysis/passes/inspect",
 +        "//go/analysis/passes/internal/analysisutil",
++        "//go/ast/astutil",
 +        "//go/ast/inspector",
 +    ],
 +)
@@ -5636,7 +5688,6 @@ diff -urN b/go/analysis/passes/unsafeptr/BUILD.bazel c/go/analysis/passes/unsafe
 +go_test(
 +    name = "unsafeptr_test",
 +    srcs = ["unsafeptr_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":unsafeptr",
 +        "//go/analysis/analysistest",
@@ -5644,7 +5695,7 @@ diff -urN b/go/analysis/passes/unsafeptr/BUILD.bazel c/go/analysis/passes/unsafe
 +    ],
 +)
 diff -urN b/go/analysis/passes/unsafeptr/testdata/src/a/BUILD.bazel c/go/analysis/passes/unsafeptr/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/unsafeptr/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/unsafeptr/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/unsafeptr/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5665,7 +5716,7 @@ diff -urN b/go/analysis/passes/unsafeptr/testdata/src/a/BUILD.bazel c/go/analysi
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/unsafeptr/testdata/src/typeparams/BUILD.bazel c/go/analysis/passes/unsafeptr/testdata/src/typeparams/BUILD.bazel
---- b/go/analysis/passes/unsafeptr/testdata/src/typeparams/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/unsafeptr/testdata/src/typeparams/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/unsafeptr/testdata/src/typeparams/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5683,7 +5734,7 @@ diff -urN b/go/analysis/passes/unsafeptr/testdata/src/typeparams/BUILD.bazel c/g
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/unusedresult/BUILD.bazel c/go/analysis/passes/unusedresult/BUILD.bazel
---- b/go/analysis/passes/unusedresult/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/unusedresult/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/unusedresult/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -5701,6 +5752,7 @@ diff -urN b/go/analysis/passes/unusedresult/BUILD.bazel c/go/analysis/passes/unu
 +        "//go/analysis",
 +        "//go/analysis/passes/inspect",
 +        "//go/analysis/passes/internal/analysisutil",
++        "//go/ast/astutil",
 +        "//go/ast/inspector",
 +        "//go/types/typeutil",
 +    ],
@@ -5715,7 +5767,6 @@ diff -urN b/go/analysis/passes/unusedresult/BUILD.bazel c/go/analysis/passes/unu
 +go_test(
 +    name = "unusedresult_test",
 +    srcs = ["unusedresult_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":unusedresult",
 +        "//go/analysis/analysistest",
@@ -5723,7 +5774,7 @@ diff -urN b/go/analysis/passes/unusedresult/BUILD.bazel c/go/analysis/passes/unu
 +    ],
 +)
 diff -urN b/go/analysis/passes/unusedresult/cmd/unusedresult/BUILD.bazel c/go/analysis/passes/unusedresult/cmd/unusedresult/BUILD.bazel
---- b/go/analysis/passes/unusedresult/cmd/unusedresult/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/unusedresult/cmd/unusedresult/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/unusedresult/cmd/unusedresult/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -5745,7 +5796,7 @@ diff -urN b/go/analysis/passes/unusedresult/cmd/unusedresult/BUILD.bazel c/go/an
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/unusedresult/testdata/src/a/BUILD.bazel c/go/analysis/passes/unusedresult/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/unusedresult/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/unusedresult/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/unusedresult/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5763,7 +5814,7 @@ diff -urN b/go/analysis/passes/unusedresult/testdata/src/a/BUILD.bazel c/go/anal
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/unusedresult/testdata/src/typeparams/BUILD.bazel c/go/analysis/passes/unusedresult/testdata/src/typeparams/BUILD.bazel
---- b/go/analysis/passes/unusedresult/testdata/src/typeparams/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/unusedresult/testdata/src/typeparams/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/unusedresult/testdata/src/typeparams/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5781,7 +5832,7 @@ diff -urN b/go/analysis/passes/unusedresult/testdata/src/typeparams/BUILD.bazel 
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/unusedresult/testdata/src/typeparams/userdefs/BUILD.bazel c/go/analysis/passes/unusedresult/testdata/src/typeparams/userdefs/BUILD.bazel
---- b/go/analysis/passes/unusedresult/testdata/src/typeparams/userdefs/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/unusedresult/testdata/src/typeparams/userdefs/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/unusedresult/testdata/src/typeparams/userdefs/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5799,9 +5850,9 @@ diff -urN b/go/analysis/passes/unusedresult/testdata/src/typeparams/userdefs/BUI
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/unusedwrite/BUILD.bazel c/go/analysis/passes/unusedwrite/BUILD.bazel
---- b/go/analysis/passes/unusedwrite/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/unusedwrite/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/unusedwrite/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -5830,14 +5881,13 @@ diff -urN b/go/analysis/passes/unusedwrite/BUILD.bazel c/go/analysis/passes/unus
 +go_test(
 +    name = "unusedwrite_test",
 +    srcs = ["unusedwrite_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":unusedwrite",
 +        "//go/analysis/analysistest",
 +    ],
 +)
 diff -urN b/go/analysis/passes/unusedwrite/testdata/src/a/BUILD.bazel c/go/analysis/passes/unusedwrite/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/unusedwrite/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/unusedwrite/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/unusedwrite/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5855,9 +5905,9 @@ diff -urN b/go/analysis/passes/unusedwrite/testdata/src/a/BUILD.bazel c/go/analy
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/usesgenerics/BUILD.bazel c/go/analysis/passes/usesgenerics/BUILD.bazel
---- b/go/analysis/passes/usesgenerics/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/usesgenerics/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/usesgenerics/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,36 @@
+@@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -5887,7 +5937,6 @@ diff -urN b/go/analysis/passes/usesgenerics/BUILD.bazel c/go/analysis/passes/use
 +go_test(
 +    name = "usesgenerics_test",
 +    srcs = ["usesgenerics_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":usesgenerics",
 +        "//go/analysis/analysistest",
@@ -5895,7 +5944,7 @@ diff -urN b/go/analysis/passes/usesgenerics/BUILD.bazel c/go/analysis/passes/use
 +    ],
 +)
 diff -urN b/go/analysis/passes/usesgenerics/testdata/src/a/BUILD.bazel c/go/analysis/passes/usesgenerics/testdata/src/a/BUILD.bazel
---- b/go/analysis/passes/usesgenerics/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/usesgenerics/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/usesgenerics/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5913,7 +5962,7 @@ diff -urN b/go/analysis/passes/usesgenerics/testdata/src/a/BUILD.bazel c/go/anal
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/usesgenerics/testdata/src/b/BUILD.bazel c/go/analysis/passes/usesgenerics/testdata/src/b/BUILD.bazel
---- b/go/analysis/passes/usesgenerics/testdata/src/b/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/usesgenerics/testdata/src/b/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/usesgenerics/testdata/src/b/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5931,7 +5980,7 @@ diff -urN b/go/analysis/passes/usesgenerics/testdata/src/b/BUILD.bazel c/go/anal
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/usesgenerics/testdata/src/c/BUILD.bazel c/go/analysis/passes/usesgenerics/testdata/src/c/BUILD.bazel
---- b/go/analysis/passes/usesgenerics/testdata/src/c/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/usesgenerics/testdata/src/c/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/usesgenerics/testdata/src/c/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5949,7 +5998,7 @@ diff -urN b/go/analysis/passes/usesgenerics/testdata/src/c/BUILD.bazel c/go/anal
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/passes/usesgenerics/testdata/src/d/BUILD.bazel c/go/analysis/passes/usesgenerics/testdata/src/d/BUILD.bazel
---- b/go/analysis/passes/usesgenerics/testdata/src/d/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/passes/usesgenerics/testdata/src/d/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/usesgenerics/testdata/src/d/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5967,7 +6016,7 @@ diff -urN b/go/analysis/passes/usesgenerics/testdata/src/d/BUILD.bazel c/go/anal
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/singlechecker/BUILD.bazel c/go/analysis/singlechecker/BUILD.bazel
---- b/go/analysis/singlechecker/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/singlechecker/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/singlechecker/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -5991,7 +6040,7 @@ diff -urN b/go/analysis/singlechecker/BUILD.bazel c/go/analysis/singlechecker/BU
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/analysis/unitchecker/BUILD.bazel c/go/analysis/unitchecker/BUILD.bazel
---- b/go/analysis/unitchecker/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/analysis/unitchecker/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/unitchecker/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,69 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -6064,7 +6113,7 @@ diff -urN b/go/analysis/unitchecker/BUILD.bazel c/go/analysis/unitchecker/BUILD.
 +    ],
 +)
 diff -urN b/go/ast/astutil/BUILD.bazel c/go/ast/astutil/BUILD.bazel
---- b/go/ast/astutil/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ast/astutil/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ast/astutil/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -6099,7 +6148,7 @@ diff -urN b/go/ast/astutil/BUILD.bazel c/go/ast/astutil/BUILD.bazel
 +    deps = ["//internal/typeparams"],
 +)
 diff -urN b/go/ast/inspector/BUILD.bazel c/go/ast/inspector/BUILD.bazel
---- b/go/ast/inspector/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ast/inspector/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ast/inspector/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -6130,7 +6179,7 @@ diff -urN b/go/ast/inspector/BUILD.bazel c/go/ast/inspector/BUILD.bazel
 +    ],
 +)
 diff -urN b/go/buildutil/BUILD.bazel c/go/buildutil/BUILD.bazel
---- b/go/buildutil/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/buildutil/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/buildutil/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -6169,7 +6218,7 @@ diff -urN b/go/buildutil/BUILD.bazel c/go/buildutil/BUILD.bazel
 +    ],
 +)
 diff -urN b/go/callgraph/BUILD.bazel c/go/callgraph/BUILD.bazel
---- b/go/callgraph/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/callgraph/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/callgraph/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -6206,7 +6255,7 @@ diff -urN b/go/callgraph/BUILD.bazel c/go/callgraph/BUILD.bazel
 +    ],
 +)
 diff -urN b/go/callgraph/cha/BUILD.bazel c/go/callgraph/cha/BUILD.bazel
---- b/go/callgraph/cha/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/callgraph/cha/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/callgraph/cha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,132 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -6342,7 +6391,7 @@ diff -urN b/go/callgraph/cha/BUILD.bazel c/go/callgraph/cha/BUILD.bazel
 +    }),
 +)
 diff -urN b/go/callgraph/cha/testdata/BUILD.bazel c/go/callgraph/cha/testdata/BUILD.bazel
---- b/go/callgraph/cha/testdata/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/callgraph/cha/testdata/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/callgraph/cha/testdata/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -6360,7 +6409,7 @@ diff -urN b/go/callgraph/cha/testdata/BUILD.bazel c/go/callgraph/cha/testdata/BU
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/callgraph/rta/BUILD.bazel c/go/callgraph/rta/BUILD.bazel
---- b/go/callgraph/rta/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/callgraph/rta/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/callgraph/rta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,133 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -6387,7 +6436,7 @@ diff -urN b/go/callgraph/rta/BUILD.bazel c/go/callgraph/rta/BUILD.bazel
 +go_test(
 +    name = "rta_test",
 +    srcs = ["rta_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
++    data = glob(["testdata/**"]),
 +    deps = select({
 +        "@io_bazel_rules_go//go/platform:aix": [
 +            ":rta",
@@ -6497,7 +6546,7 @@ diff -urN b/go/callgraph/rta/BUILD.bazel c/go/callgraph/rta/BUILD.bazel
 +    }),
 +)
 diff -urN b/go/callgraph/static/BUILD.bazel c/go/callgraph/static/BUILD.bazel
---- b/go/callgraph/static/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/callgraph/static/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/callgraph/static/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,32 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -6533,7 +6582,7 @@ diff -urN b/go/callgraph/static/BUILD.bazel c/go/callgraph/static/BUILD.bazel
 +    ],
 +)
 diff -urN b/go/callgraph/vta/BUILD.bazel c/go/callgraph/vta/BUILD.bazel
---- b/go/callgraph/vta/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/callgraph/vta/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/callgraph/vta/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,50 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -6587,7 +6636,7 @@ diff -urN b/go/callgraph/vta/BUILD.bazel c/go/callgraph/vta/BUILD.bazel
 +    ],
 +)
 diff -urN b/go/callgraph/vta/internal/trie/BUILD.bazel c/go/callgraph/vta/internal/trie/BUILD.bazel
---- b/go/callgraph/vta/internal/trie/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/callgraph/vta/internal/trie/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/callgraph/vta/internal/trie/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,29 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -6619,60 +6668,8 @@ diff -urN b/go/callgraph/vta/internal/trie/BUILD.bazel c/go/callgraph/vta/intern
 +    ],
 +    embed = [":trie"],
 +)
-diff -urN b/go/callgraph/vta/testdata/src/BUILD.bazel c/go/callgraph/vta/testdata/src/BUILD.bazel
---- b/go/callgraph/vta/testdata/src/BUILD.bazel	1970-01-01 08:00:00
-+++ c/go/callgraph/vta/testdata/src/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,48 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "src",
-+    srcs = [
-+        "arrays_generics.go",
-+        "callgraph_collections.go",
-+        "callgraph_field_funcs.go",
-+        "callgraph_fields.go",
-+        "callgraph_generics.go",
-+        "callgraph_ho.go",
-+        "callgraph_interfaces.go",
-+        "callgraph_issue_57756.go",
-+        "callgraph_nested_ptr.go",
-+        "callgraph_pointers.go",
-+        "callgraph_recursive_types.go",
-+        "callgraph_static.go",
-+        "channels.go",
-+        "closures.go",
-+        "dynamic_calls.go",
-+        "fields.go",
-+        "function_alias.go",
-+        "go117.go",
-+        "maps.go",
-+        "node_uniqueness.go",
-+        "panic.go",
-+        "phi.go",
-+        "phi_alias.go",
-+        "ranges.go",
-+        "returns.go",
-+        "select.go",
-+        "simple.go",
-+        "static_calls.go",
-+        "store.go",
-+        "store_load_alias.go",
-+        "stores_arrays.go",
-+        "type_assertions.go",
-+        "type_conversions.go",
-+    ],
-+    importpath = "golang.org/x/tools/go/callgraph/vta/testdata/src",
-+    visibility = ["//visibility:public"],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":src",
-+    visibility = ["//visibility:public"],
-+)
 diff -urN b/go/callgraph/vta/testdata/src/d/BUILD.bazel c/go/callgraph/vta/testdata/src/d/BUILD.bazel
---- b/go/callgraph/vta/testdata/src/d/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/callgraph/vta/testdata/src/d/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/callgraph/vta/testdata/src/d/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6690,7 +6687,7 @@ diff -urN b/go/callgraph/vta/testdata/src/d/BUILD.bazel c/go/callgraph/vta/testd
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/callgraph/vta/testdata/src/t/BUILD.bazel c/go/callgraph/vta/testdata/src/t/BUILD.bazel
---- b/go/callgraph/vta/testdata/src/t/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/callgraph/vta/testdata/src/t/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/callgraph/vta/testdata/src/t/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6708,7 +6705,7 @@ diff -urN b/go/callgraph/vta/testdata/src/t/BUILD.bazel c/go/callgraph/vta/testd
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/cfg/BUILD.bazel c/go/cfg/BUILD.bazel
---- b/go/cfg/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/cfg/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/cfg/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -6735,7 +6732,7 @@ diff -urN b/go/cfg/BUILD.bazel c/go/cfg/BUILD.bazel
 +    embed = [":cfg"],
 +)
 diff -urN b/go/expect/BUILD.bazel c/go/expect/BUILD.bazel
---- b/go/expect/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/expect/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/expect/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -6763,7 +6760,7 @@ diff -urN b/go/expect/BUILD.bazel c/go/expect/BUILD.bazel
 +    deps = [":expect"],
 +)
 diff -urN b/go/expect/testdata/BUILD.bazel c/go/expect/testdata/BUILD.bazel
---- b/go/expect/testdata/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/expect/testdata/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/expect/testdata/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6781,7 +6778,7 @@ diff -urN b/go/expect/testdata/BUILD.bazel c/go/expect/testdata/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/gccgoexportdata/BUILD.bazel c/go/gccgoexportdata/BUILD.bazel
---- b/go/gccgoexportdata/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/gccgoexportdata/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/gccgoexportdata/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -6803,13 +6800,13 @@ diff -urN b/go/gccgoexportdata/BUILD.bazel c/go/gccgoexportdata/BUILD.bazel
 +go_test(
 +    name = "gccgoexportdata_test",
 +    srcs = ["gccgoexportdata_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
++    data = glob(["testdata/**"]),
 +    deps = [":gccgoexportdata"],
 +)
 diff -urN b/go/gcexportdata/BUILD.bazel c/go/gcexportdata/BUILD.bazel
---- b/go/gcexportdata/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/gcexportdata/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/gcexportdata/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,56 @@
+@@ -0,0 +1,59 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -6845,6 +6842,9 @@ diff -urN b/go/gcexportdata/BUILD.bazel c/go/gcexportdata/BUILD.bazel
 +        "@io_bazel_rules_go//go/platform:freebsd": [
 +            ":gcexportdata",
 +        ],
++        "@io_bazel_rules_go//go/platform:illumos": [
++            ":gcexportdata",
++        ],
 +        "@io_bazel_rules_go//go/platform:linux": [
 +            ":gcexportdata",
 +        ],
@@ -6867,7 +6867,7 @@ diff -urN b/go/gcexportdata/BUILD.bazel c/go/gcexportdata/BUILD.bazel
 +    }),
 +)
 diff -urN b/go/internal/cgo/BUILD.bazel c/go/internal/cgo/BUILD.bazel
---- b/go/internal/cgo/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/internal/cgo/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/internal/cgo/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6889,7 +6889,7 @@ diff -urN b/go/internal/cgo/BUILD.bazel c/go/internal/cgo/BUILD.bazel
 +    visibility = ["//go:__subpackages__"],
 +)
 diff -urN b/go/internal/gccgoimporter/BUILD.bazel c/go/internal/gccgoimporter/BUILD.bazel
---- b/go/internal/gccgoimporter/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/internal/gccgoimporter/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/internal/gccgoimporter/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -6924,12 +6924,12 @@ diff -urN b/go/internal/gccgoimporter/BUILD.bazel c/go/internal/gccgoimporter/BU
 +        "parser_test.go",
 +        "testenv_test.go",
 +    ],
-+    data = glob(["testdata/**"], allow_empty = True),
++    data = glob(["testdata/**"]),
 +    embed = [":gccgoimporter"],
 +    deps = ["//internal/testenv"],
 +)
 diff -urN b/go/internal/packagesdriver/BUILD.bazel c/go/internal/packagesdriver/BUILD.bazel
---- b/go/internal/packagesdriver/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/internal/packagesdriver/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/internal/packagesdriver/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -6948,7 +6948,7 @@ diff -urN b/go/internal/packagesdriver/BUILD.bazel c/go/internal/packagesdriver/
 +    visibility = ["//go:__subpackages__"],
 +)
 diff -urN b/go/loader/BUILD.bazel c/go/loader/BUILD.bazel
---- b/go/loader/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/loader/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/loader/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,37 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -6989,7 +6989,7 @@ diff -urN b/go/loader/BUILD.bazel c/go/loader/BUILD.bazel
 +    ],
 +)
 diff -urN b/go/loader/testdata/BUILD.bazel c/go/loader/testdata/BUILD.bazel
---- b/go/loader/testdata/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/loader/testdata/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/loader/testdata/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7011,7 +7011,7 @@ diff -urN b/go/loader/testdata/BUILD.bazel c/go/loader/testdata/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/loader/testdata/issue46877/BUILD.bazel c/go/loader/testdata/issue46877/BUILD.bazel
---- b/go/loader/testdata/issue46877/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/loader/testdata/issue46877/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/loader/testdata/issue46877/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7033,7 +7033,7 @@ diff -urN b/go/loader/testdata/issue46877/BUILD.bazel c/go/loader/testdata/issue
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/packages/BUILD.bazel c/go/packages/BUILD.bazel
---- b/go/packages/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/packages/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/packages/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,47 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -7084,7 +7084,7 @@ diff -urN b/go/packages/BUILD.bazel c/go/packages/BUILD.bazel
 +    ],
 +)
 diff -urN b/go/packages/gopackages/BUILD.bazel c/go/packages/gopackages/BUILD.bazel
---- b/go/packages/gopackages/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/packages/gopackages/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/packages/gopackages/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -7107,7 +7107,7 @@ diff -urN b/go/packages/gopackages/BUILD.bazel c/go/packages/gopackages/BUILD.ba
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/packages/internal/nodecount/BUILD.bazel c/go/packages/internal/nodecount/BUILD.bazel
---- b/go/packages/internal/nodecount/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/packages/internal/nodecount/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/packages/internal/nodecount/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -7126,7 +7126,7 @@ diff -urN b/go/packages/internal/nodecount/BUILD.bazel c/go/packages/internal/no
 +    visibility = ["//go/packages:__subpackages__"],
 +)
 diff -urN b/go/packages/packagestest/BUILD.bazel c/go/packages/packagestest/BUILD.bazel
---- b/go/packages/packagestest/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/packages/packagestest/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/packages/packagestest/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,42 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -7172,7 +7172,7 @@ diff -urN b/go/packages/packagestest/BUILD.bazel c/go/packages/packagestest/BUIL
 +    ],
 +)
 diff -urN b/go/packages/packagestest/testdata/BUILD.bazel c/go/packages/packagestest/testdata/BUILD.bazel
---- b/go/packages/packagestest/testdata/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/packages/packagestest/testdata/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/packages/packagestest/testdata/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -7199,7 +7199,7 @@ diff -urN b/go/packages/packagestest/testdata/BUILD.bazel c/go/packages/packages
 +    embed = [":testdata"],
 +)
 diff -urN b/go/packages/packagestest/testdata/groups/one/modules/example.com/extra/BUILD.bazel c/go/packages/packagestest/testdata/groups/one/modules/example.com/extra/BUILD.bazel
---- b/go/packages/packagestest/testdata/groups/one/modules/example.com/extra/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/packages/packagestest/testdata/groups/one/modules/example.com/extra/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/packages/packagestest/testdata/groups/one/modules/example.com/extra/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7217,7 +7217,7 @@ diff -urN b/go/packages/packagestest/testdata/groups/one/modules/example.com/ext
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/packages/packagestest/testdata/groups/one/primarymod/BUILD.bazel c/go/packages/packagestest/testdata/groups/one/primarymod/BUILD.bazel
---- b/go/packages/packagestest/testdata/groups/one/primarymod/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/packages/packagestest/testdata/groups/one/primarymod/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/packages/packagestest/testdata/groups/one/primarymod/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7235,7 +7235,7 @@ diff -urN b/go/packages/packagestest/testdata/groups/one/primarymod/BUILD.bazel 
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/packages/packagestest/testdata/groups/two/modules/example.com/extra/BUILD.bazel c/go/packages/packagestest/testdata/groups/two/modules/example.com/extra/BUILD.bazel
---- b/go/packages/packagestest/testdata/groups/two/modules/example.com/extra/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/packages/packagestest/testdata/groups/two/modules/example.com/extra/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/packages/packagestest/testdata/groups/two/modules/example.com/extra/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7253,7 +7253,7 @@ diff -urN b/go/packages/packagestest/testdata/groups/two/modules/example.com/ext
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/packages/packagestest/testdata/groups/two/modules/example.com/extra/geez/BUILD.bazel c/go/packages/packagestest/testdata/groups/two/modules/example.com/extra/geez/BUILD.bazel
---- b/go/packages/packagestest/testdata/groups/two/modules/example.com/extra/geez/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/packages/packagestest/testdata/groups/two/modules/example.com/extra/geez/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/packages/packagestest/testdata/groups/two/modules/example.com/extra/geez/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7271,7 +7271,7 @@ diff -urN b/go/packages/packagestest/testdata/groups/two/modules/example.com/ext
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/packages/packagestest/testdata/groups/two/modules/example.com/extra/v2/BUILD.bazel c/go/packages/packagestest/testdata/groups/two/modules/example.com/extra/v2/BUILD.bazel
---- b/go/packages/packagestest/testdata/groups/two/modules/example.com/extra/v2/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/packages/packagestest/testdata/groups/two/modules/example.com/extra/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/packages/packagestest/testdata/groups/two/modules/example.com/extra/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7289,7 +7289,7 @@ diff -urN b/go/packages/packagestest/testdata/groups/two/modules/example.com/ext
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/packages/packagestest/testdata/groups/two/modules/example.com/extra/v2/geez/BUILD.bazel c/go/packages/packagestest/testdata/groups/two/modules/example.com/extra/v2/geez/BUILD.bazel
---- b/go/packages/packagestest/testdata/groups/two/modules/example.com/extra/v2/geez/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/packages/packagestest/testdata/groups/two/modules/example.com/extra/v2/geez/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/packages/packagestest/testdata/groups/two/modules/example.com/extra/v2/geez/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7307,7 +7307,7 @@ diff -urN b/go/packages/packagestest/testdata/groups/two/modules/example.com/ext
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/packages/packagestest/testdata/groups/two/modules/example.com/tempmod/BUILD.bazel c/go/packages/packagestest/testdata/groups/two/modules/example.com/tempmod/BUILD.bazel
---- b/go/packages/packagestest/testdata/groups/two/modules/example.com/tempmod/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/packages/packagestest/testdata/groups/two/modules/example.com/tempmod/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/packages/packagestest/testdata/groups/two/modules/example.com/tempmod/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7325,7 +7325,7 @@ diff -urN b/go/packages/packagestest/testdata/groups/two/modules/example.com/tem
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/packages/packagestest/testdata/groups/two/modules/example.com/what@v1.0.0/BUILD.bazel c/go/packages/packagestest/testdata/groups/two/modules/example.com/what@v1.0.0/BUILD.bazel
---- b/go/packages/packagestest/testdata/groups/two/modules/example.com/what@v1.0.0/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/packages/packagestest/testdata/groups/two/modules/example.com/what@v1.0.0/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/packages/packagestest/testdata/groups/two/modules/example.com/what@v1.0.0/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7343,7 +7343,7 @@ diff -urN b/go/packages/packagestest/testdata/groups/two/modules/example.com/wha
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/packages/packagestest/testdata/groups/two/modules/example.com/what@v1.1.0/BUILD.bazel c/go/packages/packagestest/testdata/groups/two/modules/example.com/what@v1.1.0/BUILD.bazel
---- b/go/packages/packagestest/testdata/groups/two/modules/example.com/what@v1.1.0/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/packages/packagestest/testdata/groups/two/modules/example.com/what@v1.1.0/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/packages/packagestest/testdata/groups/two/modules/example.com/what@v1.1.0/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7361,7 +7361,7 @@ diff -urN b/go/packages/packagestest/testdata/groups/two/modules/example.com/wha
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/packages/packagestest/testdata/groups/two/primarymod/BUILD.bazel c/go/packages/packagestest/testdata/groups/two/primarymod/BUILD.bazel
---- b/go/packages/packagestest/testdata/groups/two/primarymod/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/packages/packagestest/testdata/groups/two/primarymod/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/packages/packagestest/testdata/groups/two/primarymod/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7379,7 +7379,7 @@ diff -urN b/go/packages/packagestest/testdata/groups/two/primarymod/BUILD.bazel 
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/packages/packagestest/testdata/groups/two/primarymod/expect/BUILD.bazel c/go/packages/packagestest/testdata/groups/two/primarymod/expect/BUILD.bazel
---- b/go/packages/packagestest/testdata/groups/two/primarymod/expect/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/packages/packagestest/testdata/groups/two/primarymod/expect/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/packages/packagestest/testdata/groups/two/primarymod/expect/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -7402,9 +7402,9 @@ diff -urN b/go/packages/packagestest/testdata/groups/two/primarymod/expect/BUILD
 +    srcs = ["yo_test.go"],
 +)
 diff -urN b/go/ssa/BUILD.bazel c/go/ssa/BUILD.bazel
---- b/go/ssa/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,118 @@
+@@ -0,0 +1,76 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -7420,8 +7420,6 @@ diff -urN b/go/ssa/BUILD.bazel c/go/ssa/BUILD.bazel
 +        "dom.go",
 +        "emit.go",
 +        "func.go",
-+        "identical.go",
-+        "identical_17.go",
 +        "instantiate.go",
 +        "lift.go",
 +        "lvalue.go",
@@ -7434,6 +7432,7 @@ diff -urN b/go/ssa/BUILD.bazel c/go/ssa/BUILD.bazel
 +        "ssa.go",
 +        "subst.go",
 +        "util.go",
++        "versions_go122.go",
 +        "wrappers.go",
 +    ],
 +    importpath = "golang.org/x/tools/go/ssa",
@@ -7455,13 +7454,12 @@ diff -urN b/go/ssa/BUILD.bazel c/go/ssa/BUILD.bazel
 +    name = "ssa_test",
 +    srcs = [
 +        "builder_generic_test.go",
-+        "builder_go117_test.go",
 +        "builder_go120_test.go",
++        "builder_go122_test.go",
 +        "builder_test.go",
 +        "const_test.go",
 +        "coretype_test.go",
 +        "example_test.go",
-+        "identical_test.go",
 +        "instantiate_test.go",
 +        "methods_test.go",
 +        "parameterized_test.go",
@@ -7470,63 +7468,23 @@ diff -urN b/go/ssa/BUILD.bazel c/go/ssa/BUILD.bazel
 +        "subst_test.go",
 +        "testhelper_test.go",
 +    ],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    embed = [":ssa"],
 +    deps = [
 +        "//go/ast/astutil",
 +        "//go/buildutil",
 +        "//go/expect",
 +        "//go/loader",
++        "//go/packages",
 +        "//go/ssa/ssautil",
 +        "//internal/testenv",
 +        "//internal/typeparams",
-+    ] + select({
-+        "@io_bazel_rules_go//go/platform:aix": [
-+            "//go/packages",
-+        ],
-+        "@io_bazel_rules_go//go/platform:darwin": [
-+            "//go/packages",
-+        ],
-+        "@io_bazel_rules_go//go/platform:dragonfly": [
-+            "//go/packages",
-+        ],
-+        "@io_bazel_rules_go//go/platform:freebsd": [
-+            "//go/packages",
-+        ],
-+        "@io_bazel_rules_go//go/platform:illumos": [
-+            "//go/packages",
-+        ],
-+        "@io_bazel_rules_go//go/platform:ios": [
-+            "//go/packages",
-+        ],
-+        "@io_bazel_rules_go//go/platform:js": [
-+            "//go/packages",
-+        ],
-+        "@io_bazel_rules_go//go/platform:linux": [
-+            "//go/packages",
-+        ],
-+        "@io_bazel_rules_go//go/platform:netbsd": [
-+            "//go/packages",
-+        ],
-+        "@io_bazel_rules_go//go/platform:openbsd": [
-+            "//go/packages",
-+        ],
-+        "@io_bazel_rules_go//go/platform:plan9": [
-+            "//go/packages",
-+        ],
-+        "@io_bazel_rules_go//go/platform:solaris": [
-+            "//go/packages",
-+        ],
-+        "@io_bazel_rules_go//go/platform:windows": [
-+            "//go/packages",
-+        ],
-+        "//conditions:default": [],
-+    }),
++        "//txtar",
++    ],
 +)
 diff -urN b/go/ssa/interp/BUILD.bazel c/go/ssa/interp/BUILD.bazel
---- b/go/ssa/interp/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/interp/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/interp/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,41 @@
+@@ -0,0 +1,43 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -7558,6 +7516,7 @@ diff -urN b/go/ssa/interp/BUILD.bazel c/go/ssa/interp/BUILD.bazel
 +    srcs = [
 +        "interp_go120_test.go",
 +        "interp_go121_test.go",
++        "interp_go122_test.go",
 +        "interp_test.go",
 +    ],
 +    deps = [
@@ -7565,11 +7524,12 @@ diff -urN b/go/ssa/interp/BUILD.bazel c/go/ssa/interp/BUILD.bazel
 +        "//go/loader",
 +        "//go/ssa",
 +        "//go/ssa/ssautil",
++        "//internal/testenv",
 +        "//internal/typeparams",
 +    ],
 +)
 diff -urN b/go/ssa/interp/testdata/fixedbugs/BUILD.bazel c/go/ssa/interp/testdata/fixedbugs/BUILD.bazel
---- b/go/ssa/interp/testdata/fixedbugs/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/interp/testdata/fixedbugs/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/interp/testdata/fixedbugs/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -7592,7 +7552,7 @@ diff -urN b/go/ssa/interp/testdata/fixedbugs/BUILD.bazel c/go/ssa/interp/testdat
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/interp/testdata/src/encoding/BUILD.bazel c/go/ssa/interp/testdata/src/encoding/BUILD.bazel
---- b/go/ssa/interp/testdata/src/encoding/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/interp/testdata/src/encoding/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/interp/testdata/src/encoding/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7610,7 +7570,7 @@ diff -urN b/go/ssa/interp/testdata/src/encoding/BUILD.bazel c/go/ssa/interp/test
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/interp/testdata/src/errors/BUILD.bazel c/go/ssa/interp/testdata/src/errors/BUILD.bazel
---- b/go/ssa/interp/testdata/src/errors/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/interp/testdata/src/errors/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/interp/testdata/src/errors/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7628,7 +7588,7 @@ diff -urN b/go/ssa/interp/testdata/src/errors/BUILD.bazel c/go/ssa/interp/testda
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/interp/testdata/src/fmt/BUILD.bazel c/go/ssa/interp/testdata/src/fmt/BUILD.bazel
---- b/go/ssa/interp/testdata/src/fmt/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/interp/testdata/src/fmt/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/interp/testdata/src/fmt/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7646,7 +7606,7 @@ diff -urN b/go/ssa/interp/testdata/src/fmt/BUILD.bazel c/go/ssa/interp/testdata/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/interp/testdata/src/io/BUILD.bazel c/go/ssa/interp/testdata/src/io/BUILD.bazel
---- b/go/ssa/interp/testdata/src/io/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/interp/testdata/src/io/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/interp/testdata/src/io/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7664,7 +7624,7 @@ diff -urN b/go/ssa/interp/testdata/src/io/BUILD.bazel c/go/ssa/interp/testdata/s
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/interp/testdata/src/log/BUILD.bazel c/go/ssa/interp/testdata/src/log/BUILD.bazel
---- b/go/ssa/interp/testdata/src/log/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/interp/testdata/src/log/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/interp/testdata/src/log/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7682,7 +7642,7 @@ diff -urN b/go/ssa/interp/testdata/src/log/BUILD.bazel c/go/ssa/interp/testdata/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/interp/testdata/src/math/BUILD.bazel c/go/ssa/interp/testdata/src/math/BUILD.bazel
---- b/go/ssa/interp/testdata/src/math/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/interp/testdata/src/math/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/interp/testdata/src/math/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7700,7 +7660,7 @@ diff -urN b/go/ssa/interp/testdata/src/math/BUILD.bazel c/go/ssa/interp/testdata
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/interp/testdata/src/os/BUILD.bazel c/go/ssa/interp/testdata/src/os/BUILD.bazel
---- b/go/ssa/interp/testdata/src/os/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/interp/testdata/src/os/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/interp/testdata/src/os/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7718,7 +7678,7 @@ diff -urN b/go/ssa/interp/testdata/src/os/BUILD.bazel c/go/ssa/interp/testdata/s
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/interp/testdata/src/reflect/BUILD.bazel c/go/ssa/interp/testdata/src/reflect/BUILD.bazel
---- b/go/ssa/interp/testdata/src/reflect/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/interp/testdata/src/reflect/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/interp/testdata/src/reflect/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,17 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7739,7 +7699,7 @@ diff -urN b/go/ssa/interp/testdata/src/reflect/BUILD.bazel c/go/ssa/interp/testd
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/interp/testdata/src/runtime/BUILD.bazel c/go/ssa/interp/testdata/src/runtime/BUILD.bazel
---- b/go/ssa/interp/testdata/src/runtime/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/interp/testdata/src/runtime/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/interp/testdata/src/runtime/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7757,7 +7717,7 @@ diff -urN b/go/ssa/interp/testdata/src/runtime/BUILD.bazel c/go/ssa/interp/testd
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/interp/testdata/src/sort/BUILD.bazel c/go/ssa/interp/testdata/src/sort/BUILD.bazel
---- b/go/ssa/interp/testdata/src/sort/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/interp/testdata/src/sort/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/interp/testdata/src/sort/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7775,7 +7735,7 @@ diff -urN b/go/ssa/interp/testdata/src/sort/BUILD.bazel c/go/ssa/interp/testdata
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/interp/testdata/src/strconv/BUILD.bazel c/go/ssa/interp/testdata/src/strconv/BUILD.bazel
---- b/go/ssa/interp/testdata/src/strconv/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/interp/testdata/src/strconv/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/interp/testdata/src/strconv/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7793,7 +7753,7 @@ diff -urN b/go/ssa/interp/testdata/src/strconv/BUILD.bazel c/go/ssa/interp/testd
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/interp/testdata/src/strings/BUILD.bazel c/go/ssa/interp/testdata/src/strings/BUILD.bazel
---- b/go/ssa/interp/testdata/src/strings/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/interp/testdata/src/strings/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/interp/testdata/src/strings/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7811,7 +7771,7 @@ diff -urN b/go/ssa/interp/testdata/src/strings/BUILD.bazel c/go/ssa/interp/testd
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/interp/testdata/src/sync/BUILD.bazel c/go/ssa/interp/testdata/src/sync/BUILD.bazel
---- b/go/ssa/interp/testdata/src/sync/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/interp/testdata/src/sync/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/interp/testdata/src/sync/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7829,7 +7789,7 @@ diff -urN b/go/ssa/interp/testdata/src/sync/BUILD.bazel c/go/ssa/interp/testdata
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/interp/testdata/src/time/BUILD.bazel c/go/ssa/interp/testdata/src/time/BUILD.bazel
---- b/go/ssa/interp/testdata/src/time/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/interp/testdata/src/time/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/interp/testdata/src/time/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7847,7 +7807,7 @@ diff -urN b/go/ssa/interp/testdata/src/time/BUILD.bazel c/go/ssa/interp/testdata
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/interp/testdata/src/unicode/utf8/BUILD.bazel c/go/ssa/interp/testdata/src/unicode/utf8/BUILD.bazel
---- b/go/ssa/interp/testdata/src/unicode/utf8/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/interp/testdata/src/unicode/utf8/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/interp/testdata/src/unicode/utf8/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7865,7 +7825,7 @@ diff -urN b/go/ssa/interp/testdata/src/unicode/utf8/BUILD.bazel c/go/ssa/interp/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/interp/testdata/src/unsafe/BUILD.bazel c/go/ssa/interp/testdata/src/unsafe/BUILD.bazel
---- b/go/ssa/interp/testdata/src/unsafe/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/interp/testdata/src/unsafe/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/interp/testdata/src/unsafe/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7883,7 +7843,7 @@ diff -urN b/go/ssa/interp/testdata/src/unsafe/BUILD.bazel c/go/ssa/interp/testda
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/ssautil/BUILD.bazel c/go/ssa/ssautil/BUILD.bazel
---- b/go/ssa/ssautil/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/ssautil/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/ssautil/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,81 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -7917,7 +7877,7 @@ diff -urN b/go/ssa/ssautil/BUILD.bazel c/go/ssa/ssautil/BUILD.bazel
 +        "load_test.go",
 +        "switch_test.go",
 +    ],
-+    data = glob(["testdata/**"], allow_empty = True),
++    data = glob(["testdata/**"]),
 +    deps = [
 +        ":ssautil",
 +        "//go/packages",
@@ -7968,7 +7928,7 @@ diff -urN b/go/ssa/ssautil/BUILD.bazel c/go/ssa/ssautil/BUILD.bazel
 +    }),
 +)
 diff -urN b/go/ssa/testdata/src/bytes/BUILD.bazel c/go/ssa/testdata/src/bytes/BUILD.bazel
---- b/go/ssa/testdata/src/bytes/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/testdata/src/bytes/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/testdata/src/bytes/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -7986,7 +7946,7 @@ diff -urN b/go/ssa/testdata/src/bytes/BUILD.bazel c/go/ssa/testdata/src/bytes/BU
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/testdata/src/context/BUILD.bazel c/go/ssa/testdata/src/context/BUILD.bazel
---- b/go/ssa/testdata/src/context/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/testdata/src/context/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/testdata/src/context/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8004,7 +7964,7 @@ diff -urN b/go/ssa/testdata/src/context/BUILD.bazel c/go/ssa/testdata/src/contex
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/testdata/src/encoding/BUILD.bazel c/go/ssa/testdata/src/encoding/BUILD.bazel
---- b/go/ssa/testdata/src/encoding/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/testdata/src/encoding/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/testdata/src/encoding/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8022,7 +7982,7 @@ diff -urN b/go/ssa/testdata/src/encoding/BUILD.bazel c/go/ssa/testdata/src/encod
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/testdata/src/encoding/json/BUILD.bazel c/go/ssa/testdata/src/encoding/json/BUILD.bazel
---- b/go/ssa/testdata/src/encoding/json/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/testdata/src/encoding/json/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/testdata/src/encoding/json/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8040,7 +8000,7 @@ diff -urN b/go/ssa/testdata/src/encoding/json/BUILD.bazel c/go/ssa/testdata/src/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/testdata/src/encoding/xml/BUILD.bazel c/go/ssa/testdata/src/encoding/xml/BUILD.bazel
---- b/go/ssa/testdata/src/encoding/xml/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/testdata/src/encoding/xml/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/testdata/src/encoding/xml/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8058,7 +8018,7 @@ diff -urN b/go/ssa/testdata/src/encoding/xml/BUILD.bazel c/go/ssa/testdata/src/e
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/testdata/src/errors/BUILD.bazel c/go/ssa/testdata/src/errors/BUILD.bazel
---- b/go/ssa/testdata/src/errors/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/testdata/src/errors/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/testdata/src/errors/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8076,7 +8036,7 @@ diff -urN b/go/ssa/testdata/src/errors/BUILD.bazel c/go/ssa/testdata/src/errors/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/testdata/src/fmt/BUILD.bazel c/go/ssa/testdata/src/fmt/BUILD.bazel
---- b/go/ssa/testdata/src/fmt/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/testdata/src/fmt/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/testdata/src/fmt/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8094,7 +8054,7 @@ diff -urN b/go/ssa/testdata/src/fmt/BUILD.bazel c/go/ssa/testdata/src/fmt/BUILD.
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/testdata/src/io/BUILD.bazel c/go/ssa/testdata/src/io/BUILD.bazel
---- b/go/ssa/testdata/src/io/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/testdata/src/io/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/testdata/src/io/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8112,7 +8072,7 @@ diff -urN b/go/ssa/testdata/src/io/BUILD.bazel c/go/ssa/testdata/src/io/BUILD.ba
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/testdata/src/log/BUILD.bazel c/go/ssa/testdata/src/log/BUILD.bazel
---- b/go/ssa/testdata/src/log/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/testdata/src/log/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/testdata/src/log/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8130,7 +8090,7 @@ diff -urN b/go/ssa/testdata/src/log/BUILD.bazel c/go/ssa/testdata/src/log/BUILD.
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/testdata/src/math/BUILD.bazel c/go/ssa/testdata/src/math/BUILD.bazel
---- b/go/ssa/testdata/src/math/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/testdata/src/math/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/testdata/src/math/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8148,7 +8108,7 @@ diff -urN b/go/ssa/testdata/src/math/BUILD.bazel c/go/ssa/testdata/src/math/BUIL
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/testdata/src/os/BUILD.bazel c/go/ssa/testdata/src/os/BUILD.bazel
---- b/go/ssa/testdata/src/os/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/testdata/src/os/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/testdata/src/os/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8166,7 +8126,7 @@ diff -urN b/go/ssa/testdata/src/os/BUILD.bazel c/go/ssa/testdata/src/os/BUILD.ba
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/testdata/src/reflect/BUILD.bazel c/go/ssa/testdata/src/reflect/BUILD.bazel
---- b/go/ssa/testdata/src/reflect/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/testdata/src/reflect/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/testdata/src/reflect/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8184,7 +8144,7 @@ diff -urN b/go/ssa/testdata/src/reflect/BUILD.bazel c/go/ssa/testdata/src/reflec
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/testdata/src/runtime/BUILD.bazel c/go/ssa/testdata/src/runtime/BUILD.bazel
---- b/go/ssa/testdata/src/runtime/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/testdata/src/runtime/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/testdata/src/runtime/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8202,7 +8162,7 @@ diff -urN b/go/ssa/testdata/src/runtime/BUILD.bazel c/go/ssa/testdata/src/runtim
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/testdata/src/sort/BUILD.bazel c/go/ssa/testdata/src/sort/BUILD.bazel
---- b/go/ssa/testdata/src/sort/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/testdata/src/sort/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/testdata/src/sort/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8220,7 +8180,7 @@ diff -urN b/go/ssa/testdata/src/sort/BUILD.bazel c/go/ssa/testdata/src/sort/BUIL
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/testdata/src/strconv/BUILD.bazel c/go/ssa/testdata/src/strconv/BUILD.bazel
---- b/go/ssa/testdata/src/strconv/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/testdata/src/strconv/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/testdata/src/strconv/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8238,7 +8198,7 @@ diff -urN b/go/ssa/testdata/src/strconv/BUILD.bazel c/go/ssa/testdata/src/strcon
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/testdata/src/strings/BUILD.bazel c/go/ssa/testdata/src/strings/BUILD.bazel
---- b/go/ssa/testdata/src/strings/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/testdata/src/strings/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/testdata/src/strings/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8255,26 +8215,8 @@ diff -urN b/go/ssa/testdata/src/strings/BUILD.bazel c/go/ssa/testdata/src/string
 +    actual = ":strings",
 +    visibility = ["//visibility:public"],
 +)
-diff -urN b/go/ssa/testdata/src/sync/BUILD.bazel c/go/ssa/testdata/src/sync/BUILD.bazel
---- b/go/ssa/testdata/src/sync/BUILD.bazel	1970-01-01 08:00:00
-+++ c/go/ssa/testdata/src/sync/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,14 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "sync",
-+    srcs = ["sync.go"],
-+    importpath = "golang.org/x/tools/go/ssa/testdata/src/sync",
-+    visibility = ["//visibility:public"],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":sync",
-+    visibility = ["//visibility:public"],
-+)
 diff -urN b/go/ssa/testdata/src/sync/atomic/BUILD.bazel c/go/ssa/testdata/src/sync/atomic/BUILD.bazel
---- b/go/ssa/testdata/src/sync/atomic/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/testdata/src/sync/atomic/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/testdata/src/sync/atomic/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8291,8 +8233,26 @@ diff -urN b/go/ssa/testdata/src/sync/atomic/BUILD.bazel c/go/ssa/testdata/src/sy
 +    actual = ":atomic",
 +    visibility = ["//visibility:public"],
 +)
+diff -urN b/go/ssa/testdata/src/sync/BUILD.bazel c/go/ssa/testdata/src/sync/BUILD.bazel
+--- b/go/ssa/testdata/src/sync/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ c/go/ssa/testdata/src/sync/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,14 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "sync",
++    srcs = ["sync.go"],
++    importpath = "golang.org/x/tools/go/ssa/testdata/src/sync",
++    visibility = ["//visibility:public"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":sync",
++    visibility = ["//visibility:public"],
++)
 diff -urN b/go/ssa/testdata/src/time/BUILD.bazel c/go/ssa/testdata/src/time/BUILD.bazel
---- b/go/ssa/testdata/src/time/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/testdata/src/time/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/testdata/src/time/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8310,7 +8270,7 @@ diff -urN b/go/ssa/testdata/src/time/BUILD.bazel c/go/ssa/testdata/src/time/BUIL
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/ssa/testdata/src/unsafe/BUILD.bazel c/go/ssa/testdata/src/unsafe/BUILD.bazel
---- b/go/ssa/testdata/src/unsafe/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/ssa/testdata/src/unsafe/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/testdata/src/unsafe/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8328,7 +8288,7 @@ diff -urN b/go/ssa/testdata/src/unsafe/BUILD.bazel c/go/ssa/testdata/src/unsafe/
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/go/types/internal/play/BUILD.bazel c/go/types/internal/play/BUILD.bazel
---- b/go/types/internal/play/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/types/internal/play/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/types/internal/play/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -8352,9 +8312,9 @@ diff -urN b/go/types/internal/play/BUILD.bazel c/go/types/internal/play/BUILD.ba
 +    visibility = ["//go/types:__subpackages__"],
 +)
 diff -urN b/go/types/objectpath/BUILD.bazel c/go/types/objectpath/BUILD.bazel
---- b/go/types/objectpath/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/types/objectpath/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/types/objectpath/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,29 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -8362,10 +8322,7 @@ diff -urN b/go/types/objectpath/BUILD.bazel c/go/types/objectpath/BUILD.bazel
 +    srcs = ["objectpath.go"],
 +    importpath = "golang.org/x/tools/go/types/objectpath",
 +    visibility = ["//visibility:public"],
-+    deps = [
-+        "//internal/typeparams",
-+        "//internal/typesinternal",
-+    ],
++    deps = ["//internal/typeparams"],
 +)
 +
 +alias(
@@ -8388,7 +8345,7 @@ diff -urN b/go/types/objectpath/BUILD.bazel c/go/types/objectpath/BUILD.bazel
 +    ],
 +)
 diff -urN b/go/types/typeutil/BUILD.bazel c/go/types/typeutil/BUILD.bazel
---- b/go/types/typeutil/BUILD.bazel	1970-01-01 08:00:00
+--- b/go/types/typeutil/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/types/typeutil/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,39 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -8430,8 +8387,29 @@ diff -urN b/go/types/typeutil/BUILD.bazel c/go/types/typeutil/BUILD.bazel
 +        "//internal/typeparams",
 +    ],
 +)
+diff -urN b/godoc/analysis/BUILD.bazel c/godoc/analysis/BUILD.bazel
+--- b/godoc/analysis/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ c/godoc/analysis/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,17 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "analysis",
++    srcs = [
++        "analysis.go",
++        "json.go",
++    ],
++    importpath = "golang.org/x/tools/godoc/analysis",
++    visibility = ["//visibility:public"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":analysis",
++    visibility = ["//visibility:public"],
++)
 diff -urN b/godoc/BUILD.bazel c/godoc/BUILD.bazel
---- b/godoc/BUILD.bazel	1970-01-01 08:00:00
+--- b/godoc/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/godoc/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,66 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -8500,29 +8478,8 @@ diff -urN b/godoc/BUILD.bazel c/godoc/BUILD.bazel
 +        "//internal/typeparams",
 +    ],
 +)
-diff -urN b/godoc/analysis/BUILD.bazel c/godoc/analysis/BUILD.bazel
---- b/godoc/analysis/BUILD.bazel	1970-01-01 08:00:00
-+++ c/godoc/analysis/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,17 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "analysis",
-+    srcs = [
-+        "analysis.go",
-+        "json.go",
-+    ],
-+    importpath = "golang.org/x/tools/godoc/analysis",
-+    visibility = ["//visibility:public"],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":analysis",
-+    visibility = ["//visibility:public"],
-+)
 diff -urN b/godoc/redirect/BUILD.bazel c/godoc/redirect/BUILD.bazel
---- b/godoc/redirect/BUILD.bazel	1970-01-01 08:00:00
+--- b/godoc/redirect/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/godoc/redirect/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -8546,7 +8503,7 @@ diff -urN b/godoc/redirect/BUILD.bazel c/godoc/redirect/BUILD.bazel
 +    embed = [":redirect"],
 +)
 diff -urN b/godoc/static/BUILD.bazel c/godoc/static/BUILD.bazel
---- b/godoc/static/BUILD.bazel	1970-01-01 08:00:00
+--- b/godoc/static/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/godoc/static/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -8574,7 +8531,7 @@ diff -urN b/godoc/static/BUILD.bazel c/godoc/static/BUILD.bazel
 +    embed = [":static"],
 +)
 diff -urN b/godoc/util/BUILD.bazel c/godoc/util/BUILD.bazel
---- b/godoc/util/BUILD.bazel	1970-01-01 08:00:00
+--- b/godoc/util/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/godoc/util/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8596,7 +8553,7 @@ diff -urN b/godoc/util/BUILD.bazel c/godoc/util/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/godoc/vfs/BUILD.bazel c/godoc/vfs/BUILD.bazel
---- b/godoc/vfs/BUILD.bazel	1970-01-01 08:00:00
+--- b/godoc/vfs/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/godoc/vfs/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,32 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -8632,7 +8589,7 @@ diff -urN b/godoc/vfs/BUILD.bazel c/godoc/vfs/BUILD.bazel
 +    ],
 +)
 diff -urN b/godoc/vfs/gatefs/BUILD.bazel c/godoc/vfs/gatefs/BUILD.bazel
---- b/godoc/vfs/gatefs/BUILD.bazel	1970-01-01 08:00:00
+--- b/godoc/vfs/gatefs/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/godoc/vfs/gatefs/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -8660,7 +8617,7 @@ diff -urN b/godoc/vfs/gatefs/BUILD.bazel c/godoc/vfs/gatefs/BUILD.bazel
 +    ],
 +)
 diff -urN b/godoc/vfs/httpfs/BUILD.bazel c/godoc/vfs/httpfs/BUILD.bazel
---- b/godoc/vfs/httpfs/BUILD.bazel	1970-01-01 08:00:00
+--- b/godoc/vfs/httpfs/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/godoc/vfs/httpfs/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8679,7 +8636,7 @@ diff -urN b/godoc/vfs/httpfs/BUILD.bazel c/godoc/vfs/httpfs/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/godoc/vfs/mapfs/BUILD.bazel c/godoc/vfs/mapfs/BUILD.bazel
---- b/godoc/vfs/mapfs/BUILD.bazel	1970-01-01 08:00:00
+--- b/godoc/vfs/mapfs/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/godoc/vfs/mapfs/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -8704,7 +8661,7 @@ diff -urN b/godoc/vfs/mapfs/BUILD.bazel c/godoc/vfs/mapfs/BUILD.bazel
 +    embed = [":mapfs"],
 +)
 diff -urN b/godoc/vfs/zipfs/BUILD.bazel c/godoc/vfs/zipfs/BUILD.bazel
---- b/godoc/vfs/zipfs/BUILD.bazel	1970-01-01 08:00:00
+--- b/godoc/vfs/zipfs/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/godoc/vfs/zipfs/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -8730,7 +8687,7 @@ diff -urN b/godoc/vfs/zipfs/BUILD.bazel c/godoc/vfs/zipfs/BUILD.bazel
 +    deps = ["//godoc/vfs"],
 +)
 diff -urN b/imports/BUILD.bazel c/imports/BUILD.bazel
---- b/imports/BUILD.bazel	1970-01-01 08:00:00
+--- b/imports/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/imports/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8752,7 +8709,7 @@ diff -urN b/imports/BUILD.bazel c/imports/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/internal/analysisinternal/BUILD.bazel c/internal/analysisinternal/BUILD.bazel
---- b/internal/analysisinternal/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/analysisinternal/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/analysisinternal/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8770,7 +8727,7 @@ diff -urN b/internal/analysisinternal/BUILD.bazel c/internal/analysisinternal/BU
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN b/internal/apidiff/BUILD.bazel c/internal/apidiff/BUILD.bazel
---- b/internal/apidiff/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/apidiff/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/apidiff/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,30 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -8804,7 +8761,7 @@ diff -urN b/internal/apidiff/BUILD.bazel c/internal/apidiff/BUILD.bazel
 +    ],
 +)
 diff -urN b/internal/apidiff/testdata/BUILD.bazel c/internal/apidiff/testdata/BUILD.bazel
---- b/internal/apidiff/testdata/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/apidiff/testdata/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/apidiff/testdata/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8822,7 +8779,7 @@ diff -urN b/internal/apidiff/testdata/BUILD.bazel c/internal/apidiff/testdata/BU
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN b/internal/apidiff/testdata/exported_fields/BUILD.bazel c/internal/apidiff/testdata/exported_fields/BUILD.bazel
---- b/internal/apidiff/testdata/exported_fields/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/apidiff/testdata/exported_fields/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/apidiff/testdata/exported_fields/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8839,8 +8796,26 @@ diff -urN b/internal/apidiff/testdata/exported_fields/BUILD.bazel c/internal/api
 +    actual = ":exported_fields",
 +    visibility = ["//:__subpackages__"],
 +)
+diff -urN b/internal/astutil/BUILD.bazel c/internal/astutil/BUILD.bazel
+--- b/internal/astutil/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ c/internal/astutil/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,14 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "astutil",
++    srcs = ["clone.go"],
++    importpath = "golang.org/x/tools/internal/astutil",
++    visibility = ["//:__subpackages__"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":astutil",
++    visibility = ["//:__subpackages__"],
++)
 diff -urN b/internal/bisect/BUILD.bazel c/internal/bisect/BUILD.bazel
---- b/internal/bisect/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/bisect/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/bisect/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -8864,9 +8839,9 @@ diff -urN b/internal/bisect/BUILD.bazel c/internal/bisect/BUILD.bazel
 +    embed = [":bisect"],
 +)
 diff -urN b/internal/cmd/deadcode/BUILD.bazel c/internal/cmd/deadcode/BUILD.bazel
---- b/internal/cmd/deadcode/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/cmd/deadcode/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/cmd/deadcode/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 +
 +go_library(
@@ -8879,6 +8854,7 @@ diff -urN b/internal/cmd/deadcode/BUILD.bazel c/internal/cmd/deadcode/BUILD.baze
 +    importpath = "golang.org/x/tools/internal/cmd/deadcode",
 +    visibility = ["//visibility:private"],
 +    deps = [
++        "//go/callgraph",
 +        "//go/callgraph/rta",
 +        "//go/packages",
 +        "//go/ssa",
@@ -8895,14 +8871,14 @@ diff -urN b/internal/cmd/deadcode/BUILD.bazel c/internal/cmd/deadcode/BUILD.baze
 +go_test(
 +    name = "deadcode_test",
 +    srcs = ["deadcode_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
++    data = glob(["testdata/**"]),
 +    deps = [
 +        "//internal/testenv",
 +        "//txtar",
 +    ],
 +)
 diff -urN b/internal/compat/BUILD.bazel c/internal/compat/BUILD.bazel
---- b/internal/compat/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/compat/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/compat/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8924,7 +8900,7 @@ diff -urN b/internal/compat/BUILD.bazel c/internal/compat/BUILD.bazel
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN b/internal/constraints/BUILD.bazel c/internal/constraints/BUILD.bazel
---- b/internal/constraints/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/constraints/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/constraints/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -8942,7 +8918,7 @@ diff -urN b/internal/constraints/BUILD.bazel c/internal/constraints/BUILD.bazel
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN b/internal/diff/BUILD.bazel c/internal/diff/BUILD.bazel
---- b/internal/diff/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/diff/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/diff/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,32 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -8978,7 +8954,7 @@ diff -urN b/internal/diff/BUILD.bazel c/internal/diff/BUILD.bazel
 +    ],
 +)
 diff -urN b/internal/diff/difftest/BUILD.bazel c/internal/diff/difftest/BUILD.bazel
---- b/internal/diff/difftest/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/diff/difftest/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/diff/difftest/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -9006,7 +8982,7 @@ diff -urN b/internal/diff/difftest/BUILD.bazel c/internal/diff/difftest/BUILD.ba
 +    ],
 +)
 diff -urN b/internal/diff/lcs/BUILD.bazel c/internal/diff/lcs/BUILD.bazel
---- b/internal/diff/lcs/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/diff/lcs/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/diff/lcs/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,29 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -9039,7 +9015,7 @@ diff -urN b/internal/diff/lcs/BUILD.bazel c/internal/diff/lcs/BUILD.bazel
 +    embed = [":lcs"],
 +)
 diff -urN b/internal/diff/myers/BUILD.bazel c/internal/diff/myers/BUILD.bazel
---- b/internal/diff/myers/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/diff/myers/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/diff/myers/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -9067,7 +9043,7 @@ diff -urN b/internal/diff/myers/BUILD.bazel c/internal/diff/myers/BUILD.bazel
 +    ],
 +)
 diff -urN b/internal/diffp/BUILD.bazel c/internal/diffp/BUILD.bazel
---- b/internal/diffp/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/diffp/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/diffp/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -9088,12 +9064,12 @@ diff -urN b/internal/diffp/BUILD.bazel c/internal/diffp/BUILD.bazel
 +go_test(
 +    name = "diffp_test",
 +    srcs = ["diff_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
++    data = glob(["testdata/**"]),
 +    embed = [":diffp"],
 +    deps = ["//txtar"],
 +)
 diff -urN b/internal/edit/BUILD.bazel c/internal/edit/BUILD.bazel
---- b/internal/edit/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/edit/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/edit/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -9117,7 +9093,7 @@ diff -urN b/internal/edit/BUILD.bazel c/internal/edit/BUILD.bazel
 +    embed = [":edit"],
 +)
 diff -urN b/internal/event/BUILD.bazel c/internal/event/BUILD.bazel
---- b/internal/event/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/event/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/event/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,34 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -9155,7 +9131,7 @@ diff -urN b/internal/event/BUILD.bazel c/internal/event/BUILD.bazel
 +    ],
 +)
 diff -urN b/internal/event/core/BUILD.bazel c/internal/event/core/BUILD.bazel
---- b/internal/event/core/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/event/core/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/event/core/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9181,7 +9157,7 @@ diff -urN b/internal/event/core/BUILD.bazel c/internal/event/core/BUILD.bazel
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN b/internal/event/export/BUILD.bazel c/internal/event/export/BUILD.bazel
---- b/internal/event/export/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/event/export/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/event/export/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -9223,7 +9199,7 @@ diff -urN b/internal/event/export/BUILD.bazel c/internal/event/export/BUILD.baze
 +    ],
 +)
 diff -urN b/internal/event/export/eventtest/BUILD.bazel c/internal/event/export/eventtest/BUILD.bazel
---- b/internal/event/export/eventtest/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/event/export/eventtest/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/event/export/eventtest/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9247,7 +9223,7 @@ diff -urN b/internal/event/export/eventtest/BUILD.bazel c/internal/event/export/
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN b/internal/event/export/metric/BUILD.bazel c/internal/event/export/metric/BUILD.bazel
---- b/internal/event/export/metric/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/event/export/metric/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/event/export/metric/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9275,7 +9251,7 @@ diff -urN b/internal/event/export/metric/BUILD.bazel c/internal/event/export/met
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN b/internal/event/export/ocagent/BUILD.bazel c/internal/event/export/ocagent/BUILD.bazel
---- b/internal/event/export/ocagent/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/event/export/ocagent/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/event/export/ocagent/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,44 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -9323,7 +9299,7 @@ diff -urN b/internal/event/export/ocagent/BUILD.bazel c/internal/event/export/oc
 +    ],
 +)
 diff -urN b/internal/event/export/ocagent/wire/BUILD.bazel c/internal/event/export/ocagent/wire/BUILD.bazel
---- b/internal/event/export/ocagent/wire/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/event/export/ocagent/wire/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/event/export/ocagent/wire/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -9352,7 +9328,7 @@ diff -urN b/internal/event/export/ocagent/wire/BUILD.bazel c/internal/event/expo
 +    embed = [":wire"],
 +)
 diff -urN b/internal/event/export/prometheus/BUILD.bazel c/internal/event/export/prometheus/BUILD.bazel
---- b/internal/event/export/prometheus/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/event/export/prometheus/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/event/export/prometheus/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9376,7 +9352,7 @@ diff -urN b/internal/event/export/prometheus/BUILD.bazel c/internal/event/export
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN b/internal/event/keys/BUILD.bazel c/internal/event/keys/BUILD.bazel
---- b/internal/event/keys/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/event/keys/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/event/keys/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9398,7 +9374,7 @@ diff -urN b/internal/event/keys/BUILD.bazel c/internal/event/keys/BUILD.bazel
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN b/internal/event/label/BUILD.bazel c/internal/event/label/BUILD.bazel
---- b/internal/event/label/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/event/label/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/event/label/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -9425,7 +9401,7 @@ diff -urN b/internal/event/label/BUILD.bazel c/internal/event/label/BUILD.bazel
 +    ],
 +)
 diff -urN b/internal/event/tag/BUILD.bazel c/internal/event/tag/BUILD.bazel
---- b/internal/event/tag/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/event/tag/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/event/tag/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9444,9 +9420,9 @@ diff -urN b/internal/event/tag/BUILD.bazel c/internal/event/tag/BUILD.bazel
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN b/internal/facts/BUILD.bazel c/internal/facts/BUILD.bazel
---- b/internal/facts/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/facts/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/facts/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,35 @@
+@@ -0,0 +1,34 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -9461,14 +9437,13 @@ diff -urN b/internal/facts/BUILD.bazel c/internal/facts/BUILD.bazel
 +        "//go/analysis",
 +        "//go/types/objectpath",
 +        "//internal/typeparams",
-+        "//internal/typesinternal",
 +    ],
 +)
 +
 +alias(
 +    name = "go_default_library",
 +    actual = ":facts",
-+    visibility = ["//:__subpackages__"],
++    visibility = ["//visibility:public"],
 +)
 +
 +go_test(
@@ -9483,7 +9458,7 @@ diff -urN b/internal/facts/BUILD.bazel c/internal/facts/BUILD.bazel
 +    ],
 +)
 diff -urN b/internal/fakenet/BUILD.bazel c/internal/fakenet/BUILD.bazel
---- b/internal/fakenet/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/fakenet/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/fakenet/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9500,42 +9475,8 @@ diff -urN b/internal/fakenet/BUILD.bazel c/internal/fakenet/BUILD.bazel
 +    actual = ":fakenet",
 +    visibility = ["//:__subpackages__"],
 +)
-diff -urN b/internal/fastwalk/BUILD.bazel c/internal/fastwalk/BUILD.bazel
---- b/internal/fastwalk/BUILD.bazel	1970-01-01 08:00:00
-+++ c/internal/fastwalk/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,30 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-+
-+go_library(
-+    name = "fastwalk",
-+    srcs = [
-+        "fastwalk.go",
-+        "fastwalk_darwin.go",
-+        "fastwalk_dirent_fileno.go",
-+        "fastwalk_dirent_ino.go",
-+        "fastwalk_dirent_namlen_bsd.go",
-+        "fastwalk_dirent_namlen_linux.go",
-+        "fastwalk_portable.go",
-+        "fastwalk_unix.go",
-+    ],
-+    cgo = True,
-+    importpath = "golang.org/x/tools/internal/fastwalk",
-+    visibility = ["//:__subpackages__"],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":fastwalk",
-+    visibility = ["//:__subpackages__"],
-+)
-+
-+go_test(
-+    name = "fastwalk_test",
-+    srcs = ["fastwalk_test.go"],
-+    deps = [":fastwalk"],
-+)
 diff -urN b/internal/fuzzy/BUILD.bazel c/internal/fuzzy/BUILD.bazel
---- b/internal/fuzzy/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/fuzzy/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/fuzzy/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,32 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -9571,7 +9512,7 @@ diff -urN b/internal/fuzzy/BUILD.bazel c/internal/fuzzy/BUILD.bazel
 +    ],
 +)
 diff -urN b/internal/gcimporter/BUILD.bazel c/internal/gcimporter/BUILD.bazel
---- b/internal/gcimporter/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/gcimporter/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/gcimporter/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,60 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -9635,7 +9576,7 @@ diff -urN b/internal/gcimporter/BUILD.bazel c/internal/gcimporter/BUILD.bazel
 +    ],
 +)
 diff -urN b/internal/gcimporter/testdata/a/BUILD.bazel c/internal/gcimporter/testdata/a/BUILD.bazel
---- b/internal/gcimporter/testdata/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/gcimporter/testdata/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/gcimporter/testdata/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9652,8 +9593,26 @@ diff -urN b/internal/gcimporter/testdata/a/BUILD.bazel c/internal/gcimporter/tes
 +    actual = ":a",
 +    visibility = ["//:__subpackages__"],
 +)
+diff -urN b/internal/gcimporter/testdata/issue51836/a/BUILD.bazel c/internal/gcimporter/testdata/issue51836/a/BUILD.bazel
+--- b/internal/gcimporter/testdata/issue51836/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ c/internal/gcimporter/testdata/issue51836/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,14 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "a",
++    srcs = ["a.go"],
++    importpath = "golang.org/x/tools/internal/gcimporter/testdata/issue51836/a",
++    visibility = ["//:__subpackages__"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":a",
++    visibility = ["//:__subpackages__"],
++)
 diff -urN b/internal/gcimporter/testdata/issue51836/BUILD.bazel c/internal/gcimporter/testdata/issue51836/BUILD.bazel
---- b/internal/gcimporter/testdata/issue51836/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/gcimporter/testdata/issue51836/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/gcimporter/testdata/issue51836/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9674,26 +9633,8 @@ diff -urN b/internal/gcimporter/testdata/issue51836/BUILD.bazel c/internal/gcimp
 +    actual = ":issue51836",
 +    visibility = ["//:__subpackages__"],
 +)
-diff -urN b/internal/gcimporter/testdata/issue51836/a/BUILD.bazel c/internal/gcimporter/testdata/issue51836/a/BUILD.bazel
---- b/internal/gcimporter/testdata/issue51836/a/BUILD.bazel	1970-01-01 08:00:00
-+++ c/internal/gcimporter/testdata/issue51836/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,14 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "a",
-+    srcs = ["a.go"],
-+    importpath = "golang.org/x/tools/internal/gcimporter/testdata/issue51836/a",
-+    visibility = ["//:__subpackages__"],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":a",
-+    visibility = ["//:__subpackages__"],
-+)
 diff -urN b/internal/gcimporter/testdata/issue58296/a/BUILD.bazel c/internal/gcimporter/testdata/issue58296/a/BUILD.bazel
---- b/internal/gcimporter/testdata/issue58296/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/gcimporter/testdata/issue58296/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/gcimporter/testdata/issue58296/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9711,7 +9652,7 @@ diff -urN b/internal/gcimporter/testdata/issue58296/a/BUILD.bazel c/internal/gci
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN b/internal/gcimporter/testdata/issue58296/b/BUILD.bazel c/internal/gcimporter/testdata/issue58296/b/BUILD.bazel
---- b/internal/gcimporter/testdata/issue58296/b/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/gcimporter/testdata/issue58296/b/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/gcimporter/testdata/issue58296/b/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9729,7 +9670,7 @@ diff -urN b/internal/gcimporter/testdata/issue58296/b/BUILD.bazel c/internal/gci
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN b/internal/gcimporter/testdata/issue58296/c/BUILD.bazel c/internal/gcimporter/testdata/issue58296/c/BUILD.bazel
---- b/internal/gcimporter/testdata/issue58296/c/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/gcimporter/testdata/issue58296/c/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/gcimporter/testdata/issue58296/c/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9747,7 +9688,7 @@ diff -urN b/internal/gcimporter/testdata/issue58296/c/BUILD.bazel c/internal/gci
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN b/internal/gcimporter/testdata/versions/BUILD.bazel c/internal/gcimporter/testdata/versions/BUILD.bazel
---- b/internal/gcimporter/testdata/versions/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/gcimporter/testdata/versions/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/gcimporter/testdata/versions/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9765,7 +9706,7 @@ diff -urN b/internal/gcimporter/testdata/versions/BUILD.bazel c/internal/gcimpor
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN b/internal/gocommand/BUILD.bazel c/internal/gocommand/BUILD.bazel
---- b/internal/gocommand/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/gocommand/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/gocommand/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -9805,9 +9746,9 @@ diff -urN b/internal/gocommand/BUILD.bazel c/internal/gocommand/BUILD.bazel
 +    deps = ["//internal/testenv"],
 +)
 diff -urN b/internal/gopathwalk/BUILD.bazel c/internal/gopathwalk/BUILD.bazel
---- b/internal/gopathwalk/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/gopathwalk/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/gopathwalk/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,21 @@
+@@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -9815,7 +9756,6 @@ diff -urN b/internal/gopathwalk/BUILD.bazel c/internal/gopathwalk/BUILD.bazel
 +    srcs = ["walk.go"],
 +    importpath = "golang.org/x/tools/internal/gopathwalk",
 +    visibility = ["//:__subpackages__"],
-+    deps = ["//internal/fastwalk"],
 +)
 +
 +alias(
@@ -9830,7 +9770,7 @@ diff -urN b/internal/gopathwalk/BUILD.bazel c/internal/gopathwalk/BUILD.bazel
 +    embed = [":gopathwalk"],
 +)
 diff -urN b/internal/goroot/BUILD.bazel c/internal/goroot/BUILD.bazel
---- b/internal/goroot/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/goroot/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/goroot/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -9848,7 +9788,7 @@ diff -urN b/internal/goroot/BUILD.bazel c/internal/goroot/BUILD.bazel
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN b/internal/imports/BUILD.bazel c/internal/imports/BUILD.bazel
---- b/internal/imports/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/imports/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/imports/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,49 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -9888,7 +9828,7 @@ diff -urN b/internal/imports/BUILD.bazel c/internal/imports/BUILD.bazel
 +        "mod_cache_test.go",
 +        "mod_test.go",
 +    ],
-+    data = glob(["testdata/**"], allow_empty = True),
++    data = glob(["testdata/**"]),
 +    embed = [":imports"],
 +    deps = [
 +        "//go/packages/packagestest",
@@ -9901,7 +9841,7 @@ diff -urN b/internal/imports/BUILD.bazel c/internal/imports/BUILD.bazel
 +    ],
 +)
 diff -urN b/internal/jsonrpc2/BUILD.bazel c/internal/jsonrpc2/BUILD.bazel
---- b/internal/jsonrpc2/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/jsonrpc2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/jsonrpc2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,42 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -9947,7 +9887,7 @@ diff -urN b/internal/jsonrpc2/BUILD.bazel c/internal/jsonrpc2/BUILD.bazel
 +    ],
 +)
 diff -urN b/internal/jsonrpc2/servertest/BUILD.bazel c/internal/jsonrpc2/servertest/BUILD.bazel
---- b/internal/jsonrpc2/servertest/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/jsonrpc2/servertest/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/jsonrpc2/servertest/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,22 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -9973,7 +9913,7 @@ diff -urN b/internal/jsonrpc2/servertest/BUILD.bazel c/internal/jsonrpc2/servert
 +    deps = ["//internal/jsonrpc2"],
 +)
 diff -urN b/internal/jsonrpc2_v2/BUILD.bazel c/internal/jsonrpc2_v2/BUILD.bazel
---- b/internal/jsonrpc2_v2/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/jsonrpc2_v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/jsonrpc2_v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,45 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -10022,7 +9962,7 @@ diff -urN b/internal/jsonrpc2_v2/BUILD.bazel c/internal/jsonrpc2_v2/BUILD.bazel
 +    ],
 +)
 diff -urN b/internal/memoize/BUILD.bazel c/internal/memoize/BUILD.bazel
---- b/internal/memoize/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/memoize/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/memoize/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -10047,7 +9987,7 @@ diff -urN b/internal/memoize/BUILD.bazel c/internal/memoize/BUILD.bazel
 +    deps = [":memoize"],
 +)
 diff -urN b/internal/packagesinternal/BUILD.bazel c/internal/packagesinternal/BUILD.bazel
---- b/internal/packagesinternal/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/packagesinternal/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/packagesinternal/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10066,7 +10006,7 @@ diff -urN b/internal/packagesinternal/BUILD.bazel c/internal/packagesinternal/BU
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN b/internal/persistent/BUILD.bazel c/internal/persistent/BUILD.bazel
---- b/internal/persistent/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/persistent/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/persistent/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -10098,7 +10038,7 @@ diff -urN b/internal/persistent/BUILD.bazel c/internal/persistent/BUILD.bazel
 +    deps = ["//internal/constraints"],
 +)
 diff -urN b/internal/pkgbits/BUILD.bazel c/internal/pkgbits/BUILD.bazel
---- b/internal/pkgbits/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/pkgbits/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/pkgbits/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10128,7 +10068,7 @@ diff -urN b/internal/pkgbits/BUILD.bazel c/internal/pkgbits/BUILD.bazel
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN b/internal/pprof/BUILD.bazel c/internal/pprof/BUILD.bazel
---- b/internal/pprof/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/pprof/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/pprof/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -10149,11 +10089,11 @@ diff -urN b/internal/pprof/BUILD.bazel c/internal/pprof/BUILD.bazel
 +go_test(
 +    name = "pprof_test",
 +    srcs = ["pprof_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
++    data = glob(["testdata/**"]),
 +    deps = [":pprof"],
 +)
 diff -urN b/internal/proxydir/BUILD.bazel c/internal/proxydir/BUILD.bazel
---- b/internal/proxydir/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/proxydir/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/proxydir/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -10177,64 +10117,10 @@ diff -urN b/internal/proxydir/BUILD.bazel c/internal/proxydir/BUILD.bazel
 +    srcs = ["proxydir_test.go"],
 +    embed = [":proxydir"],
 +)
-diff -urN b/internal/refactor/inline/BUILD.bazel c/internal/refactor/inline/BUILD.bazel
---- b/internal/refactor/inline/BUILD.bazel	1970-01-01 08:00:00
-+++ c/internal/refactor/inline/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,50 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-+
-+go_library(
-+    name = "inline",
-+    srcs = [
-+        "callee.go",
-+        "calleefx.go",
-+        "doc.go",
-+        "escape.go",
-+        "falcon.go",
-+        "inline.go",
-+        "util.go",
-+    ],
-+    importpath = "golang.org/x/tools/internal/refactor/inline",
-+    visibility = ["//:__subpackages__"],
-+    deps = [
-+        "//go/ast/astutil",
-+        "//go/types/typeutil",
-+        "//imports",
-+        "//internal/typeparams",
-+    ],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":inline",
-+    visibility = ["//:__subpackages__"],
-+)
-+
-+go_test(
-+    name = "inline_test",
-+    srcs = [
-+        "calleefx_test.go",
-+        "everything_test.go",
-+        "export_test.go",
-+        "falcon_test.go",
-+        "inline_test.go",
-+    ],
-+    data = glob(["testdata/**"], allow_empty = True),
-+    embed = [":inline"],
-+    deps = [
-+        "//go/ast/astutil",
-+        "//go/expect",
-+        "//go/packages",
-+        "//go/types/typeutil",
-+        "//internal/diff",
-+        "//internal/testenv",
-+        "//txtar",
-+    ],
-+)
 diff -urN b/internal/refactor/inline/analyzer/BUILD.bazel c/internal/refactor/inline/analyzer/BUILD.bazel
---- b/internal/refactor/inline/analyzer/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/refactor/inline/analyzer/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/refactor/inline/analyzer/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,31 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -10261,14 +10147,13 @@ diff -urN b/internal/refactor/inline/analyzer/BUILD.bazel c/internal/refactor/in
 +go_test(
 +    name = "analyzer_test",
 +    srcs = ["analyzer_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
 +    deps = [
 +        ":analyzer",
 +        "//go/analysis/analysistest",
 +    ],
 +)
 diff -urN b/internal/refactor/inline/analyzer/testdata/src/a/BUILD.bazel c/internal/refactor/inline/analyzer/testdata/src/a/BUILD.bazel
---- b/internal/refactor/inline/analyzer/testdata/src/a/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/refactor/inline/analyzer/testdata/src/a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/refactor/inline/analyzer/testdata/src/a/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10286,7 +10171,7 @@ diff -urN b/internal/refactor/inline/analyzer/testdata/src/a/BUILD.bazel c/inter
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN b/internal/refactor/inline/analyzer/testdata/src/b/BUILD.bazel c/internal/refactor/inline/analyzer/testdata/src/b/BUILD.bazel
---- b/internal/refactor/inline/analyzer/testdata/src/b/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/refactor/inline/analyzer/testdata/src/b/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/refactor/inline/analyzer/testdata/src/b/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10303,8 +10188,63 @@ diff -urN b/internal/refactor/inline/analyzer/testdata/src/b/BUILD.bazel c/inter
 +    actual = ":b",
 +    visibility = ["//:__subpackages__"],
 +)
+diff -urN b/internal/refactor/inline/BUILD.bazel c/internal/refactor/inline/BUILD.bazel
+--- b/internal/refactor/inline/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ c/internal/refactor/inline/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,51 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "inline",
++    srcs = [
++        "callee.go",
++        "calleefx.go",
++        "doc.go",
++        "escape.go",
++        "falcon.go",
++        "inline.go",
++        "util.go",
++    ],
++    importpath = "golang.org/x/tools/internal/refactor/inline",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//go/ast/astutil",
++        "//go/types/typeutil",
++        "//imports",
++        "//internal/astutil",
++        "//internal/typeparams",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":inline",
++    visibility = ["//:__subpackages__"],
++)
++
++go_test(
++    name = "inline_test",
++    srcs = [
++        "calleefx_test.go",
++        "everything_test.go",
++        "export_test.go",
++        "falcon_test.go",
++        "inline_test.go",
++    ],
++    data = glob(["testdata/**"]),
++    embed = [":inline"],
++    deps = [
++        "//go/ast/astutil",
++        "//go/expect",
++        "//go/packages",
++        "//go/types/typeutil",
++        "//internal/diff",
++        "//internal/testenv",
++        "//txtar",
++    ],
++)
 diff -urN b/internal/robustio/BUILD.bazel c/internal/robustio/BUILD.bazel
---- b/internal/robustio/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/robustio/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/robustio/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,29 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -10337,7 +10277,7 @@ diff -urN b/internal/robustio/BUILD.bazel c/internal/robustio/BUILD.bazel
 +    deps = [":robustio"],
 +)
 diff -urN b/internal/stack/BUILD.bazel c/internal/stack/BUILD.bazel
---- b/internal/stack/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/stack/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/stack/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -10365,7 +10305,7 @@ diff -urN b/internal/stack/BUILD.bazel c/internal/stack/BUILD.bazel
 +    deps = [":stack"],
 +)
 diff -urN b/internal/stack/gostacks/BUILD.bazel c/internal/stack/gostacks/BUILD.bazel
---- b/internal/stack/gostacks/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/stack/gostacks/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/stack/gostacks/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
@@ -10384,7 +10324,7 @@ diff -urN b/internal/stack/gostacks/BUILD.bazel c/internal/stack/gostacks/BUILD.
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN b/internal/stack/stacktest/BUILD.bazel c/internal/stack/stacktest/BUILD.bazel
---- b/internal/stack/stacktest/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/stack/stacktest/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/stack/stacktest/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10403,7 +10343,7 @@ diff -urN b/internal/stack/stacktest/BUILD.bazel c/internal/stack/stacktest/BUIL
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN b/internal/testenv/BUILD.bazel c/internal/testenv/BUILD.bazel
---- b/internal/testenv/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/testenv/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/testenv/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10431,7 +10371,7 @@ diff -urN b/internal/testenv/BUILD.bazel c/internal/testenv/BUILD.bazel
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN b/internal/tokeninternal/BUILD.bazel c/internal/tokeninternal/BUILD.bazel
---- b/internal/tokeninternal/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/tokeninternal/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/tokeninternal/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -10455,7 +10395,7 @@ diff -urN b/internal/tokeninternal/BUILD.bazel c/internal/tokeninternal/BUILD.ba
 +    deps = [":tokeninternal"],
 +)
 diff -urN b/internal/tool/BUILD.bazel c/internal/tool/BUILD.bazel
---- b/internal/tool/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/tool/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/tool/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10473,7 +10413,7 @@ diff -urN b/internal/tool/BUILD.bazel c/internal/tool/BUILD.bazel
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN b/internal/typeparams/BUILD.bazel c/internal/typeparams/BUILD.bazel
---- b/internal/typeparams/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/typeparams/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/typeparams/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,39 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -10516,7 +10456,7 @@ diff -urN b/internal/typeparams/BUILD.bazel c/internal/typeparams/BUILD.bazel
 +    ],
 +)
 diff -urN b/internal/typeparams/genericfeatures/BUILD.bazel c/internal/typeparams/genericfeatures/BUILD.bazel
---- b/internal/typeparams/genericfeatures/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/typeparams/genericfeatures/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/typeparams/genericfeatures/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10538,9 +10478,9 @@ diff -urN b/internal/typeparams/genericfeatures/BUILD.bazel c/internal/typeparam
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN b/internal/typesinternal/BUILD.bazel c/internal/typesinternal/BUILD.bazel
---- b/internal/typesinternal/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/typesinternal/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/typesinternal/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,25 @@
+@@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -10548,7 +10488,6 @@ diff -urN b/internal/typesinternal/BUILD.bazel c/internal/typesinternal/BUILD.ba
 +    srcs = [
 +        "errorcode.go",
 +        "errorcode_string.go",
-+        "objectpath.go",
 +        "types.go",
 +        "types_118.go",
 +    ],
@@ -10567,7 +10506,7 @@ diff -urN b/internal/typesinternal/BUILD.bazel c/internal/typesinternal/BUILD.ba
 +    srcs = ["errorcode_test.go"],
 +)
 diff -urN b/internal/xcontext/BUILD.bazel c/internal/xcontext/BUILD.bazel
---- b/internal/xcontext/BUILD.bazel	1970-01-01 08:00:00
+--- b/internal/xcontext/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/xcontext/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10585,7 +10524,7 @@ diff -urN b/internal/xcontext/BUILD.bazel c/internal/xcontext/BUILD.bazel
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN b/playground/BUILD.bazel c/playground/BUILD.bazel
---- b/playground/BUILD.bazel	1970-01-01 08:00:00
+--- b/playground/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/playground/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -10603,7 +10542,7 @@ diff -urN b/playground/BUILD.bazel c/playground/BUILD.bazel
 +    visibility = ["//visibility:public"],
 +)
 diff -urN b/playground/socket/BUILD.bazel c/playground/socket/BUILD.bazel
---- b/playground/socket/BUILD.bazel	1970-01-01 08:00:00
+--- b/playground/socket/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/playground/socket/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -10632,7 +10571,7 @@ diff -urN b/playground/socket/BUILD.bazel c/playground/socket/BUILD.bazel
 +    embed = [":socket"],
 +)
 diff -urN b/present/BUILD.bazel c/present/BUILD.bazel
---- b/present/BUILD.bazel	1970-01-01 08:00:00
+--- b/present/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/present/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,44 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -10676,11 +10615,11 @@ diff -urN b/present/BUILD.bazel c/present/BUILD.bazel
 +        "parse_test.go",
 +        "style_test.go",
 +    ],
-+    data = glob(["testdata/**"], allow_empty = True),
++    data = glob(["testdata/**"]),
 +    embed = [":present"],
 +)
 diff -urN b/refactor/eg/BUILD.bazel c/refactor/eg/BUILD.bazel
---- b/refactor/eg/BUILD.bazel	1970-01-01 08:00:00
+--- b/refactor/eg/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/refactor/eg/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,93 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -10706,7 +10645,7 @@ diff -urN b/refactor/eg/BUILD.bazel c/refactor/eg/BUILD.bazel
 +go_test(
 +    name = "eg_test",
 +    srcs = ["eg_test.go"],
-+    data = glob(["testdata/**"], allow_empty = True),
++    data = glob(["testdata/**"]),
 +    deps = select({
 +        "@io_bazel_rules_go//go/platform:aix": [
 +            ":eg",
@@ -10777,7 +10716,7 @@ diff -urN b/refactor/eg/BUILD.bazel c/refactor/eg/BUILD.bazel
 +    }),
 +)
 diff -urN b/refactor/importgraph/BUILD.bazel c/refactor/importgraph/BUILD.bazel
---- b/refactor/importgraph/BUILD.bazel	1970-01-01 08:00:00
+--- b/refactor/importgraph/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/refactor/importgraph/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,75 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -10856,7 +10795,7 @@ diff -urN b/refactor/importgraph/BUILD.bazel c/refactor/importgraph/BUILD.bazel
 +    }),
 +)
 diff -urN b/refactor/rename/BUILD.bazel c/refactor/rename/BUILD.bazel
---- b/refactor/rename/BUILD.bazel	1970-01-01 08:00:00
+--- b/refactor/rename/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/refactor/rename/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,42 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -10902,7 +10841,7 @@ diff -urN b/refactor/rename/BUILD.bazel c/refactor/rename/BUILD.bazel
 +    ],
 +)
 diff -urN b/refactor/satisfy/BUILD.bazel c/refactor/satisfy/BUILD.bazel
---- b/refactor/satisfy/BUILD.bazel	1970-01-01 08:00:00
+--- b/refactor/satisfy/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/refactor/satisfy/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,28 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -10934,7 +10873,7 @@ diff -urN b/refactor/satisfy/BUILD.bazel c/refactor/satisfy/BUILD.bazel
 +    ],
 +)
 diff -urN b/txtar/BUILD.bazel c/txtar/BUILD.bazel
---- b/txtar/BUILD.bazel	1970-01-01 08:00:00
+--- b/txtar/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/txtar/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,20 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")


### PR DESCRIPTION
The new version of x/tools reverts a breaking change in https://github.com/golang/tools/commit/b9b97d982b0a16d0bc8d95fb1dc654120b0d4940, which will make the release less intrusive. We should upgrade this dependency before releasing the new rules_go version