### PR TITLE
Always attempt to set RUNFILES_DIR and JAVA_RUNFILES in `runfiles.Env`

### DIFF
--- a/go/runfiles/directory.go
+++ b/go/runfiles/directory.go
@@ -23,8 +23,11 @@ type Directory string
 
 func (d Directory) new(sourceRepo SourceRepo) (*Runfiles, error) {
 	r := &Runfiles{
-		impl:       d,
-		env:        directoryVar + "=" + string(d),
+		impl: d,
+		env: []string{
+			directoryVar + "=" + string(d),
+			legacyDirectoryVar + "=" + string(d),
+		},
 		sourceRepo: string(sourceRepo),
 	}
 	err := r.loadRepoMapping()

--- a/go/runfiles/runfiles.go
+++ b/go/runfiles/runfiles.go
@@ -14,19 +14,19 @@
 
 // Package runfiles provides access to Bazel runfiles.
 //
-// Usage
+// # Usage
 //
 // This package has two main entry points, the global functions Rlocation and Env,
 // and the Runfiles type.
 //
-// Global functions
+// # Global functions
 //
 // For simple use cases that don’t require hermetic behavior, use the Rlocation and
 // Env functions to access runfiles.  Use Rlocation to find the filesystem location
 // of a runfile, and use Env to obtain environmental variables to pass on to
 // subprocesses.
 //
-// Runfiles type
+// # Runfiles type
 //
 // If you need hermetic behavior or want to change the runfiles discovery
 // process, use New to create a Runfiles object.  New accepts a few options to
@@ -45,8 +45,9 @@ import (
 )
 
 const (
-	directoryVar    = "RUNFILES_DIR"
-	manifestFileVar = "RUNFILES_MANIFEST_FILE"
+	directoryVar       = "RUNFILES_DIR"
+	legacyDirectoryVar = "JAVA_RUNFILES"
+	manifestFileVar    = "RUNFILES_MANIFEST_FILE"
 )
 
 type repoMappingKey struct {
@@ -62,7 +63,7 @@ type Runfiles struct {
 	// We don’t need concurrency control since Runfiles objects are
 	// immutable once created.
 	impl        runfiles
-	env         string
+	env         []string
 	repoMapping map[repoMappingKey]string
 	sourceRepo  string
 }
@@ -198,10 +199,7 @@ func (r *Runfiles) loadRepoMapping() error {
 // The return value is a newly-allocated slice; you can modify it at will.  If
 // r is the zero Runfiles object, the return value is nil.
 func (r *Runfiles) Env() []string {
-	if r.env == "" {
-		return nil
-	}
-	return []string{r.env}
+	return r.env
 }
 
 // WithSourceRepo returns a Runfiles instance identical to the current one,

--- a/tests/runfiles/runfiles_test.go
+++ b/tests/runfiles/runfiles_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -145,5 +146,44 @@ func TestRunfiles_manifestWithDir(t *testing.T) {
 				t.Errorf("Rlocation failed: got %q, want %q", got, want)
 			}
 		})
+	}
+}
+
+func TestRunfiles_dirEnv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows doesn't have a runfiles directory by default")
+	}
+
+	dir := t.TempDir()
+	r, err := runfiles.New(runfiles.Directory(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"RUNFILES_DIR=" + dir, "JAVA_RUNFILES=" + dir}
+	if !reflect.DeepEqual(r.Env(), want) {
+		t.Errorf("Env: got %v, want %v", r.Env(), want)
+	}
+}
+
+func TestRunfiles_manifestEnv(t *testing.T) {
+	tmp := t.TempDir()
+	dir := filepath.Join(tmp, "foo.runfiles")
+	err := os.Mkdir(dir, 0o755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := filepath.Join(tmp, "foo.runfiles_manifest")
+	if err = os.WriteFile(manifest, []byte("foo/dir path/to/foo/dir\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	r, err := runfiles.New(runfiles.ManifestFile(manifest))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"RUNFILES_MANIFEST_FILE=" + manifest, "RUNFILES_DIR=" + dir, "JAVA_RUNFILES=" + dir}
+	if !reflect.DeepEqual(r.Env(), want) {
+		t.Errorf("Env: got %v, want %v", r.Env(), want)
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

These variables are needed by e.g. the Java launcher even when running with a manifest file. Match the logic of the Bazel-provided runfiles libraries.

**Which issues(s) does this PR fix?**

Fixes https://bazelbuild.slack.com/archives/C01HMGN77Q8/p1701887957242259

**Other notes for review**
