### PR TITLE
Exclude assembly files in cgo packages in pure mode

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -119,9 +119,16 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
         )
     else:
         cgo_deps = depset()
+        sources = split.go + split.c + split.cxx + split.objc + split.headers
+        # If the package has cgo, cgo processes the Assembly files first.
+        # Implicitly, this means a package with cgo cannot have pure Go
+        # assembly files.
+        if len(split.headers) + len(split.c) == 0:
+            sources += split.asm
+
         emit_compilepkg(
             go,
-            sources = split.go + split.c + split.asm + split.cxx + split.objc + split.headers,
+            sources = sources,
             cover = source.cover,
             embedsrcs = source.embedsrcs,
             importpath = importpath,


### PR DESCRIPTION
This matches `go build` behavior: assembly files in packages with cgo are processed through cgo first. This means that noncgo compilation excludes assembly files in packages with cgo.

Note https://github.com/golang/go/blob/2184a394777ccc9ce9625932b2ad773e6e626be0/src/cmd/go/internal/work/exec.go#L758 in Go build source

Example package: https://github.com/cloudflare/circl/tree/main/dh/x25519 curve_amd64.(h|s)

Does not compile correctly before this patch when pure = "on".