### PR TITLE
registering timeout handler synchronously

### DIFF
--- a/go/tools/bzltestutil/timeout.go
+++ b/go/tools/bzltestutil/timeout.go
@@ -22,13 +22,13 @@ import (
 )
 
 func RegisterTimeoutHandler() {
+	// When the Bazel test timeout is reached, Bazel sends a SIGTERM. We
+	// panic just like native go test would so that the user gets stack
+	// traces of all running go routines.
+	// See https://github.com/golang/go/blob/e816eb50140841c524fd07ecb4eaa078954eb47c/src/testing/testing.go#L2351
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGTERM)
 	go func() {
-		// When the Bazel test timeout is reached, Bazel sends a SIGTERM. We
-		// panic just like native go test would so that the user gets stack
-		// traces of all running go routines.
-		// See https://github.com/golang/go/blob/e816eb50140841c524fd07ecb4eaa078954eb47c/src/testing/testing.go#L2351
-		c := make(chan os.Signal, 1)
-		signal.Notify(c, syscall.SIGTERM)
 		<-c
 		debug.SetTraceback("all")
 		panic("test timed out")


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
Some tests need to send SIGTERM to child processes, which would cause panic in the timeout handler. A way to fix that is to call `signal.Reset(syscall.SIGTERM)` in TestMain to unregister the timeout handler. However, we need to make sure `signal.Reset(syscall.SIGTERM)` is called after `signal.Notify(c, syscall.SIGTERM)` in `RegisterTimeoutHandler()`. This PR moves the `signal.Notify(c, syscall.SIGTERM)` outside the goroutine so it's called synchronously before TestMain

**Other notes for review**
