### PR TITLE
Update to modern protoc plugins

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -37,6 +37,7 @@ use_repo(
     "com_github_golang_protobuf",
     "org_golang_google_genproto",
     "org_golang_google_grpc",
+    "org_golang_google_grpc_cmd_protoc_gen_go_grpc",
     "org_golang_google_protobuf",
     "org_golang_x_net",
 )

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	golang.org/x/tools v0.15.0
 	google.golang.org/genproto v0.0.0-20231127180814-3a041ad873d4
 	google.golang.org/grpc v1.59.0
+	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0
 	google.golang.org/protobuf v1.31.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20231120223509-83a465c0220f h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20231120223509-83a465c0220f/go.mod h1:L9KNLi232K1/xB6f7AlSX692koaRnKaWSR0stBki0Yc=
 google.golang.org/grpc v1.59.0 h1:Z5Iec2pjwb+LEOqzpB2MR12/eKFhDPhuqW91O+4bwUk=
 google.golang.org/grpc v1.59.0/go.mod h1:aUPDwccQo6OTjy7Hct4AfBPD1GptF4fyUjIkQ9YtF98=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0 h1:rNBFJjBCOgVr9pWD7rs/knKL4FRTKgpZmsRfV214zcA=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0/go.mod h1:Dk1tviKTvMCz5tvh7t+fh94dhmQVHuCt2OzJB3CTW9Y=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -174,19 +174,19 @@ def go_rules_dependencies(force = False):
     )
 
     # gRPC protoc plugin
-    # releaser:upgrade-dep grpc grpc-go
+    # releaser:upgrade-dep grpc grpc-go cmd/protoc-gen-go-grpc
     wrapper(
         http_archive,
         name = "org_golang_google_grpc_cmd_protoc_gen_go_grpc",
         sha256 = "1e84df03c94d1cded8e94da7a2df162463f3be4c7a94289d85c0871f14c7b8e3",
-        # v1.3.0, latest as of 2023-12-07
+        # cmd/protoc-gen-go-grpc/v1.3.0, latest as of 2023-12-13
         urls = [
             "https://mirror.bazel.build/github.com/grpc/grpc-go/archive/refs/tags/cmd/protoc-gen-go-grpc/v1.3.0.zip",
             "https://github.com/grpc/grpc-go/archive/refs/tags/cmd/protoc-gen-go-grpc/v1.3.0.zip",
         ],
         strip_prefix = "grpc-go-cmd-protoc-gen-go-grpc-v1.3.0/cmd/protoc-gen-go-grpc",
         patches = [
-            # releaser:patch-cmd gazelle -repo_root ./cmd/protoc-gen-go-grpc -go_prefix google.golang.org/grpc/cmd/protoc-gen-go-grpc -go_naming_convention import_alias -proto disable_global ./cmd/protoc-gen-go-grpc
+            # releaser:patch-cmd gazelle -repo_root . -go_prefix google.golang.org/grpc/cmd/protoc-gen-go-grpc -go_naming_convention import_alias -proto disable_global
             Label("//third_party:org_golang_google_grpc_cmd_protoc_gen_go_grpc.patch"),
         ],
         patch_args = ["-p1"],

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -173,9 +173,26 @@ def go_rules_dependencies(force = False):
         patch_args = ["-p1"],
     )
 
+    # gRPC protoc plugin
+    # releaser:upgrade-dep grpc grpc-go
+    wrapper(
+        http_archive,
+        name = "org_golang_google_grpc_cmd_protoc_gen_go_grpc",
+        sha256 = "1e84df03c94d1cded8e94da7a2df162463f3be4c7a94289d85c0871f14c7b8e3",
+        # v1.3.0, latest as of 2023-12-07
+        urls = [
+            "https://mirror.bazel.build/github.com/grpc/grpc-go/archive/refs/tags/cmd/protoc-gen-go-grpc/v1.3.0.zip",
+            "https://github.com/grpc/grpc-go/archive/refs/tags/cmd/protoc-gen-go-grpc/v1.3.0.zip",
+        ],
+        strip_prefix = "grpc-go-cmd-protoc-gen-go-grpc-v1.3.0/cmd/protoc-gen-go-grpc",
+        patches = [
+            # releaser:patch-cmd gazelle -repo_root ./cmd/protoc-gen-go-grpc -go_prefix google.golang.org/grpc/cmd/protoc-gen-go-grpc -go_naming_convention import_alias -proto disable_global ./cmd/protoc-gen-go-grpc
+            Label("//third_party:org_golang_google_grpc_cmd_protoc_gen_go_grpc.patch"),
+        ],
+        patch_args = ["-p1"],
+    )
+
     # Legacy protobuf compiler, runtime, and utilities.
-    # We still use protoc-gen-go because the new one doesn't support gRPC, and
-    # the gRPC compiler doesn't exist yet.
     # We need to apply a patch to enable both go_proto_library and
     # go_library with pre-generated sources.
     # releaser:upgrade-dep golang protobuf

--- a/go/tools/releaser/file.go
+++ b/go/tools/releaser/file.go
@@ -122,6 +122,9 @@ func extractZip(zf *os.File, name, dir, stripPrefix string) (err error) {
 		if err != nil {
 			return err
 		}
+		if outPath == "" {
+			return nil
+		}
 		if strings.HasSuffix(f.Name, "/") {
 			return os.MkdirAll(outPath, 0777)
 		}
@@ -169,6 +172,9 @@ func extractTar(r io.Reader, name, dir, stripPrefix string) (err error) {
 		if err != nil {
 			return err
 		}
+		if outPath == "" {
+			return nil
+		}
 		switch hdr.Typeflag {
 		case tar.TypeDir:
 			return os.MkdirAll(outPath, 0777)
@@ -209,7 +215,8 @@ func extractTar(r io.Reader, name, dir, stripPrefix string) (err error) {
 // point outside dir.
 func extractedPath(dir, stripPrefix, entryName string) (string, error) {
 	if !strings.HasPrefix(entryName, stripPrefix) {
-		return "", fmt.Errorf("entry does not start with prefix %s: %q", stripPrefix, entryName)
+		// Skip the file.
+		return "", nil
 	}
 	entryName = entryName[len(stripPrefix):]
 	if entryName == "" {

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -23,13 +23,18 @@ go_proto_compiler(
 
 go_proto_compiler(
     name = "go_proto",
+    plugin = "@org_golang_google_protobuf//cmd/protoc-gen-go",
     visibility = ["//visibility:public"],
     deps = PROTO_RUNTIME_DEPS + WELL_KNOWN_TYPES_APIV2,
 )
 
 go_proto_compiler(
     name = "go_grpc",
-    options = ["plugins=grpc"],
+    # Do not break existing code with this upgrade
+    # See https://github.com/grpc/grpc-go/blob/master/cmd/protoc-gen-go-grpc/README.md#future-proofing-services
+    options = ["require_unimplemented_servers=false"],
+    plugin = "@org_golang_google_grpc_cmd_protoc_gen_go_grpc//:protoc-gen-go-grpc",
+    suffix = "_grpc.pb.go",
     visibility = ["//visibility:public"],
     deps = PROTO_RUNTIME_DEPS + WELL_KNOWN_TYPES_APIV2 + [
         "@org_golang_google_grpc//:go_default_library",

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -30,6 +30,20 @@ go_proto_compiler(
 
 go_proto_compiler(
     name = "go_grpc",
+    deprecation = "Migrate to //proto:go_grpc_v2 compiler via go_grpc_library() rule.",
+    options = ["plugins=grpc"],
+    plugin = "@com_github_golang_protobuf//protoc-gen-go",
+    visibility = ["//visibility:public"],
+    deps = PROTO_RUNTIME_DEPS + WELL_KNOWN_TYPES_APIV2 + [
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes:go_default_library",
+        "@org_golang_google_grpc//status:go_default_library",
+        "@org_golang_x_net//context:go_default_library",
+    ],
+)
+
+go_proto_compiler(
+    name = "go_grpc_v2",
     # Do not break existing code with this upgrade
     # See https://github.com/grpc/grpc-go/blob/master/cmd/protoc-gen-go-grpc/README.md#future-proofing-services
     options = ["require_unimplemented_servers=false"],

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -183,9 +183,15 @@ go_proto_library = rule(
 # go_proto_library is a rule that takes a proto_library (in the proto
 # attribute) and produces a go library for it.
 
-def go_grpc_library(**kwargs):
-    # TODO: Deprecate once gazelle generates just go_proto_library
-    go_proto_library(compilers = [Label("//proto:go_grpc")], **kwargs)
+def go_grpc_library(name, **kwargs):
+    go_proto_library(
+        name = name,
+        compilers = [
+            Label("//proto:go_proto"),
+            Label("//proto:go_grpc_v2"),
+        ],
+        **kwargs
+    )
 
 def proto_register_toolchains():
     print("You no longer need to call proto_register_toolchains(), it does nothing")

--- a/proto/wkt/well_known_types.bzl
+++ b/proto/wkt/well_known_types.bzl
@@ -45,6 +45,7 @@ PROTO_RUNTIME_DEPS = [
     "@com_github_golang_protobuf//proto:go_default_library",
     "@org_golang_google_protobuf//proto:go_default_library",
     "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
+    "@org_golang_google_protobuf//reflect/protoregistry:go_default_library",
     "@org_golang_google_protobuf//runtime/protoiface:go_default_library",
     "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
 ]

--- a/tests/integration/googleapis/BUILD.bazel
+++ b/tests/integration/googleapis/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_grpc_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
@@ -11,9 +11,8 @@ proto_library(
     ],
 )
 
-go_proto_library(
+go_grpc_library(
     name = "color_service_go_proto",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
     importpath = "github.com/bazelbuild/rules_go/tests/integration/googleapis/color_service_proto",
     proto = ":color_service_proto",
     deps = [

--- a/tests/integration/googleapis/BUILD.bazel
+++ b/tests/integration/googleapis/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("@io_bazel_rules_go//proto:def.bzl", "go_grpc_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
@@ -11,8 +11,9 @@ proto_library(
     ],
 )
 
-go_grpc_library(
+go_proto_library(
     name = "color_service_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
     importpath = "github.com/bazelbuild/rules_go/tests/integration/googleapis/color_service_proto",
     proto = ":color_service_proto",
     deps = [

--- a/third_party/org_golang_google_grpc_cmd_protoc_gen_go_grpc.patch
+++ b/third_party/org_golang_google_grpc_cmd_protoc_gen_go_grpc.patch
@@ -1,0 +1,29 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+new file mode 100644
+index 00000000..c87b2ab8
+--- /dev/null
++++ b/BUILD.bazel
+@@ -0,0 +1,23 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
++
++go_library(
++    name = "protoc-gen-go-grpc_lib",
++    srcs = [
++        "grpc.go",
++        "main.go",
++    ],
++    importpath = "google.golang.org/grpc/cmd/protoc-gen-go-grpc",
++    visibility = ["//visibility:private"],
++    deps = [
++        "@org_golang_google_protobuf//compiler/protogen:go_default_library",
++        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
++        "@org_golang_google_protobuf//types/descriptorpb:go_default_library",
++        "@org_golang_google_protobuf//types/pluginpb:go_default_library",
++    ],
++)
++
++go_binary(
++    name = "protoc-gen-go-grpc",
++    embed = [":protoc-gen-go-grpc_lib"],
++    visibility = ["//visibility:public"],
++)

--- a/third_party/org_golang_google_grpc_cmd_protoc_gen_go_grpc.patch
+++ b/third_party/org_golang_google_grpc_cmd_protoc_gen_go_grpc.patch
@@ -1,8 +1,6 @@
-diff --git a/BUILD.bazel b/BUILD.bazel
-new file mode 100644
-index 00000000..c87b2ab8
---- /dev/null
-+++ b/BUILD.bazel
+diff -urN a/BUILD.bazel b/BUILD.bazel
+--- a/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
++++ b/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 +

--- a/tools.go
+++ b/tools.go
@@ -13,4 +13,5 @@ import (
 	_ "google.golang.org/genproto/protobuf/api"
 	_ "google.golang.org/grpc"
 	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
+	_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
 )


### PR DESCRIPTION
**What type of PR is this?**

Update

**What does this PR do? Why is it needed?**

The module [`github.com/golang/protobuf`](https://pkg.go.dev/mod/github.com/golang/protobuf) has been superseded by the [`google.golang.org/protobuf`](https://pkg.go.dev/mod/google.golang.org/protobuf) and [`google.golang.org/grpc`](https://pkg.go.dev/mod/google.golang.org/grpc) modules, which contain an updated and simplified API, support for protobuf reflection, and many other improvements.

The `go_grpc_library()` macro maintains the current behavior of generating both the proto and the service definitions.

**Which issues(s) does this PR fix?**

Fixes #3022

Supercedes #3437, #3783

**Other notes for review**
