### PR TITLE
Add linux/ppc64le to GOARCH constraints

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,7 +9,7 @@ module(
 # conflicting with the real bazel_features repo.
 bazel_dep(name = "bazel_features", version = "1.9.1", repo_name = "io_bazel_rules_go_bazel_features")
 bazel_dep(name = "bazel_skylib", version = "1.2.0")
-bazel_dep(name = "platforms", version = "0.0.4")
+bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_proto", version = "6.0.0")
 bazel_dep(name = "protobuf", version = "3.19.2", repo_name = "com_google_protobuf")
 

--- a/go/private/platforms.bzl
+++ b/go/private/platforms.bzl
@@ -31,7 +31,7 @@ BAZEL_GOARCH_CONSTRAINTS = {
     "arm": "@platforms//cpu:armv7",
     "arm64": "@platforms//cpu:aarch64",
     "ppc64": "@platforms//cpu:ppc",
-    "ppc64le": "@platforms//cpu:ppc",
+    "ppc64le": "@platforms//cpu:ppc64le",
     "s390x": "@platforms//cpu:s390x",
 }
 

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -258,6 +258,16 @@ def go_rules_dependencies(force = False):
         patch_args = ["-p1"],
     )
 
+    wrapper(
+        http_archive,
+        name = "platforms",
+        sha256 = "218efe8ee736d26a3572663b374a253c012b716d8af0c07e842e82f238a0a7ee",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
+            "https://github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
+        ],
+    )
+
     # releaser:upgrade-dep golang mock
     _maybe(
         http_archive,


### PR DESCRIPTION
This also updates `platforms` module dependency to 0.0.10

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
This PR adds support to cross-compile for linux/ppc64le target.

**Which issues(s) does this PR fix?**

Fixes #854 and fixes #1186