### PR TITLE
fix sdk download for common execution platforms

### DIFF
--- a/go/private/extensions.bzl
+++ b/go/private/extensions.bzl
@@ -224,8 +224,8 @@ def _go_sdk_impl(ctx):
                     )
                     go_download_sdk_rule(
                         name = default_name,
-                        goos = download_tag.goos,
-                        goarch = download_tag.goarch,
+                        goos = goos,
+                        goarch = goarch,
                         sdks = download_tag.sdks,
                         urls = download_tag.urls,
                         version = download_tag.version,


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This PR fixes a bug where host platform is passed in `go_download_sdk_rule` instead of execution platform.

**Which issues(s) does this PR fix?**

It is very small bug fix, not sure if issue is needed.

**Other notes for review**
