### PR TITLE
Migrate to macos_arm64

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -91,7 +91,7 @@ tasks:
       - "@go_default_sdk//..."
     test_targets:
       - "//..."
-  macos_legacy:
+  macos_arm64:
     shell_commands:
       - tests/core/cgo/generate_imported_dylib.sh
     build_flags:

--- a/go/tools/bazel_testing/bazel_testing.go
+++ b/go/tools/bazel_testing/bazel_testing.go
@@ -179,9 +179,9 @@ func TestMain(m *testing.M, args Args) {
 // hide that this code is executing inside a bazel test.
 func BazelCmd(args ...string) *exec.Cmd {
 	cmd := exec.Command("bazel")
-    // --nosystem_rc isn't used here because Bazel may need essential flags set in
-    // system rc to be able to work correctly
-    // See https://github.com/bazelbuild/rules_go/pull/3969#issuecomment-2220405416
+	// --nosystem_rc isn't used here because Bazel may need essential flags set in
+	// system rc to be able to work correctly
+	// See https://github.com/bazelbuild/rules_go/pull/3969#issuecomment-2220405416
 	cmd.Args = append(cmd.Args, "--nohome_rc")
 	cmd.Args = append(cmd.Args, args...)
 	for _, e := range os.Environ() {

--- a/go/tools/bazel_testing/bazel_testing.go
+++ b/go/tools/bazel_testing/bazel_testing.go
@@ -179,6 +179,9 @@ func TestMain(m *testing.M, args Args) {
 // hide that this code is executing inside a bazel test.
 func BazelCmd(args ...string) *exec.Cmd {
 	cmd := exec.Command("bazel")
+    // --nosystem_rc isn't used here because Bazel may need essential flags set in
+    // system rc to be able to work correctly
+    // See https://github.com/bazelbuild/rules_go/pull/3969#issuecomment-2220405416
 	cmd.Args = append(cmd.Args, "--nohome_rc")
 	cmd.Args = append(cmd.Args, args...)
 	for _, e := range os.Environ() {

--- a/go/tools/bazel_testing/bazel_testing.go
+++ b/go/tools/bazel_testing/bazel_testing.go
@@ -179,7 +179,7 @@ func TestMain(m *testing.M, args Args) {
 // hide that this code is executing inside a bazel test.
 func BazelCmd(args ...string) *exec.Cmd {
 	cmd := exec.Command("bazel")
-	cmd.Args = append(cmd.Args, "--nosystem_rc", "--nohome_rc")
+	cmd.Args = append(cmd.Args, "--nohome_rc")
 	cmd.Args = append(cmd.Args, args...)
 	for _, e := range os.Environ() {
 		// Filter environment variables set by the bazel test wrapper script.


### PR DESCRIPTION
Bazel CI is going to remove `macos_legacy` soon.

Removing `--nosystem_rc` in test setup to pick up `--host_jvm_args=-Djava.net.preferIPv6Addresses=true` set in `/private/etc/bazel.bazelrc` on Bazel CI's Mac VMs (ipv6-only).

Context: https://github.com/bazelbuild/continuous-integration/issues/1981#issuecomment-2230296824