### PR TITLE
Remove orig_srcs

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -171,7 +171,6 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
 
         # GoSource fields
         srcs = as_tuple(source.srcs),
-        orig_srcs = as_tuple(source.orig_srcs),
         _cover = source.cover,
         _embedsrcs = as_tuple(source.embedsrcs),
         _x_defs = tuple(source.x_defs.items()),

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -216,7 +216,6 @@ def _new_library(go, name = None, importpath = None, resolver = None, importable
 def _merge_embed(source, embed):
     s = get_source(embed)
     source["srcs"] = s.srcs + source["srcs"]
-    source["orig_srcs"] = s.orig_srcs + source["orig_srcs"]
     source["embedsrcs"] = source["embedsrcs"] + s.embedsrcs
     source["cover"] = depset(transitive = [source["cover"], s.cover])
     source["deps"] = source["deps"] + s.deps
@@ -267,7 +266,6 @@ def _library_to_source(go, attr, library, coverage_instrumented):
         "library": library,
         "mode": go.mode,
         "srcs": srcs,
-        "orig_srcs": srcs,
         "embedsrcs": embedsrcs,
         "cover": depset(attr_srcs) if coverage_instrumented else depset(),
         "x_defs": {},

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -672,7 +672,6 @@ def _recompile_external_deps(go, external_source, internal_archive, library_labe
             library = library,
             mode = go.mode,
             srcs = as_list(arc_data.srcs),
-            orig_srcs = as_list(arc_data.orig_srcs),
             cover = arc_data._cover,
             embedsrcs = as_list(arc_data._embedsrcs),
             x_defs = dict(arc_data._x_defs),

--- a/go/private/tools/path.bzl
+++ b/go/private/tools/path.bzl
@@ -57,7 +57,7 @@ def _go_path_impl(ctx):
             pkg = struct(
                 importpath = importpath,
                 dir = "src/" + pkgpath,
-                srcs = as_list(archive.orig_srcs),
+                srcs = as_list(archive.srcs),
                 runfiles = archive.runfiles,
                 embedsrcs = as_list(archive._embedsrcs),
                 pkgs = {mode: archive.file},

--- a/go/providers.rst
+++ b/go/providers.rst
@@ -129,11 +129,6 @@ method. In general, only rules_go should need to build or handle these.
 +--------------------------------+-----------------------------------------------------------------+
 | The sources to compile into the archive.                                                         |
 +--------------------------------+-----------------------------------------------------------------+
-| :param:`orig_srcs`             | :type:`list of File`                                            |
-+--------------------------------+-----------------------------------------------------------------+
-| The original source files this library is based on. This may differ from                         |
-| :param:`srcs` if processing tools such as cgo or cover are applied.                              |
-+--------------------------------+-----------------------------------------------------------------+
 | :param:`embedsrcs`             | :type:`list of File`                                            |
 +--------------------------------+-----------------------------------------------------------------+
 | Files that may be embedded into the compiled package using ``//go:embed``                        |
@@ -265,10 +260,6 @@ rule.  Instead, it's referenced in the ``data`` field of GoArchive_.
 +--------------------------------+-----------------------------------------------------------------+
 | The .go sources compiled into the archive. May have been generated or                            |
 | transformed with tools like cgo and cover.                                                       |
-+--------------------------------+-----------------------------------------------------------------+
-| :param:`orig_srcs`             | :type:`tuple of File`                                           |
-+--------------------------------+-----------------------------------------------------------------+
-| The unmodified sources provided to the rule, including .go, .s, .h, .c files.                    |
 +--------------------------------+-----------------------------------------------------------------+
 | :param:`runfiles`              | :type:`runfiles`                                           |
 +--------------------------------+-----------------------------------------------------------------+

--- a/go/tools/gopackagesdriver/aspect.bzl
+++ b/go/tools/gopackagesdriver/aspect.bzl
@@ -50,23 +50,20 @@ def file_path(f):
     return paths.join(prefix, f.path)
 
 def _go_archive_to_pkg(archive):
+    go_files = [
+        file_path(src)
+        for src in archive.data.srcs
+        if src.path.endswith(".go")
+    ]
     return struct(
         ID = str(archive.data.label),
         PkgPath = archive.data.importpath,
         ExportFile = file_path(archive.data.export_file),
-        GoFiles = [
-            file_path(src)
-            for src in archive.data.orig_srcs
-            if src.path.endswith(".go")
-        ],
-        CompiledGoFiles = [
-            file_path(src)
-            for src in archive.data.srcs
-            if src.path.endswith(".go")
-        ],
+        GoFiles = go_files,
+        CompiledGoFiles = go_files,
         OtherFiles = [
             file_path(src)
-            for src in archive.data.orig_srcs
+            for src in archive.data.srcs
             if not src.path.endswith(".go")
         ],
         Imports = {


### PR DESCRIPTION
**What type of PR is this?**
Starlark cleanup

**What does this PR do? Why is it needed?**
The documentation says it can differ from `srcs` "if processing tools such as cgo or cover are applied." but in practice I did not see it mutating in the code; I suspect this may have been true in an earlier iteration of the rules. I also put in an assert in the provider creation code if they are different at the end and it didn't fire.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
