### PR TITLE
Prefer rfind to rpartition in go_context

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -348,7 +348,7 @@ def _check_binary_dep(go, dep, edge):
 
     go_binary and go_test may return providers with useful information for other
     rules (like go_path), but go_binary and go_test may not depend on other
-    go_binary and go_binary targets. Their dependencies may be built in
+    go_binary and go_test targets. Their dependencies may be built in
     different modes, resulting in conflicts and opaque errors.
     """
     if (type(dep) == "Target" and
@@ -538,7 +538,7 @@ def go_context(ctx, attr = None):
             cgo_tools.ld_dynamic_lib_path,
         ]
         for tool_path in tool_paths:
-            tool_dir, _, _ = tool_path.rpartition("/")
+            tool_dir = tool_path[:tool_path.rfind("/")]
             path_set[tool_dir] = None
         paths = sorted(path_set.keys())
         if ctx.configuration.host_path_separator == ":":


### PR DESCRIPTION
**What type of PR is this?**
Code cleanup

**What does this PR do? Why is it needed?**
It's a bit faster due to not allocating the array

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
