### PR TITLE
Remove get_nogo from context

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -17,6 +17,10 @@ load(
     "as_tuple",
 )
 load(
+    "//go/private:context.bzl",
+    "get_nogo",
+)
+load(
     "//go/private:mode.bzl",
     "LINKMODE_C_ARCHIVE",
     "LINKMODE_C_SHARED",
@@ -59,14 +63,16 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
     # store export information for compiling dependent packages separately
     out_export = go.declare_file(go, name = source.library.name, ext = pre_ext + ".x")
     out_cgo_export_h = None  # set if cgo used in c-shared or c-archive mode
-    out_facts = None
-    out_nogo_log = None
-    out_nogo_validation = None
-    nogo = go.get_nogo(go)
+
+    nogo = get_nogo(go)
     if nogo:
         out_facts = go.declare_file(go, name = source.library.name, ext = pre_ext + ".facts")
         out_nogo_log = go.declare_file(go, name = source.library.name, ext = pre_ext + ".nogo.log")
         out_nogo_validation = go.declare_file(go, name = source.library.name, ext = pre_ext + ".nogo")
+    else:
+        out_facts = None
+        out_nogo_log = None
+        out_nogo_validation = None
 
     direct = [get_archive(dep) for dep in source.deps]
 

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -433,9 +433,9 @@ def _matches_scopes(label, scopes):
             return True
     return False
 
-def _get_nogo(go):
+def get_nogo(go):
     """Returns the nogo file for this target, if enabled and in scope."""
-    label = go._ctx.label
+    label = go.label
     if _matches_scopes(label, NOGO_INCLUDES) and not _matches_scopes(label, NOGO_EXCLUDES):
         return go.nogo
     else:
@@ -604,7 +604,6 @@ def go_context(ctx, attr = None):
         library_to_source = _library_to_source,
         declare_file = _declare_file,
         declare_directory = _declare_directory,
-        get_nogo = _get_nogo,
 
         # Private
         # TODO: All uses of this should be removed


### PR DESCRIPTION
**What type of PR is this?**
Cleanup

**What does this PR do? Why is it needed?**
It seems odd to hang helpers off the `go` context because they still need to take `go` as a param. It's clearer to just import them.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
