### PR TITLE
Fix a race detected only if a test times out

### DIFF
--- a/go/tools/bzltestutil/wrap.go
+++ b/go/tools/bzltestutil/wrap.go
@@ -128,19 +128,22 @@ func Wrap(pkg string) error {
 	cmd.Env = append(os.Environ(), "GO_TEST_WRAP=0")
 	cmd.Stderr = io.MultiWriter(os.Stderr, streamMerger.ErrW)
 	cmd.Stdout = io.MultiWriter(os.Stdout, streamMerger.OutW)
-	go func() {
-		// When the Bazel test timeout is reached, Bazel sends a SIGTERM that
-		// we need to forward to the inner process.
-		// TODO: This never triggers on Windows, even though Go should simulate
-		//  a SIGTERM when Windows asks the process to close. It is not clear
-		//  whether Bazel uses the required graceful shutdown mechanism.
-		c := make(chan os.Signal, 1)
-		signal.Notify(c, syscall.SIGTERM)
-		<-c
-		cmd.Process.Signal(syscall.SIGTERM)
-	}()
 	streamMerger.Start()
-	err := cmd.Run()
+	err := cmd.Start()
+	if err == nil {
+		go func() {
+			// When the Bazel test timeout is reached, Bazel sends a SIGTERM that
+			// we need to forward to the inner process.
+			// TODO: This never triggers on Windows, even though Go should simulate
+			//  a SIGTERM when Windows asks the process to close. It is not clear
+			//  whether Bazel uses the required graceful shutdown mechanism.
+			c := make(chan os.Signal, 1)
+			signal.Notify(c, syscall.SIGTERM)
+			<-c
+			cmd.Process.Signal(syscall.SIGTERM)
+		}()
+		err = cmd.Wait()
+	}
 	streamMerger.ErrW.Close()
 	streamMerger.OutW.Close()
 	streamMerger.Wait()


### PR DESCRIPTION
I believe this can happen because the goroutine is started before the command is started. Start the process first, then on success, start the signal handler. Add a test for regression.

I verified the test fails without my change to wrap.go and the race is from the signal handling goroutine.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

It prevents a race detection when a test is timed out. We saw this a bunch and devs were really confused thinking there was a legit race detected.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
