### PR TITLE
release patch version 0.45.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_go",
-    version = "0.45.0",
+    version = "0.45.1",
     compatibility_level = 0,
     repo_name = "io_bazel_rules_go",
 )

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -121,7 +121,7 @@ TOOLS_NOGO = [str(Label(l)) for l in _TOOLS_NOGO]
 
 # Current version or next version to be tagged. Gazelle and other tools may
 # check this to determine compatibility.
-RULES_GO_VERSION = "0.45.0"
+RULES_GO_VERSION = "0.45.1"
 
 go_context = _go_context
 gomock = _gomock


### PR DESCRIPTION
This includes various bug fixes from 0.45.0 and fixes the BCR publishing. In the interest of compatibility we are not upgrading any dependencies for this release.