### PR TITLE
Making gopackagesdriver correctly handle relative queries made from a subdirectory.

### DIFF
--- a/go/tools/gopackagesdriver/bazel.go
+++ b/go/tools/gopackagesdriver/bazel.go
@@ -35,11 +35,12 @@ const (
 )
 
 type Bazel struct {
-	bazelBin          string
-	workspaceRoot     string
-	bazelStartupFlags []string
-	info              map[string]string
-	version           bazelVersion
+	bazelBin              string
+	workspaceRoot         string
+	buildWorkingDirectory string
+	bazelStartupFlags     []string
+	info                  map[string]string
+	version               bazelVersion
 }
 
 // Minimal BEP structs to access the build outputs
@@ -52,11 +53,12 @@ type BEPNamedSet struct {
 	} `json:"namedSetOfFiles"`
 }
 
-func NewBazel(ctx context.Context, bazelBin, workspaceRoot string, bazelStartupFlags []string) (*Bazel, error) {
+func NewBazel(ctx context.Context, bazelBin, workspaceRoot string, buildWorkingDirectory string, bazelStartupFlags []string) (*Bazel, error) {
 	b := &Bazel{
-		bazelBin:          bazelBin,
-		workspaceRoot:     workspaceRoot,
-		bazelStartupFlags: bazelStartupFlags,
+		bazelBin:              bazelBin,
+		workspaceRoot:         workspaceRoot,
+		buildWorkingDirectory: buildWorkingDirectory,
+		bazelStartupFlags:     bazelStartupFlags,
 	}
 	if err := b.fillInfo(ctx); err != nil {
 		return nil, fmt.Errorf("unable to query bazel info: %w", err)
@@ -161,6 +163,10 @@ func (b *Bazel) Query(ctx context.Context, args ...string) ([]string, error) {
 
 func (b *Bazel) WorkspaceRoot() string {
 	return b.workspaceRoot
+}
+
+func (b *Bazel) BuildWorkingDirectory() string {
+	return b.buildWorkingDirectory
 }
 
 func (b *Bazel) ExecutionRoot() string {

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -46,6 +46,8 @@ func (b *BazelJSONBuilder) fileQuery(filename string) string {
 		filename = filepath.Join(b.bazel.BuildWorkingDirectory(), filename)
 	}
 	label, _ := filepath.Rel(b.bazel.WorkspaceRoot(), filename)
+	// Note: Using ToSlash for handling windows backslashes
+	label = filepath.ToSlash(label)
 
 	if matches := externalRe.FindStringSubmatch(filename); len(matches) == 5 {
 		// if filepath is for a third party lib, we need to know, what external
@@ -100,7 +102,8 @@ func (b *BazelJSONBuilder) localQuery(request string) string {
 		absRequest = filepath.Join(b.bazel.BuildWorkingDirectory(), request)
 	}
 	if relPath, err := filepath.Rel(workspaceRoot, absRequest); err == nil {
-		request = relPath
+		// Note: Using ToSlash for handling windows backslashes
+		request = filepath.ToSlash(relPath)
 	}
 
 	if !strings.HasSuffix(request, "...") {

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -88,7 +87,7 @@ func (b *BazelJSONBuilder) getKind() string {
 }
 
 func (b *BazelJSONBuilder) localQuery(request string) string {
-	request = path.Clean(b.adjustToRelativePathIfPossible(request))
+	request = b.adjustToRelativePathIfPossible(request)
 
 	if !strings.HasSuffix(request, "...") {
 		request = fmt.Sprintf("%s:*", request)
@@ -107,6 +106,8 @@ func (b *BazelJSONBuilder) adjustToRelativePathIfPossible(request string) string
 	}
 	if relPath, err := filepath.Rel(workspaceRoot, absRequest); err == nil {
 		request = filepath.ToSlash(relPath)
+	} else {
+		fmt.Fprintf(os.Stderr, "error adjusting path to be relative to the workspace root from request %s: %v\n", request, err)
 	}
 	return request
 }

--- a/go/tools/gopackagesdriver/main.go
+++ b/go/tools/gopackagesdriver/main.go
@@ -62,6 +62,7 @@ var (
 	bazelQueryScope       = getenvDefault("GOPACKAGESDRIVER_BAZEL_QUERY_SCOPE", "")
 	bazelBuildFlags       = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_BUILD_FLAGS"))
 	workspaceRoot         = os.Getenv("BUILD_WORKSPACE_DIRECTORY")
+	buildWorkingDirectory = os.Getenv("BUILD_WORKING_DIRECTORY")
 	additionalAspects     = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_ADDTL_ASPECTS"))
 	additionalKinds       = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_KINDS"))
 	emptyResponse         = &driverResponse{
@@ -81,7 +82,7 @@ func run(ctx context.Context, in io.Reader, out io.Writer, args []string) error 
 		return fmt.Errorf("unable to read request: %w", err)
 	}
 
-	bazel, err := NewBazel(ctx, bazelBin, workspaceRoot, bazelStartupFlags)
+	bazel, err := NewBazel(ctx, bazelBin, workspaceRoot, buildWorkingDirectory, bazelStartupFlags)
 	if err != nil {
 		return fmt.Errorf("unable to create bazel instance: %w", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

It allows gopackagesdriver to be called within a subdirectory of a workspace and properly resolve queries from gopls from IDEs like VSCode when they include relative references. For example, if you have the following repo/workspace structure:
```
WORKSPACE
project1/BUILD.bazel
project1/main.go
project2/BUILD.bazel
project2/main.go
...
```

If you run gopackagesdriver using bazel run from project1 directory and receive the following queries:
```
file=./main.go
./...
```
The existing code will try to resolve those queries against the root of the workspace, when instead we would expect it to resolve relative to the project1 directory.

**Which issues(s) does this PR fix?**

Fixes #4001 

**Other notes for review**
