### PR TITLE
Don't ignore the return value of runfiles.merge_all()

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -75,7 +75,7 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
         files.append(a.runfiles)
         if a.source.mode != go.mode:
             fail("Archive mode does not match {} is {} expected {}".format(a.data.label, mode_string(a.source.mode), mode_string(go.mode)))
-    runfiles.merge_all(files)
+    runfiles = runfiles.merge_all(files)
 
     importmap = "main" if source.library.is_main else source.library.importmap
     importpath, _ = effective_importpath_pkgpath(source.library)


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

I'm running into an issue where data dependencies of C/C++ libraries don't end up being placed in the input roots of Go based tests that depend on these libraries via cgo. It turns out that this is caused by emit_archive() not properly merging runfiles from all GoArchive dependencies.

I tried to make a small reproduction case of this under tests/core/cgo, but for the life of me I can't seem to reproduce this. Maybe this can only be observed when cross compiling or using custom C++ toolchains?

**Which issues(s) does this PR fix?**

Couldn't find any.

**Other notes for review**
