### PR TITLE
Mark `go_sdk` extension as `reproducible`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
 
 # The custom repo_name is used to prevent our bazel_features polyfill for WORKSPACE builds from
 # conflicting with the real bazel_features repo.
-bazel_dep(name = "bazel_features", version = "1.1.1", repo_name = "io_bazel_rules_go_bazel_features")
+bazel_dep(name = "bazel_features", version = "1.9.1", repo_name = "io_bazel_rules_go_bazel_features")
 bazel_dep(name = "bazel_skylib", version = "1.2.0")
 bazel_dep(name = "platforms", version = "0.0.4")
 bazel_dep(name = "rules_proto", version = "4.0.0")

--- a/go/private/extensions.bzl
+++ b/go/private/extensions.bzl
@@ -289,6 +289,11 @@ def _go_sdk_impl(ctx):
         sdk_versions = [toolchain.sdk_version for toolchain in toolchains],
     )
 
+    if bazel_features.external_deps.extension_metadata_has_reproducible:
+        return ctx.extension_metadata(reproducible = True)
+    else:
+        return None
+
 def _default_go_sdk_name(*, module, multi_version, tag_type, index, suffix = ""):
     # Keep the version out of the repository name if possible to prevent unnecessary rebuilds when
     # it changes.


### PR DESCRIPTION
Setting the new `reproducible` parameter of [`module_ctx.extension_metadata`](https://bazel.build/rules/lib/builtins/module_ctx#extension_metadata) to `True` results in the `go_sdk` extension being omitted from the lockfile. This is especially useful since it depends on OS/arch and thus makes lockfile maintenance more difficult if present.