### PR TITLE
Print stack traces without panicking on test timeout

### DIFF
--- a/tests/core/go_test/BUILD.bazel
+++ b/tests/core/go_test/BUILD.bazel
@@ -250,6 +250,15 @@ go_test(
     shard_count = 2,
 )
 
+go_test(
+    name = "sigterm_handler_test",
+    srcs = ["sigterm_handler_test.go"],
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+)
+
 go_bazel_test(
     name = "env_inherit_test",
     srcs = ["env_inherit_test.go"],

--- a/tests/core/go_test/sigterm_handler_test.go
+++ b/tests/core/go_test/sigterm_handler_test.go
@@ -1,0 +1,40 @@
+package sigterm_handler_test
+
+import (
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestRegisterSignalHandler(t *testing.T) {
+	called := false
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGTERM)
+
+	go func() {
+		switch <-c {
+		case syscall.SIGTERM:
+			called = true
+			wg.Done()
+		}
+	}()
+
+	if err := syscall.Kill(os.Getpid(), syscall.SIGTERM); err != nil {
+		t.Fatalf("Failed to send SIGTERM: %v", err)
+	}
+	wg.Wait()
+
+	// Give any signal handlers registered by rules_go a chance to run.
+	time.Sleep(1 * time.Second)
+
+	if !called {
+		t.Fatal("Our handler has not run")
+	}
+}

--- a/tests/core/go_test/timeout_test.go
+++ b/tests/core/go_test/timeout_test.go
@@ -38,7 +38,7 @@ func neverTerminates() {
 
 func TestTimeout(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("panics on timeouts are not yet supported on Windows")
+		t.Skip("stack traces on timeouts are not yet supported on Windows")
 	}
 
 	if err := bazel_testing.RunBazel("test", "//:timeout_test", "--test_timeout=3"); err == nil {
@@ -57,8 +57,8 @@ func TestTimeout(t *testing.T) {
 	}
 
 	testLog := string(b)
-	if !strings.Contains(testLog, "panic: test timed out") {
-		t.Fatalf("test log does not contain expected panic:\n%s", testLog)
+	if !strings.Contains(testLog, "Received SIGTERM, printing stack traces of all goroutines:") {
+		t.Fatalf("test log does not contain expected header:\n%s", testLog)
 	}
 	if !strings.Contains(testLog, "timeout_test.neverTerminates(") {
 		t.Fatalf("test log does not contain expected stack trace:\n%s", testLog)


### PR DESCRIPTION
**What type of PR is this?**

Bug fix
Feature

**What does this PR do? Why is it needed?**

It replaces a call to `panic` in the timeout handler to just printing all stack traces, which removes the need to deregister the `SIGTERM` handler when the test relies on particular `SIGTERM` behavior at the cost of having Bazel kill the process after the grace period instead of the `panic` doing it right away.

Also removes the `SIGTERM` forwarding logic from the wrapper as it isn't needed: Bazel sends `SIGTERM` to all child processes.

**Which issues(s) does this PR fix?**

Related to #3827 

**Other notes for review**
