### PR TITLE
add nogo parsing support for nogo explanations

### DIFF
--- a/go/tools/builders/nolint.go
+++ b/go/tools/builders/nolint.go
@@ -23,6 +23,11 @@ func parseNolint(text string) (map[string]bool, bool) {
 	if !strings.HasPrefix(text, "nolint") {
 		return nil, false
 	}
+
+	// strip explanation comments
+	split := strings.Split(text, "//")
+	text = strings.TrimSpace(split[0])
+
 	parts := strings.Split(text, ":")
 	if len(parts) == 1 {
 		return nil, true

--- a/go/tools/builders/nolint_test.go
+++ b/go/tools/builders/nolint_test.go
@@ -51,8 +51,20 @@ func TestParseNolint(t *testing.T) {
 			Linters: []string{"foo"},
 		},
 		{
+			Name:    "Single linter with an explanation",
+			Comment: "//nolint:foo // the foo lint is invalid for this line",
+			Valid:   true,
+			Linters: []string{"foo"},
+		},
+		{
 			Name:    "Multiple linters",
 			Comment: "// nolint:a,b,c",
+			Valid:   true,
+			Linters: []string{"a", "b", "c"},
+		},
+		{
+			Name:    "Multiple linters with explanation",
+			Comment: "// nolint:a,b,c // some reason",
 			Valid:   true,
 			Linters: []string{"a", "b", "c"},
 		},


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Adds support for parsing nogo nolint directives that have explanation comments.

**Which issues(s) does this PR fix?**

n/a

**Other notes for review**

The nolint directive seems to be based off of golangci-lint's nolint directive. Golangci-lint covers explanation comments as part of the [nolintlint](https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/nolintlint/README.md).
