### PR TITLE
GoLink action. Use -extar <ar path> if cc_toolchain provides ar path

### DIFF
--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -89,6 +89,10 @@ def emit_link(
     builder_args = go.builder_args(go, "link")
     tool_args = go.tool_args(go)
 
+    # use ar tool from cc toolchain if cc toolchain provides it
+    if go.cgo_tools and go.cgo_tools.ar_path and go.cgo_tools.ar_path.endswith("ar"):
+        tool_args.add_all(["-extar", go.cgo_tools.ar_path])
+
     # Add in any mode specific behaviours
     if go.mode.race:
         tool_args.add("-race")

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -837,6 +837,7 @@ def _cgo_context_data_impl(ctx):
             ld_static_lib_path = ld_static_lib_path,
             ld_dynamic_lib_path = ld_dynamic_lib_path,
             ld_dynamic_lib_options = ld_dynamic_lib_options,
+            ar_path = cc_toolchain.ar_executable,
         ),
     )]
 


### PR DESCRIPTION
**What type of PR is this?**

 Bug fix

**What does this PR do? Why is it needed?**

This PR solves  GoLink actions issue, when we can't create static library if go toolchain depends on portable cc toolchain.

Prerequisites:
- was found on MacOS, but behavior is general
- go toolchain uses cc **portable** toolchain

GoLink action uses `link` tool under the hood. `link` tool calls `ar` tool for archiving jobs and `ar` tool is called by name.
GoLink action envs contains PATH variable containing path to cc_toolchain.
If `ar` tool is found in PATH absolute path, everything is fine. In case of relative path, `link` raises an error: "cannot execute tool by relative path".

This PR forces `link` tool to explicitly use `ar` tool from cc_toolchain if cc_toolchain provides it.

**Which issues(s) does this PR fix?**

Issue is not created

**Other notes for review**
