### PR TITLE
Add support for path mapping

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,7 +1,6 @@
 workspace(name = "io_bazel_rules_go")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 # Required by toolchains_protoc.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,15 +2,6 @@ workspace(name = "io_bazel_rules_go")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-http_archive(
-    name = "platforms",
-    sha256 = "5eda539c841265031c2f82d8ae7a3a6490bd62176e0c038fc469eabf91f6149b",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.9.tar.gz",
-        "https://github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.9.tar.gz",
-    ],
-)
-
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 # Required by toolchains_protoc.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,16 @@
 workspace(name = "io_bazel_rules_go")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "platforms",
+    sha256 = "5eda539c841265031c2f82d8ae7a3a6490bd62176e0c038fc469eabf91f6149b",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.9.tar.gz",
+        "https://github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.9.tar.gz",
+    ],
+)
+
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 # Required by toolchains_protoc.

--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -16,6 +16,7 @@ load(
     "//go/private:common.bzl",
     "COVERAGE_OPTIONS_DENYLIST",
     "GO_TOOLCHAIN_LABEL",
+    "SUPPORTS_PATH_MAPPING_REQUIREMENT",
 )
 load(
     "//go/private:mode.bzl",
@@ -120,10 +121,16 @@ def _sdk_stdlib(go):
         root_file = go.sdk.root_file,
     )
 
+def _dirname(file):
+    return file.dirname
+
 def _build_stdlib(go):
     pkg = go.declare_directory(go, path = "pkg")
-    args = go.builder_args(go, "stdlib")
-    args.add("-out", pkg.dirname)
+    args = go.builder_args(go, "stdlib", use_path_mapping = True)
+
+    # Use a file rather than pkg.dirname as the latter is just a string and thus
+    # not subject to path mapping.
+    args.add_all("-out", [pkg], map_each = _dirname, expand_directories = False)
     if go.mode.race:
         args.add("-race")
     args.add("-package", "std")
@@ -152,6 +159,7 @@ def _build_stdlib(go):
         arguments = [args],
         env = _build_env(go),
         toolchain = GO_TOOLCHAIN_LABEL,
+        execution_requirements = SUPPORTS_PATH_MAPPING_REQUIREMENT,
     )
     return GoStdLib(
         _list_json = _build_stdlib_list_json(go),

--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -271,3 +271,7 @@ RULES_GO_STDLIB_PREFIX = RULES_GO_REPO_NAME + "//stdlib:"
 
 # TODO: Remove the "and" once the rules_go repo itself uses Bzlmod.
 RULES_GO_IS_BZLMOD_REPO = _RULES_GO_RAW_REPO_NAME.lstrip("@") != "io_bazel_rules_go" and _RULES_GO_RAW_REPO_NAME.lstrip("@")
+
+# Marks an action as supporting path mapping (--experimental_output_paths=strip).
+# See https://www.youtube.com/watch?v=Et1rjb7ixUU for more details.
+SUPPORTS_PATH_MAPPING_REQUIREMENT = {"supports-path-mapping": "1"}

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -20,6 +20,7 @@ load(
     "//go/private:common.bzl",
     "GO_TOOLCHAIN",
     "GO_TOOLCHAIN_LABEL",
+    "SUPPORTS_PATH_MAPPING_REQUIREMENT",
     "as_list",
     "asm_exts",
     "cgo_exts",
@@ -94,7 +95,7 @@ def _go_test_impl(ctx):
         run_dir = repo_relative_rundir
 
     main_go = go.declare_file(go, path = "testmain.go")
-    arguments = go.builder_args(go, "gentestmain")
+    arguments = go.builder_args(go, "gentestmain", use_path_mapping = True)
     arguments.add("-output", main_go)
     if go.coverage_enabled:
         if go.mode.race:
@@ -114,6 +115,7 @@ def _go_test_impl(ctx):
     )
     arguments.add("-pkgname", internal_source.library.importpath)
     arguments.add_all(go_srcs, before_each = "-src", format_each = "l=%s")
+
     ctx.actions.run(
         inputs = go_srcs,
         outputs = [main_go],
@@ -121,7 +123,8 @@ def _go_test_impl(ctx):
         executable = go.toolchain._builder,
         arguments = [arguments],
         toolchain = GO_TOOLCHAIN_LABEL,
-        env = go.env,
+        env = go.env_for_path_mapping,
+        execution_requirements = SUPPORTS_PATH_MAPPING_REQUIREMENT,
     )
 
     test_gc_linkopts = gc_linkopts(ctx)

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -88,7 +88,7 @@ func compilePkg(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	if err := goenv.checkFlags(); err != nil {
+	if err := goenv.checkFlagsAndSetGoroot(); err != nil {
 		return err
 	}
 	if importPath == "" {

--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -48,6 +48,9 @@ type env struct {
 	// platform. This may be different than GOROOT.
 	sdk string
 
+	// goroot is set as the value of GOROOT if non-empty.
+	goroot string
+
 	// installSuffix is the name of the directory below GOROOT/pkg that contains
 	// the .a files for the standard library we should build against.
 	// For example, linux_amd64_race.
@@ -67,6 +70,7 @@ type env struct {
 func envFlags(flags *flag.FlagSet) *env {
 	env := &env{}
 	flags.StringVar(&env.sdk, "sdk", "", "Path to the Go SDK.")
+	flags.StringVar(&env.goroot, "goroot", "", "The value to set for GOROOT.")
 	flags.Var(&tagFlag{}, "tags", "List of build tags considered true.")
 	flags.StringVar(&env.installSuffix, "installsuffix", "", "Standard library under GOROOT/pkg")
 	flags.BoolVar(&env.verbose, "v", false, "Whether subprocess command lines should be printed")
@@ -74,11 +78,17 @@ func envFlags(flags *flag.FlagSet) *env {
 	return env
 }
 
-// checkFlags checks whether env flags were set to valid values. checkFlags
-// should be called after parsing flags.
-func (e *env) checkFlags() error {
+// checkFlagsAndSetGoroot checks whether env flags were set to valid values and sets GOROOT.
+// checkFlagsAndSetGoroot should be called after parsing flags.
+func (e *env) checkFlagsAndSetGoroot() error {
 	if e.sdk == "" {
 		return errors.New("-sdk was not set")
+	}
+	if e.goroot != "" {
+		err := os.Setenv("GOROOT", e.goroot)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/go/tools/builders/generate_test_main.go
+++ b/go/tools/builders/generate_test_main.go
@@ -272,7 +272,7 @@ func genTestMain(args []string) error {
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
-	if err := goenv.checkFlags(); err != nil {
+	if err := goenv.checkFlagsAndSetGoroot(); err != nil {
 		return err
 	}
 	// Process import args

--- a/go/tools/builders/info.go
+++ b/go/tools/builders/info.go
@@ -35,7 +35,7 @@ func run(args []string) error {
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
-	if err := goenv.checkFlags(); err != nil {
+	if err := goenv.checkFlagsAndSetGoroot(); err != nil {
 		return err
 	}
 	os.Setenv("GO111MODULE", "off")

--- a/go/tools/builders/link.go
+++ b/go/tools/builders/link.go
@@ -54,7 +54,7 @@ func link(args []string) error {
 	if err := flags.Parse(builderArgs); err != nil {
 		return err
 	}
-	if err := goenv.checkFlags(); err != nil {
+	if err := goenv.checkFlagsAndSetGoroot(); err != nil {
 		return err
 	}
 

--- a/go/tools/builders/stdlib.go
+++ b/go/tools/builders/stdlib.go
@@ -41,7 +41,7 @@ func stdlib(args []string) error {
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
-	if err := goenv.checkFlags(); err != nil {
+	if err := goenv.checkFlagsAndSetGoroot(); err != nil {
 		return err
 	}
 	goroot := os.Getenv("GOROOT")

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -206,7 +206,7 @@ func stdliblist(args []string) error {
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
-	if err := goenv.checkFlags(); err != nil {
+	if err := goenv.checkFlagsAndSetGoroot(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Path mapping improves disk/remote cache hit ratio by automatically removing the configuration-specific path segments (e.g. `k8-fastbuild-ST-12345678`) from action command lines before staging them for execution.

This commit makes the stdlib, compilepkg (assuming no cgo) and gentestmain actions compatible with path mapping, which is mostly automatic except that `GOROOT` now needs to be passed in via a flag rather than an environment variable.

See https://www.youtube.com/watch?v=Et1rjb7ixUU for more information on path mapping.

**Which issues(s) does this PR fix?**

**Other notes for review**

Can be tested via `--experimental_output_paths=strip` with Bazel last_green.

