### PR TITLE
Support GOOS=wasip1

### DIFF
--- a/go/private/platforms.bzl
+++ b/go/private/platforms.bzl
@@ -90,6 +90,7 @@ GOOS_GOARCH = (
     ("plan9", "amd64"),
     ("plan9", "arm"),
     ("solaris", "amd64"),
+    ("wasip1", "wasm"),
     ("windows", "386"),
     ("windows", "amd64"),
     ("windows", "arm"),

--- a/go/tools/internal/stdlib_tags/stdlib_tags.go
+++ b/go/tools/internal/stdlib_tags/stdlib_tags.go
@@ -125,7 +125,7 @@ func isConstraint(line string) bool {
 }
 
 // Taken from
-// https://github.com/golang/go/blob/3d5391ed87d813110e10b954c62bf7ed578b591f/src/go/build/syslist.go
+// https://github.com/golang/go/blob/2693f77b3583585172810427e12a634b28d34493/src/internal/syslist/syslist.go
 var knownOS = map[string]bool{
 	"aix":       true,
 	"android":   true,
@@ -142,6 +142,7 @@ var knownOS = map[string]bool{
 	"openbsd":   true,
 	"plan9":     true,
 	"solaris":   true,
+	"wasip1":    true,
 	"windows":   true,
 	"zos":       true,
 }


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Adds support for GOOS=wasip1 so that users can build wasi binaries using rules_go

**Which issues(s) does this PR fix?**

Fixes https://github.com/bazelbuild/rules_go/issues/4046

**Other notes for review**

None
