### PR TITLE
Remove more hasattr/getattr calls in go_context

### DIFF
--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -115,7 +115,13 @@ _go_cc_aspect = aspect(
 
 def _go_binary_impl(ctx):
     """go_binary_impl emits actions for compiling and linking a go executable."""
-    go = go_context(ctx, include_deprecated_properties = False)
+    go = go_context(
+        ctx,
+        include_deprecated_properties = False,
+        importpath = ctx.attr.importpath,
+        embed = ctx.attr.embed,
+        go_context_data = ctx.attr._go_context_data,
+    )
 
     is_main = go.mode.link not in (LINKMODE_SHARED, LINKMODE_PLUGIN)
     library = go.new_library(go, importable = False, is_main = is_main)

--- a/go/private/rules/library.bzl
+++ b/go/private/rules/library.bzl
@@ -39,8 +39,11 @@ def _go_library_impl(ctx):
         include_deprecated_properties = False,
         importpath = ctx.attr.importpath,
         importmap = ctx.attr.importmap,
+        importpath_aliases = ctx.attr.importpath_aliases,
         embed = ctx.attr.embed,
+        go_context_data = ctx.attr._go_context_data,
     )
+
     library = go.new_library(go)
     source = go.library_to_source(go, ctx.attr, library, ctx.coverage_instrumented())
     archive = go.archive(go, source)
@@ -204,8 +207,22 @@ go_library = rule(
 
 # See docs/go/core/rules.md#go_library for full documentation.
 
+def _go_tool_library_impl(ctx):
+    """Implements the go_tool_library() rule."""
+    go = go_context(ctx, include_deprecated_properties = False)
+
+    library = go.new_library(go)
+    source = go.library_to_source(go, ctx.attr, library, ctx.coverage_instrumented())
+    archive = go.archive(go, source)
+
+    return [
+        library,
+        source,
+        archive,
+    ]
+
 go_tool_library = rule(
-    _go_library_impl,
+    _go_tool_library_impl,
     attrs = {
         "data": attr.label_list(allow_files = True),
         "srcs": attr.label_list(allow_files = True),

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -56,7 +56,13 @@ def _go_test_impl(ctx):
     It emits an action to run the test generator, and then compiles the
     test into a binary."""
 
-    go = go_context(ctx, include_deprecated_properties = False)
+    go = go_context(
+        ctx,
+        include_deprecated_properties = False,
+        importpath = ctx.attr.importpath,
+        embed = ctx.attr.embed,
+        go_context_data = ctx.attr._go_context_data,
+    )
 
     # Compile the library to test with internal white box tests
     internal_library = go.new_library(go, testfilter = "exclude")


### PR DESCRIPTION
**What type of PR is this?**
starlark cleanup

**What does this PR do? Why is it needed?**
The current logic to grab all the providers is confusing; it runs the fallback logics even in the case when `go_context_data` is found. Easier to follow when we pass the data in explicitly, and a bit faster as well.

I also considered making a `go_context_v2` api that doesn't have all the fallbacks and using that to power `go_context`, but didn't do it for now.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
