### PR TITLE
prepare release 0.49.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_go",
-    version = "0.48.1",
+    version = "0.49.0",
     compatibility_level = 0,
     repo_name = "io_bazel_rules_go",
 )

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -121,7 +121,7 @@ TOOLS_NOGO = [str(Label(l)) for l in _TOOLS_NOGO]
 
 # Current version or next version to be tagged. Gazelle and other tools may
 # check this to determine compatibility.
-RULES_GO_VERSION = "0.48.1"
+RULES_GO_VERSION = "0.49.0"
 
 go_context = _go_context
 gomock = _gomock


### PR DESCRIPTION
To keep backward compatibility, we will not be upgrading dependencies this release. 

We will do some internal dependency upgrades before the next upgrade.