### PR TITLE
WIP: Try to avoid recompiling deps

### DIFF
--- a/go/private/BUILD.sdk.bazel
+++ b/go/private/BUILD.sdk.bazel
@@ -23,7 +23,24 @@ filegroup(
 
 filegroup(
     name = "srcs",
-    srcs = glob(["src/**"]),
+    srcs = glob(
+        ["src/**"],
+        exclude = [
+            "src/**/testdata/**",
+            "src/cmd/cgo/internal/cgotest/**",
+            "src/cmd/cgo/internal/test/**",
+            "src/cmd/cgo/internal/test*/**",
+            "src/cmd/compile/internal/test/**",
+            "src/cmd/go/internal/imports/testdata/**",
+            "src/cmd/go/internal/modfetch/zip_sum_test/**",
+            "src/cmd/go/internal/script/scripttest/**",
+            "src/cmd/go/internal/vcweb/vcstest/**",
+            "src/log/slog/internal/benchmarks/**",
+            "src/reflect/internal/example*/**",
+            "src/runtime/internal/startlinetest/**",
+            "src/runtime/internal/wasitest/**",
+        ],
+    ),
 )
 
 filegroup(

--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -37,7 +37,7 @@ load(
     "cgo_configure",
 )
 
-def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_deps = None, is_external_pkg = False):
+def emit_archive(go, source = None, is_external_pkg = False):
     """See go/toolchains.rst#archive for full documentation."""
 
     if source == None:
@@ -51,8 +51,8 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
         pre_ext = ".internal"
     elif testfilter == "only":
         pre_ext = ".external"
-    if _recompile_suffix:
-        pre_ext += _recompile_suffix
+    elif testfilter == "lib_only":
+        pre_ext = ".lib_only"
     out_lib = go.declare_file(go, name = source.library.name, ext = pre_ext + ".a")
 
     # store export information for compiling dependent packages separately
@@ -146,7 +146,6 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
             gc_goopts = source.gc_goopts,
             cgo = False,
             testfilter = testfilter,
-            recompile_internal_deps = recompile_internal_deps,
             is_external_pkg = is_external_pkg,
         )
 

--- a/go/private/actions/binary.bzl
+++ b/go/private/actions/binary.bzl
@@ -41,6 +41,7 @@ def emit_binary(
         fail("either name or executable must be set")
 
     archive = go.archive(go, source)
+    print("binary", archive.data.importpath)
     if not executable:
         if go.mode.linkmode == LINKMODE_C_SHARED:
             name = "lib" + name  # shared libraries need a "lib" prefix in their name

--- a/go/private/actions/compilepkg.bzl
+++ b/go/private/actions/compilepkg.bzl
@@ -74,7 +74,6 @@ def emit_compilepkg(
         out_cgo_export_h = None,
         gc_goopts = [],
         testfilter = None,  # TODO: remove when test action compiles packages
-        recompile_internal_deps = [],
         is_external_pkg = False):
     """Compiles a complete Go package."""
     if sources == None:
@@ -126,8 +125,6 @@ def emit_compilepkg(
         args.add_all(cover, before_each = "-cover")
 
     args.add_all(archives, before_each = "-arc", map_each = _archive)
-    if recompile_internal_deps:
-        args.add_all(recompile_internal_deps, before_each = "-recompile_internal_deps")
     if importpath:
         args.add("-importpath", importpath)
     else:

--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -142,6 +142,7 @@ def _build_stdlib(go):
 
     sdk = go.sdk
     inputs_direct = [sdk.go, sdk.package_list, sdk.root_file]
+    print(sdk.srcs)
     inputs_transitive = [sdk.headers, sdk.srcs, sdk.tools, go.cc_toolchain_files]
 
     if go.mode.pgoprofile:

--- a/go/tools/builders/filter.go
+++ b/go/tools/builders/filter.go
@@ -136,6 +136,14 @@ func applyTestFilter(testFilter string, srcs *archiveSrcs) error {
 			}
 		}
 		srcs.goSrcs = libSrcs
+	case "lib_only":
+		libSrcs := make([]fileInfo, 0, len(srcs.goSrcs))
+		for _, f := range srcs.goSrcs {
+			if !strings.HasSuffix(f.filename, "_test.go") {
+				libSrcs = append(libSrcs, f)
+			}
+		}
+		srcs.goSrcs = libSrcs
 	default:
 		return fmt.Errorf("invalid test filter %q", testFilter)
 	}

--- a/go/tools/builders/link.go
+++ b/go/tools/builders/link.go
@@ -91,7 +91,20 @@ func link(args []string) error {
 	}
 
 	// Build an importcfg file.
-	importcfgName, err := buildImportcfgFileForLink(archives, *packageList, goenv.installSuffix, filepath.Dir(*outFile))
+	var archives2 []archive
+	for _, arc := range archives {
+		//fmt.Println(arc.file, arc)
+		//if !strings.Contains(arc.file, "indirect_import_test.lib_only.a") &&
+		//	!strings.Contains(arc.file, "indirect_import_lib.a") {
+		//	archives2 = append(archives2, arc)
+		//}
+		if !strings.Contains(arc.file, "indirect_import_lib") &&
+			!strings.Contains(arc.file, "indirect_import_test.lib_only") {
+			archives2 = append(archives2, arc)
+		}
+	}
+
+	importcfgName, err := buildImportcfgFileForLink(archives2, *packageList, goenv.installSuffix, filepath.Dir(*outFile))
 	if err != nil {
 		return err
 	}
@@ -157,6 +170,7 @@ func link(args []string) error {
 		os.Setenv("GOROOT", "GOROOT")
 		defer os.Setenv("GOROOT", oldroot)
 	}
+	fmt.Println(goargs)
 	if err := goenv.runCommand(goargs); err != nil {
 		return err
 	}

--- a/go/tools/builders/nogo.go
+++ b/go/tools/builders/nogo.go
@@ -20,7 +20,7 @@ func nogo(args []string) error {
 
 	fs := flag.NewFlagSet("GoNogo", flag.ExitOnError)
 	goenv := envFlags(fs)
-	var unfilteredSrcs, ignoreSrcs, recompileInternalDeps multiFlag
+	var unfilteredSrcs, ignoreSrcs multiFlag
 	var deps, facts archiveMultiFlag
 	var importPath, packagePath, nogoPath, packageListPath string
 	var testFilter string
@@ -33,7 +33,6 @@ func nogo(args []string) error {
 	fs.StringVar(&importPath, "importpath", "", "The import path of the package being compiled. Not passed to the compiler, but may be displayed in debug data.")
 	fs.StringVar(&packagePath, "p", "", "The package path (importmap) of the package being compiled")
 	fs.StringVar(&packageListPath, "package_list", "", "The file containing the list of standard library packages")
-	fs.Var(&recompileInternalDeps, "recompile_internal_deps", "The import path of the direct dependencies that needs to be recompiled.")
 	fs.StringVar(&coverMode, "cover_mode", "", "The coverage mode to use. Empty if coverage instrumentation should not be added.")
 	fs.StringVar(&testFilter, "testfilter", "off", "Controls test package filtering")
 	fs.StringVar(&nogoPath, "nogo", "", "The nogo binary")
@@ -77,7 +76,7 @@ func nogo(args []string) error {
 	defer cleanup()
 
 	compilingWithCgo := os.Getenv("CGO_ENABLED") == "1" && haveCgo
-	importcfgPath, err := checkImportsAndBuildCfg(goenv, importPath, srcs, deps, packageListPath, recompileInternalDeps, compilingWithCgo, coverMode, workDir)
+	importcfgPath, err := checkImportsAndBuildCfg(goenv, importPath, srcs, deps, packageListPath, compilingWithCgo, coverMode, workDir)
 	if err != nil {
 		return err
 	}
@@ -148,4 +147,3 @@ func runNogo(workDir string, nogoPath string, srcs, ignores []string, facts []ar
 	}
 	return nil
 }
-


### PR DESCRIPTION
I tried to follow what https://github.com/bazelbuild/rules_go/issues/4013#issuecomment-2286007545 observed, but I think this that log was misleading. I suspect the reason one of the packages was unused is that the test is too simple - if we had a another binary that depended on `lib/dep` and didn't participate in the cycle, it would have ended up using the other version of `lib/dep`.

So we probably do need an aspect if we want to clean this up

**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix
> Feature
> Documentation
> Other

**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
