### PR TITLE
fix(gpd): don't panic on invalid root

### DIFF
--- a/go/tools/gopackagesdriver/packageregistry.go
+++ b/go/tools/gopackagesdriver/packageregistry.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -82,6 +83,11 @@ func (pr *PackageRegistry) ResolveImports() error {
 
 func (pr *PackageRegistry) walk(acc map[string]*FlatPackage, root string) {
 	pkg := pr.packagesByID[root]
+
+	if pkg == nil {
+		fmt.Fprintf(os.Stderr, "Error: package ID not found %v\n", root)
+		return
+	}
 
 	acc[pkg.ID] = pkg
 	for _, pkgID := range pkg.Imports {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

In rare cases the root won't actually have a package in the registry, causing the lookup to panic, and subsequently cause gopls (or other tools) to fail their resolution, and likely try multiple times. 

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

Will add a test case shortly, hence the draft