### PR TITLE
Allow compilers to be overwritten in go_grpc_library()

### DIFF
--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -184,12 +184,13 @@ go_proto_library = rule(
 # attribute) and produces a go library for it.
 
 def go_grpc_library(name, **kwargs):
-    go_proto_library(
-        name = name,
-        compilers = [
+    if "compilers" not in kwargs:
+        kwargs["compilers"] = [
             Label("//proto:go_proto"),
             Label("//proto:go_grpc_v2"),
-        ],
+        ]
+    go_proto_library(
+        name = name,
         **kwargs
     )
 


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This makes the Gazelle implementation in bazelbuild/bazel-gazelle#1711 easier.

**Which issues(s) does this PR fix?**

**Other notes for review**
