### PR TITLE
Cleanup importpath/importmap handling in go_context

### DIFF
--- a/go/private/rules/library.bzl
+++ b/go/private/rules/library.bzl
@@ -34,7 +34,13 @@ load(
 
 def _go_library_impl(ctx):
     """Implements the go_library() rule."""
-    go = go_context(ctx, include_deprecated_properties = False)
+    go = go_context(
+        ctx,
+        include_deprecated_properties = False,
+        importpath = ctx.attr.importpath,
+        importmap = ctx.attr.importmap,
+        embed = ctx.attr.embed,
+    )
     library = go.new_library(go)
     source = go.library_to_source(go, ctx.attr, library, ctx.coverage_instrumented())
     archive = go.archive(go, source)

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -148,7 +148,7 @@ def _go_test_impl(ctx):
         resolve = None,
     )
     test_deps = external_archive.direct + [external_archive] + ctx.attr._testmain_additional_deps
-    if ctx.configuration.coverage_enabled:
+    if go.coverage_enabled:
         test_deps.append(go.coverdata)
     test_source = go.library_to_source(go, struct(
         srcs = [struct(files = [main_go])],


### PR DESCRIPTION
**What type of PR is this?**
Starlark cleanup

**What does this PR do? Why is it needed?**
This looks like a 50-100ms speedup from avoiding the array allocation in infer_importpaths and reduced `getattr` calls. Is `getattr` slower than direct property access? (If not, we can avoid passing in the values from go_library)

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
