### PR TITLE
Add support for `--incompatible_enable_proto_toolchain_resolution`

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -74,6 +74,22 @@ tasks:
       - "@go_default_sdk//..."
     test_targets:
       - "//..."
+  bcr_tests_proto:
+    name: BCR test module (--incompatible_enable_proto_toolchain_resolution)
+    platform: ${{ platform }}
+    bazel: 7.1.1
+    working_directory: tests/bcr
+    build_flags:
+      - "--allow_yanked_versions=all"
+      - "--incompatible_enable_proto_toolchain_resolution"
+    test_flags:
+      - "--allow_yanked_versions=all"
+      - "--incompatible_enable_proto_toolchain_resolution"
+    build_targets:
+      - "//..."
+      - "@go_default_sdk//..."
+    test_targets:
+      - "//..."
   macos:
     shell_commands:
       - tests/core/cgo/generate_imported_dylib.sh

--- a/.bazelrc
+++ b/.bazelrc
@@ -33,7 +33,8 @@ build:incompatible --incompatible_enforce_config_setting_visibility
 build:incompatible --incompatible_disallow_empty_glob
 build:incompatible --incompatible_disable_starlark_host_transitions
 build:incompatible --nolegacy_external_runfiles
+build:incompatible --incompatible_enable_proto_toolchain_resolution
 # Also enable all incompatible flags in go_bazel_test by default.
 # TODO: Add --incompatible_disallow_empty_glob once
 # https://github.com/bazelbuild/bazel-gazelle/pull/1405 has been released.
-test:incompatible --test_env=GO_BAZEL_TEST_BAZELFLAGS='--incompatible_load_proto_rules_from_bzl --incompatible_enable_cc_toolchain_resolution --incompatible_config_setting_private_default_visibility --incompatible_enforce_config_setting_visibility --incompatible_disable_starlark_host_transitions --nolegacy_external_runfiles'
+test:incompatible --test_env=GO_BAZEL_TEST_BAZELFLAGS='--incompatible_load_proto_rules_from_bzl --incompatible_enable_cc_toolchain_resolution --incompatible_config_setting_private_default_visibility --incompatible_enforce_config_setting_visibility --incompatible_disable_starlark_host_transitions --nolegacy_external_runfiles --incompatible_enable_proto_toolchain_resolution'

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,7 @@ module(
 bazel_dep(name = "bazel_features", version = "1.9.1", repo_name = "io_bazel_rules_go_bazel_features")
 bazel_dep(name = "bazel_skylib", version = "1.2.0")
 bazel_dep(name = "platforms", version = "0.0.4")
-bazel_dep(name = "rules_proto", version = "4.0.0")
+bazel_dep(name = "rules_proto", version = "6.0.0-rc2")
 bazel_dep(name = "protobuf", version = "3.19.2", repo_name = "com_google_protobuf")
 
 go_sdk = use_extension("//go:extensions.bzl", "go_sdk")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,7 @@ module(
 bazel_dep(name = "bazel_features", version = "1.9.1", repo_name = "io_bazel_rules_go_bazel_features")
 bazel_dep(name = "bazel_skylib", version = "1.2.0")
 bazel_dep(name = "platforms", version = "0.0.4")
-bazel_dep(name = "rules_proto", version = "6.0.0-rc2")
+bazel_dep(name = "rules_proto", version = "6.0.0")
 bazel_dep(name = "protobuf", version = "3.19.2", repo_name = "com_google_protobuf")
 
 go_sdk = use_extension("//go:extensions.bzl", "go_sdk")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,9 +3,60 @@ workspace(name = "io_bazel_rules_go")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
+# Required by toolchains_protoc.
+http_archive(
+    name = "platforms",
+    sha256 = "5eda539c841265031c2f82d8ae7a3a6490bd62176e0c038fc469eabf91f6149b",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.9.tar.gz",
+        "https://github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.9.tar.gz",
+    ],
+)
+
+# The non-polyfill version of this is needed by rules_proto below.
+http_archive(
+    name = "bazel_features",
+    sha256 = "d7787da289a7fb497352211ad200ec9f698822a9e0757a4976fd9f713ff372b3",
+    strip_prefix = "bazel_features-1.9.1",
+    url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.9.1/bazel_features-v1.9.1.tar.gz",
+)
+
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
 go_rules_dependencies()
 
 go_register_toolchains(version = "1.21.8")
+
+http_archive(
+    name = "rules_proto",
+    sha256 = "71fdbed00a0709521ad212058c60d13997b922a5d01dbfd997f0d57d689e7b67",
+    strip_prefix = "rules_proto-6.0.0-rc2",
+    url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.0-rc2/rules_proto-6.0.0-rc2.tar.gz",
+)
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
+
+rules_proto_dependencies()
+
+load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
+
+rules_proto_toolchains()
+
+http_archive(
+    name = "toolchains_protoc",
+    sha256 = "b312e6de6485e01f753cb87fa09b4193f1762593141790dd0a90abf5e520b1d7",
+    strip_prefix = "toolchains_protoc-0.2.1",
+    url = "https://github.com/alexeagle/toolchains_protoc/releases/download/v0.2.1/toolchains_protoc-v0.2.1.tar.gz",
+)
+
+load("@toolchains_protoc//protoc:toolchain.bzl", "protoc_toolchains")
+
+protoc_toolchains(
+    name = "protoc_toolchains",
+    version = "v25.3",
+)
 
 http_archive(
     name = "com_google_protobuf",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,10 +6,10 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 # Required by toolchains_protoc.
 http_archive(
     name = "platforms",
-    sha256 = "5eda539c841265031c2f82d8ae7a3a6490bd62176e0c038fc469eabf91f6149b",
+    sha256 = "218efe8ee736d26a3572663b374a253c012b716d8af0c07e842e82f238a0a7ee",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.9.tar.gz",
-        "https://github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.9.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
+        "https://github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
     ],
 )
 
@@ -31,9 +31,9 @@ go_register_toolchains(version = "1.21.8")
 
 http_archive(
     name = "rules_proto",
-    sha256 = "71fdbed00a0709521ad212058c60d13997b922a5d01dbfd997f0d57d689e7b67",
-    strip_prefix = "rules_proto-6.0.0-rc2",
-    url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.0-rc2/rules_proto-6.0.0-rc2.tar.gz",
+    sha256 = "303e86e722a520f6f326a50b41cfc16b98fe6d1955ce46642a5b7a67c11c0f5d",
+    strip_prefix = "rules_proto-6.0.0",
+    url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.0/rules_proto-6.0.0.tar.gz",
 )
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
@@ -46,9 +46,9 @@ rules_proto_toolchains()
 
 http_archive(
     name = "toolchains_protoc",
-    sha256 = "b312e6de6485e01f753cb87fa09b4193f1762593141790dd0a90abf5e520b1d7",
-    strip_prefix = "toolchains_protoc-0.2.1",
-    url = "https://github.com/alexeagle/toolchains_protoc/releases/download/v0.2.1/toolchains_protoc-v0.2.1.tar.gz",
+    sha256 = "1f3cd768bbb92164952301228bac5e5079743843488598f2b17fecd41163cadb",
+    strip_prefix = "toolchains_protoc-0.2.4",
+    url = "https://github.com/aspect-build/toolchains_protoc/releases/download/v0.2.4/toolchains_protoc-v0.2.4.tar.gz",
 )
 
 load("@toolchains_protoc//protoc:toolchain.bzl", "protoc_toolchains")

--- a/go/tools/bazel_testing/bazel_testing.go
+++ b/go/tools/bazel_testing/bazel_testing.go
@@ -77,6 +77,10 @@ type Args struct {
 	// NogoExcludes is the list of targets to include for Nogo linting.
 	NogoExcludes []string
 
+	// WorkspacePrefix is a string that should be inserted at the beginning
+	// of the default generated WORKSPACE file.
+	WorkspacePrefix string
+
 	// WorkspaceSuffix is a string that should be appended to the end
 	// of the default generated WORKSPACE file.
 	WorkspaceSuffix string
@@ -90,7 +94,7 @@ type Args struct {
 	// workspace. It is executed once and only once before the beginning of
 	// all tests. If SetUp returns a non-nil error, execution is halted and
 	// tests cases are not executed.
-	SetUp func() error
+	SetUp           func() error
 }
 
 // debug may be set to make the test print the test workspace path and stop
@@ -409,6 +413,7 @@ func setupWorkspace(args Args, files []string) (dir string, cleanup func() error
 			}
 		}()
 		info := workspaceTemplateInfo{
+			Prefix:       args.WorkspacePrefix,
 			Suffix:       args.WorkspaceSuffix,
 			Nogo:         args.Nogo,
 			NogoIncludes: args.NogoIncludes,
@@ -538,6 +543,7 @@ type workspaceTemplateInfo struct {
 	Nogo           string
 	NogoIncludes   []string
 	NogoExcludes   []string
+	Prefix         string
 	Suffix         string
 }
 
@@ -548,6 +554,8 @@ local_repository(
     path = "../{{.}}",
 )
 {{end}}
+
+{{.Prefix}}
 
 {{if not .GoSDKPath}}
 load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")

--- a/go/tools/bazel_testing/bazel_testing.go
+++ b/go/tools/bazel_testing/bazel_testing.go
@@ -466,15 +466,6 @@ func setupWorkspace(args Args, files []string) (dir string, cleanup func() error
 		if err := defaultModuleBazelTpl.Execute(w, info); err != nil {
 			return "", cleanup, err
 		}
-
-		// Enable Bzlmod.
-		bazelrcPath := filepath.Join(mainDir, ".bazelrc")
-		if _, err = os.Stat(bazelrcPath); os.IsNotExist(err) {
-			err = os.WriteFile(bazelrcPath, []byte("common --enable_bzlmod"), 0666)
-			if err != nil {
-				return "", cleanup, err
-			}
-		}
 	}
 
 	return mainDir, cleanup, nil

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -134,14 +134,20 @@ non_go_reset_target(
 filegroup(
     name = "all_rules",
     testonly = True,
-    srcs = glob(["*.bzl"]) + ["//proto/wkt:all_rules"],
+    srcs = glob(["*.bzl"]) + [
+        "//proto/private",
+        "//proto/wkt:all_rules",
+    ],
     visibility = ["//:__subpackages__"],
 )
 
 filegroup(
     name = "all_files",
     testonly = True,
-    srcs = glob(["**"]) + ["//proto/wkt:all_files"],
+    srcs = glob(["**"]) + [
+        "//proto/private",
+        "//proto/wkt:all_files",
+    ],
     visibility = ["//:__subpackages__"],
 )
 

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -135,7 +135,7 @@ filegroup(
     name = "all_rules",
     testonly = True,
     srcs = glob(["*.bzl"]) + [
-        "//proto/private",
+        "//proto/private:all_files",
         "//proto/wkt:all_rules",
     ],
     visibility = ["//:__subpackages__"],
@@ -145,7 +145,7 @@ filegroup(
     name = "all_files",
     testonly = True,
     srcs = glob(["**"]) + [
-        "//proto/private",
+        "//proto/private:all_files",
         "//proto/wkt:all_files",
     ],
     visibility = ["//:__subpackages__"],

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -127,6 +127,7 @@ go_proto_compiler(
 non_go_reset_target(
     name = "protoc",
     dep = "@com_google_protobuf//:protoc",
+    deprecation = "No longer used by rules_go, will be removed in a future release.",
     visibility = ["//visibility:public"],
 )
 

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -212,7 +212,7 @@ def _go_proto_compiler_impl(ctx):
 
 _go_proto_compiler = rule(
     implementation = _go_proto_compiler_impl,
-    attrs = {
+    attrs = dict({
         "deps": attr.label_list(providers = [GoLibrary]),
         "options": attr.string_list(),
         "suffix": attr.string(default = ".pb.go"),
@@ -232,7 +232,7 @@ _go_proto_compiler = rule(
         "_go_context_data": attr.label(
             default = "//:go_context_data",
         ),
-    } | proto_toolchains.if_legacy_toolchain({
+    }, **proto_toolchains.if_legacy_toolchain({
         "_legacy_proto_toolchain": attr.label(
             # Setting cfg = "exec" here as the legacy_proto_toolchain target
             # already needs to apply the non_go_tool_transition. Flipping the
@@ -241,7 +241,7 @@ _go_proto_compiler = rule(
             cfg = "exec",
             default = "//proto/private:legacy_proto_toolchain",
         ),
-    }),
+    })),
     toolchains = [GO_TOOLCHAIN] + proto_toolchains.use_toolchain(_PROTO_TOOLCHAIN_TYPE),
 )
 

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -17,6 +17,11 @@ load(
     "paths",
 )
 load(
+    "@rules_proto//proto:proto_common.bzl",
+    "ProtoLangToolchainInfo",
+    proto_toolchains = "toolchains",
+)
+load(
     "//go:def.bzl",
     "GoLibrary",
     "go_context",
@@ -30,6 +35,15 @@ load(
     "//go/private/rules:transition.bzl",
     "go_reset_target",
 )
+
+# This is actually a misuse of Proto toolchains: The proper way to use `protoc` would be to go
+# through a Go-specific `proto_lang_toolchain` and use the methods on `proto_common` to interact
+# with `protoc`. Since rules_go has a very bespoke setup with customizable compilers and the need
+# to apply reset transitions in case `protoc` *is* built from source, this would require major
+# changes.
+# TODO: Revisit this after --incompatible_enable_proto_toolchain_resolution has been enabled by
+#  default.
+_PROTO_TOOLCHAIN_TYPE = "@rules_proto//proto:toolchain_type"
 
 GoProtoCompiler = provider(
     doc = "Information and dependencies needed to generate Go code from protos",
@@ -104,7 +118,7 @@ def go_proto_compile(go, compiler, protos, imports, importpath):
     transitive_descriptor_sets = depset(direct = [], transitive = desc_sets)
 
     args = go.actions.args()
-    args.add("-protoc", compiler.internal.protoc)
+    args.add("-protoc", compiler.internal.protoc.executable)
     args.add("-importpath", importpath)
     args.add("-out_path", outpath)
     args.add("-plugin", compiler.internal.plugin)
@@ -122,7 +136,6 @@ def go_proto_compile(go, compiler, protos, imports, importpath):
         inputs = depset(
             direct = [
                 compiler.internal.go_protoc,
-                compiler.internal.protoc,
                 compiler.internal.plugin,
             ],
             transitive = [transitive_descriptor_sets],
@@ -132,6 +145,7 @@ def go_proto_compile(go, compiler, protos, imports, importpath):
         mnemonic = "GoProtocGen",
         executable = compiler.internal.go_protoc,
         toolchain = GO_TOOLCHAIN_LABEL,
+        tools = [compiler.internal.protoc],
         arguments = [args],
         env = go.env,
         # We may need the shell environment (potentially augmented with --action_env)
@@ -172,6 +186,11 @@ def _go_proto_compiler_impl(ctx):
     go = go_context(ctx)
     library = go.new_library(go)
     source = go.library_to_source(go, ctx.attr, library, ctx.coverage_instrumented())
+    proto_toolchain = proto_toolchains.find_toolchain(
+        ctx,
+        legacy_attr = "_legacy_proto_toolchain",
+        toolchain_type = _PROTO_TOOLCHAIN_TYPE,
+    )
     return [
         GoProtoCompiler(
             deps = ctx.attr.deps,
@@ -181,7 +200,7 @@ def _go_proto_compiler_impl(ctx):
                 options = ctx.attr.options,
                 suffix = ctx.attr.suffix,
                 suffixes = ctx.attr.suffixes,
-                protoc = ctx.executable._protoc,
+                protoc = proto_toolchain.proto_compiler,
                 go_protoc = ctx.executable._go_protoc,
                 plugin = ctx.executable.plugin,
                 import_path_option = ctx.attr.import_path_option,
@@ -210,16 +229,20 @@ _go_proto_compiler = rule(
             cfg = "exec",
             default = "//go/tools/builders:go-protoc",
         ),
-        "_protoc": attr.label(
-            executable = True,
-            cfg = "exec",
-            default = "//proto:protoc",
-        ),
         "_go_context_data": attr.label(
             default = "//:go_context_data",
         ),
-    },
-    toolchains = [GO_TOOLCHAIN],
+    } | proto_toolchains.if_legacy_toolchain({
+        "_legacy_proto_toolchain": attr.label(
+            # Setting cfg = "exec" here as the legacy_proto_toolchain target
+            # already needs to apply the non_go_tool_transition. Flipping the
+            # two would be more idiomatic, but proto_toolchains.find_toolchain
+            # doesn't support split transitions.
+            cfg = "exec",
+            default = "//proto/private:legacy_proto_toolchain",
+        ),
+    }),
+    toolchains = [GO_TOOLCHAIN] + proto_toolchains.use_toolchain(_PROTO_TOOLCHAIN_TYPE),
 )
 
 def go_proto_compiler(name, **kwargs):

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -18,7 +18,6 @@ load(
 )
 load(
     "@rules_proto//proto:proto_common.bzl",
-    "ProtoLangToolchainInfo",
     proto_toolchains = "toolchains",
 )
 load(

--- a/proto/private/BUILD.bazel
+++ b/proto/private/BUILD.bazel
@@ -4,3 +4,17 @@ legacy_proto_toolchain(
     name = "legacy_proto_toolchain",
     visibility = ["//visibility:public"],
 )
+
+filegroup(
+    name = "all_rules",
+    testonly = True,
+    srcs = glob(["*.bzl"]),
+    visibility = ["//:__subpackages__"],
+)
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]),
+    visibility = ["//:__subpackages__"],
+)

--- a/proto/private/BUILD.bazel
+++ b/proto/private/BUILD.bazel
@@ -1,0 +1,6 @@
+load(":toolchain.bzl", "legacy_proto_toolchain")
+
+legacy_proto_toolchain(
+    name = "legacy_proto_toolchain",
+    visibility = ["//proto:__pkg__"],
+)

--- a/proto/private/BUILD.bazel
+++ b/proto/private/BUILD.bazel
@@ -2,5 +2,5 @@ load(":toolchain.bzl", "legacy_proto_toolchain")
 
 legacy_proto_toolchain(
     name = "legacy_proto_toolchain",
-    visibility = ["//proto:__pkg__"],
+    visibility = ["//visibility:public"],
 )

--- a/proto/private/toolchain.bzl
+++ b/proto/private/toolchain.bzl
@@ -1,0 +1,47 @@
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Helper that wraps --proto_compiler into a ProtoLangToolchainInfo for backwards
+# compatibility with --noincompatible_enable_proto_toolchain_resolution.
+
+load(
+    "@rules_proto//proto:proto_common.bzl",
+    "ProtoLangToolchainInfo",
+)
+load(
+    "//go/private/rules:transition.bzl",
+    "go_reset_target",
+    "non_go_tool_transition",
+)
+
+def _legacy_proto_toolchain_impl(ctx):
+    return [
+        ProtoLangToolchainInfo(
+            proto_compiler = ctx.attr._protoc.files_to_run,
+        ),
+    ]
+
+legacy_proto_toolchain = rule(
+    implementation = _legacy_proto_toolchain_impl,
+    cfg = non_go_tool_transition,
+    attrs = {
+        "_protoc": attr.label(
+            default = configuration_field(fragment = "proto", name = "proto_compiler"),
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+    fragments = ["proto"],
+)

--- a/proto/private/toolchain.bzl
+++ b/proto/private/toolchain.bzl
@@ -21,7 +21,6 @@ load(
 )
 load(
     "//go/private/rules:transition.bzl",
-    "go_reset_target",
     "non_go_tool_transition",
 )
 

--- a/tests/bcr/MODULE.bazel
+++ b/tests/bcr/MODULE.bazel
@@ -21,6 +21,10 @@ local_path_override(
 bazel_dep(name = "gazelle", version = "0.33.0")
 bazel_dep(name = "protobuf", version = "3.19.6")
 
+# Required with --incompatible_enable_proto_toolchain_resolution.
+# Avoids building protoc from source, which speeds up CI runs.
+bazel_dep(name = "toolchains_protoc", version = "0.2.1")
+
 go_sdk = use_extension("@my_rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(
     patch_strip = 1,

--- a/tests/core/cross/proto_test.go
+++ b/tests/core/cross/proto_test.go
@@ -21,6 +21,19 @@ import (
 )
 
 var testArgs = bazel_testing.Args{
+	WorkspacePrefix: `
+# The non-polyfill version of this is needed by rules_proto below.
+http_archive(
+    name = "bazel_features",
+    sha256 = "d7787da289a7fb497352211ad200ec9f698822a9e0757a4976fd9f713ff372b3",
+    strip_prefix = "bazel_features-1.9.1",
+    url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.9.1/bazel_features-v1.9.1.tar.gz",
+)
+
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+`,
 	WorkspaceSuffix: `
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 

--- a/tests/core/cross/proto_test.go
+++ b/tests/core/cross/proto_test.go
@@ -22,6 +22,8 @@ import (
 
 var testArgs = bazel_testing.Args{
 	WorkspacePrefix: `
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 # The non-polyfill version of this is needed by rules_proto below.
 http_archive(
     name = "bazel_features",

--- a/tests/core/cross/proto_test.go
+++ b/tests/core/cross/proto_test.go
@@ -41,14 +41,16 @@ protobuf_deps()
 
 http_archive(
     name = "rules_proto",
-    sha256 = "4d421d51f9ecfe9bf96ab23b55c6f2b809cbaf0eea24952683e397decfbd0dd0",
-    strip_prefix = "rules_proto-f6b8d89b90a7956f6782a4a3609b2f0eee3ce965",
-    # master, as of 2020-01-06
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/f6b8d89b90a7956f6782a4a3609b2f0eee3ce965.tar.gz",
-        "https://github.com/bazelbuild/rules_proto/archive/f6b8d89b90a7956f6782a4a3609b2f0eee3ce965.tar.gz",
-    ],
+    sha256 = "71fdbed00a0709521ad212058c60d13997b922a5d01dbfd997f0d57d689e7b67",
+    strip_prefix = "rules_proto-6.0.0-rc2",
+    url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.0-rc2/rules_proto-6.0.0-rc2.tar.gz",
 )
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
+rules_proto_dependencies()
+
+load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
+rules_proto_toolchains()
 `,
 	Main: `
 -- BUILD.bazel --

--- a/tests/core/cross/proto_test.go
+++ b/tests/core/cross/proto_test.go
@@ -21,51 +21,9 @@ import (
 )
 
 var testArgs = bazel_testing.Args{
-	WorkspacePrefix: `
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-# The non-polyfill version of this is needed by rules_proto below.
-http_archive(
-    name = "bazel_features",
-    sha256 = "d7787da289a7fb497352211ad200ec9f698822a9e0757a4976fd9f713ff372b3",
-    strip_prefix = "bazel_features-1.9.1",
-    url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.9.1/bazel_features-v1.9.1.tar.gz",
-)
-
-load("@bazel_features//:deps.bzl", "bazel_features_deps")
-
-bazel_features_deps()
-`,
-	WorkspaceSuffix: `
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-http_archive(
-    name = "com_google_protobuf",
-    sha256 = "75be42bd736f4df6d702a0e4e4d30de9ee40eac024c4b845d17ae4cc831fe4ae",
-    strip_prefix = "protobuf-21.7",
-    # latest available in BCR, as of 2022-09-30
-    urls = [
-        "https://github.com/protocolbuffers/protobuf/archive/v21.7.tar.gz",
-        "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v21.7.tar.gz",
-    ],
-)
-
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
-protobuf_deps()
-
-http_archive(
-    name = "rules_proto",
-    sha256 = "71fdbed00a0709521ad212058c60d13997b922a5d01dbfd997f0d57d689e7b67",
-    strip_prefix = "rules_proto-6.0.0-rc2",
-    url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.0-rc2/rules_proto-6.0.0-rc2.tar.gz",
-)
-
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
-rules_proto_dependencies()
-
-load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
-rules_proto_toolchains()
+	ModuleFileSuffix: `
+bazel_dep(name = "rules_proto", version = "6.0.0")
+bazel_dep(name = "toolchains_protoc", version = "0.2.4")
 `,
 	Main: `
 -- BUILD.bazel --

--- a/tests/core/cross/proto_test.go
+++ b/tests/core/cross/proto_test.go
@@ -25,6 +25,52 @@ var testArgs = bazel_testing.Args{
 bazel_dep(name = "rules_proto", version = "6.0.0")
 bazel_dep(name = "toolchains_protoc", version = "0.2.4")
 `,
+	WorkspacePrefix: `
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# The non-polyfill version of this is needed by rules_proto below.
+http_archive(
+    name = "bazel_features",
+    sha256 = "d7787da289a7fb497352211ad200ec9f698822a9e0757a4976fd9f713ff372b3",
+    strip_prefix = "bazel_features-1.9.1",
+    url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.9.1/bazel_features-v1.9.1.tar.gz",
+)
+
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+`,
+	WorkspaceSuffix: `
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "com_google_protobuf",
+    sha256 = "75be42bd736f4df6d702a0e4e4d30de9ee40eac024c4b845d17ae4cc831fe4ae",
+    strip_prefix = "protobuf-21.7",
+    # latest available in BCR, as of 2022-09-30
+    urls = [
+        "https://github.com/protocolbuffers/protobuf/archive/v21.7.tar.gz",
+        "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v21.7.tar.gz",
+    ],
+)
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
+http_archive(
+    name = "rules_proto",
+    sha256 = "303e86e722a520f6f326a50b41cfc16b98fe6d1955ce46642a5b7a67c11c0f5d",
+    strip_prefix = "rules_proto-6.0.0",
+    url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.0/rules_proto-6.0.0.tar.gz",
+)
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
+rules_proto_dependencies()
+
+load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
+rules_proto_toolchains()
+`,
 	Main: `
 -- BUILD.bazel --
 load("@rules_proto//proto:defs.bzl", "proto_library")

--- a/tests/core/transition/hermeticity_test.go
+++ b/tests/core/transition/hermeticity_test.go
@@ -122,6 +122,8 @@ message Foo {
 }
 `,
 		WorkspacePrefix: `
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 # The non-polyfill version of this is needed by rules_proto below.
 http_archive(
     name = "bazel_features",

--- a/tests/core/transition/hermeticity_test.go
+++ b/tests/core/transition/hermeticity_test.go
@@ -141,14 +141,16 @@ protobuf_deps()
 
 http_archive(
     name = "rules_proto",
-    sha256 = "4d421d51f9ecfe9bf96ab23b55c6f2b809cbaf0eea24952683e397decfbd0dd0",
-    strip_prefix = "rules_proto-f6b8d89b90a7956f6782a4a3609b2f0eee3ce965",
-    # master, as of 2020-01-06
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/f6b8d89b90a7956f6782a4a3609b2f0eee3ce965.tar.gz",
-        "https://github.com/bazelbuild/rules_proto/archive/f6b8d89b90a7956f6782a4a3609b2f0eee3ce965.tar.gz",
-    ],
+    sha256 = "71fdbed00a0709521ad212058c60d13997b922a5d01dbfd997f0d57d689e7b67",
+    strip_prefix = "rules_proto-6.0.0-rc2",
+    url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.0-rc2/rules_proto-6.0.0-rc2.tar.gz",
 )
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
+rules_proto_dependencies()
+
+load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
+rules_proto_toolchains()
 `,
 	})
 }

--- a/tests/core/transition/hermeticity_test.go
+++ b/tests/core/transition/hermeticity_test.go
@@ -121,6 +121,19 @@ message Foo {
   int64 value = 1;
 }
 `,
+		WorkspacePrefix: `
+# The non-polyfill version of this is needed by rules_proto below.
+http_archive(
+    name = "bazel_features",
+    sha256 = "d7787da289a7fb497352211ad200ec9f698822a9e0757a4976fd9f713ff372b3",
+    strip_prefix = "bazel_features-1.9.1",
+    url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.9.1/bazel_features-v1.9.1.tar.gz",
+)
+
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+`,
 		WorkspaceSuffix: `
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 

--- a/tests/core/transition/hermeticity_test.go
+++ b/tests/core/transition/hermeticity_test.go
@@ -126,6 +126,52 @@ bazel_dep(name = "protobuf", version = "21.7", repo_name = "com_google_protobuf"
 bazel_dep(name = "rules_proto", version = "6.0.0")
 bazel_dep(name = "toolchains_protoc", version = "0.2.4")
 `,
+		WorkspacePrefix: `
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# The non-polyfill version of this is needed by rules_proto below.
+http_archive(
+    name = "bazel_features",
+    sha256 = "d7787da289a7fb497352211ad200ec9f698822a9e0757a4976fd9f713ff372b3",
+    strip_prefix = "bazel_features-1.9.1",
+    url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.9.1/bazel_features-v1.9.1.tar.gz",
+)
+
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+`,
+		WorkspaceSuffix: `
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "com_google_protobuf",
+    sha256 = "75be42bd736f4df6d702a0e4e4d30de9ee40eac024c4b845d17ae4cc831fe4ae",
+    strip_prefix = "protobuf-21.7",
+    # latest available in BCR, as of 2022-09-30
+    urls = [
+        "https://github.com/protocolbuffers/protobuf/archive/v21.7.tar.gz",
+        "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v21.7.tar.gz",
+    ],
+)
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
+http_archive(
+    name = "rules_proto",
+    sha256 = "303e86e722a520f6f326a50b41cfc16b98fe6d1955ce46642a5b7a67c11c0f5d",
+    strip_prefix = "rules_proto-6.0.0",
+    url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.0/rules_proto-6.0.0.tar.gz",
+)
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
+rules_proto_dependencies()
+
+load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
+rules_proto_toolchains()
+`,
 	})
 }
 


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

With `--incompatible_enable_proto_toolchain_resolution`, users of `protoc` are expected to obtain it through `@rules_proto//proto:toolchain_type` instead of the Bazel command line flag `--proto_compiler`. This change adds support for this in a backwards compatible way.

Note that the above is actually a lie: The proper way to use `protoc` would be to go through a Go-specific `proto_lang_toolchain` and use the methods on `proto_common` to interact with `protoc`. Since rules_go has a very bespoke setup with customizable compilers and the need to apply reset transitions in case `protoc` *is* built from source, this would require major changes. We should revisit this after Proto toolchainization has been enabled by default.

**Which issues(s) does this PR fix?**

Fixes #3895

**Other notes for review**
