### PR TITLE
Simplify duplicate importmap handling

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -180,7 +180,6 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
 
         # Information on dependencies
         _dep_labels = tuple([d.data.label for d in direct]),
-        _dep_importmaps = tuple([d.data.importmap for d in direct]),
 
         # Information needed by dependents
         file = out_lib,

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -106,13 +106,11 @@ def emit_link(
     if go.mode.link == LINKMODE_PLUGIN:
         tool_args.add("-pluginpath", archive.data.importpath)
 
+    if go.coverage_enabled and go.coverdata:
+        test_archives = list(test_archives) + [go.coverdata.data]
+
     arcs = depset(test_archives, transitive = [d.transitive for d in archive.direct])
     builder_args.add_all(arcs, before_each = "-arc", map_each = _format_archive)
-
-    if (go.coverage_enabled and go.coverdata):
-        # The linker knows to exclude the coverdata archive if it's already included in `arcs`.
-        builder_args.add("-arc", _format_archive(go.coverdata.data))
-
     builder_args.add("-package_list", go.sdk.package_list)
 
     # Build a list of rpaths for dynamic libraries we need to find.

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -37,29 +37,6 @@ load(
 def _format_archive(d):
     return "{}={}={}".format(d.label, d.importmap, d.file.path)
 
-def _transitive_archives_without_test_archives(archive, test_archives):
-    # Build the set of transitive dependencies. Currently, we tolerate multiple
-    # archives with the same importmap (though this will be an error in the
-    # future), but there is a special case which is difficult to avoid:
-    # If a go_test has internal and external archives, and the external test
-    # transitively depends on the library under test, we need to exclude the
-    # library under test and use the internal test archive instead.
-    deps = depset(transitive = [d.transitive for d in archive.direct])
-    result = {}
-
-    # Unfortunately, Starlark doesn't support set()
-    test_imports = {}
-    for t in test_archives:
-        test_imports[t.importmap] = True
-    for d in deps.to_list():
-        if d.importmap in test_imports:
-            continue
-        if d.importmap in result:
-            print("Multiple copies of {} passed to the linker. Ignoring {} in favor of {}".format(d.importmap, d.file.path, result[d.importmap].file.path))
-            continue
-        result[d.importmap] = d
-    return result.values()
-
 def emit_link(
         go,
         archive = None,
@@ -82,8 +59,7 @@ def emit_link(
 
     if go.coverage_enabled:
         extldflags.append("--coverage")
-    gc_linkopts = list(gc_linkopts)
-    gc_linkopts.extend(go.mode.gc_linkopts)
+    gc_linkopts = gc_linkopts + go.mode.gc_linkopts
     gc_linkopts, extldflags = _extract_extldflags(gc_linkopts, extldflags)
     builder_args = go.builder_args(go, "link")
     tool_args = go.tool_args(go)
@@ -130,12 +106,14 @@ def emit_link(
     if go.mode.link == LINKMODE_PLUGIN:
         tool_args.add("-pluginpath", archive.data.importpath)
 
-    arcs = _transitive_archives_without_test_archives(archive, test_archives)
-    arcs.extend(test_archives)
-    if (go.coverage_enabled and go.coverdata and
-        not any([arc.importmap == go.coverdata.data.importmap for arc in arcs])):
-        arcs.append(go.coverdata.data)
+    # Use preorder traversal so that the test archives override the transitive ones if they have the same importmap.
+    arcs = depset(test_archives, transitive = [d.transitive for d in archive.direct], order = "preorder")
     builder_args.add_all(arcs, before_each = "-arc", map_each = _format_archive)
+
+    if (go.coverage_enabled and go.coverdata):
+        # The linker knows to exclude the coverdata archive if it's already included in `arcs`.
+        builder_args.add("-arc", _format_archive(go.coverdata.data))
+
     builder_args.add("-package_list", go.sdk.package_list)
 
     # Build a list of rpaths for dynamic libraries we need to find.
@@ -187,13 +165,6 @@ def emit_link(
         tool_args.add("-s", "-w")
     tool_args.add_joined("-extldflags", extldflags, join_with = " ")
 
-    conflict_err = _check_conflicts(arcs)
-    if conflict_err:
-        # Report package conflict errors in execution instead of analysis.
-        # We could call fail() with this message, but Bazel prints a stack
-        # that doesn't give useful information.
-        builder_args.add("-conflict_err", conflict_err)
-
     inputs_direct = stamp_inputs + [go.sdk.package_list]
     if go.coverage_enabled and go.coverdata:
         inputs_direct.append(go.coverdata.data.file)
@@ -241,41 +212,3 @@ def _extract_extldflags(gc_linkopts, extldflags):
         else:
             filtered_gc_linkopts.append(opt)
     return filtered_gc_linkopts, extldflags
-
-def _check_conflicts(arcs):
-    importmap_to_label = {}
-    for arc in arcs:
-        if arc.importmap in importmap_to_label:
-            return """package conflict error: {}: multiple copies of package passed to linker:
-	{}
-	{}
-Set "importmap" to different paths or use 'bazel cquery' to ensure only one
-package with this path is linked.""".format(
-                arc.importmap,
-                importmap_to_label[arc.importmap],
-                arc.label,
-            )
-        importmap_to_label[arc.importmap] = arc.label
-    for arc in arcs:
-        for dep_importmap, dep_label in zip(arc._dep_importmaps, arc._dep_labels):
-            if dep_importmap not in importmap_to_label:
-                return "package conflict error: {}: package needed by {} was not passed to linker".format(
-                    dep_importmap,
-                    arc.label,
-                )
-            if importmap_to_label[dep_importmap] != dep_label:
-                err = """package conflict error: {}: package imports {}
-	  was compiled with: {}
-	but was linked with: {}""".format(
-                    arc.importmap,
-                    dep_importmap,
-                    dep_label,
-                    importmap_to_label[dep_importmap],
-                )
-                if importmap_to_label[dep_importmap].name.endswith("_test"):
-                    err += """
-This sometimes happens when an external test (package ending with _test)
-imports a package that imports the library being tested. This is not supported."""
-                err += "\nSee https://github.com/bazelbuild/rules_go/issues/1877."
-                return err
-    return None

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -106,8 +106,7 @@ def emit_link(
     if go.mode.link == LINKMODE_PLUGIN:
         tool_args.add("-pluginpath", archive.data.importpath)
 
-    # Use preorder traversal so that the test archives override the transitive ones if they have the same importmap.
-    arcs = depset(test_archives, transitive = [d.transitive for d in archive.direct], order = "preorder")
+    arcs = depset(test_archives, transitive = [d.transitive for d in archive.direct])
     builder_args.add_all(arcs, before_each = "-arc", map_each = _format_archive)
 
     if (go.coverage_enabled and go.coverdata):

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -42,7 +42,7 @@ load(
 )
 load(
     "//go/private/rules:transition.bzl",
-    "non_go_tool_transition",
+    "non_request_nogo_transition",
     "request_nogo_transition",
 )
 load(
@@ -576,7 +576,7 @@ go_context_data = rule(
         "cgo_context_data": attr.label(),
         "coverdata": attr.label(
             mandatory = True,
-            cfg = non_go_tool_transition,
+            cfg = non_request_nogo_transition,
             providers = [GoArchive],
         ),
         "go_config": attr.label(

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -42,6 +42,7 @@ load(
 )
 load(
     "//go/private/rules:transition.bzl",
+    "non_go_tool_transition",
     "request_nogo_transition",
 )
 load(
@@ -559,7 +560,7 @@ def _go_context_data_impl(ctx):
     nogo = ctx.files.nogo[0] if ctx.files.nogo else None
     providers = [
         GoContextInfo(
-            coverdata = ctx.attr.coverdata[GoArchive],
+            coverdata = ctx.attr.coverdata[0][GoArchive],
             nogo = nogo,
         ),
         ctx.attr.stdlib[GoStdLib],
@@ -575,6 +576,7 @@ go_context_data = rule(
         "cgo_context_data": attr.label(),
         "coverdata": attr.label(
             mandatory = True,
+            cfg = non_go_tool_transition,
             providers = [GoArchive],
         ),
         "go_config": attr.label(

--- a/go/private/rules/transition.bzl
+++ b/go/private/rules/transition.bzl
@@ -166,6 +166,17 @@ request_nogo_transition = transition(
     outputs = ["//go/private:request_nogo"],
 )
 
+def _non_request_nogo_transition(_settings, _attr):
+    # This transition is used to make sure we only end up with 1 copy of coverdata,
+    # even if a test links against it and is run in coverage mode.
+    return {"//go/private:request_nogo": False}
+
+non_request_nogo_transition = transition(
+    implementation = _non_request_nogo_transition,
+    inputs = [],
+    outputs = ["//go/private:request_nogo"],
+)
+
 go_transition = transition(
     implementation = _go_transition_impl,
     inputs = [

--- a/go/tools/builders/importcfg.go
+++ b/go/tools/builders/importcfg.go
@@ -177,7 +177,23 @@ func buildImportcfgFileForLink(archives []archive, stdPackageListPath, installSu
 	if err := scanner.Err(); err != nil {
 		return "", err
 	}
+	depsSeen := map[string]string{}
 	for _, arc := range archives {
+		if prevLabel, ok := depsSeen[arc.packagePath]; ok {
+			return "", fmt.Errorf(`
+package conflict error: %s: multiple copies of package passed to linker:
+    %s
+    %s
+Set "importmap" to different paths or use 'bazel cquery' to ensure only one
+package with this path is linked.`,
+				arc.packagePath,
+				arc.importPath,
+				prevLabel)
+		}
+		// TODO(zbarsky): The labels are empty, and `importPath` contains the label.
+		// The parsing is incorrect because arrchiveMultiFlag assuming the formatting from
+		// `compilepkg.bzl` but `_format_archive` in `link.bzl` formats differently.
+		depsSeen[arc.packagePath] = arc.importPath
 		fmt.Fprintf(buf, "packagefile %s=%s\n", arc.packagePath, arc.file)
 	}
 	f, err := ioutil.TempFile(dir, "importcfg")

--- a/go/tools/builders/importcfg.go
+++ b/go/tools/builders/importcfg.go
@@ -177,12 +177,7 @@ func buildImportcfgFileForLink(archives []archive, stdPackageListPath, installSu
 	if err := scanner.Err(); err != nil {
 		return "", err
 	}
-	depsSeen := map[string]string{}
 	for _, arc := range archives {
-		if _, ok := depsSeen[arc.packagePath]; ok {
-			return "", fmt.Errorf("internal error: package %s provided multiple times. This should have been detected during analysis.", arc.packagePath)
-		}
-		depsSeen[arc.packagePath] = arc.label
 		fmt.Fprintf(buf, "packagefile %s=%s\n", arc.packagePath, arc.file)
 	}
 	f, err := ioutil.TempFile(dir, "importcfg")


### PR DESCRIPTION
**What does this PR do? Why is it needed?**
Starlark cleanup and perf improvement - saves around 250ms on buildbuddy

- It's more efficient to ignore a duplicate archive inside the action vs in analysis phase
- I belive `_transitive_archives_without_test_archives` is no longer needed due to the `recompile_external_deps` machinery for tests
- This allows to remove some data from the providers as well

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
