### PR TITLE
Add exec_compatible_with to @go_sdk//:builder

### DIFF
--- a/go/private/BUILD.sdk.bazel
+++ b/go/private/BUILD.sdk.bazel
@@ -64,6 +64,7 @@ go_tool_binary(
     srcs = ["@io_bazel_rules_go//go/tools/builders:builder_srcs"],
     ldflags = "-X main.rulesGoStdlibPrefix={}".format(RULES_GO_STDLIB_PREFIX),
     sdk = ":go_sdk",
+    exec_compatible_with = {exec_compatible_with},
 )
 
 non_go_reset_target(

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -15,6 +15,7 @@
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "patch", "read_user_netrc", "use_netrc")
 load("//go/private:common.bzl", "executable_path")
 load("//go/private:nogo.bzl", "go_register_nogo")
+load("//go/private:platforms.bzl", "GOARCH_CONSTRAINTS", "GOOS_CONSTRAINTS")
 load("//go/private/skylib/lib:versions.bzl", "versions")
 
 MIN_SUPPORTED_VERSION = (1, 14, 0)
@@ -515,6 +516,10 @@ def _sdk_build_file(ctx, platform, version, experiments):
             "{exe}": ".exe" if goos == "windows" else "",
             "{version}": version,
             "{experiments}": repr(experiments),
+            "{exec_compatible_with}": repr([
+                GOARCH_CONSTRAINTS[goarch],
+                GOOS_CONSTRAINTS[goos],
+            ]),
         },
     )
 


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

go_tool_binary() is completely oblivious of toolchains. The reason being that Go toolchains actually depend on their output. Adding a toolchain dependency would thus add a cyclic dependency. This is problematic, because it means that the actions with mnemonic GoToolchainBinaryBuild end up getting scheduled on arbitrary workers.

Address this by adding exec_compatible_with to the locations where go_tool_binary() is instantiated, namely the auto-generated BUILD files that are part of Go SDKs.

**Which issues(s) does this PR fix?**

Fixes: #3942

**Other notes for review**
