### PR TITLE
Expose protoc-gen-go-grpc as a go_proto_compiler option

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -136,6 +136,15 @@ go_repository(
     version = "v0.0.0-20221024183307-1bc688fe9f3e",
 )
 
+go_repository(
+    name = "org_golang_google_grpc_cmd_protoc_gen_go_grpc",
+    build_file_proto_mode = "disable",
+    importpath = "google.golang.org/grpc/cmd/protoc-gen-go-grpc",
+    sum = "h1:rNBFJjBCOgVr9pWD7rs/knKL4FRTKgpZmsRfV214zcA=",
+    version = "v1.3.0",
+)
+
+
 # TODO(sluongng): Gazelle v0.25.0 switched to static dependency resolution which cause
 # build files generation in external dependencies to wrongly resolve these repositories.
 # We should investigate in Gazelle why this happen and fix it.

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -39,6 +39,19 @@ go_proto_compiler(
     ],
 )
 
+go_proto_compiler(
+    name = "go_grpc_v2",
+    plugin = "@org_golang_google_grpc_cmd_protoc_gen_go_grpc//:protoc-gen-go-grpc",
+    suffix = "_grpc.pb.go",
+    visibility = ["//visibility:public"],
+    deps = WELL_KNOWN_TYPES_APIV2 + [
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes:go_default_library",
+        "@org_golang_google_grpc//status:go_default_library",
+        "@org_golang_x_net//context:go_default_library",
+    ],
+)
+
 GOGO_VARIANTS = [
     "combo",
     "gogo",

--- a/tests/integration/googleapis/BUILD.bazel
+++ b/tests/integration/googleapis/BUILD.bazel
@@ -22,18 +22,6 @@ go_proto_library(
     ],
 )
 
-# This is a test that the v2 protobuf-gen-go-grpc compiler also works
-go_proto_library(
-    name = "color_service_go_proto_v2",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc_v2"],
-    importpath = "github.com/bazelbuild/rules_go/tests/integration/googleapis/color_service_proto",
-    proto = ":color_service_proto",
-    deps = [
-        "@org_golang_google_genproto//googleapis/rpc/status",
-        "@org_golang_google_genproto//googleapis/type/color",
-    ],
-)
-
 go_library(
     name = "color_service",
     srcs = ["color_service.go"],

--- a/tests/integration/googleapis/BUILD.bazel
+++ b/tests/integration/googleapis/BUILD.bazel
@@ -22,6 +22,18 @@ go_proto_library(
     ],
 )
 
+# This is a test that the v2 protobuf-gen-go-grpc compiler also works
+go_proto_library(
+    name = "color_service_go_proto_v2",
+    compilers = ["@io_bazel_rules_go//proto:go_grpc_v2"],
+    importpath = "github.com/bazelbuild/rules_go/tests/integration/googleapis/color_service_proto",
+    proto = ":color_service_proto",
+    deps = [
+        "@org_golang_google_genproto//googleapis/rpc/status",
+        "@org_golang_google_genproto//googleapis/type/color",
+    ],
+)
+
 go_library(
     name = "color_service",
     srcs = ["color_service.go"],

--- a/tests/integration/grpc_plugin/BUILD.bazel
+++ b/tests/integration/grpc_plugin/BUILD.bazel
@@ -1,0 +1,36 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "hello_proto",
+    srcs = ["hello.proto"],
+    deps = [],
+)
+
+go_proto_library(
+    name = "hello_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:go_grpc_v2", "@io_bazel_rules_go//proto:go_proto"],
+    importpath = "github.com/bazelbuild/rules_go/tests/integration/grpc_plugin/hello_proto",
+    proto = ":hello_proto",
+    deps = [],
+)
+
+go_library(
+    name = "hello",
+    srcs = ["hello.go"],
+    importpath = "github.com/bazelbuild/rules_go/tests/integration/grpc_plugin/hello",
+    deps = [
+        ":hello_go_proto",
+    ],
+)
+
+go_test(
+    name = "hello_test",
+    srcs = ["hello_test.go"],
+    deps = [
+        ":hello",
+        ":hello_go_proto",
+        "@org_golang_google_grpc//:go_default_library",
+    ],
+)

--- a/tests/integration/grpc_plugin/README.rst
+++ b/tests/integration/grpc_plugin/README.rst
@@ -1,7 +1,9 @@
 Testing that the protoc-gen-go-grpc plugin works
 =======================================
 
-server_test
+hello_test
 ------------------
 
-Verifies that the generated code for a simple gRPC service has the expected interfaces
+Verifies that the generated code for a simple gRPC service:
+- exposes a `pb.UnimplementedGreetServer` style struct
+- exposes a `pb.RegisterGreetServer` method that accepts a `grpc.ServiceRegistrar` instead of a raw `*grpc.Server`

--- a/tests/integration/grpc_plugin/README.rst
+++ b/tests/integration/grpc_plugin/README.rst
@@ -1,0 +1,7 @@
+Testing that the protoc-gen-go-grpc plugin works
+=======================================
+
+server_test
+------------------
+
+Verifies that the generated code for a simple gRPC service has the expected interfaces

--- a/tests/integration/grpc_plugin/hello.go
+++ b/tests/integration/grpc_plugin/hello.go
@@ -21,7 +21,7 @@ import (
 )
 
 type greeter struct {
-  pb.UnimplementedGreetServer
+	pb.UnimplementedGreetServer
 }
 
 func GreetServer() pb.GreetServer {

--- a/tests/integration/grpc_plugin/hello.go
+++ b/tests/integration/grpc_plugin/hello.go
@@ -1,0 +1,33 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hello
+
+import (
+	"context"
+
+	pb "github.com/bazelbuild/rules_go/tests/integration/grpc_plugin/hello_proto"
+)
+
+type greeter struct {
+  pb.UnimplementedGreetServer
+}
+
+func GreetServer() pb.GreetServer {
+	return &greeter{}
+}
+
+func (g *greeter) Hello(ctx context.Context, r *pb.HelloRequest) (*pb.HelloResponse, error) {
+	return &pb.HelloResponse{}, nil
+}

--- a/tests/integration/grpc_plugin/hello.proto
+++ b/tests/integration/grpc_plugin/hello.proto
@@ -1,0 +1,26 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package rules_go.tests.integration.grpc_plugin;
+
+option go_package = "github.com/bazelbuild/rules_go/tests/integration/grpc_plugin/hello_proto";
+
+service Greet {
+  rpc Hello(HelloRequest) returns (HelloResponse);
+}
+
+message HelloRequest {}
+message HelloResponse {}

--- a/tests/integration/grpc_plugin/hello_test.go
+++ b/tests/integration/grpc_plugin/hello_test.go
@@ -1,0 +1,40 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hello_test
+
+import (
+  "reflect"
+	"testing"
+
+  "github.com/bazelbuild/rules_go/tests/integration/grpc_plugin/hello"
+	pb "github.com/bazelbuild/rules_go/tests/integration/grpc_plugin/hello_proto"
+  "google.golang.org/grpc"
+)
+
+func Test_ServiceRegistrar(t *testing.T) {
+  fr := &fakeRegistrar{}
+  pb.RegisterGreetServer(fr, hello.GreetServer())
+  if got, want := fr.services, []string{"rules_go.tests.integration.grpc_plugin.Greet"}; !reflect.DeepEqual(got, want) {
+    t.Fatalf("got %v, want %v", got, want)
+  }
+}
+
+type fakeRegistrar struct {
+  services []string
+}
+
+func (fr *fakeRegistrar) RegisterService(desc *grpc.ServiceDesc, impl any) {
+  fr.services = append(fr.services, desc.ServiceName)
+}

--- a/tests/integration/grpc_plugin/hello_test.go
+++ b/tests/integration/grpc_plugin/hello_test.go
@@ -15,26 +15,26 @@
 package hello_test
 
 import (
-  "reflect"
+	"reflect"
 	"testing"
 
-  "github.com/bazelbuild/rules_go/tests/integration/grpc_plugin/hello"
+	"github.com/bazelbuild/rules_go/tests/integration/grpc_plugin/hello"
 	pb "github.com/bazelbuild/rules_go/tests/integration/grpc_plugin/hello_proto"
-  "google.golang.org/grpc"
+	"google.golang.org/grpc"
 )
 
 func Test_ServiceRegistrar(t *testing.T) {
-  fr := &fakeRegistrar{}
-  pb.RegisterGreetServer(fr, hello.GreetServer())
-  if got, want := fr.services, []string{"rules_go.tests.integration.grpc_plugin.Greet"}; !reflect.DeepEqual(got, want) {
-    t.Fatalf("got %v, want %v", got, want)
-  }
+	fr := &fakeRegistrar{}
+	pb.RegisterGreetServer(fr, hello.GreetServer())
+	if got, want := fr.services, []string{"rules_go.tests.integration.grpc_plugin.Greet"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
 }
 
 type fakeRegistrar struct {
-  services []string
+	services []string
 }
 
 func (fr *fakeRegistrar) RegisterService(desc *grpc.ServiceDesc, impl any) {
-  fr.services = append(fr.services, desc.ServiceName)
+	fr.services = append(fr.services, desc.ServiceName)
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

In https://github.com/bazelbuild/rules_go/issues/3022 it was noted that the default `go_proto_compiler` exposed by `rules_go` is no longer actively being maintained. Most recent development effort is going into google.golang.org/protobuf/cmd/protoc-gen-go

You can see this in the gRPC tutorial: https://grpc.io/docs/languages/go/quickstart/ which recommends
```
$ go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28
$ go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
```

Specifically there are a few changes to how this other gRPC compiler plugin generates code that are desireable:
- it simplifies forwards-compatibility by introducing an `UnimplementedXyzServer` struct that implementers must embed
- it modifies the `RegisterXyzServer` function so that it accepts a `grpc.ServiceRegistrar` interface rather than a concrete `*grpc.Server` pointer

Unfortunately, these exact benefits make it a bit rocky to transition from the old plugin to the new one. Rather than try to swap out the default proto compiler, I've opted in this PR to simply _expose an additional option_. This should be backwards compatible, but will allow `rules_go` users to begin incrementally transitioning their gRPC code over to the new plugin.

In a future release, you might consider fully deprecating the old plugin, but that will be a pretty significant breaking change and should be undertaken carefully.

**Which issues(s) does this PR fix?**

Partially addresses https://github.com/bazelbuild/rules_go/issues/3022