### PR TITLE
Fix invocation of assembler for go1.22

### DIFF
--- a/go/tools/builders/asm.go
+++ b/go/tools/builders/asm.go
@@ -35,7 +35,7 @@ var ASM_DEFINES = []string{
 // by the compiler. This is only needed in go1.12+ when there is at least one
 // .s file. If the symabis file is not needed, no file will be generated,
 // and "", nil will be returned.
-func buildSymabisFile(goenv *env, sFiles, hFiles []fileInfo, asmhdr string) (string, error) {
+func buildSymabisFile(goenv *env, packagePath string, sFiles, hFiles []fileInfo, asmhdr string) (string, error) {
 	if len(sFiles) == 0 {
 		return "", nil
 	}
@@ -93,6 +93,13 @@ func buildSymabisFile(goenv *env, sFiles, hFiles []fileInfo, asmhdr string) (str
 			asmargs = append(asmargs, "-I", hdrDir)
 			seenHdrDirs[hdrDir] = true
 		}
+	}
+	// The package path has to be specified as of Go 1.22 or the resulting
+	// object will be unlinkable, but the -p flag is only required in
+	// preparing symabis since Go1.22, however, go build has been
+	// emitting -p for both symabi and actual assembly since at least Go1.19
+	if packagePath != "" && isGo119OrHigher() {
+		asmargs = append(asmargs, "-p", packagePath)
 	}
 	asmargs = append(asmargs, ASM_DEFINES...)
 	asmargs = append(asmargs, "-gensymabis", "-o", symabisName, "--")

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -471,7 +471,7 @@ func compileArchive(
 	}
 	var symabisPath string
 	if !haveCgo {
-		symabisPath, err = buildSymabisFile(goenv, srcs.sSrcs, srcs.hSrcs, asmHdrPath)
+		symabisPath, err = buildSymabisFile(goenv, packagePath, srcs.sSrcs, srcs.hSrcs, asmHdrPath)
 		if symabisPath != "" {
 			if !goenv.shouldPreserveWorkDir {
 				defer os.Remove(symabisPath)


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

In go1.19 through go1.22-devel (as of https://github.com/golang/go/commit/6382893890b82bbc0439eade5b132d9d1b3fb3a7) a series of changes were made to the way assembly files' symabis are produced.

https://go-review.googlesource.com/c/go/+/523337

Most significantly, the packagename now *must* be passed to the assembler via the -p flag, even when generating only the symabis. The go build system does this, but Bazel Go rules have not, and this finally breaks in go1.22-devel as the compatibility code is removed.

Now, without specifying -p to the assembler when generating symabis, the output symabis file will contain something like:

```
def <unlinkable>.s2Decode ABI0
```

instead of

```
def github.com/klauspost/compress/s2.s2Decode ABI0
```

The result is that the compiler will default to using ABIInternal instead of ABI0 if it cannot resolve the imported symbol's ABI in symabis, and default the symbol as ABIInternal in the assembled object files NonPkgDefs.

This will inevitably cause a link failure as the consuming object files declare their expecatation of ABI0 in their NonPkgRefs.

```
Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
github.com/klauspost/compress/s2.Decode: relocation target github.com/klauspost/compress/s2.s2Decode not defined for ABIInternal (but is defined for ABI0)
link: error running subcommand external/go_sdk/pkg/tool/darwin_arm64/link: exit status 2
```

**Which issues(s) does this PR fix?**

Fixes #3755,  #3849

**Other notes for review**
