### PR TITLE
[go_library] add .x file to declared output files in DefaultInfo

### DIFF
--- a/go/private/rules/library.bzl
+++ b/go/private/rules/library.bzl
@@ -44,7 +44,7 @@ def _go_library_impl(ctx):
         source,
         archive,
         DefaultInfo(
-            files = depset([archive.data.file]),
+            files = depset([archive.data.export_file]),
         ),
         coverage_common.instrumented_files_info(
             ctx,


### PR DESCRIPTION
After https://github.com/bazelbuild/rules_go/pull/3789, there's no easy way to analyze the package information of a library file from a test using [`bazel.ListRunfiles`](https://pkg.go.dev/github.com/bazelbuild/rules_go/go/tools/bazel#ListRunfiles) without manually copying over the `.x` file somewhere.

This file is arguably more important to users than the machine code, and is generally small, so we should consider exporting it.

