### PR TITLE
Workaround for windows symlinked bins

### DIFF
--- a/tests/core/go_binary/linkmode.bzl
+++ b/tests/core/go_binary/linkmode.bzl
@@ -1,3 +1,5 @@
+load("@bazel_skylib//rules/private:copy_file_private.bzl", "copy_cmd")
+
 _LINKMODE_SETTING = "//go/config:linkmode"
 
 def _linkmode_pie_transition_impl(settings, attr):
@@ -11,10 +13,19 @@ _linkmode_pie_transition = transition(
     outputs = [_LINKMODE_SETTING],
 )
 
+def _is_windows(ctx):
+    return ctx.configuration.host_path_separator == ";"
+
 def _linkmode_pie_wrapper(ctx):
     in_binary = ctx.attr.target[0][DefaultInfo].files.to_list()[0]
     out_binary = ctx.actions.declare_file(ctx.attr.name)
-    ctx.actions.symlink(output = out_binary, target_file = in_binary)
+
+    # On windows symlinks are not reliable when using remote cache so we copy the binary instead.
+    # See https://github.com/bazelbuild/bazel/issues/21747
+    if _is_windows(ctx):
+        copy_cmd(ctx, in_binary, out_binary)
+    else:
+        ctx.actions.symlink(output = out_binary, target_file = in_binary)
     return [
         DefaultInfo(
             files = depset([out_binary]),


### PR DESCRIPTION
When using remote cache, Windows symlinks
which should be executable may break, see:
https://github.com/bazelbuild/bazel/issues/21747

Instead of creating symlinks, copy the bins instead until the issue is resolved.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
Bug fix


**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

Fixes #3976

**Other notes for review**
