### PR TITLE
Remove cgo_deps from GoSource provider

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -236,7 +236,6 @@ def _merge_embed(source, embed):
     source["copts"] = source["copts"] or s.copts
     source["cxxopts"] = source["cxxopts"] or s.cxxopts
     source["clinkopts"] = source["clinkopts"] or s.clinkopts
-    source["cgo_deps"] = source["cgo_deps"] + s.cgo_deps
     source["cgo_exports"] = source["cgo_exports"] + s.cgo_exports
 
 def _dedup_deps(deps):
@@ -288,7 +287,6 @@ def _library_to_source(go, attr, library, coverage_instrumented):
         "copts": _expand_opts(go, "copts", getattr(attr, "copts", [])),
         "cxxopts": _expand_opts(go, "cxxopts", getattr(attr, "cxxopts", [])),
         "clinkopts": _expand_opts(go, "clinkopts", getattr(attr, "clinkopts", [])),
-        "cgo_deps": [],
         "cgo_exports": [],
         "cc_info": None,
         "pgoprofile": getattr(attr, "pgoprofile", None),

--- a/go/providers.rst
+++ b/go/providers.rst
@@ -191,10 +191,6 @@ method. In general, only rules_go should need to build or handle these.
 +--------------------------------+-----------------------------------------------------------------+
 | List of additional flags to pass to the external linker.                                         |
 +--------------------------------+-----------------------------------------------------------------+
-| :param:`cgo_deps`              | :type:`list of File`                                            |
-+--------------------------------+-----------------------------------------------------------------+
-| Deprecated; use ``cdeps`` instead. The direct cgo dependencies of this library.                  |
-+--------------------------------+-----------------------------------------------------------------+
 | :param:`cgo_exports`           | :type:`list of File`                                            |
 +--------------------------------+-----------------------------------------------------------------+
 | The exposed cc headers for these sources.                                                        |


### PR DESCRIPTION
**What type of PR is this?**
This field was deprecated over 6 years ago, we can clean it up.

**What does this PR do? Why is it needed?**
Simplify the providers.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
