### PR TITLE
pass correct (non `"main"`) importpath to nogo for `main` package

### DIFF
--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -453,7 +453,7 @@ func compileArchive(
 		ctx, cancel := context.WithCancel(context.Background())
 		nogoChan = make(chan error)
 		go func() {
-			nogoChan <- runNogo(ctx, workDir, nogoPath, goSrcsNogo, facts, packagePath, importcfgPath, outFactsPath)
+			nogoChan <- runNogo(ctx, workDir, nogoPath, goSrcsNogo, facts, importPath, importcfgPath, outFactsPath)
 		}()
 		defer func() {
 			if nogoChan != nil {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

In https://github.com/bazelbuild/rules_go/pull/2135, the importmap passed to `emit_compilepkg` is `"main"` if `is_main` is set (typically via the `go_binary` rule). This value also gets sent to nogo, which is the wrong value to send for a `main` package:

<details>
<summary>Minimal reproduction using <code>x/tools/go/analysis/singlechecker</code></summary>

```go.mod
// go.mod
module sampletext

go 1.21.6

require golang.org/x/tools v0.18.0
require golang.org/x/mod v0.15.0 // indirect
```

```go
// main.go
package main

import (
	"fmt"

	"golang.org/x/tools/go/analysis"
	"golang.org/x/tools/go/analysis/singlechecker"
)

var Analyzer = &analysis.Analyzer{
	Name: "test", 
    Doc:  "test", 
    Run: func(p *analysis.Pass) (interface{}, error) {
		fmt.Println(p.Pkg.Path())
		return nil, nil
	},
}

func main() { singlechecker.Main(Analyzer) }
```

```
$ go run main.go .
sampletext
```

</details>

**Which issues(s) does this PR fix?**

No issue opened. Should I open one alongside this PR?

**Other notes for review**

My original note of the issue: https://github.com/sourcegraph/sourcegraph/issues/54836#issuecomment-1854325505
PR where I introduced a first-iteration patch: https://github.com/sourcegraph/sourcegraph/pull/58971/files
I'd been meaning to open a PR for this here for some time, but only found the time to do so now. Apologies!
