### PR TITLE
prepare v0.48.0 release

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_go",
-    version = "0.47.1",
+    version = "0.48.0",
     compatibility_level = 0,
     repo_name = "io_bazel_rules_go",
 )

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -121,7 +121,7 @@ TOOLS_NOGO = [str(Label(l)) for l in _TOOLS_NOGO]
 
 # Current version or next version to be tagged. Gazelle and other tools may
 # check this to determine compatibility.
-RULES_GO_VERSION = "0.47.1"
+RULES_GO_VERSION = "0.48.0"
 
 go_context = _go_context
 gomock = _gomock

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -51,12 +51,12 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "bazel_skylib",
-        # 1.5.0, latest as of 2024-04-19
+        # 1.6.1, latest as of 2024-05-20
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
-            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.6.1/bazel-skylib-1.6.1.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.6.1/bazel-skylib-1.6.1.tar.gz",
         ],
-        sha256 = "cd55a062e763b9349921f0f5db8c3933288dc8ba4f76dd9416aac68acee3cb94",
+        sha256 = "9f38886a40548c6e96c106b752f242130ee11aaa068a56ba7e56f4511f33e4f2",
         strip_prefix = "",
     )
 
@@ -65,13 +65,13 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "org_golang_x_tools",
-        # v0.20.0, latest as of 2024-04-19
+        # v0.21.0, latest as of 2024-05-20
         urls = [
-            "https://mirror.bazel.build/github.com/golang/tools/archive/refs/tags/v0.20.0.zip",
-            "https://github.com/golang/tools/archive/refs/tags/v0.20.0.zip",
+            "https://mirror.bazel.build/github.com/golang/tools/archive/refs/tags/v0.21.0.zip",
+            "https://github.com/golang/tools/archive/refs/tags/v0.21.0.zip",
         ],
-        sha256 = "06d29c1c1844c668bad5d57c755f5a11b99242f7a8ecd09c7b5f66aabeab32bc",
-        strip_prefix = "tools-0.20.0",
+        sha256 = "3e679aad1044575b90c14d13f2caa27840e46b38ac2a1dd391937300af56467a",
+        strip_prefix = "tools-0.21.0",
         patches = [
             # deletegopls removes the gopls subdirectory. It contains a nested
             # module with additional dependencies. It's not needed by rules_go.
@@ -106,13 +106,13 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "org_golang_x_sys",
-        # v0.19.0, latest as of 2024-04-19
+        # v0.20.0, latest as of 2024-05-20
         urls = [
-            "https://mirror.bazel.build/github.com/golang/sys/archive/refs/tags/v0.19.0.zip",
-            "https://github.com/golang/sys/archive/refs/tags/v0.19.0.zip",
+            "https://mirror.bazel.build/github.com/golang/sys/archive/refs/tags/v0.20.0.zip",
+            "https://github.com/golang/sys/archive/refs/tags/v0.20.0.zip",
         ],
-        sha256 = "a2fa1126030bf928b0ab559d2e985ea99fc974bf58a2d512f4e2e1a5303a57ae",
-        strip_prefix = "sys-0.19.0",
+        sha256 = "e9ad578952169036fb5023b0f53c0315d5f73146fc33d70255fa6d6edd859f84",
+        strip_prefix = "sys-0.20.0",
         patches = [
             # releaser:patch-cmd gazelle -repo_root . -go_prefix golang.org/x/sys -go_naming_convention import_alias
             Label("//third_party:org_golang_x_sys-gazelle.patch"),
@@ -125,7 +125,7 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "org_golang_x_xerrors",
-        # master, as of 2024-04-19
+        # master, as of 2024-05-20
         urls = [
             "https://mirror.bazel.build/github.com/golang/xerrors/archive/104605ab7028f4af38a8aff92ac848a51bd53c5d.zip",
             "https://github.com/golang/xerrors/archive/104605ab7028f4af38a8aff92ac848a51bd53c5d.zip",
@@ -180,7 +180,7 @@ def go_rules_dependencies(force = False):
         http_archive,
         name = "org_golang_google_grpc_cmd_protoc_gen_go_grpc",
         sha256 = "1e84df03c94d1cded8e94da7a2df162463f3be4c7a94289d85c0871f14c7b8e3",
-        # cmd/protoc-gen-go-grpc/v1.3.0, latest as of 2024-04-19
+        # cmd/protoc-gen-go-grpc/v1.3.0, latest as of 2024-05-20
         urls = [
             "https://mirror.bazel.build/github.com/grpc/grpc-go/archive/refs/tags/cmd/protoc-gen-go-grpc/v1.3.0.zip",
             "https://github.com/grpc/grpc-go/archive/refs/tags/cmd/protoc-gen-go-grpc/v1.3.0.zip",
@@ -200,7 +200,7 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "com_github_golang_protobuf",
-        # v1.5.4, latest as of 2024-04-19
+        # v1.5.4, latest as of 2024-05-20
         urls = [
             "https://mirror.bazel.build/github.com/golang/protobuf/archive/refs/tags/v1.5.4.zip",
             "https://github.com/golang/protobuf/archive/refs/tags/v1.5.4.zip",
@@ -218,7 +218,7 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "com_github_gogo_protobuf",
-        # v1.3.2, latest as of 2024-04-19
+        # v1.3.2, latest as of 2024-05-20
         urls = [
             "https://mirror.bazel.build/github.com/gogo/protobuf/archive/refs/tags/v1.3.2.zip",
             "https://github.com/gogo/protobuf/archive/refs/tags/v1.3.2.zip",
@@ -244,13 +244,13 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "org_golang_google_genproto",
-        # main, as of 2024-04-19
+        # main, as of 2024-05-20
         urls = [
-            "https://mirror.bazel.build/github.com/googleapis/go-genproto/archive/8c6c420018be7d99c6336d84554d856523d514bf.zip",
-            "https://github.com/googleapis/go-genproto/archive/8c6c420018be7d99c6336d84554d856523d514bf.zip",
+            "https://mirror.bazel.build/github.com/googleapis/go-genproto/archive/dc85e6b867a5ebdfeaa293ddb423f00255ec921e.zip",
+            "https://github.com/googleapis/go-genproto/archive/dc85e6b867a5ebdfeaa293ddb423f00255ec921e.zip",
         ],
-        sha256 = "eddb238f5a61df730989baa6e0303666af3adf2835f226185e6c64f2958855c9",
-        strip_prefix = "go-genproto-8c6c420018be7d99c6336d84554d856523d514bf",
+        sha256 = "ef3c82a1e6951a7931107d00ad4fe034366903290feae82bb1a19211c86d9d2f",
+        strip_prefix = "go-genproto-dc85e6b867a5ebdfeaa293ddb423f00255ec921e",
         patches = [
             # releaser:patch-cmd gazelle -repo_root . -go_prefix google.golang.org/genproto -go_naming_convention import_alias -proto disable_global
             Label("//third_party:org_golang_google_genproto-gazelle.patch"),
@@ -262,7 +262,7 @@ def go_rules_dependencies(force = False):
     _maybe(
         http_archive,
         name = "com_github_golang_mock",
-        # v1.6.0, latest as of 2024-04-19
+        # v1.6.0, latest as of 2024-05-20
         urls = [
             "https://mirror.bazel.build/github.com/golang/mock/archive/refs/tags/v1.6.0.zip",
             "https://github.com/golang/mock/archive/refs/tags/v1.6.0.zip",

--- a/third_party/org_golang_google_genproto-gazelle.patch
+++ b/third_party/org_golang_google_genproto-gazelle.patch
@@ -9135,7 +9135,7 @@ diff -urN a/googleapis/datastore/admin/v1beta1/BUILD.bazel b/googleapis/datastor
 +    visibility = ["//visibility:public"],
 +    deps = [
 +        "//googleapis/api/annotations",
-+        "//googleapis/longrunning",
++        "@com_google_cloud_go_longrunning//autogen/longrunningpb:go_default_library",
 +        "@org_golang_google_grpc//:go_default_library",
 +        "@org_golang_google_grpc//codes:go_default_library",
 +        "@org_golang_google_grpc//status:go_default_library",
@@ -10150,9 +10150,9 @@ diff -urN a/googleapis/genomics/v1/BUILD.bazel b/googleapis/genomics/v1/BUILD.ba
 +    visibility = ["//visibility:public"],
 +    deps = [
 +        "//googleapis/api/annotations",
-+        "//googleapis/iam/v1:iam",
-+        "//googleapis/longrunning",
 +        "//googleapis/rpc/status",
++        "@com_google_cloud_go_iam//apiv1/iampb:go_default_library",
++        "@com_google_cloud_go_longrunning//autogen/longrunningpb:go_default_library",
 +        "@org_golang_google_grpc//:go_default_library",
 +        "@org_golang_google_grpc//codes:go_default_library",
 +        "@org_golang_google_grpc//status:go_default_library",
@@ -10185,8 +10185,8 @@ diff -urN a/googleapis/genomics/v1alpha2/BUILD.bazel b/googleapis/genomics/v1alp
 +    visibility = ["//visibility:public"],
 +    deps = [
 +        "//googleapis/api/annotations",
-+        "//googleapis/longrunning",
 +        "//googleapis/rpc/code",
++        "@com_google_cloud_go_longrunning//autogen/longrunningpb:go_default_library",
 +        "@org_golang_google_grpc//:go_default_library",
 +        "@org_golang_google_grpc//codes:go_default_library",
 +        "@org_golang_google_grpc//status:go_default_library",
@@ -11066,7 +11066,7 @@ diff -urN a/googleapis/partner/aistreams/v1alpha1/BUILD.bazel b/googleapis/partn
 +    visibility = ["//visibility:public"],
 +    deps = [
 +        "//googleapis/api/annotations",
-+        "//googleapis/longrunning",
++        "@com_google_cloud_go_longrunning//autogen/longrunningpb:go_default_library",
 +        "@org_golang_google_grpc//:go_default_library",
 +        "@org_golang_google_grpc//codes:go_default_library",
 +        "@org_golang_google_grpc//status:go_default_library",

--- a/third_party/org_golang_x_sys-gazelle.patch
+++ b/third_party/org_golang_x_sys-gazelle.patch
@@ -150,7 +150,7 @@ diff -urN a/plan9/BUILD.bazel b/plan9/BUILD.bazel
 diff -urN a/unix/BUILD.bazel b/unix/BUILD.bazel
 --- a/unix/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/unix/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,301 @@
+@@ -0,0 +1,303 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -174,6 +174,7 @@ diff -urN a/unix/BUILD.bazel b/unix/BUILD.bazel
 +        "asm_linux_s390x.s",
 +        "asm_solaris_amd64.s",
 +        "bluetooth_linux.go",
++        "bpxsvc_zos.s",
 +        "cap_freebsd.go",
 +        "constants.go",
 +        "dev_aix_ppc64.go",
@@ -209,6 +210,7 @@ diff -urN a/unix/BUILD.bazel b/unix/BUILD.bazel
 +        "sockcmsg_linux.go",
 +        "sockcmsg_unix.go",
 +        "sockcmsg_unix_other.go",
++        "sockcmsg_zos.go",
 +        "syscall.go",
 +        "syscall_aix.go",
 +        "syscall_aix_ppc64.go",
@@ -479,7 +481,7 @@ diff -urN a/unix/internal/mkmerge/BUILD.bazel b/unix/internal/mkmerge/BUILD.baze
 diff -urN a/windows/BUILD.bazel b/windows/BUILD.bazel
 --- a/windows/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/windows/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,54 @@
+@@ -0,0 +1,53 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -487,7 +489,6 @@ diff -urN a/windows/BUILD.bazel b/windows/BUILD.bazel
 +    srcs = [
 +        "aliases.go",
 +        "dll_windows.go",
-+        "empty.s",
 +        "env_windows.go",
 +        "eventlog.go",
 +        "exec_windows.go",

--- a/third_party/org_golang_x_tools-gazelle.patch
+++ b/third_party/org_golang_x_tools-gazelle.patch
@@ -1567,7 +1567,7 @@ diff -urN b/go/analysis/internal/analysisflags/BUILD.bazel c/go/analysis/interna
 diff -urN b/go/analysis/internal/checker/BUILD.bazel c/go/analysis/internal/checker/BUILD.bazel
 --- b/go/analysis/internal/checker/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/internal/checker/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,42 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -1579,6 +1579,7 @@ diff -urN b/go/analysis/internal/checker/BUILD.bazel c/go/analysis/internal/chec
 +        "//go/analysis",
 +        "//go/analysis/internal/analysisflags",
 +        "//go/packages",
++        "//internal/analysisinternal",
 +        "//internal/diff",
 +        "//internal/robustio",
 +    ],
@@ -1605,6 +1606,8 @@ diff -urN b/go/analysis/internal/checker/BUILD.bazel c/go/analysis/internal/chec
 +        "//go/analysis/passes/inspect",
 +        "//go/ast/inspector",
 +        "//internal/testenv",
++        "//internal/testfiles",
++        "//txtar",
 +    ],
 +)
 diff -urN b/go/analysis/internal/versiontest/BUILD.bazel c/go/analysis/internal/versiontest/BUILD.bazel
@@ -3347,7 +3350,7 @@ diff -urN b/go/analysis/passes/inspect/BUILD.bazel c/go/analysis/passes/inspect/
 diff -urN b/go/analysis/passes/internal/analysisutil/BUILD.bazel c/go/analysis/passes/internal/analysisutil/BUILD.bazel
 --- b/go/analysis/passes/internal/analysisutil/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/internal/analysisutil/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,24 @@
+@@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -3356,6 +3359,7 @@ diff -urN b/go/analysis/passes/internal/analysisutil/BUILD.bazel c/go/analysis/p
 +    importpath = "golang.org/x/tools/go/analysis/passes/internal/analysisutil",
 +    visibility = ["//go/analysis/passes:__subpackages__"],
 +    deps = [
++        "//go/analysis",
 +        "//internal/aliases",
 +        "//internal/analysisinternal",
 +    ],
@@ -3375,7 +3379,7 @@ diff -urN b/go/analysis/passes/internal/analysisutil/BUILD.bazel c/go/analysis/p
 diff -urN b/go/analysis/passes/loopclosure/BUILD.bazel c/go/analysis/passes/loopclosure/BUILD.bazel
 --- b/go/analysis/passes/loopclosure/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/loopclosure/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -3409,10 +3413,9 @@ diff -urN b/go/analysis/passes/loopclosure/BUILD.bazel c/go/analysis/passes/loop
 +    srcs = ["loopclosure_test.go"],
 +    deps = [
 +        ":loopclosure",
-+        "//go/analysis",
 +        "//go/analysis/analysistest",
 +        "//internal/testenv",
-+        "//txtar",
++        "//internal/testfiles",
 +    ],
 +)
 diff -urN b/go/analysis/passes/loopclosure/testdata/src/a/BUILD.bazel c/go/analysis/passes/loopclosure/testdata/src/a/BUILD.bazel
@@ -4480,7 +4483,7 @@ diff -urN b/go/analysis/passes/stdmethods/testdata/src/typeparams/BUILD.bazel c/
 diff -urN b/go/analysis/passes/stdversion/BUILD.bazel c/go/analysis/passes/stdversion/BUILD.bazel
 --- b/go/analysis/passes/stdversion/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/passes/stdversion/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -4509,10 +4512,9 @@ diff -urN b/go/analysis/passes/stdversion/BUILD.bazel c/go/analysis/passes/stdve
 +    data = glob(["testdata/**"]),
 +    deps = [
 +        ":stdversion",
-+        "//go/analysis",
 +        "//go/analysis/analysistest",
 +        "//internal/testenv",
-+        "//txtar",
++        "//internal/testfiles",
 +    ],
 +)
 diff -urN b/go/analysis/passes/stringintconv/BUILD.bazel c/go/analysis/passes/stringintconv/BUILD.bazel
@@ -5513,7 +5515,7 @@ diff -urN b/go/analysis/singlechecker/BUILD.bazel c/go/analysis/singlechecker/BU
 diff -urN b/go/analysis/unitchecker/BUILD.bazel c/go/analysis/unitchecker/BUILD.bazel
 --- b/go/analysis/unitchecker/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/analysis/unitchecker/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,70 @@
+@@ -0,0 +1,72 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -5524,6 +5526,7 @@ diff -urN b/go/analysis/unitchecker/BUILD.bazel c/go/analysis/unitchecker/BUILD.
 +    deps = [
 +        "//go/analysis",
 +        "//go/analysis/internal/analysisflags",
++        "//internal/analysisinternal",
 +        "//internal/facts",
 +        "//internal/versions",
 +    ],
@@ -5581,6 +5584,7 @@ diff -urN b/go/analysis/unitchecker/BUILD.bazel c/go/analysis/unitchecker/BUILD.
 +        "//go/packages",
 +        "//go/packages/packagestest",
 +        "//internal/testenv",
++        "//internal/testfiles",
 +        "//txtar",
 +    ],
 +)
@@ -5724,7 +5728,7 @@ diff -urN b/go/callgraph/BUILD.bazel c/go/callgraph/BUILD.bazel
 diff -urN b/go/callgraph/cha/BUILD.bazel c/go/callgraph/cha/BUILD.bazel
 --- b/go/callgraph/cha/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/callgraph/cha/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,119 @@
+@@ -0,0 +1,132 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -5752,6 +5756,7 @@ diff -urN b/go/callgraph/cha/BUILD.bazel c/go/callgraph/cha/BUILD.bazel
 +    deps = select({
 +        "@io_bazel_rules_go//go/platform:aix": [
 +            ":cha",
++            "//go/buildutil",
 +            "//go/callgraph",
 +            "//go/loader",
 +            "//go/ssa",
@@ -5759,6 +5764,7 @@ diff -urN b/go/callgraph/cha/BUILD.bazel c/go/callgraph/cha/BUILD.bazel
 +        ],
 +        "@io_bazel_rules_go//go/platform:darwin": [
 +            ":cha",
++            "//go/buildutil",
 +            "//go/callgraph",
 +            "//go/loader",
 +            "//go/ssa",
@@ -5766,6 +5772,7 @@ diff -urN b/go/callgraph/cha/BUILD.bazel c/go/callgraph/cha/BUILD.bazel
 +        ],
 +        "@io_bazel_rules_go//go/platform:dragonfly": [
 +            ":cha",
++            "//go/buildutil",
 +            "//go/callgraph",
 +            "//go/loader",
 +            "//go/ssa",
@@ -5773,6 +5780,7 @@ diff -urN b/go/callgraph/cha/BUILD.bazel c/go/callgraph/cha/BUILD.bazel
 +        ],
 +        "@io_bazel_rules_go//go/platform:freebsd": [
 +            ":cha",
++            "//go/buildutil",
 +            "//go/callgraph",
 +            "//go/loader",
 +            "//go/ssa",
@@ -5780,6 +5788,7 @@ diff -urN b/go/callgraph/cha/BUILD.bazel c/go/callgraph/cha/BUILD.bazel
 +        ],
 +        "@io_bazel_rules_go//go/platform:illumos": [
 +            ":cha",
++            "//go/buildutil",
 +            "//go/callgraph",
 +            "//go/loader",
 +            "//go/ssa",
@@ -5787,6 +5796,7 @@ diff -urN b/go/callgraph/cha/BUILD.bazel c/go/callgraph/cha/BUILD.bazel
 +        ],
 +        "@io_bazel_rules_go//go/platform:ios": [
 +            ":cha",
++            "//go/buildutil",
 +            "//go/callgraph",
 +            "//go/loader",
 +            "//go/ssa",
@@ -5794,6 +5804,7 @@ diff -urN b/go/callgraph/cha/BUILD.bazel c/go/callgraph/cha/BUILD.bazel
 +        ],
 +        "@io_bazel_rules_go//go/platform:js": [
 +            ":cha",
++            "//go/buildutil",
 +            "//go/callgraph",
 +            "//go/loader",
 +            "//go/ssa",
@@ -5801,6 +5812,7 @@ diff -urN b/go/callgraph/cha/BUILD.bazel c/go/callgraph/cha/BUILD.bazel
 +        ],
 +        "@io_bazel_rules_go//go/platform:linux": [
 +            ":cha",
++            "//go/buildutil",
 +            "//go/callgraph",
 +            "//go/loader",
 +            "//go/ssa",
@@ -5808,6 +5820,7 @@ diff -urN b/go/callgraph/cha/BUILD.bazel c/go/callgraph/cha/BUILD.bazel
 +        ],
 +        "@io_bazel_rules_go//go/platform:netbsd": [
 +            ":cha",
++            "//go/buildutil",
 +            "//go/callgraph",
 +            "//go/loader",
 +            "//go/ssa",
@@ -5815,6 +5828,7 @@ diff -urN b/go/callgraph/cha/BUILD.bazel c/go/callgraph/cha/BUILD.bazel
 +        ],
 +        "@io_bazel_rules_go//go/platform:openbsd": [
 +            ":cha",
++            "//go/buildutil",
 +            "//go/callgraph",
 +            "//go/loader",
 +            "//go/ssa",
@@ -5822,6 +5836,7 @@ diff -urN b/go/callgraph/cha/BUILD.bazel c/go/callgraph/cha/BUILD.bazel
 +        ],
 +        "@io_bazel_rules_go//go/platform:plan9": [
 +            ":cha",
++            "//go/buildutil",
 +            "//go/callgraph",
 +            "//go/loader",
 +            "//go/ssa",
@@ -5829,6 +5844,7 @@ diff -urN b/go/callgraph/cha/BUILD.bazel c/go/callgraph/cha/BUILD.bazel
 +        ],
 +        "@io_bazel_rules_go//go/platform:solaris": [
 +            ":cha",
++            "//go/buildutil",
 +            "//go/callgraph",
 +            "//go/loader",
 +            "//go/ssa",
@@ -5836,6 +5852,7 @@ diff -urN b/go/callgraph/cha/BUILD.bazel c/go/callgraph/cha/BUILD.bazel
 +        ],
 +        "@io_bazel_rules_go//go/platform:windows": [
 +            ":cha",
++            "//go/buildutil",
 +            "//go/callgraph",
 +            "//go/loader",
 +            "//go/ssa",
@@ -6587,7 +6604,7 @@ diff -urN b/go/packages/internal/nodecount/BUILD.bazel c/go/packages/internal/no
 diff -urN b/go/packages/packagestest/BUILD.bazel c/go/packages/packagestest/BUILD.bazel
 --- b/go/packages/packagestest/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/packages/packagestest/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,41 @@
+@@ -0,0 +1,40 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -6597,7 +6614,6 @@ diff -urN b/go/packages/packagestest/BUILD.bazel c/go/packages/packagestest/BUIL
 +        "export.go",
 +        "gopath.go",
 +        "modules.go",
-+        "modules_111.go",
 +    ],
 +    importpath = "golang.org/x/tools/go/packages/packagestest",
 +    visibility = ["//visibility:public"],
@@ -6862,7 +6878,7 @@ diff -urN b/go/packages/packagestest/testdata/groups/two/primarymod/expect/BUILD
 diff -urN b/go/ssa/BUILD.bazel c/go/ssa/BUILD.bazel
 --- b/go/ssa/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/go/ssa/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,78 @@
+@@ -0,0 +1,79 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -6929,6 +6945,7 @@ diff -urN b/go/ssa/BUILD.bazel c/go/ssa/BUILD.bazel
 +    ],
 +    embed = [":ssa"],
 +    deps = [
++        "//go/analysis/analysistest",
 +        "//go/ast/astutil",
 +        "//go/buildutil",
 +        "//go/expect",
@@ -6937,8 +6954,8 @@ diff -urN b/go/ssa/BUILD.bazel c/go/ssa/BUILD.bazel
 +        "//go/ssa/ssautil",
 +        "//internal/aliases",
 +        "//internal/testenv",
++        "//internal/testfiles",
 +        "//internal/typeparams",
-+        "//txtar",
 +    ],
 +)
 diff -urN b/go/ssa/interp/BUILD.bazel c/go/ssa/interp/BUILD.bazel
@@ -8204,7 +8221,7 @@ diff -urN b/internal/aliases/BUILD.bazel c/internal/aliases/BUILD.bazel
 diff -urN b/internal/analysisinternal/BUILD.bazel c/internal/analysisinternal/BUILD.bazel
 --- b/internal/analysisinternal/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/analysisinternal/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,24 @@
+@@ -0,0 +1,27 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -8215,7 +8232,10 @@ diff -urN b/internal/analysisinternal/BUILD.bazel c/internal/analysisinternal/BU
 +    ],
 +    importpath = "golang.org/x/tools/internal/analysisinternal",
 +    visibility = ["//:__subpackages__"],
-+    deps = ["//internal/aliases"],
++    deps = [
++        "//go/analysis",
++        "//internal/aliases",
++    ],
 +)
 +
 +alias(
@@ -8232,7 +8252,7 @@ diff -urN b/internal/analysisinternal/BUILD.bazel c/internal/analysisinternal/BU
 diff -urN b/internal/apidiff/BUILD.bazel c/internal/apidiff/BUILD.bazel
 --- b/internal/apidiff/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/apidiff/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,35 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -8265,6 +8285,7 @@ diff -urN b/internal/apidiff/BUILD.bazel c/internal/apidiff/BUILD.bazel
 +    deps = [
 +        "//go/packages",
 +        "//internal/testenv",
++        "@com_github_google_go_cmp//cmp:go_default_library",
 +    ],
 +)
 diff -urN b/internal/apidiff/testdata/BUILD.bazel c/internal/apidiff/testdata/BUILD.bazel
@@ -8594,9 +8615,9 @@ diff -urN b/internal/event/export/BUILD.bazel c/internal/event/export/BUILD.baze
 +    name = "export",
 +    srcs = [
 +        "id.go",
++        "labels.go",
 +        "log.go",
 +        "printer.go",
-+        "tag.go",
 +        "trace.go",
 +    ],
 +    importpath = "golang.org/x/tools/internal/event/export",
@@ -8834,25 +8855,6 @@ diff -urN b/internal/event/label/BUILD.bazel c/internal/event/label/BUILD.bazel
 +        ":label",
 +        "//internal/event/keys",
 +    ],
-+)
-diff -urN b/internal/event/tag/BUILD.bazel c/internal/event/tag/BUILD.bazel
---- b/internal/event/tag/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
-+++ c/internal/event/tag/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,15 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "tag",
-+    srcs = ["tag.go"],
-+    importpath = "golang.org/x/tools/internal/event/tag",
-+    visibility = ["//:__subpackages__"],
-+    deps = ["//internal/event/keys"],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":tag",
-+    visibility = ["//:__subpackages__"],
 +)
 diff -urN b/internal/facts/BUILD.bazel c/internal/facts/BUILD.bazel
 --- b/internal/facts/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
@@ -9142,7 +9144,7 @@ diff -urN b/internal/gcimporter/testdata/versions/BUILD.bazel c/internal/gcimpor
 diff -urN b/internal/gocommand/BUILD.bazel c/internal/gocommand/BUILD.bazel
 --- b/internal/gocommand/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/gocommand/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,35 @@
+@@ -0,0 +1,34 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -9158,7 +9160,6 @@ diff -urN b/internal/gocommand/BUILD.bazel c/internal/gocommand/BUILD.bazel
 +        "//internal/event",
 +        "//internal/event/keys",
 +        "//internal/event/label",
-+        "//internal/event/tag",
 +        "@org_golang_x_mod//semver:go_default_library",
 +    ],
 +)
@@ -9223,7 +9224,7 @@ diff -urN b/internal/goroot/BUILD.bazel c/internal/goroot/BUILD.bazel
 diff -urN b/internal/imports/BUILD.bazel c/internal/imports/BUILD.bazel
 --- b/internal/imports/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/imports/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,50 @@
+@@ -0,0 +1,51 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -9259,6 +9260,7 @@ diff -urN b/internal/imports/BUILD.bazel c/internal/imports/BUILD.bazel
 +        "fix_test.go",
 +        "imports_test.go",
 +        "mod_cache_test.go",
++        "mod_go122_test.go",
 +        "mod_test.go",
 +    ],
 +    data = glob(["testdata/**"]),
@@ -9277,7 +9279,7 @@ diff -urN b/internal/imports/BUILD.bazel c/internal/imports/BUILD.bazel
 diff -urN b/internal/jsonrpc2/BUILD.bazel c/internal/jsonrpc2/BUILD.bazel
 --- b/internal/jsonrpc2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/internal/jsonrpc2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,42 @@
+@@ -0,0 +1,43 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -9286,6 +9288,7 @@ diff -urN b/internal/jsonrpc2/BUILD.bazel c/internal/jsonrpc2/BUILD.bazel
 +        "conn.go",
 +        "handler.go",
 +        "jsonrpc2.go",
++        "labels.go",
 +        "messages.go",
 +        "serve.go",
 +        "stream.go",
@@ -9295,8 +9298,8 @@ diff -urN b/internal/jsonrpc2/BUILD.bazel c/internal/jsonrpc2/BUILD.bazel
 +    visibility = ["//:__subpackages__"],
 +    deps = [
 +        "//internal/event",
++        "//internal/event/keys",
 +        "//internal/event/label",
-+        "//internal/event/tag",
 +    ],
 +)
 +
@@ -9371,7 +9374,7 @@ diff -urN b/internal/jsonrpc2_v2/BUILD.bazel c/internal/jsonrpc2_v2/BUILD.bazel
 +        "//internal/event",
 +        "//internal/event/keys",
 +        "//internal/event/label",
-+        "//internal/event/tag",
++        "//internal/jsonrpc2",
 +    ],
 +)
 +
@@ -9790,6 +9793,77 @@ diff -urN b/internal/testenv/BUILD.bazel c/internal/testenv/BUILD.bazel
 +alias(
 +    name = "go_default_library",
 +    actual = ":testenv",
++    visibility = ["//:__subpackages__"],
++)
+diff -urN b/internal/testfiles/BUILD.bazel c/internal/testfiles/BUILD.bazel
+--- b/internal/testfiles/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ c/internal/testfiles/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,27 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "testfiles",
++    srcs = ["testfiles.go"],
++    importpath = "golang.org/x/tools/internal/testfiles",
++    visibility = ["//:__subpackages__"],
++    deps = ["//txtar"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":testfiles",
++    visibility = ["//:__subpackages__"],
++)
++
++go_test(
++    name = "testfiles_test",
++    srcs = ["testfiles_test.go"],
++    deps = [
++        ":testfiles",
++        "//go/analysis",
++        "//go/analysis/analysistest",
++        "//internal/testenv",
++        "//internal/versions",
++    ],
++)
+diff -urN b/internal/testfiles/testdata/versions/BUILD.bazel c/internal/testfiles/testdata/versions/BUILD.bazel
+--- b/internal/testfiles/testdata/versions/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ c/internal/testfiles/testdata/versions/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,18 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "versions",
++    srcs = [
++        "mod.go",
++        "post.go",
++        "pre.go",
++    ],
++    importpath = "golang.org/x/tools/internal/testfiles/testdata/versions",
++    visibility = ["//:__subpackages__"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":versions",
++    visibility = ["//:__subpackages__"],
++)
+diff -urN b/internal/testfiles/testdata/versions/sub.test/BUILD.bazel c/internal/testfiles/testdata/versions/sub.test/BUILD.bazel
+--- b/internal/testfiles/testdata/versions/sub.test/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ c/internal/testfiles/testdata/versions/sub.test/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,14 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "sub_test",
++    srcs = ["sub.go"],
++    importpath = "golang.org/x/tools/internal/testfiles/testdata/versions/sub.test",
++    visibility = ["//:__subpackages__"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":sub_test",
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN b/internal/tokeninternal/BUILD.bazel c/internal/tokeninternal/BUILD.bazel
@@ -10259,7 +10333,7 @@ diff -urN b/refactor/importgraph/BUILD.bazel c/refactor/importgraph/BUILD.bazel
 diff -urN b/refactor/rename/BUILD.bazel c/refactor/rename/BUILD.bazel
 --- b/refactor/rename/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ c/refactor/rename/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,43 @@
+@@ -0,0 +1,44 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -10300,6 +10374,7 @@ diff -urN b/refactor/rename/BUILD.bazel c/refactor/rename/BUILD.bazel
 +    embed = [":rename"],
 +    deps = [
 +        "//go/buildutil",
++        "//internal/aliases",
 +        "//internal/testenv",
 +    ],
 +)


### PR DESCRIPTION
This PR prepares a minor release to allow downstream users to begin integrating with https://github.com/bazelbuild/rules_go/pull/3919 