### PR TITLE
Cleanup GoArchiveData usage of as_tuple

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -13,10 +13,6 @@
 # limitations under the License.
 
 load(
-    "//go/private:common.bzl",
-    "as_tuple",
-)
-load(
     "//go/private:context.bzl",
     "get_nogo",
 )
@@ -170,17 +166,17 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
         pathtype = source.library.pathtype,
 
         # GoSource fields
-        srcs = as_tuple(source.srcs),
+        srcs = tuple(source.srcs),
         _cover = source.cover,
-        _embedsrcs = as_tuple(source.embedsrcs),
+        _embedsrcs = tuple(source.embedsrcs),
         _x_defs = tuple(source.x_defs.items()),
-        _gc_goopts = as_tuple(source.gc_goopts),
+        _gc_goopts = tuple(source.gc_goopts),
         _cgo = source.cgo,
-        _cdeps = as_tuple(source.cdeps),
-        _cppopts = as_tuple(source.cppopts),
-        _copts = as_tuple(source.copts),
-        _cxxopts = as_tuple(source.cxxopts),
-        _clinkopts = as_tuple(source.clinkopts),
+        _cdeps = tuple(source.cdeps),
+        _cppopts = tuple(source.cppopts),
+        _copts = tuple(source.copts),
+        _cxxopts = tuple(source.cxxopts),
+        _clinkopts = tuple(source.clinkopts),
 
         # Information on dependencies
         _dep_labels = tuple([d.data.label for d in direct]),
@@ -192,7 +188,7 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
         facts_file = out_facts,
         runfiles = source.runfiles,
         _validation_output = out_nogo_validation,
-        _cgo_deps = as_tuple(cgo_deps),
+        _cgo_deps = cgo_deps,
     )
     x_defs = dict(source.x_defs)
     for a in direct:

--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -162,16 +162,6 @@ def as_iterable(v):
         return v.to_list()
     fail("as_iterator failed on {}".format(v))
 
-def as_tuple(v):
-    """Returns a list, tuple, or depset as a tuple."""
-    if type(v) == "tuple":
-        return v
-    if type(v) == "list":
-        return tuple(v)
-    if type(v) == "depset":
-        return tuple(v.to_list())
-    fail("as_tuple failed on {}".format(v))
-
 def count_group_matches(v, prefix, suffix):
     """Counts reluctant substring matches between prefix and suffix.
 

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -699,7 +699,7 @@ def _recompile_external_deps(go, external_source, internal_archive, library_labe
                 libs = depset(direct = [arc_data.file], transitive = [a.libs for a in deps]),
                 transitive = depset(direct = [arc_data], transitive = [a.transitive for a in deps]),
                 x_defs = source.x_defs,
-                cgo_deps = depset(direct = arc_data._cgo_deps, transitive = [a.cgo_deps for a in deps]),
+                cgo_deps = depset(transitive = [arc_data._cgo_deps] + [a.cgo_deps for a in deps]),
                 cgo_exports = depset(transitive = [a.cgo_exports for a in deps]),
                 runfiles = source.runfiles,
                 mode = go.mode,


### PR DESCRIPTION
**What type of PR is this?**
Starlark cleanup

**What does this PR do? Why is it needed?**
`as_tuple` was showing up in profiles, we can just call `tuple` directly. This exposed that we were flattening a depset which isn't necessary.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
