### PR TITLE
Make exec cfg check for `//go` stricter

### DIFF
--- a/go/private/rules/go_bin_for_host.bzl
+++ b/go/private/rules/go_bin_for_host.bzl
@@ -19,7 +19,7 @@ def _ensure_target_cfg(ctx):
     # A target is assumed to be built in the target configuration if it is neither in the exec nor
     # the host configuration (the latter has been removed in Bazel 6). Since there is no API for
     # this, use the output directory to determine the configuration, which is a common pattern.
-    if "-exec-" in ctx.bin_dir.path or "/host/" in ctx.bin_dir.path:
+    if "-exec" in ctx.bin_dir.path or "/host/" in ctx.bin_dir.path:
         fail("//go is only meant to be used with 'bazel run', not as a tool. " +
              "If you need to use it as a tool (e.g. in a genrule), please " +
              "open an issue at " +


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel/issues/14444#issuecomment-1945642624.