### PR TITLE
Support Go version schema change since 1.21

### DIFF
--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -685,8 +685,6 @@ def _version_less(a, b):
 
 def _version_string(v):
     suffix = v[3] if _version_is_prerelease(v) else ""
-    if v[-1] == 0:
-        v = v[:-1]
     return ".".join([str(n) for n in v]) + suffix
 
 def _have_same_length(*lists):


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Since Golang 1.21, the initial minor version has a `.0` suffix e.g `1.21.0`. As a result, it breaks the default behaviour of `go_download_sdk`. 

By default (see the [doc](https://github.com/bazelbuild/rules_go/blob/master/go/toolchains.rst#go_download_sdk)), if no `version` is specified, then the latest version is used. After it searches for the highest Go version, it uses `_version_string` function to make small transformation. The deleted lines removes that `.0` suffix and will cause following error:

`Error in fail: did not find version 1.22 in https://go.dev/dl/?mode=json`

**Which issues(s) does this PR fix?**

Fixes #3850

**Other notes for review**
