### PR TITLE
prepare patch release 0.50.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_go",
-    version = "0.50.0",
+    version = "0.50.1",
     compatibility_level = 0,
     repo_name = "io_bazel_rules_go",
 )

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -125,7 +125,7 @@ TOOLS_NOGO = [str(Label(l)) for l in _TOOLS_NOGO]
 
 # Current version or next version to be tagged. Gazelle and other tools may
 # check this to determine compatibility.
-RULES_GO_VERSION = "0.50.0"
+RULES_GO_VERSION = "0.50.1"
 
 go_context = _go_context
 gomock = _gomock


### PR DESCRIPTION
This PR prepares for the cherry-picked `0.50.1` patch release, which will include:
#4081 
#4082 
#4083 

These commits will be cherry-picked to the branch `release-0.50`