### PR TITLE
Replace instances of to_json() method with json.encode(..)

### DIFF
--- a/go/private/tools/path.bzl
+++ b/go/private/tools/path.bzl
@@ -112,7 +112,7 @@ def _go_path_impl(ctx):
             f.basename,
         )
     manifest_file = ctx.actions.declare_file(ctx.label.name + "~manifest")
-    manifest_entries_json = [e.to_json() for e in manifest_entries]
+    manifest_entries_json = [json.encode(e) for e in manifest_entries]
     manifest_content = "[\n  " + ",\n  ".join(manifest_entries_json) + "\n]"
     ctx.actions.write(manifest_file, manifest_content)
     inputs.append(manifest_file)

--- a/go/tools/gopackagesdriver/aspect.bzl
+++ b/go/tools/gopackagesdriver/aspect.bzl
@@ -77,7 +77,7 @@ def _go_archive_to_pkg(archive):
 
 def make_pkg_json(ctx, name, pkg_info):
     pkg_json_file = ctx.actions.declare_file(name + ".pkg.json")
-    ctx.actions.write(pkg_json_file, content = pkg_info.to_json())
+    ctx.actions.write(pkg_json_file, content = json.encode(pkg_info))
     return pkg_json_file
 
 def _go_pkg_info_aspect_impl(target, ctx):


### PR DESCRIPTION
The to_json and to_proto methods on struct are deprecated and will be removed.
The "json" and "proto" builtin modules should be used instead.

This replaces instances of `foo.to_json()` with `json.encode(foo)`.