### PR TITLE
feat(mode): add `purego` tag when `pure`

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -62,6 +62,7 @@ tasks:
       - "//..."
   bcr_tests:
     name: BCR test module
+    bazel: 6.3.0 # silent ignore override in `gazelle@0.36.0`
     platform: ${{ platform }}
     working_directory: tests/bcr
     build_flags:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -71,10 +71,10 @@ bazel_skylib_workspace()
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "b7387f72efb59f876e4daae42f1d3912d0d45563eac7cb23d1de0b094ab588cf",
+    sha256 = "75df288c4b31c81eb50f51e2e14f4763cb7548daae126817247064637fd9ea62",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.34.0/bazel-gazelle-v0.34.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.34.0/bazel-gazelle-v0.34.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.36.0/bazel-gazelle-v0.36.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.36.0/bazel-gazelle-v0.36.0.tar.gz",
     ],
 )
 

--- a/go/modes.rst
+++ b/go/modes.rst
@@ -68,6 +68,8 @@ or using `Bazel configuration transitions`_.
 | Disables cgo, even when a C/C++ toolchain is configured (similar to setting  |
 | ``CGO_ENABLED=0``). Packages that contain cgo code may still be built, but   |
 | the cgo code will be filtered out, and the ``cgo`` build tag will be false.  |
+| Sets the de-facto ``purego`` build tag for conditional inclusion of source   |
+| files.                                                                       |
 +-------------------+---------------------+------------------------------------+
 | :param:`debug`    | :type:`bool`        | :value:`false`                     |
 +-------------------+---------------------+------------------------------------+

--- a/go/private/mode.bzl
+++ b/go/private/mode.bzl
@@ -122,6 +122,8 @@ def get_mode(ctx, go_toolchain, cgo_context_info, go_config_info):
         tags.append("race")
     if msan:
         tags.append("msan")
+    if pure:
+        tags.append("purego")
 
     return struct(
         static = static,

--- a/tests/core/cgo/BUILD.bazel
+++ b/tests/core/cgo/BUILD.bazel
@@ -334,6 +334,7 @@ go_test(
     data = [
         ":tag_cgo_bin",
         ":tag_pure_bin",
+        ":tag_purego_bin",
     ],
     rundir = ".",
     deps = ["//go/tools/bazel:go_default_library"],
@@ -345,6 +346,17 @@ go_binary(
         "tag_pure.go",
         "tag_pure_err.c",
         "tag_pure_err.go",
+    ],
+    cgo = True,
+    pure = "on",
+)
+
+go_binary(
+    name = "tag_purego_bin",
+    srcs = [
+        "tag_purego.go",
+        "tag_purego_err.c",
+        "tag_purego_err.go",
     ],
     cgo = True,
     pure = "on",

--- a/tests/core/cgo/tag_purego.go
+++ b/tests/core/cgo/tag_purego.go
@@ -1,0 +1,9 @@
+// +build purego
+
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("purego")
+}

--- a/tests/core/cgo/tag_purego_err.c
+++ b/tests/core/cgo/tag_purego_err.c
@@ -1,0 +1,1 @@
+#error should not be compiled

--- a/tests/core/cgo/tag_purego_err.go
+++ b/tests/core/cgo/tag_purego_err.go
@@ -1,0 +1,6 @@
+// +build !purego
+
+package main
+
+// this file should not be compiled
+!!!

--- a/tests/core/cgo/tag_test.go
+++ b/tests/core/cgo/tag_test.go
@@ -16,6 +16,9 @@ func Test(t *testing.T) {
 			name: "tag_pure_bin",
 			want: "pure",
 		}, {
+			name: "tag_purego_bin",
+			want: "purego",
+		}, {
 			name: "tag_cgo_bin",
 			want: "cgo",
 		},

--- a/tests/integration/gazelle/gazelle_test.go
+++ b/tests/integration/gazelle/gazelle_test.go
@@ -53,8 +53,8 @@ func TestUpdate(t *testing.T) {
 	}
 	got := strings.TrimSpace(string(data))
 	want := strings.TrimSpace(`
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@bazel_gazelle//:def.bzl", "gazelle")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 # gazelle:prefix example.com/hello
 gazelle(

--- a/third_party/org_golang_google_protobuf-gazelle.patch
+++ b/third_party/org_golang_google_protobuf-gazelle.patch
@@ -1635,7 +1635,7 @@ diff -urN a/internal/genid/BUILD.bazel b/internal/genid/BUILD.bazel
 diff -urN a/internal/impl/BUILD.bazel b/internal/impl/BUILD.bazel
 --- a/internal/impl/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/impl/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,111 @@
+@@ -0,0 +1,113 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -1651,6 +1651,7 @@ diff -urN a/internal/impl/BUILD.bazel b/internal/impl/BUILD.bazel
 +        "codec_map_go112.go",
 +        "codec_message.go",
 +        "codec_messageset.go",
++        "codec_reflect.go",
 +        "codec_tables.go",
 +        "codec_unsafe.go",
 +        "convert.go",
@@ -1671,6 +1672,7 @@ diff -urN a/internal/impl/BUILD.bazel b/internal/impl/BUILD.bazel
 +        "message_reflect.go",
 +        "message_reflect_field.go",
 +        "message_reflect_gen.go",
++        "pointer_reflect.go",
 +        "pointer_unsafe.go",
 +        "validate.go",
 +        "weak.go",
@@ -1917,13 +1919,14 @@ diff -urN a/internal/set/BUILD.bazel b/internal/set/BUILD.bazel
 diff -urN a/internal/strs/BUILD.bazel b/internal/strs/BUILD.bazel
 --- a/internal/strs/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/strs/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,28 @@
+@@ -0,0 +1,29 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
 +    name = "strs",
 +    srcs = [
 +        "strings.go",
++        "strings_pure.go",
 +        "strings_unsafe_go120.go",
 +        "strings_unsafe_go121.go",
 +    ],
@@ -3352,7 +3355,7 @@ diff -urN a/reflect/protorange/BUILD.bazel b/reflect/protorange/BUILD.bazel
 diff -urN a/reflect/protoreflect/BUILD.bazel b/reflect/protoreflect/BUILD.bazel
 --- a/reflect/protoreflect/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/reflect/protoreflect/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,40 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -3365,6 +3368,7 @@ diff -urN a/reflect/protoreflect/BUILD.bazel b/reflect/protoreflect/BUILD.bazel
 +        "type.go",
 +        "value.go",
 +        "value_equal.go",
++        "value_pure.go",
 +        "value_union.go",
 +        "value_unsafe_go120.go",
 +        "value_unsafe_go121.go",


### PR DESCRIPTION
The community has agreed[1] that "pure" builds of Go code should use the `purego` build tag.

This change adds that de-facto tag.

[1]: https://github.com/golang/go/issues/23172

Spun out from bazelbuild/bazel-central-registry#1629 to solve building of `circl`.