### PR TITLE
improving logging for subcommand failure

### DIFF
--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -168,7 +168,7 @@ func runAndLogCommand(cmd *exec.Cmd, verbose bool) error {
 	cleanup := passLongArgsInResponseFiles(cmd)
 	defer cleanup()
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("error running subcommand %s: %v", cmd.Path, err)
+		return fmt.Errorf("error running subcommand %s: %w", formatCommand(cmd), err)
 	}
 	return nil
 }


### PR DESCRIPTION
Printing out the full command line args when a subcommand fails, so it's easier to debug.
