### PR TITLE
Fix revive warning in testmain.go files

### DIFF
--- a/go/tools/builders/generate_test_main.go
+++ b/go/tools/builders/generate_test_main.go
@@ -167,14 +167,14 @@ func testsInShard() []testing.InternalTest {
 func main() {
 	if bzltestutil.ShouldWrap() {
 		err := bzltestutil.Wrap("{{.Pkgname}}")
+		exitCode := 0
 		if xerr, ok := err.(*exec.ExitError); ok {
-			os.Exit(xerr.ExitCode())
+			exitCode = xerr.ExitCode()
 		} else if err != nil {
 			log.Print(err)
-			os.Exit(bzltestutil.TestWrapperAbnormalExit)
-		} else {
-			os.Exit(0)
+			exitCode = bzltestutil.TestWrapperAbnormalExit
 		}
+		os.Exit(exitCode)
 	}
 
 	testDeps :=


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

When configuring nogo() to run the revive linter, we currently see builds of testmain.go files fail with the following error:

    if block ends with call to os.Exit function, so drop this else and outdent its block (move short variable declaration to its own line if necessary)

Let's restructure this code slightly, so that this is no longer an issue.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
