### PR TITLE
gopackagesdriver: fix version check with Bazel development versions

### DIFF
--- a/go/tools/gopackagesdriver/bazel.go
+++ b/go/tools/gopackagesdriver/bazel.go
@@ -57,7 +57,6 @@ func NewBazel(ctx context.Context, bazelBin, workspaceRoot string, bazelStartupF
 		bazelBin:          bazelBin,
 		workspaceRoot:     workspaceRoot,
 		bazelStartupFlags: bazelStartupFlags,
-		version:           bazelVersion{6, 0, 0}, // assumed until 'bazel info' output parsed
 	}
 	if err := b.fillInfo(ctx); err != nil {
 		return nil, fmt.Errorf("unable to query bazel info: %w", err)
@@ -197,4 +196,15 @@ func (a bazelVersion) compare(b bazelVersion) int {
 		}
 	}
 	return 0
+}
+
+// isAtLeast returns true if a.compare(b) >= 0 (that is, if a is greater than
+// or equal to be) or if a is the zero value.
+//
+// Development versions of Bazel do not have valid version strings, not even a
+// prerelease, so parseBazelVersion fails and returns the zero value. If we
+// have such a version, we assume it's newer than whatever we're comparing
+// it with.
+func (a bazelVersion) isAtLeast(b bazelVersion) bool {
+	return a.compare(b) >= 0 || a == bazelVersion{}
 }

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -161,7 +161,7 @@ func (b *BazelJSONBuilder) outputGroupsForMode(mode LoadMode) string {
 
 func (b *BazelJSONBuilder) query(ctx context.Context, query string) ([]string, error) {
 	var bzlmodQueryFlags []string
-	if b.bazel.version.compare(bazelVersion{6, 4, 0}) >= 0 {
+	if b.bazel.version.isAtLeast(bazelVersion{6, 4, 0}) {
 		bzlmodQueryFlags = []string{"--consistent_labels"}
 	}
 	queryArgs := concatStringsArrays(bazelQueryFlags, bzlmodQueryFlags, []string{

--- a/go/tools/gopackagesdriver/packageregistry.go
+++ b/go/tools/gopackagesdriver/packageregistry.go
@@ -101,7 +101,7 @@ func (pr *PackageRegistry) Match(labels []string) ([]string, []*FlatPackage) {
 
 	for _, label := range labels {
 		// When packagesdriver is ran from rules go, rulesGoRepositoryName will just be @
-		if pr.bazelVersion.compare(bazelVersion{6, 0, 0}) >= 0 &&
+		if pr.bazelVersion.isAtLeast(bazelVersion{6, 0, 0}) &&
 			!strings.HasPrefix(label, "@") {
 			// Canonical labels is only since Bazel 6.0.0
 			label = fmt.Sprintf("@%s", label)


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Adds method `bazelVersion.isAtLeast` to check that Bazel's version is greater than or equal to a given value. It assumes that if Bazel's version is the zero value, it's a development release, newer than anything being compared.

Replaced calls to `.compare` with `.isAtLeast`.

**Which issues(s) does this PR fix?**

Fixes #3889

**Other notes for review**

n/a