### PR TITLE
feat(packagesdriver): add _test suffix to pkgPath

### DIFF
--- a/go/tools/gopackagesdriver/flatpackage.go
+++ b/go/tools/gopackagesdriver/flatpackage.go
@@ -154,7 +154,7 @@ func (fp *FlatPackage) MoveTestFiles() *FlatPackage {
 	return &FlatPackage{
 		ID:              fp.ID + "_xtest",
 		Name:            fp.Name + "_test",
-		PkgPath:         fp.PkgPath,
+		PkgPath:         fp.PkgPath + "_test",
 		Imports:         newImports,
 		Errors:          fp.Errors,
 		GoFiles:         append([]string{}, xtgf...),

--- a/tests/integration/gopackagesdriver/gopackagesdriver_test.go
+++ b/tests/integration/gopackagesdriver/gopackagesdriver_test.go
@@ -175,6 +175,9 @@ func TestExternalTests(t *testing.T) {
 
 	for _, p := range resp.Packages {
 		if p.ID == xTestId {
+			if !strings.HasSuffix(p.PkgPath, "_test") {
+				t.Errorf("PkgPath missing _test suffix")
+			}
 			assertSuffixesInList(t, p.GoFiles, "/hello_external_test.go")
 		} else if p.ID == testId {
 			assertSuffixesInList(t, p.GoFiles, "/hello.go", "/hello_test.go")


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

When I made the change to enable xtest style packages, I forgot to also suffix the package path. In certain cases this can make gopls segfault (since it conflicts with the base package). Adding the suffix fixes this issue.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
