### PR TITLE
Allow unused parameters when building the stdlib

### DIFF
--- a/go/platform/apple.bzl
+++ b/go/platform/apple.bzl
@@ -44,5 +44,6 @@ def apple_ensure_options(ctx, env, _tags, compiler_option_lists, linker_option_l
     min_version = _apple_version_min(ctx, platform, platform_type)
     for compiler_options in compiler_option_lists:
         compiler_options.append(min_version)
+        compiler_options.append('-Wno-unused-parameter')
     for linker_options in linker_option_lists:
         linker_options.append(min_version)

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -96,6 +96,8 @@ _COMPILER_OPTIONS_DENYLIST = dict({
     # fmax-errors limits that and causes build failures.
     "-fmax-errors=": None,
     "-Wall": None,
+    "-Wunused-parameter": None,
+    "-Wextra": None,
 
     # Symbols are needed by Go, so keep them
     "-g0": None,


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The stdlib build does not support building with -Wextra or -Wunused-parameter since it has unused parameters. This patch removes these flags from the stdlib build.