### PR TITLE
[nogo] match regexp againts relative paths

### DIFF
--- a/go/tools/builders/nogo_main.go
+++ b/go/tools/builders/nogo_main.go
@@ -32,6 +32,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"sort"
@@ -442,6 +443,10 @@ func checkAnalysisResults(actions []*action, pkg *goPackage) string {
 	}
 	var diagnostics []entry
 	var errs []error
+	cwd, err := os.Getwd()
+	if cwd == "" || err != nil {
+		errs = append(errs, fmt.Errorf("nogo failed to get CWD: %w", err))
+	}
 	for _, act := range actions {
 		if act.err != nil {
 			// Analyzer failed.
@@ -484,6 +489,11 @@ func checkAnalysisResults(actions []*action, pkg *goPackage) string {
 			filename := "-"
 			if p.IsValid() {
 				filename = p.Filename
+			}
+			if cwd != "" {
+				if relname, err := filepath.Rel(cwd, filename); err == nil {
+					filename = relname
+				}
 			}
 			include := true
 			if len(currentConfig.onlyFiles) > 0 {


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**
This PR makes it so that regular expressions in `only_files` and `exclude_files` are matched against relative paths. This allows use of anchored regexps.

**Which issues(s) does this PR fix?**

Fixes #3250

**Other notes for review**

This overwriting of stderr have caused a lot of surprise when I was trying to debug-print filenames from inside of nogo.
https://github.com/bazelbuild/rules_go/blob/aeb83e878033ef357642c87122e193df44da03fe/go/tools/builders/env.go#L140