### PR TITLE
docs: add missing anchor to Bazel toolchains definition

### DIFF
--- a/docs/go/core/cross_compilation.md
+++ b/docs/go/core/cross_compilation.md
@@ -21,7 +21,7 @@ which disables cgo; cgo files will not be compiled, and C/C++ dependencies will
 not be compiled or linked.
 
 Cross-compiling cgo code is possible, but not fully supported. You will need to
-[define and register a C/C++ toolchain and platforms]. You'll need to ensure it
+[define and register a C/C++ toolchain and platforms](https://bazel.build/extending/toolchains#toolchain-definitions). You'll need to ensure it
 works by building `cc_binary` and `cc_library` targets with the `--platforms`
 command line flag set. Then, to build a mixed Go / C / C++ project, add
 `pure = "off"` to your `go_binary` target and run Bazel with `--platforms`.


### PR DESCRIPTION
**What type of PR is this?**

Documentation

**What does this PR do? Why is it needed?**

Add missing link to https://bazel.build/extending/toolchains#toolchain-definitions for the change introduced by https://github.com/bazelbuild/rules_go/pull/3986.

**Which issues(s) does this PR fix?**

`None`

**Other notes for review**

`None`