### PR TITLE
prepare release 0.44.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_go",
-    version = "0.43.0",
+    version = "0.44.0",
     compatibility_level = 0,
     repo_name = "io_bazel_rules_go",
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bazelbuild/rules_go
 
-go 1.21.0
+go 1.21.1
 
 require (
 	github.com/gogo/protobuf v1.3.2
@@ -16,7 +16,7 @@ require (
 
 require (
 	golang.org/x/mod v0.14.0 // indirect
-	golang.org/x/sys v0.14.0 // indirect
+	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231120223509-83a465c0220f // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
-golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
+golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -121,7 +121,7 @@ TOOLS_NOGO = [str(Label(l)) for l in _TOOLS_NOGO]
 
 # Current version or next version to be tagged. Gazelle and other tools may
 # check this to determine compatibility.
-RULES_GO_VERSION = "0.43.0"
+RULES_GO_VERSION = "0.44.0"
 
 go_context = _go_context
 gomock = _gomock

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -50,7 +50,7 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "bazel_skylib",
-        # 1.5.0, latest as of 2023-11-16
+        # 1.5.0, latest as of 2023-12-15
         urls = [
             "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
             "https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
@@ -105,13 +105,13 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "org_golang_x_sys",
-        # v0.14.0, latest as of 2023-11-16
+        # v0.15.0, latest as of 2023-12-15
         urls = [
-            "https://mirror.bazel.build/github.com/golang/sys/archive/refs/tags/v0.14.0.zip",
-            "https://github.com/golang/sys/archive/refs/tags/v0.14.0.zip",
+            "https://mirror.bazel.build/github.com/golang/sys/archive/refs/tags/v0.15.0.zip",
+            "https://github.com/golang/sys/archive/refs/tags/v0.15.0.zip",
         ],
-        sha256 = "0791dad0d738ef5e92304d6691d58e37c8a643844f13dfad26d28e1adb6c61ce",
-        strip_prefix = "sys-0.14.0",
+        sha256 = "36e7b6587b60eabebcd5102211ef5fabc6c6f40d93dd0db83dcefd13cdeb1b71",
+        strip_prefix = "sys-0.15.0",
         patches = [
             # releaser:patch-cmd gazelle -repo_root . -go_prefix golang.org/x/sys -go_naming_convention import_alias
             Label("//third_party:org_golang_x_sys-gazelle.patch"),
@@ -124,7 +124,7 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "org_golang_x_xerrors",
-        # master, as of 2023-11-16
+        # master, as of 2023-12-15
         urls = [
             "https://mirror.bazel.build/github.com/golang/xerrors/archive/104605ab7028f4af38a8aff92ac848a51bd53c5d.zip",
             "https://github.com/golang/xerrors/archive/104605ab7028f4af38a8aff92ac848a51bd53c5d.zip",
@@ -160,7 +160,7 @@ def go_rules_dependencies(force = False):
         http_archive,
         name = "org_golang_google_protobuf",
         sha256 = "f5d1f6d0e9b836aceb715f1df2dc065083a55b07ecec3b01b5e89d039b14da02",
-        # v1.31.0, latest as of 2023-11-16
+        # v1.31.0, latest as of 2023-12-15
         urls = [
             "https://mirror.bazel.build/github.com/protocolbuffers/protobuf-go/archive/refs/tags/v1.31.0.zip",
             "https://github.com/protocolbuffers/protobuf-go/archive/refs/tags/v1.31.0.zip",
@@ -199,7 +199,7 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "com_github_golang_protobuf",
-        # v1.5.3, latest as of 2023-11-16
+        # v1.5.3, latest as of 2023-12-15
         urls = [
             "https://mirror.bazel.build/github.com/golang/protobuf/archive/refs/tags/v1.5.3.zip",
             "https://github.com/golang/protobuf/archive/refs/tags/v1.5.3.zip",
@@ -217,7 +217,7 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "com_github_gogo_protobuf",
-        # v1.3.2, latest as of 2023-11-16
+        # v1.3.2, latest as of 2023-12-15
         urls = [
             "https://mirror.bazel.build/github.com/gogo/protobuf/archive/refs/tags/v1.3.2.zip",
             "https://github.com/gogo/protobuf/archive/refs/tags/v1.3.2.zip",
@@ -243,13 +243,13 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "org_golang_google_genproto",
-        # main, as of 2023-11-16
+        # main, as of 2023-12-15
         urls = [
-            "https://mirror.bazel.build/github.com/googleapis/go-genproto/archive/bbf56f31fb17579209f44dda2d2567d20ff21a20.zip",
-            "https://github.com/googleapis/go-genproto/archive/bbf56f31fb17579209f44dda2d2567d20ff21a20.zip",
+            "https://mirror.bazel.build/github.com/googleapis/go-genproto/archive/995d672761c0c5b9ac6127b488b48825f9a2e5fb.zip",
+            "https://github.com/googleapis/go-genproto/archive/995d672761c0c5b9ac6127b488b48825f9a2e5fb.zip",
         ],
-        sha256 = "28f26095dca7821661b37190516955185c295a49c44d026de24df7755d46c389",
-        strip_prefix = "go-genproto-bbf56f31fb17579209f44dda2d2567d20ff21a20",
+        sha256 = "14164722fe3c601a0515a911b319a4d6a397f96ee74d9c12b57e5b5501f8cb48",
+        strip_prefix = "go-genproto-995d672761c0c5b9ac6127b488b48825f9a2e5fb",
         patches = [
             # releaser:patch-cmd gazelle -repo_root . -go_prefix google.golang.org/genproto -go_naming_convention import_alias -proto disable_global
             Label("//third_party:org_golang_google_genproto-gazelle.patch"),
@@ -261,7 +261,7 @@ def go_rules_dependencies(force = False):
     _maybe(
         http_archive,
         name = "com_github_golang_mock",
-        # v1.7.0-rc.1, latest as of 2023-11-16
+        # v1.7.0-rc.1, latest as of 2023-12-18
         urls = [
             "https://mirror.bazel.build/github.com/golang/mock/archive/refs/tags/v1.7.0-rc.1.zip",
             "https://github.com/golang/mock/archive/refs/tags/v1.7.0-rc.1.zip",

--- a/third_party/org_golang_google_grpc_cmd_protoc_gen_go_grpc.patch
+++ b/third_party/org_golang_google_grpc_cmd_protoc_gen_go_grpc.patch
@@ -1,6 +1,8 @@
-diff -urN a/BUILD.bazel b/BUILD.bazel
---- a/BUILD.bazel	1970-01-01 01:00:00.000000000 +0100
-+++ b/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+diff --git a/BUILD.bazel b/BUILD.bazel
+new file mode 100644
+index 00000000..c87b2ab8
+--- /dev/null
++++ b/BUILD.bazel
 @@ -0,0 +1,23 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 +


### PR DESCRIPTION
This PR prepares the new release of `rules_go` version `0.44.0`.

At this time we can't upgrade `x/tools` because releases after `0.15.0` remove [the persistent package](https://pkg.go.dev/golang.org/x/tools/internal/persistent)