### PR TITLE
Slightly tweak deprecation wording for //proto:go_grpc

### DIFF
--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -30,7 +30,7 @@ go_proto_compiler(
 
 go_proto_compiler(
     name = "go_grpc",
-    deprecation = "Migrate to //proto:go_grpc_v2 compiler via go_grpc_library() rule.",
+    deprecation = "Migrate to //proto:go_grpc_v2 compiler (which you'll get automatically if you use the go_grpc_library() rule).",
     options = ["plugins=grpc"],
     plugin = "@com_github_golang_protobuf//protoc-gen-go",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Suggestion from https://github.com/bazelbuild/rules_go/pull/3761#discussion_r1432062895