### PR TITLE
add maintainers to metadata.json template

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -5,6 +5,16 @@
       "email": "fabian@meumertzhe.im",
       "github": "fmeum",
       "name": "Fabian Meumertzheim"
+    },
+    {
+      "email": "zplin@uber.com",
+      "github": "linzhp",
+      "name": "Zhongpeng Lin"
+    },
+    {
+      "email": "tfrench@uber.com",
+      "github": "tyler-french",
+      "name": "Tyler French"
     }
   ],
   "repository": [


### PR DESCRIPTION
We need to add this to the `rules_go` file, rather than the BCR file.

[This commit](https://github.com/bazelbuild/bazel-central-registry/commit/3b4a13302dee3a676a07181976a56f6d4fe3dbee) automatically removed the [changes manually added to the BCR.](https://github.com/bazelbuild/bazel-central-registry/commit/f84d372dafb4228e864b867bf512b7ada005399c)