### PR TITLE
Do not test on centos7

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,6 +1,5 @@
 matrix:
   platform:
-    - centos7
     - debian10
     - ubuntu2004
     - macos
@@ -16,7 +15,6 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-      - centos7
       - debian10
       - ubuntu2004
       - macos


### PR DESCRIPTION
This platform doesn't support `-std=c++14` with gcc, which is now the default in Bazel.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix
> Feature
> Documentation
> Other

**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
