### PR TITLE
Bump Go version to 1.21.8

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,7 +16,7 @@ bazel_dep(name = "protobuf", version = "3.19.2", repo_name = "com_google_protobu
 go_sdk = use_extension("//go:extensions.bzl", "go_sdk")
 go_sdk.download(
     name = "go_default_sdk",
-    version = "1.21.1",
+    version = "1.21.8",
 )
 use_repo(
     go_sdk,

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,7 +5,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.21.1")
+go_register_toolchains(version = "1.21.8")
 
 http_archive(
     name = "com_google_protobuf",


### PR DESCRIPTION
Follows our policy of using the latest patch release of the oldest supported minor version.