### PR TITLE
Remove unused aspect from go_proto_library

### DIFF
--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -66,20 +66,6 @@ def get_imports(attr, importpath):
     ]
     return depset(direct = direct.keys(), transitive = transitive)
 
-def _go_proto_aspect_impl(_target, ctx):
-    go = go_context(ctx, ctx.rule.attr)
-    imports = get_imports(ctx.rule.attr, go.importpath)
-    return [GoProtoImports(imports = imports)]
-
-_go_proto_aspect = aspect(
-    _go_proto_aspect_impl,
-    attr_aspects = [
-        "deps",
-        "embed",
-    ],
-    toolchains = [GO_TOOLCHAIN],
-)
-
 def _proto_library_to_source(_go, attr, source, merge):
     if attr.compiler:
         compilers = [attr.compiler]
@@ -159,7 +145,6 @@ go_proto_library = rule(
         ),
         "deps": attr.label_list(
             providers = [GoLibrary],
-            aspects = [_go_proto_aspect],
         ),
         "importpath": attr.string(),
         "importmap": attr.string(),


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

I was reviewing the source for the go_proto_library rule and I found this aspect that appears to be unused.
I removed this and ran a few of the tests and it seemed to work fine.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

N/A