### PR TITLE
make `go_reset_target` public

### DIFF
--- a/docs/go/core/rules.bzl
+++ b/docs/go/core/rules.bzl
@@ -33,6 +33,7 @@
   [go_path]: #go_path
   [go_source]: #go_source
   [go_test]: #go_test
+  [go_reset_target]: #go_reset_target
   [Examples]: examples.md#examples
   [Defines and stamping]: defines_and_stamping.md#defines-and-stamping
   [Stamping with the workspace status script]: defines_and_stamping.md#stamping-with-the-workspace-status-script
@@ -119,6 +120,7 @@ load("//go/private/rules:cross.bzl", _go_cross_binary = "go_cross_binary")
 load("//go/private/rules:library.bzl", _go_library = "go_library")
 load("//go/private/rules:source.bzl", _go_source = "go_source")
 load("//go/private/rules:test.bzl", _go_test = "go_test")
+load("//go/private/rules:transition.bzl", _go_reset_target = "go_reset_target")
 load("//go/private/tools:path.bzl", _go_path = "go_path")
 
 go_library = _go_library
@@ -127,3 +129,4 @@ go_test = _go_test
 go_source = _go_source
 go_path = _go_path
 go_cross_binary = _go_cross_binary
+go_reset_target = _go_reset_target

--- a/docs/go/core/rules.md
+++ b/docs/go/core/rules.md
@@ -35,6 +35,7 @@
   [go_path]: #go_path
   [go_source]: #go_source
   [go_test]: #go_test
+  [go_reset_target]: #go_reset_target
   [Examples]: examples.md#examples
   [Defines and stamping]: defines_and_stamping.md#defines-and-stamping
   [Stamping with the workspace status script]: defines_and_stamping.md#stamping-with-the-workspace-status-script
@@ -288,6 +289,42 @@ go_path(<a href="#go_path-name">name</a>, <a href="#go_path-data">data</a>, <a h
 | <a id="go_path-include_pkg"></a>include_pkg |  When true, a <code>pkg</code> subdirectory containing the compiled libraries will be created in the             generated <code>GOPATH</code> containing compiled libraries.   | Boolean | optional | False |
 | <a id="go_path-include_transitive"></a>include_transitive |  When true, the transitive dependency graph will be included in the generated <code>GOPATH</code>. This is             the default behaviour. When false, only the direct dependencies will be included in the             generated <code>GOPATH</code>.   | Boolean | optional | True |
 | <a id="go_path-mode"></a>mode |  Determines how the generated directory is provided. May be one of:             <ul>                 <li><code>"archive"</code>: The generated directory is packaged as a single .zip file.</li>                 <li><code>"copy"</code>: The generated directory is a single tree artifact. Source files                 are copied into the tree.</li>                 <li><code>"link"</code>: <b>Unmaintained due to correctness issues</b>. Source files                 are symlinked into the tree. All of the symlink files are provided as separate output                 files.</li>             </ul>              ***Note:*** In <code>"copy"</code> mode, when a <code>GoPath</code> is consumed as a set of input             files or run files, Bazel may provide symbolic links instead of regular files.             Any program that consumes these files should dereference links, e.g., if you             run <code>tar</code>, use the <code>--dereference</code> flag.   | String | optional | "copy" |
+
+
+
+
+
+<a id="#go_reset_target"></a>
+
+## go_reset_target
+
+<pre>
+go_reset_target(<a href="#go_reset_target-name">name</a>, <a href="#go_reset_target-dep">dep</a>)
+</pre>
+
+Forwards providers from a target and default Go binary settings.
+
+go_reset_target depends on a single target and builds it to be a Go tool binary. It
+forwards Go providers and DefaultInfo.
+
+go_reset_target does two things using transitions:
+   1. builds the tool with 'cfg = "exec"' so they work on the execution platform.
+   2. Sets most Go settings to default value and disables nogo.
+
+This is used for Go tool binaries that shouldn't depend on the link mode or tags of the
+target configuration and neither the tools nor the code they potentially
+generate should be subject to Nogo's static analysis. This is helpful, for example, so
+a tool isn't built as a shared library with race instrumentation. This acts as an
+intermediate rule that allows users to apply these transitions.
+
+
+### **Attributes**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="go_reset_target-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="go_reset_target-dep"></a>dep |  The target to forward providers from and apply go_tool_transition to.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 
 
 

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -64,6 +64,10 @@ load(
     _go_source = "go_source",
 )
 load(
+    "//go/private/rules:transition.bzl",
+    _go_reset_target = "go_reset_target",
+)
+load(
     "//go/private/rules:wrappers.bzl",
     _go_binary_macro = "go_binary_macro",
     _go_library_macro = "go_library_macro",
@@ -162,6 +166,9 @@ go_source = _go_source
 
 # See docs/go/core/rules.md#go_path for full documentation.
 go_path = _go_path
+
+# See docs/go/core/rules.md#go_reset_target for full documentation.
+go_reset_target = _go_reset_target
 
 # See docs/go/core/rules.md#go_cross_binary for full documentation.
 go_cross_binary = _go_cross_binary

--- a/go/private/rules/transition.bzl
+++ b/go/private/rules/transition.bzl
@@ -318,21 +318,26 @@ go_reset_target = rule(
         "dep": attr.label(
             mandatory = True,
             cfg = go_tool_transition,
+            doc = """The target to forward providers from and apply go_tool_transition to.""",
         ),
         "_allowlist_function_transition": attr.label(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),
     },
-    doc = """Forwards providers from a target and applies go_tool_transition.
+    doc = """Forwards providers from a target and default Go binary settings.
 
-go_reset_target depends on a single target, built using go_tool_transition. It
+go_reset_target depends on a single target and builds it to be a Go tool binary. It
 forwards Go providers and DefaultInfo.
 
-This is used to work around a problem with building tools: Go tools should be
-built with 'cfg = "exec"' so they work on the execution platform, but we also
-need to apply go_tool_transition so that e.g. a tool isn't built as a shared
-library with race instrumentation. This acts as an intermediate rule that allows
-to apply both both transitions.
+go_reset_target does two things using transitions:
+   1. builds the tool with 'cfg = "exec"' so they work on the execution platform.
+   2. Sets most Go settings to default value and disables nogo.
+
+This is used for Go tool binaries that shouldn't depend on the link mode or tags of the
+target configuration and neither the tools nor the code they potentially
+generate should be subject to Nogo's static analysis. This is helpful, for example, so
+a tool isn't built as a shared library with race instrumentation. This acts as an
+intermediate rule that allows users to apply these transitions.
 """,
 )
 


### PR DESCRIPTION
`go_reset_target` is helpful when certain plugins or tool attributes to rules can't build under certain configurations. For example, many thrift plugins fail to build when a dependency of a `go_binary` with `c-shared` instrumentation.

To alleviate this issue, you can pass the tool to `go_reset_target`.