### PR TITLE
Support matching release candidate toolchain versions

### DIFF
--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -171,6 +171,14 @@ def declare_bazel_toolchains(
     )
 
     native.config_setting(
+        name = prefix + "match_minor_release_candidate",
+        flag_values = {
+            sdk_version_label: major + "." + minor + prerelease,
+        },
+        visibility = ["//visibility:private"],
+    )
+
+    native.config_setting(
         name = prefix + "match_sdk_type",
         flag_values = {
             sdk_version_label: sdk_type,
@@ -186,6 +194,7 @@ def declare_bazel_toolchains(
             ":" + prefix + "match_major_minor_version",
             ":" + prefix + "match_patch_version",
             ":" + prefix + "match_prerelease_version",
+            ":" + prefix + "match_minor_release_candidate",
             ":" + prefix + "match_sdk_type",
         ],
         visibility = ["//visibility:private"],

--- a/tests/core/cross/sdk_version_test.go
+++ b/tests/core/cross/sdk_version_test.go
@@ -53,6 +53,11 @@ var testCases = []testcase{
 		SDKVersion:      "1.17.1",
 		expectedVersion: "go1.17.1",
 	},
+	{
+		Name:             "1_17_release_candidate",
+		SDKVersion:       "1.17rc1",
+		expectedVersion:  "go1.17rc1",
+	},
 }
 
 func TestMain(m *testing.M) {
@@ -79,6 +84,11 @@ go_download_sdk(
     name = "go_sdk_1_17_1",
     version = "1.17.1",
 )
+go_download_sdk(
+    name = "go_sdk_1_17_rc1",
+    version = "1.17rc1",
+)
+
 go_register_toolchains()
 -- main.go --
 package main


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Go release candidate versions are of the format `X.YrcZ`. (ex: https://github.com/golang/go/commit/30b6fd60a63c738c2736e83b6a6886a032e6f269)

Unfortunately, this format doesn't get matched properly in `go_toolchain.bzl` so it's not possible to use rc versions without patching `VERSION`, or you'll run into the error, for e.g., with the added test case:
```
no matching toolchains found for types @io_bazel_rules_go//go:toolchain
```

This PR adds a way to match `rc` versions for the toolchain.