### PR TITLE
make toolchains repo more reproducible

### DIFF
--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -91,6 +91,7 @@ def _go_download_sdk_impl(ctx):
         )
 
         data = ctx.read("versions.json")
+        ctx.delete("versions.json")
         sdks_by_version = _parse_versions_json(data)
 
         if not version:


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The versions.json file results from downloading a list of versions from go.dev. (https://go.dev/dl/?mode=json)
This API is meant to be updated for every Go release and will result in different outputs when rerun in the future.

By deleting the file, we make the behavior more reproducible: As long as a specific version is requested, this should result in reproducible behavior. (This assumes that go.dev does not replace released SDK artifacts, which should be a fair assumption).

This should help other ecosystems (including Nix) with packaging Bazel, since we want to depend on the output of `bazel vendor` (and pin it against an expected hash for a given platform).

**Which issues(s) does this PR fix?**

none

**Other notes for review**
