### PR TITLE
prepare patch release 0.44.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_go",
-    version = "0.44.0",
+    version = "0.44.1",
     compatibility_level = 0,
     repo_name = "io_bazel_rules_go",
 )

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -121,7 +121,7 @@ TOOLS_NOGO = [str(Label(l)) for l in _TOOLS_NOGO]
 
 # Current version or next version to be tagged. Gazelle and other tools may
 # check this to determine compatibility.
-RULES_GO_VERSION = "0.44.0"
+RULES_GO_VERSION = "0.44.1"
 
 go_context = _go_context
 gomock = _gomock


### PR DESCRIPTION
This patch release is to include https://github.com/bazelbuild/rules_go/commit/43c40a9a596fcf37a5b7b0ae5f32832277393587 which reverts a change to forcefully upgrade genproto transitively, which is causing linker failures since `google.golang.org/genproto/googleapis/rpc` was separated from `google.golang.org/genproto`

```
Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
link: package conflict error: google.golang.org/genproto/googleapis/longrunning: package imports google.golang.org/genproto/googleapis/rpc/status
          was compiled with: @@gazelle~0.35.0~go_deps~org_golang_google_genproto//googleapis/rpc/status:status
        but was linked with: @@gazelle~0.35.0~go_deps~org_golang_google_genproto_googleapis_rpc//status:status
```