### PR TITLE
Speedup get_mode some more

### DIFF
--- a/go/platform/apple.bzl
+++ b/go/platform/apple.bzl
@@ -35,8 +35,8 @@ def _apple_env(ctx, platform):
     xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
     return apple_common.target_apple_env(xcode_config, platform)
 
-def apple_ensure_options(ctx, env, _tags, compiler_option_lists, linker_option_lists, target_gnu_system_name):
-    """Returns environment, flags, and Go tags for Apple targets."""
+def apple_ensure_options(ctx, env, compiler_option_lists, linker_option_lists, target_gnu_system_name):
+    """Returns environment and flags for Apple targets."""
     platform, platform_type = _PLATFORMS.get(target_gnu_system_name, (None, None))
     if not platform:
         return

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -763,13 +763,9 @@ def _cgo_context_data_impl(ctx):
         variables = ld_dynamic_lib_variables,
     ))
 
-    tags = []
-    if "gotags" in ctx.var:
-        tags = ctx.var["gotags"].split(",")
     apple_ensure_options(
         ctx,
         env,
-        tags,
         (c_compile_options, cxx_compile_options, objc_compile_options, objcxx_compile_options),
         (ld_executable_options, ld_dynamic_lib_options),
         cc_toolchain.target_gnu_system_name,
@@ -805,7 +801,6 @@ def _cgo_context_data_impl(ctx):
 
     return [CgoContextInfo(
         cc_toolchain_files = cc_toolchain.all_files,
-        tags = tags,
         env = env,
         cgo_tools = struct(
             cc_toolchain = cc_toolchain,
@@ -871,16 +866,28 @@ def _go_config_impl(ctx):
     else:
         pgoprofile = None
 
+    tags = list(ctx.attr.gotags[BuildSettingInfo].value)
+    if "gotags" in ctx.var:
+        tags += ctx.var["gotags"].split(",")
+
+    race = ctx.attr.race[BuildSettingInfo].value
+    if race:
+        tags.append("race")
+
+    msan = ctx.attr.msan[BuildSettingInfo].value
+    if msan:
+        tags.append("msan")
+
     return [GoConfigInfo(
         static = ctx.attr.static[BuildSettingInfo].value,
-        race = ctx.attr.race[BuildSettingInfo].value,
-        msan = ctx.attr.msan[BuildSettingInfo].value,
+        race = race,
+        msan = msan,
         pure = ctx.attr.pure[BuildSettingInfo].value,
         strip = ctx.attr.strip,
         debug = ctx.attr.debug[BuildSettingInfo].value,
         linkmode = ctx.attr.linkmode[BuildSettingInfo].value,
         gc_linkopts = ctx.attr.gc_linkopts[BuildSettingInfo].value,
-        tags = ctx.attr.gotags[BuildSettingInfo].value,
+        tags = tags,
         stamp = ctx.attr.stamp,
         cover_format = ctx.attr.cover_format[BuildSettingInfo].value,
         gc_goopts = ctx.attr.gc_goopts[BuildSettingInfo].value,

--- a/go/private/mode.bzl
+++ b/go/private/mode.bzl
@@ -105,16 +105,6 @@ def get_mode(ctx, go_toolchain, cgo_context_info, go_config_info):
             fail(("linkmode '{}' can't be used when cgo is disabled. Check that pure is not set to \"off\" and that a C/C++ toolchain is configured for " +
                   "your current platform. If you defined a custom platform, make sure that it has the @io_bazel_rules_go//go/toolchain:cgo_on constraint value.").format(linkmode))
 
-    tags = list(go_config_info.tags)
-    if "gotags" in ctx.var:
-        tags += ctx.var["gotags"].split(",")
-    if cgo_context_info:
-        tags += cgo_context_info.tags
-    if race:
-        tags.append("race")
-    if msan:
-        tags.append("msan")
-
     return struct(
         static = go_config_info.static,
         race = race,
@@ -127,7 +117,7 @@ def get_mode(ctx, go_toolchain, cgo_context_info, go_config_info):
         debug = go_config_info.debug,
         goos = goos,
         goarch = goarch,
-        tags = tags,
+        tags = go_config_info.tags,
         cover_format = go_config_info.cover_format,
         amd64 = go_config_info.amd64,
         arm = go_config_info.arm,


### PR DESCRIPTION
**What type of PR is this?**
starlark cleanup

**What does this PR do? Why is it needed?**
Looks like we were adding the `gotags` from ctx.var multiple times when cgo was enabled. This led me to realize we can compute all tags at `GoConfigInfo` creation time.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
