### PR TITLE
Temporarily undo deprecation of `//proto:go_grpc`

### DIFF
--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -30,7 +30,8 @@ go_proto_compiler(
 
 go_proto_compiler(
     name = "go_grpc",
-    deprecation = "Migrate to //proto:go_grpc_v2 compiler (which you'll get automatically if you use the go_grpc_library() rule).",
+    # TODO: Bring back the deprecation once Gazelle emits go_grpc_library.
+    #    deprecation = "Migrate to //proto:go_grpc_v2 compiler (which you'll get automatically if you use the go_grpc_library() rule).",
     options = ["plugins=grpc"],
     plugin = "@com_github_golang_protobuf//protoc-gen-go",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Until Gazelle emits `go_grpc_library`.


**Which issues(s) does this PR fix?**

Work towards https://github.com/bazelbuild/bazel-gazelle/issues/1709

**Other notes for review**
