### PR TITLE
Introduce rules_go_unsupported_feature

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -122,6 +122,9 @@ _UNSUPPORTED_FEATURES = [
     "use_header_modules",
     "fdo_instrument",
     "fdo_optimize",
+    # This is a nonspecific unsupported feature which allows the authors of C++
+    # toolchain to apply separate flags when compiling Go code.
+    "rules_go_unsupported_feature",
 ]
 
 def _match_option(option, pattern):


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This sentinel feature allows the C++ toolchain configuration to use distinct sets of flags when compiling Go rules.
See https://github.com/bazelbuild/rules_rust/commit/0e0241e9b0e4122f1e28a1ca0d358dd987f21971 for a similar change to `rules_rust`.
