### PR TITLE
Add integration tests for protoc-gen-go-grpc

### DIFF
--- a/tests/integration/grpc_plugin/BUILD.bazel
+++ b/tests/integration/grpc_plugin/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "hello_proto",
+    srcs = ["hello.proto"],
+    deps = [],
+)
+
+go_proto_library(
+    name = "hello_go_proto",
+    compilers = [
+        "@io_bazel_rules_go//proto:go_grpc_v2",
+        "@io_bazel_rules_go//proto:go_proto",
+    ],
+    importpath = "github.com/bazelbuild/rules_go/tests/integration/grpc_plugin/hello_proto",
+    proto = ":hello_proto",
+    deps = [],
+)
+
+go_library(
+    name = "hello",
+    srcs = ["hello.go"],
+    importpath = "github.com/bazelbuild/rules_go/tests/integration/grpc_plugin/hello",
+    deps = [
+        ":hello_go_proto",
+    ],
+)
+
+go_test(
+    name = "hello_test",
+    srcs = ["hello_test.go"],
+    deps = [
+        ":hello",
+        ":hello_go_proto",
+        "@org_golang_google_grpc//:go_default_library",
+    ],
+)

--- a/tests/integration/grpc_plugin/BUILD.bazel
+++ b/tests/integration/grpc_plugin/BUILD.bazel
@@ -8,12 +8,8 @@ proto_library(
     deps = [],
 )
 
-go_proto_library(
+go_grpc_library(
     name = "hello_go_proto",
-    compilers = [
-        "@io_bazel_rules_go//proto:go_grpc_v2",
-        "@io_bazel_rules_go//proto:go_proto",
-    ],
     importpath = "github.com/bazelbuild/rules_go/tests/integration/grpc_plugin/hello_proto",
     proto = ":hello_proto",
     deps = [],

--- a/tests/integration/grpc_plugin/BUILD.bazel
+++ b/tests/integration/grpc_plugin/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_grpc_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(

--- a/tests/integration/grpc_plugin/README.rst
+++ b/tests/integration/grpc_plugin/README.rst
@@ -1,0 +1,9 @@
+Testing that the protoc-gen-go-grpc plugin works
+=======================================
+
+hello_test
+------------------
+
+Verifies that the generated code for a simple gRPC service:
+- exposes a `pb.UnimplementedGreetServer` style struct
+- exposes a `pb.RegisterGreetServer` method that accepts a `grpc.ServiceRegistrar` instead of a raw `*grpc.Server`

--- a/tests/integration/grpc_plugin/hello.go
+++ b/tests/integration/grpc_plugin/hello.go
@@ -1,0 +1,33 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hello
+
+import (
+	"context"
+
+	pb "github.com/bazelbuild/rules_go/tests/integration/grpc_plugin/hello_proto"
+)
+
+type greeter struct {
+	pb.UnimplementedGreetServer
+}
+
+func GreetServer() pb.GreetServer {
+	return &greeter{}
+}
+
+func (g *greeter) Hello(ctx context.Context, r *pb.HelloRequest) (*pb.HelloResponse, error) {
+	return &pb.HelloResponse{}, nil
+}

--- a/tests/integration/grpc_plugin/hello.proto
+++ b/tests/integration/grpc_plugin/hello.proto
@@ -1,0 +1,26 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package rules_go.tests.integration.grpc_plugin;
+
+option go_package = "github.com/bazelbuild/rules_go/tests/integration/grpc_plugin/hello_proto";
+
+service Greet {
+  rpc Hello(HelloRequest) returns (HelloResponse);
+}
+
+message HelloRequest {}
+message HelloResponse {}

--- a/tests/integration/grpc_plugin/hello_test.go
+++ b/tests/integration/grpc_plugin/hello_test.go
@@ -1,0 +1,40 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hello_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/tests/integration/grpc_plugin/hello"
+	pb "github.com/bazelbuild/rules_go/tests/integration/grpc_plugin/hello_proto"
+	"google.golang.org/grpc"
+)
+
+func Test_ServiceRegistrar(t *testing.T) {
+	fr := &fakeRegistrar{}
+	pb.RegisterGreetServer(fr, hello.GreetServer())
+	if got, want := fr.services, []string{"rules_go.tests.integration.grpc_plugin.Greet"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+type fakeRegistrar struct {
+	services []string
+}
+
+func (fr *fakeRegistrar) RegisterService(desc *grpc.ServiceDesc, impl any) {
+	fr.services = append(fr.services, desc.ServiceName)
+}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Other: adding integration tests

**What does this PR do? Why is it needed?**
This is a resurrection of https://github.com/bazelbuild/rules_go/pull/3783 now that https://github.com/bazelbuild/rules_go/pull/3761 has been merged. This PR is purely testing. It adds an integration test that exercises some of the novel codegen features of the protoc-gen-go-grpc plugin.

This:
- ensures that the plugin is working properly (and can be extended in order to validate new functionality)
- serves as a bit of "living documentation" for users to demonstrate how to use the new compiler