### PR TITLE
[context.bzl] add more helpful debug message to resolver issue

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -313,16 +313,14 @@ def _library_to_source(go, attr, library, coverage_instrumented, verify_resolver
 
         # TODO(zbarsky): Remove this once downstream has a chance to migrate.
         if verify_resolver_deps:
-            has_targets = False
             for dep in source["deps"]:
                 if type(dep) == "Target":
-                    has_targets = True
+                    print('Detected Targets in `source["deps"]` as a result of _resolver: ' +
+                          "{}, from target {}. ".format(library.resolve, str(library.label)) +
+                          "Please pass a list of `GoArchive`s instead, for examples `deps = [deps[GoArchive] for dep in deps]`. " +
+                          "This will be an error in the future.")
+                    source["deps"] = [get_archive(dep) for dep in source["deps"]]
                     break
-            if has_targets:
-                print('Detected Targets in `source["deps"]` as a result of _resolver. ' +
-                      "Please pass a list of `GoArchive`s instead, for examples `deps = [deps[GoArchive] for dep in deps]`. " +
-                      "This will be an error in the future.")
-                source["deps"] = [get_archive(dep) for dep in source["deps"]]
 
     return GoSource(**source)
 


### PR DESCRIPTION
It's difficult to tell where this issue is coming from without some reference to the resolver or the target this is originating from.

This PR updates the debug message to be more explicit.

Before:
```
DEBUG: /home/user/.cache/bazel/_bazel_tfrench/b97476d719d716accead0f2d5b93104f/external/io_bazel_rules_go/go/private/context.bzl:322:22: Detected Targets in `source["deps"]` as a result of _resolver. Please pass a list of `GoArchive`s instead, for examples `deps = [deps[GoArchive] for dep in deps]`. This will be an error in the future.
DEBUG: /home/user/.cache/bazel/_bazel_tfrench/b97476d719d716accead0f2d5b93104f/external/io_bazel_rules_go/go/private/context.bzl:322:22: Detected Targets in `source["deps"]` as a result of _resolver. Please pass a list of `GoArchive`s instead, for examples `deps = [deps[GoArchive] for dep in deps]`. This will be an error in the future.
DEBUG: /home/user/.cache/bazel/_bazel_tfrench/b97476d719d716accead0f2d5b93104f/external/io_bazel_rules_go/go/private/context.bzl:322:22: Detected Targets in `source["deps"]` as a result of _resolver. Please pass a list of `GoArchive`s instead, for examples `deps = [deps[GoArchive] for dep in deps]`. This will be an error in the future.
DEBUG: /home/user/.cache/bazel/_bazel_tfrench/b97476d719d716accead0f2d5b93104f/external/io_bazel_rules_go/go/private/context.bzl:322:22: Detected Targets in `source["deps"]` as a result of _resolver. Please pass a list of `GoArchive`s instead, for examples `deps = [deps[GoArchive] for dep in deps]`. This will be an error in the future.
DEBUG: /home/user/.cache/bazel/_bazel_tfrench/b97476d719d716accead0f2d5b93104f/external/io_bazel_rules_go/go/private/context.bzl:322:22: Detected Targets in `source["deps"]` as a result of _resolver. Please pass a list of `GoArchive`s instead, for examples `deps = [deps[GoArchive] for dep in deps]`. This will be an error in the future.
DEBUG: /home/user/.cache/bazel/_bazel_tfrench/b97476d719d716accead0f2d5b93104f/external/io_bazel_rules_go/go/private/context.bzl:322:22: Detected Targets in `source["deps"]` as a result of _resolver. Please pass a list of `GoArchive`s instead, for examples `deps = [deps[GoArchive] for dep in deps]`. This will be an error in the future.
DEBUG: /home/user/.cache/bazel/_bazel_tfrench/b97476d719d716accead0f2d5b93104f/external/io_bazel_rules_go/go/private/context.bzl:322:22: Detected Targets in `source["deps"]` as a result of _resolver. Please pass a list of `GoArchive`s instead, for examples `deps = [deps[GoArchive] for dep in deps]`. This will be an error in the future.
DEBUG: /home/user/.cache/bazel/_bazel_tfrench/b97476d719d716accead0f2d5b93104f/external/io_bazel_rules_go/go/private/context.bzl:322:22: Detected Targets in `source["deps"]` as a result of _resolver. Please pass a list of `GoArchive`s instead, for examples `deps = [deps[GoArchive] for dep in deps]`. This will be an error in the future.
DEBUG: /home/user/.cache/bazel/_bazel_tfrench/b97476d719d716accead0f2d5b93104f/external/io_bazel_rules_go/go/private/context.bzl:322:22: Detected Targets in `source["deps"]` as a result of _resolver. Please pass a list of `GoArchive`s instead, for examples `deps = [deps[GoArchive] for dep in deps]`. This will be an error in the future.
DEBUG: /home/user/.cache/bazel/_bazel_tfrench/b97476d719d716accead0f2d5b93104f/external/io_bazel_rules_go/go/private/context.bzl:322:22: Detected Targets in `source["deps"]` as a result of _resolver. Please pass a list of `GoArchive`s instead, for examples `deps = [deps[GoArchive] for dep in deps]`. This will be an error in the future.
```

After:
```
DEBUG: /home/user/.cache/bazel/_bazel_tfrench/b97476d719d716accead0f2d5b93104f/external/io_bazel_rules_go/go/private/context.bzl:322:22: Detected Targets in `source["deps"]` as a result of _resolver: <function _resolve from //rules/glue:glue.bzl>, from target @//src/...:glue_gluefxPlease pass a list of `GoArchive`s instead, for examples `deps = [deps[GoArchive] for dep in deps]`. This will be an error in the future.
DEBUG: /home/user/.cache/bazel/_bazel_tfrench/b97476d719d716accead0f2d5b93104f/external/io_bazel_rules_go/go/private/context.bzl:322:22: Detected Targets in `source["deps"]` as a result of _resolver: <function _resolve from //src/.../rds/mappergen-go:rules.bzl>, from target @//src/../handler/mappers:go_default_libraryPlease pass a list of `GoArchive`s instead, for examples `deps = [deps[GoArchive] for dep in deps]`. This will be an error in the future.
...
```

Also this prints 1000s of messages. Is this overkill? Can we just warn once per rule?