### PR TITLE
Revert "improving logging for subcommand failure (#3824)"

### DIFF
--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -168,7 +168,7 @@ func runAndLogCommand(cmd *exec.Cmd, verbose bool) error {
 	cleanup := passLongArgsInResponseFiles(cmd)
 	defer cleanup()
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("error running subcommand %s: %w", formatCommand(cmd), err)
+		return fmt.Errorf("error running subcommand %s: %w", cmd.Path, err)
 	}
 	return nil
 }


### PR DESCRIPTION
This reverts commit 55ea579a70958d66f24a907433978b21edd36b29 with a minor change in error formatting.

Fixed #3890 