### PR TITLE
Disable `layering_check` feature in CGo tests

### DIFF
--- a/tests/core/cgo/BUILD.bazel
+++ b/tests/core/cgo/BUILD.bazel
@@ -1,6 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
 
+package(
+    # go_* rules do not emit module maps.
+    features = ["-layering_check"],
+)
+
 go_test(
     name = "opts_test",
     srcs = ["adder_test.go"],


### PR DESCRIPTION
`go_*` rules do not emit the module map files required for `layering_check`.

Work towards https://github.com/grailbio/bazel-toolchain/pull/246