### PR TITLE
Support custom `GOARM` architecture levels via platform constraints

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -112,6 +112,12 @@ go_config(
         # The default is v1.
         "//conditions:default": None,
     }),
+    arm = select({
+        "//go/constraints/arm:5": "5",
+        "//go/constraints/arm:6": "6",
+        "//go/constraints/arm:7": "7",
+        "//conditions:default": None,
+    }),
     cover_format = "//go/config:cover_format",
     # Always include debug symbols with -c dbg.
     debug = select({

--- a/go/BUILD.bazel
+++ b/go/BUILD.bazel
@@ -17,6 +17,7 @@ filegroup(
     srcs = glob(["**"]) + [
         "//go/config:all_files",
         "//go/constraints/amd64:all_files",
+        "//go/constraints/arm:all_files",
         "//go/platform:all_files",
         "//go/private:all_files",
         "//go/runfiles:all_files",

--- a/go/constraints/amd64/BUILD.bazel
+++ b/go/constraints/amd64/BUILD.bazel
@@ -5,7 +5,7 @@ package(
 # Represents the level of support for the particular microarchitecture of a
 # target platform based on the general amd64 architecture.
 # GOAMD64 is set based on the chosen constraint_value.
-# See https://github.com/golang/go/wiki/MinimumRequirements#amd64
+# See https://go.dev/wiki/MinimumRequirements#amd64
 constraint_setting(
     name = "amd64",
 )

--- a/go/constraints/arm/BUILD.bazel
+++ b/go/constraints/arm/BUILD.bazel
@@ -1,0 +1,33 @@
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+# Represents the level of support for the particular microarchitecture of a
+# target platform based on the general arm architecture.
+# GOARM is set based on the chosen constraint_value.
+# See https://go.dev/wiki/MinimumRequirements#arm
+constraint_setting(
+    name = "arm",
+)
+
+constraint_value(
+    name = "5",
+    constraint_setting = ":arm",
+)
+
+constraint_value(
+    name = "6",
+    constraint_setting = ":arm",
+)
+
+constraint_value(
+    name = "7",
+    constraint_setting = ":arm",
+)
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -492,6 +492,12 @@ def go_context(ctx, attr = None):
     # See https://go.dev/wiki/MinimumRequirements#amd64
     if mode.amd64:
         env["GOAMD64"] = mode.amd64
+
+    # Similarly, set GOARM based on platform constraints in //go/constraints/arm.
+    # See https://go.dev/wiki/MinimumRequirements#arm
+    if mode.arm:
+        env["GOARM"] = mode.arm
+
     if not cgo_context_info:
         crosstool = []
         cgo_tools = None
@@ -887,6 +893,7 @@ def _go_config_impl(ctx):
         cover_format = ctx.attr.cover_format[BuildSettingInfo].value,
         gc_goopts = ctx.attr.gc_goopts[BuildSettingInfo].value,
         amd64 = ctx.attr.amd64,
+        arm = ctx.attr.arm,
         pgoprofile = ctx.attr.pgoprofile,
     )]
 
@@ -936,6 +943,7 @@ go_config = rule(
             providers = [BuildSettingInfo],
         ),
         "amd64": attr.string(),
+        "arm": attr.string(),
         "pgoprofile": attr.label(
             mandatory = True,
             allow_files = True,

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -489,7 +489,7 @@ def go_context(ctx, attr = None):
 
     # The level of support is determined by the platform constraints in
     # //go/constraints/amd64.
-    # See https://github.com/golang/go/wiki/MinimumRequirements#amd64
+    # See https://go.dev/wiki/MinimumRequirements#amd64
     if mode.amd64:
         env["GOAMD64"] = mode.amd64
     if not cgo_context_info:

--- a/go/private/mode.bzl
+++ b/go/private/mode.bzl
@@ -92,6 +92,7 @@ def get_mode(ctx, go_toolchain, cgo_context_info, go_config_info):
     linkmode = go_config_info.linkmode if go_config_info else LINKMODE_NORMAL
     cover_format = go_config_info and go_config_info.cover_format
     amd64 = go_config_info.amd64 if go_config_info else None
+    arm = go_config_info.arm if go_config_info else None
     goos = go_toolchain.default_goos if getattr(ctx.attr, "goos", "auto") == "auto" else ctx.attr.goos
     goarch = go_toolchain.default_goarch if getattr(ctx.attr, "goarch", "auto") == "auto" else ctx.attr.goarch
     gc_goopts = go_config_info.gc_goopts if go_config_info else []
@@ -137,6 +138,7 @@ def get_mode(ctx, go_toolchain, cgo_context_info, go_config_info):
         tags = tags,
         cover_format = cover_format,
         amd64 = amd64,
+        arm = arm,
         gc_goopts = gc_goopts,
         pgoprofile = pgoprofile,
     )


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This PR introduces support for specifying the ARM architecture level as `GOARM` via platform constraints, mirroring the implementation in #3251 which accomplished a similar objective for `GOAMD64`.

The constraint names are taken from here: https://go.dev/wiki/MinimumRequirements#arm

**Which issues(s) does this PR fix?**

Fixes #1719

**Other notes for review**

Verification:

`WORKSPACE`:

```starlark
local_repository(
    name = "io_bazel_rules_go",
    path = "/path/to/rules_go/fork",
)

load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")

go_rules_dependencies()

go_register_toolchains(version = "1.21.6")
```

`BUILD`:

```starlark
load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_cross_binary", "go_library")

platform(
    name = "goarm_5",
    constraint_values = [
        "@platforms//os:linux",
        "@platforms//cpu:armv7",
        "@io_bazel_rules_go//go/constraints/arm:5",
    ],
)

platform(
    name = "goarm_6",
    constraint_values = [
        "@platforms//os:linux",
        "@platforms//cpu:armv7",
        "@io_bazel_rules_go//go/constraints/arm:6",
    ],
)

platform(
    name = "goarm_7",
    constraint_values = [
        "@platforms//os:linux",
        "@platforms//cpu:armv7",
        "@io_bazel_rules_go//go/constraints/arm:7",
    ],
)

go_library(
    name = "lib",
    srcs = ["main.go"],
    importpath = "sample",
)

go_binary(
    name = "main_host",
    out = "main",
    embed = [":lib"],
)

go_cross_binary(
    name = "main_arm_5",
    platform = ":goarm_5",
    target = ":main_host",
)

go_cross_binary(
    name = "main_arm_6",
    platform = ":goarm_6",
    target = ":main_host",
)

go_cross_binary(
    name = "main_arm_7",
    platform = ":goarm_7",
    target = ":main_host",
)
```

`main.go`:

```go
package main

import (
	"fmt"
)

func main() {
	fmt.Println("Hello, world!")
}
```

Compile steps:

```bash
$ bazel build //:main_arm_5
$ bazel build //:main_arm_6
$ bazel build //:main_arm_7
```

It seems that the Go compiler does not embed ARM attributes in the compiled binaries, so `readelf -A <binary>` does not produce any output. This would otherwise indicate the ARM architecture level in the `Tag_CPU_arch` tag.

So instead I copied each of these binaries to an ARM host with the following CPU feature set support:

```bash
$ cat /proc/cpuinfo
processor	: 0
model name	: ARMv6-compatible processor rev 7 (v6l)
BogoMIPS	: 697.95
Features	: half thumb fastmult vfp edsp java tls 
CPU implementer	: 0x41
CPU architecture: 7
CPU variant	: 0x0
CPU part	: 0xb76
CPU revision	: 7

Hardware	: BCM2835
Revision	: 100000e
Serial		: 00000000557be544
Model		: Raspberry Pi Model B Rev 2
```

Results:

```bash
$ ./main_arm_5
Hello, world!
$ ./main_arm_6
Hello, world!
$ ./main_arm_7
Illegal instruction
```