### PR TITLE
Use -gcflags=--pgoprofile instead of -pgo when building stdlib

### DIFF
--- a/go/tools/builders/stdlib.go
+++ b/go/tools/builders/stdlib.go
@@ -131,7 +131,7 @@ You may need to use the flags --cpu=x64_windows --compiler=mingw-gcc.`)
 		installArgs = append(installArgs, "-race")
 	}
 	if *pgoprofile != "" {
-		installArgs = append(installArgs, "-pgo", abs(*pgoprofile))
+		gcflags = append(gcflags, "-pgoprofile=" + abs(*pgoprofile))
 	}
 	if *shared {
 		gcflags = append(gcflags, "-shared")


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Go 1.23 introduces `go tool preprofile` (ref: https://github.com/golang/go/commit/e069587c8d530ec912614d138bbf59a1d1788fb9). This tool allows folks to do the heavy lifting of processing their CPU profile ahead of time, resulting in a pre-processed profile that leads to quicker PGO builds later.

The `--pgo` flag to the `go` command only accepts raw profiles due to https://github.com/golang/go/commit/081dc9fd8c9cf824f5caac3a03a1c8dfd86894c0 which makes the go command itself run the pre-processor on the input profile, which leads to errors if the given profile is already pre-processed. Since rules_go adds the `--pgo` flag when building the stdlib, this leads to errors when passing a pre-processed profile via `--@io_bazel_rules_go//go/config:pgoprofile`:

```
$ go version
go version go1.23.1 linux/amd64
$ go tool preprofile -i raw_profile -o preprocessed
$ bazel build --@io_bazel_rules_go//go/config:pgoprofile=$(pwd)/preprocessed .
...
preprofile: error parsing profile: error parsing profile: parsing profile: unknown wire type: 7
...
```

This PR uses the gcflag instead when building stdlib,
as that can accept either a raw or pre-processed profile. This is what we already do within the compile action anyways: https://github.com/bazelbuild/rules_go/blob/fb5f09191c968817d149ddf296c526289dd15219/go/tools/builders/compilepkg.go#L490-L492