### PR TITLE
runfiles: provide Rlocations to look up multiple paths

### DIFF
--- a/go/runfiles/global.go
+++ b/go/runfiles/global.go
@@ -28,12 +28,49 @@ func Rlocation(path string) (string, error) {
 	return RlocationFrom(path, CallerRepository())
 }
 
+// Rlocations returns the absolute paths name of a set of runfiles.
+// The input "paths" is expected to be a list of runfile names that match the
+// criterias documented in runfiles.Rlocation(), separated by a single white-space
+// character.
+// Usually this input value could be generated from Bazel's
+//
+//	$(rlocationpaths <target-label)
+//
+// function call in BUILD files.
+//
+// Example:
+//
+//	paths := "my_repo/files/a my_repo/files/b"
+//	locations, _ := runfiles.Rlocations(paths)
+//
+// will result in `locations` being
+//
+//	map[string]string{
+//	  "my_repo/files/a": "<some-path-on-disk>/files/a"
+//	  "my_repo/files/b": "<some-path-on-disk>/files/b"
+//	}
+//
+// For more information, see
+//
+//	https://bazel.build/reference/be/make-variables#predefined_label_variables
+func Rlocations(paths string) (map[string]string, error) {
+	return RlocationsFrom(paths, CallerRepository())
+}
+
 func RlocationFrom(path string, sourceRepo string) (string, error) {
 	r, err := g.get()
 	if err != nil {
 		return "", err
 	}
 	return r.WithSourceRepo(sourceRepo).Rlocation(path)
+}
+
+func RlocationsFrom(paths string, sourceRepo string) (map[string]string, error) {
+	r, err := g.get()
+	if err != nil {
+		return map[string]string{}, err
+	}
+	return r.WithSourceRepo(sourceRepo).Rlocations(paths)
 }
 
 // Env returns additional environmental variables to pass to subprocesses.

--- a/go/runfiles/runfiles.go
+++ b/go/runfiles/runfiles.go
@@ -164,6 +164,26 @@ func (r *Runfiles) Rlocation(path string) (string, error) {
 	return p, nil
 }
 
+// Rlocations wraps over the Rlocation call to accomodate for lookup paths
+// that were generated from `rlocationpaths` (plural).
+func (r *Runfiles) Rlocations(paths string) (map[string]string, error) {
+	pSlice := strings.Split(paths, " ")
+	if len(pSlice) == 0 {
+		return map[string]string{}, fmt.Errorf("runfiles: paths must not be empty: %s", paths)
+	}
+
+	res := make(map[string]string, len(pSlice))
+	for _, p := range strings.Split(paths, " ") {
+		location, err := r.Rlocation(p)
+		if err != nil {
+			return res, Error{p, err}
+		}
+		res[p] = location
+	}
+
+	return res, nil
+}
+
 func isNormalizedPath(s string) error {
 	if strings.HasPrefix(s, "../") || strings.Contains(s, "/../") || strings.HasSuffix(s, "/..") {
 		return fmt.Errorf(`runfiles: path %q must not contain ".." segments`, s)

--- a/tests/runfiles/BUILD.bazel
+++ b/tests/runfiles/BUILD.bazel
@@ -32,6 +32,11 @@ go_test(
 )
 
 go_bazel_test(
+    name = "rlocations_bazel_test",
+    srcs = ["rlocations_bazel_test.go"],
+)
+
+go_bazel_test(
     name = "runfiles_bazel_test",
     srcs = ["runfiles_bazel_test.go"],
 )

--- a/tests/runfiles/rlocations_bazel_test.go
+++ b/tests/runfiles/rlocations_bazel_test.go
@@ -1,0 +1,109 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rlocations_test
+
+import (
+	"regexp"
+	"runtime"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: `
+-- files/a --
+-- files/b --
+-- files/BUILD.bazel --
+filegroup(
+    name = "files",
+    srcs = ["a", "b"],
+    visibility = ["//visibility:public"],
+)
+-- BUILD.bazel --
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+
+go_binary(
+    name = "main",
+    data = ["//files"],
+    srcs = ["main.go"],
+    x_defs = {
+        "filesRunfilePath": "$(rlocationpaths //files)",
+    },
+    deps = [
+        "@io_bazel_rules_go//go/runfiles",
+    ],
+)
+-- main.go --
+package main
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/bazelbuild/rules_go/go/runfiles"
+)
+
+// set by x_defs in BUILD.bazel
+var filesRunfilePath string
+
+func main() {
+	paths, err := runfiles.Rlocations(filesRunfilePath)
+	if err != nil {
+		panic(err)
+	}
+
+	keys := make([]string, 0, len(paths))
+	for k := range paths {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		fmt.Printf("file: %q - %q\n", k, paths[k])
+	}
+}
+`,
+	})
+}
+
+var unixExpectedOutputs = []*regexp.Regexp{
+	regexp.MustCompile(`file: "(_main|__main__)/files/a" - "/.*/main/files/a"\n`),
+	regexp.MustCompile(`file: "(_main|__main__)/files/b" - "/.*/main/files/b"\n`),
+}
+
+var windowsExpectedOutputs = []*regexp.Regexp{
+	regexp.MustCompile(`file: "(_main|__main__)/files/a" - ".:\\\\.*\\\\main\\\\files\\\\a"\n`),
+	regexp.MustCompile(`file: "(_main|__main__)/files/b" - ".:\\\\.*\\\\main\\\\files\\\\b"\n`),
+}
+
+func TestCurrentRepository(t *testing.T) {
+	out, err := bazel_testing.BazelOutput("run", "//:main")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedOutputs := unixExpectedOutputs
+	if runtime.GOOS == "windows" {
+		expectedOutputs = windowsExpectedOutputs
+	}
+
+	for _, expected := range expectedOutputs {
+		if !expected.Match(out) {
+			t.Fatalf("got: %q,\n---\n want: %q", string(out), expected.String())
+		}
+	}
+}


### PR DESCRIPTION
Typically, we will be using `rlocationpath` and it's plural form,
`rlocationpaths` to generate the runfile location path from the target
label.  In the case of `rlocationpaths` (plural), the result string
will include multiple location paths, white-space separated.

Provide `runfiles.Rlocations()` to handle the string generated from
`rlocationpaths`.
