### PR TITLE
go_test: ensure external source compilation has data

### DIFF
--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -74,6 +74,7 @@ def _go_test_impl(ctx):
     )
     external_source = go.library_to_source(go, struct(
         srcs = [struct(files = go_srcs)],
+        data = ctx.attr.data,
         embedsrcs = [struct(files = internal_source.embedsrcs)],
         deps = internal_archive.direct + [internal_archive],
         x_defs = ctx.attr.x_defs,

--- a/tests/core/go_test/x_defs/BUILD.bazel
+++ b/tests/core/go_test/x_defs/BUILD.bazel
@@ -49,22 +49,36 @@ go_library(
     x_defs = {"Qux": "Qux"},
 )
 
+genrule(
+    name = "data_dep",
+    outs = ["data_dep.txt"],
+    cmd = "touch $@",
+)
+
 go_library(
     name = "x_defs_lib",
     srcs = ["x_defs_lib.go"],
-    data = ["x_defs_lib.go"],
+    data = [
+        "data_dep.txt",
+        "x_defs_lib.go",
+    ],
     importpath = "github.com/bazelbuild/rules_go/tests/core/go_test/x_defs/x_defs_lib",
     x_defs = {
         "LibGo": "$(rlocationpath x_defs_lib.go)",
+        "DataDep": "$(rlocationpath :data_dep.txt)",
     },
 )
 
 go_test(
     name = "x_defs_test",
     srcs = ["x_defs_test.go"],
-    data = ["x_defs_test.go"],
+    data = [
+        "data_dep.txt",
+        "x_defs_test.go",
+    ],
     x_defs = {
         "BinGo": "$(rlocationpath x_defs_test.go)",
+        "DataDep": "$(rlocationpath :data_dep.txt)",
     },
     deps = [
         ":x_defs_lib",

--- a/tests/core/go_test/x_defs/x_defs_lib.go
+++ b/tests/core/go_test/x_defs/x_defs_lib.go
@@ -1,3 +1,5 @@
 package x_defs_lib
 
 var LibGo = "not set"
+
+var DataDep = "not set"

--- a/tests/core/go_test/x_defs/x_defs_test.go
+++ b/tests/core/go_test/x_defs/x_defs_test.go
@@ -11,12 +11,23 @@ import (
 
 var BinGo = "not set"
 
+var DataDep = "not set"
+
 func TestLibGoPath(t *testing.T) {
 	libGoPath, err := runfiles.Rlocation(x_defs_lib.LibGo)
 	if err != nil {
 		t.Fatal(err)
 	}
 	_, err = os.Stat(libGoPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dataPath, err := runfiles.Rlocation(x_defs_lib.DataDep)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = os.Stat(dataPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,6 +39,15 @@ func TestBinGoPath(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err = os.Stat(binGoPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dataPath, err := runfiles.Rlocation(DataDep)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = os.Stat(dataPath)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
go_test is split into 2 compilation actions, one for internal test,
where package name of the test is the same with library package.

```bash
package foo

package foo
```

and external test where the package name is different.
```bash
package foo

package foo_test
```

Ensure that the compilation for external test has access to go_test's
data attribute.
