### PR TITLE
Turn source.cover into a depset

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -173,7 +173,7 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
         # GoSource fields
         srcs = as_tuple(source.srcs),
         orig_srcs = as_tuple(source.orig_srcs),
-        _cover = as_tuple(source.cover),
+        _cover = source.cover,
         _embedsrcs = as_tuple(source.embedsrcs),
         _x_defs = tuple(source.x_defs.items()),
         _gc_goopts = as_tuple(source.gc_goopts),

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -221,7 +221,7 @@ def _merge_embed(source, embed):
     source["srcs"] = s.srcs + source["srcs"]
     source["orig_srcs"] = s.orig_srcs + source["orig_srcs"]
     source["embedsrcs"] = source["embedsrcs"] + s.embedsrcs
-    source["cover"] = source["cover"] + s.cover
+    source["cover"] = depset(transitive = [source["cover"], s.cover])
     source["deps"] = source["deps"] + s.deps
     source["x_defs"].update(s.x_defs)
     source["gc_goopts"] = source["gc_goopts"] + s.gc_goopts
@@ -273,8 +273,8 @@ def _library_to_source(go, attr, library, coverage_instrumented):
         "mode": go.mode,
         "srcs": srcs,
         "orig_srcs": srcs,
-        "cover": [],
         "embedsrcs": embedsrcs,
+        "cover": depset(attr_srcs) if coverage_instrumented else depset(),
         "x_defs": {},
         "deps": deps,
         "gc_goopts": _expand_opts(go, "gc_goopts", getattr(attr, "gc_goopts", [])),
@@ -289,8 +289,7 @@ def _library_to_source(go, attr, library, coverage_instrumented):
         "cc_info": None,
         "pgoprofile": getattr(attr, "pgoprofile", None),
     }
-    if coverage_instrumented:
-        source["cover"] = attr_srcs
+
     for dep in source["deps"]:
         _check_binary_dep(go, dep, "deps")
     for e in getattr(attr, "embed", []):


### PR DESCRIPTION
**What type of PR is this?**
Starlark cleanup

**What does this PR do? Why is it needed?**
This will let us more efficiently merge `cover` with embedded sources, as well as avoid needing to convert to a tuple for the Archive.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
