### PR TITLE
Remove usage of _flatten_possibly_transitioned_attr in common case

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -410,9 +410,8 @@ def go_context(
         if hasattr(attr, "_go_config"):
             go_config_info = attr._go_config[GoConfigInfo]
         if hasattr(attr, "_stdlib"):
-            stdlib = _flatten_possibly_transitioned_attr(attr._stdlib)[GoStdLib]
+            stdlib = attr._stdlib[GoStdLib]
     else:
-        go_context_data = _flatten_possibly_transitioned_attr(go_context_data)
         if CgoContextInfo in go_context_data:
             cgo_context_info = go_context_data[CgoContextInfo]
         go_config_info = go_context_data[GoConfigInfo]

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -120,7 +120,8 @@ def _go_binary_impl(ctx):
         include_deprecated_properties = False,
         importpath = ctx.attr.importpath,
         embed = ctx.attr.embed,
-        go_context_data = ctx.attr._go_context_data,
+        # It's a list because it is transitioned.
+        go_context_data = ctx.attr._go_context_data[0],
     )
 
     is_main = go.mode.link not in (LINKMODE_SHARED, LINKMODE_PLUGIN)

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -61,7 +61,8 @@ def _go_test_impl(ctx):
         include_deprecated_properties = False,
         importpath = ctx.attr.importpath,
         embed = ctx.attr.embed,
-        go_context_data = ctx.attr._go_context_data,
+        # It's a list because it is transitioned.
+        go_context_data = ctx.attr._go_context_data[0],
     )
 
     # Compile the library to test with internal white box tests


### PR DESCRIPTION
**What type of PR is this?**
Starlark cleanup

**What does this PR do? Why is it needed?**
Making the caller deal with a transitioned attribute is cleaner and will be necessary for proper starlark typing anyway

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
