### PR TITLE
Remove cgo_exports from GoSource

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -181,7 +181,6 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
         _copts = as_tuple(source.copts),
         _cxxopts = as_tuple(source.cxxopts),
         _clinkopts = as_tuple(source.clinkopts),
-        _cgo_exports = as_tuple(source.cgo_exports),
 
         # Information on dependencies
         _dep_labels = tuple([d.data.label for d in direct]),
@@ -198,13 +197,11 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
     x_defs = dict(source.x_defs)
     for a in direct:
         x_defs.update(a.x_defs)
-    cgo_exports_direct = list(source.cgo_exports)
 
     # Ensure that the _cgo_export.h of the current target comes first when cgo_exports is iterated
     # by prepending it and specifying the order explicitly. This is required as the CcInfo attached
     # to the archive only exposes a single header rather than combining all headers.
-    if out_cgo_export_h:
-        cgo_exports_direct.insert(0, out_cgo_export_h)
+    cgo_exports_direct = [out_cgo_export_h] if out_cgo_export_h else []
     cgo_exports = depset(direct = cgo_exports_direct, transitive = [a.cgo_exports for a in direct], order = "preorder")
     return GoArchive(
         source = source,

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -230,7 +230,6 @@ def _merge_embed(source, embed):
     source["copts"] = source["copts"] or s.copts
     source["cxxopts"] = source["cxxopts"] or s.cxxopts
     source["clinkopts"] = source["clinkopts"] or s.clinkopts
-    source["cgo_exports"] = source["cgo_exports"] + s.cgo_exports
 
 def _dedup_archives(archives):
     """Returns a list of archives without duplicate import paths.
@@ -278,7 +277,6 @@ def _library_to_source(go, attr, library, coverage_instrumented):
         "copts": _expand_opts(go, "copts", getattr(attr, "copts", [])),
         "cxxopts": _expand_opts(go, "cxxopts", getattr(attr, "cxxopts", [])),
         "clinkopts": _expand_opts(go, "clinkopts", getattr(attr, "clinkopts", [])),
-        "cgo_exports": [],
         "pgoprofile": getattr(attr, "pgoprofile", None),
     }
 

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -684,7 +684,6 @@ def _recompile_external_deps(go, external_source, internal_archive, library_labe
             copts = as_list(arc_data._copts),
             cxxopts = as_list(arc_data._cxxopts),
             clinkopts = as_list(arc_data._clinkopts),
-            cgo_exports = as_list(arc_data._cgo_exports),
         )
 
         # If this archive needs to be recompiled, use go.archive.
@@ -701,7 +700,7 @@ def _recompile_external_deps(go, external_source, internal_archive, library_labe
                 transitive = depset(direct = [arc_data], transitive = [a.transitive for a in deps]),
                 x_defs = source.x_defs,
                 cgo_deps = depset(direct = arc_data._cgo_deps, transitive = [a.cgo_deps for a in deps]),
-                cgo_exports = depset(direct = list(source.cgo_exports), transitive = [a.cgo_exports for a in deps]),
+                cgo_exports = depset(transitive = [a.cgo_exports for a in deps]),
                 runfiles = source.runfiles,
                 mode = go.mode,
             )

--- a/go/providers.rst
+++ b/go/providers.rst
@@ -186,10 +186,6 @@ method. In general, only rules_go should need to build or handle these.
 +--------------------------------+-----------------------------------------------------------------+
 | List of additional flags to pass to the external linker.                                         |
 +--------------------------------+-----------------------------------------------------------------+
-| :param:`cgo_exports`           | :type:`list of File`                                            |
-+--------------------------------+-----------------------------------------------------------------+
-| The exposed cc headers for these sources.                                                        |
-+--------------------------------+-----------------------------------------------------------------+
 | :param:`cc_info`               | :type:`CcInfo`                                                  |
 +--------------------------------+-----------------------------------------------------------------+
 | The result of merging the ``CcInfo``s of all `deps` and `cdeps`                                  |
@@ -312,7 +308,7 @@ which is available through the :param:`data` field.
 +--------------------------------+-----------------------------------------------------------------+
 | :param:`cgo_exports`           | :type:`depset of GoSource`                                      |
 +--------------------------------+-----------------------------------------------------------------+
-| The the transitive set of c headers needed to reference exports of this archive.                 |
+| The transitive set of c headers needed to reference exports of this archive.                     |
 +--------------------------------+-----------------------------------------------------------------+
 | :param:`runfiles`              | runfiles_                                                       |
 +--------------------------------+-----------------------------------------------------------------+


### PR DESCRIPTION
**What type of PR is this?**
Starlark cleanup

**What does this PR do? Why is it needed?**
It looks like we are shuffling it between GoSource and GoArchive, but we only need it on the archive.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
