### PR TITLE
prepare rules_go release 0.50.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_go",
-    version = "0.49.0",
+    version = "0.50.0",
     compatibility_level = 0,
     repo_name = "io_bazel_rules_go",
 )

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -125,7 +125,7 @@ TOOLS_NOGO = [str(Label(l)) for l in _TOOLS_NOGO]
 
 # Current version or next version to be tagged. Gazelle and other tools may
 # check this to determine compatibility.
-RULES_GO_VERSION = "0.49.0"
+RULES_GO_VERSION = "0.50.0"
 
 go_context = _go_context
 gomock = _gomock


### PR DESCRIPTION
This will be merged, but we will end up cherry picking certain commits onto an `release-0.50` branch, which will not include all of the commits on master.

