### PR TITLE
Remove Latin-1 workaround on Bazel 6.4.0+

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
 
 # The custom repo_name is used to prevent our bazel_features polyfill for WORKSPACE builds from
 # conflicting with the real bazel_features repo.
-bazel_dep(name = "bazel_features", version = "1.1.1", repo_name = "io_bazel_rules_go_bazel_features")
+bazel_dep(name = "bazel_features", version = "1.6.0", repo_name = "io_bazel_rules_go_bazel_features")
 bazel_dep(name = "bazel_skylib", version = "1.2.0")
 bazel_dep(name = "platforms", version = "0.0.4")
 bazel_dep(name = "rules_proto", version = "4.0.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
 
 # The custom repo_name is used to prevent our bazel_features polyfill for WORKSPACE builds from
 # conflicting with the real bazel_features repo.
-bazel_dep(name = "bazel_features", version = "1.6.0", repo_name = "io_bazel_rules_go_bazel_features")
+bazel_dep(name = "bazel_features", version = "1.1.1", repo_name = "io_bazel_rules_go_bazel_features")
 bazel_dep(name = "bazel_skylib", version = "1.2.0")
 bazel_dep(name = "platforms", version = "0.0.4")
 bazel_dep(name = "rules_proto", version = "4.0.0")

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -16,7 +16,6 @@ load("//go/private:common.bzl", "executable_path")
 load("//go/private:nogo.bzl", "go_register_nogo")
 load("//go/private/skylib/lib:versions.bzl", "versions")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "patch", "read_user_netrc", "use_netrc")
-load("@io_bazel_rules_go_bazel_features//:features.bzl", "bazel_features")
 
 MIN_SUPPORTED_VERSION = (1, 14, 0)
 
@@ -442,7 +441,7 @@ def _remote_sdk(ctx, urls, strip_prefix, sha256):
     # in Bazel 6.0.0+ (bazelbuild/bazel#16052). The only situation where
     # .zip files are needed seems to be a macOS host using a Windows toolchain
     # for remote execution.
-    if bazel_features.external_deps.extract_supports_unicode_filenames:
+    if versions.is_at_least("6.4.0", versions.get() or "6.4.0"):
         ctx.download_and_extract(
             url = urls,
             stripPrefix = strip_prefix,

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -16,6 +16,7 @@ load("//go/private:common.bzl", "executable_path")
 load("//go/private:nogo.bzl", "go_register_nogo")
 load("//go/private/skylib/lib:versions.bzl", "versions")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "patch", "read_user_netrc", "use_netrc")
+load("@io_bazel_rules_go_bazel_features//:features.bzl", "bazel_features")
 
 MIN_SUPPORTED_VERSION = (1, 14, 0)
 
@@ -441,7 +442,14 @@ def _remote_sdk(ctx, urls, strip_prefix, sha256):
     # in Bazel 6.0.0+ (bazelbuild/bazel#16052). The only situation where
     # .zip files are needed seems to be a macOS host using a Windows toolchain
     # for remote execution.
-    if urls[0].endswith(".tar.gz"):
+    if bazel_features.external_deps.extract_supports_unicode_filenames:
+        ctx.download_and_extract(
+            url = urls,
+            stripPrefix = strip_prefix,
+            sha256 = sha256,
+            auth = auth,
+        )
+    elif urls[0].endswith(".tar.gz"):
         if strip_prefix != "go":
             fail("strip_prefix not supported")
         ctx.download(
@@ -455,7 +463,7 @@ def _remote_sdk(ctx, urls, strip_prefix, sha256):
             fail("error extracting Go SDK:\n" + res.stdout + res.stderr)
         ctx.delete("go_sdk.tar.gz")
     elif (urls[0].endswith(".zip") and
-          host_goos != "windows" and
+          host_goos == "darwin" and
           # Development versions of Bazel have an empty version string. We assume that they are
           # more recent than the version that introduced rename_files.
           versions.is_at_least("6.0.0", versions.get() or "6.0.0")):
@@ -469,13 +477,16 @@ def _remote_sdk(ctx, urls, strip_prefix, sha256):
             },
             auth = auth,
         )
-    else:
+    elif (urls[0].endswith(".zip") and
+          host_goos != "darwin"):
         ctx.download_and_extract(
             url = urls,
             stripPrefix = strip_prefix,
             sha256 = sha256,
             auth = auth,
         )
+    else:
+        fail("No supported workaround for extracting Go SDK non-ASCII filenames. Bazel 6.4.0+ has correct support for unpacking the Go SDK. {}".format(urls[0]))
 
 def _local_sdk(ctx, path):
     for entry in ctx.path(path).readdir():


### PR DESCRIPTION
The fix for Latin-1 encoded files was landed in [6.4.0] after being landed on Bazel [master].

We can conditionally use the old, unhermetic, `tar` workaround on modern Bazel versions.

[master]: https://github.com/bazelbuild/bazel/pull/18448
[6.4.0]: https://github.com/bazelbuild/bazel/pull/19765

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

We currently use a unhermetic `tar` workaround when a Go SDK URL ends with `.tar.gz` but modern Bazel versions work fine unpacking the `tar` archive. We can conditionally use the workaround.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

None