### PR TITLE
gopackagesdriver: Make kind query regexes anchored

### DIFF
--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -80,7 +80,7 @@ func (b *BazelJSONBuilder) fileQuery(filename string) string {
 	}
 
 	kinds := append(_defaultKinds, additionalKinds...)
-	return fmt.Sprintf(`kind("%s", same_pkg_direct_rdeps("%s"))`, strings.Join(kinds, "|"), label)
+	return fmt.Sprintf(`kind("^(%s) rule$", same_pkg_direct_rdeps("%s"))`, strings.Join(kinds, "|"), label)
 }
 
 func (b *BazelJSONBuilder) getKind() string {
@@ -104,7 +104,7 @@ func (b *BazelJSONBuilder) localQuery(request string) string {
 		request = fmt.Sprintf("%s:*", request)
 	}
 
-	return fmt.Sprintf(`kind("%s", %s)`, b.getKind(), request)
+	return fmt.Sprintf(`kind("^(%s) rule$", %s)`, b.getKind(), request)
 }
 
 func (b *BazelJSONBuilder) packageQuery(importPath string) string {
@@ -113,7 +113,7 @@ func (b *BazelJSONBuilder) packageQuery(importPath string) string {
 	}
 
 	return fmt.Sprintf(
-		`kind("%s", attr(importpath, "%s", deps(%s)))`,
+		`kind("^(%s) rule$", attr(importpath, "%s", deps(%s)))`,
 		b.getKind(),
 		importPath,
 		bazelQueryScope)


### PR DESCRIPTION

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

A query like `kind("go_library", ...)` also returns rules that are not go libraries but have `go_library` as a substring of the rule name, e.g. `not_a_go_library`. To fix that, add regex anchors.

**Which issues(s) does this PR fix?**

This fixes a problem that has the same effects as issue #3805, but with a different cause. Here, the gopackagesdriver returns roots that are not even go targets.

**Other notes for review**

The fix in #3806, when merged, would hide the effects of the bug addressed here, because the roots that are not go targets will also be filtered out. That also makes this fix here more difficult to test. But I still think it's worth fixing this bug.

See https://bazel.build/query/language#kind for documentation of the kind query.