### PR TITLE
Add Bazel version matrix to BCR `presubmit.yml`

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -5,10 +5,12 @@ matrix:
     - macos
     - macos_arm64
     - windows
+  bazel: [6.x, 7.x]
 tasks:
   verify_targets:
     name: Verify build targets
     platform: ${{ platform }}
+    bazel: ${{ bazel }}
     build_targets:
       - '@rules_go//go/tools/bzltestutil/...'
 bcr_test_module:
@@ -20,10 +22,12 @@ bcr_test_module:
       - macos
       - macos_arm64
       - windows
+    bazel: [6.x, 7.x]
   tasks:
     run_test_module:
       name: Run test module
       platform: ${{ platform }}
+      bazel: ${{ bazel }}
       build_targets:
         - //...
         - '@go_default_sdk//...'


### PR DESCRIPTION
Newly required by BCR policies.