### PR TITLE
Pass env to gentestmain so it will correctly filter

### DIFF
--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -120,6 +120,7 @@ def _go_test_impl(ctx):
         executable = go.toolchain._builder,
         arguments = [arguments],
         toolchain = GO_TOOLCHAIN_LABEL,
+        env = go.env,
     )
 
     test_gc_linkopts = gc_linkopts(ctx)

--- a/tests/core/cgo/BUILD.bazel
+++ b/tests/core/cgo/BUILD.bazel
@@ -472,3 +472,9 @@ cc_binary(
     srcs = ["use_c_symbol_through_go.c"],
     deps = [":use_transitive_symbol"],
 )
+
+go_test(
+    name = "cgo_required",
+    srcs = ["cgo_required_test.go"],
+    pure = "on",
+)

--- a/tests/core/cgo/cgo_required_test.go
+++ b/tests/core/cgo/cgo_required_test.go
@@ -1,0 +1,10 @@
+//go:build cgo
+// +build cgo
+
+package cgo_required
+
+import "testing"
+
+// Without correct filtering, gentestmain will try to link against this test
+// that does not exist with pure = True
+func TestHelloWorld(t *testing.T) {}


### PR DESCRIPTION
This is a fairly simple change and the test is also simple. Without the addition test.bzl, the new cgo_required test fails to compile. It's more of a regression test than anything else.

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Correctly filters test functions

**Which issues(s) does this PR fix?**

Fixes #2763 

**Other notes for review**
