### PR TITLE
feat(gpd): add overlay support for gopackagesdriver

### DIFF
--- a/go/tools/gopackagesdriver/driver_request.go
+++ b/go/tools/gopackagesdriver/driver_request.go
@@ -79,7 +79,7 @@ type DriverRequest struct {
 	Tests bool `json:"tests"`
 	// Overlay maps file paths (relative to the driver's working directory) to the byte contents
 	// of overlay files.
-	// Overlay map[string][]byte `json:"overlay"`
+	Overlay map[string][]byte `json:"overlay"`
 }
 
 func ReadDriverRequest(r io.Reader) (*DriverRequest, error) {

--- a/go/tools/gopackagesdriver/flatpackage.go
+++ b/go/tools/gopackagesdriver/flatpackage.go
@@ -169,7 +169,7 @@ func (fp *FlatPackage) IsStdlib() bool {
 	return fp.Standard
 }
 
-func (fp *FlatPackage) ResolveImports(resolve ResolvePkgFunc) error {
+func (fp *FlatPackage) ResolveImports(resolve ResolvePkgFunc, overlays map[string][]byte) error {
 	// Stdlib packages are already complete import wise
 	if fp.IsStdlib() {
 		return nil
@@ -178,7 +178,11 @@ func (fp *FlatPackage) ResolveImports(resolve ResolvePkgFunc) error {
 	fset := token.NewFileSet()
 
 	for _, file := range fp.CompiledGoFiles {
-		f, err := parser.ParseFile(fset, file, nil, parser.ImportsOnly)
+		var overlayContent []byte
+		if content, ok := overlays[file]; ok {
+			overlayContent = content
+		}
+		f, err := parser.ParseFile(fset, file, overlayContent, parser.ImportsOnly)
 		if err != nil {
 			return err
 		}

--- a/go/tools/gopackagesdriver/gopackagesdriver_test.go
+++ b/go/tools/gopackagesdriver/gopackagesdriver_test.go
@@ -135,9 +135,11 @@ func TestBaseFileLookup(t *testing.T) {
 	})
 
 	t.Run("dependency", func(t *testing.T) {
-		osPkg := findPackageByID(resp.Packages, osPkgID)
-		if osPkg == nil {
-			findPackageByID(resp.Packages, bzlmodOsPkgID)
+		var osPkg *FlatPackage
+		for _, p := range resp.Packages {
+			if p.ID == osPkgID || p.ID == bzlmodOsPkgID {
+				osPkg = p
+			}
 		}
 
 		if osPkg == nil {
@@ -387,54 +389,6 @@ func assertSuffixesInList(t *testing.T, list []string, expectedSuffixes ...strin
 			t.Errorf("Expected suffix %q in list, but was not found: %+v", suffix, list)
 		}
 	}
-}
-
-func findPackageByID(packages []*FlatPackage, id string) *FlatPackage {
-	for _, pkg := range packages {
-		if pkg.ID == id {
-			return pkg
-		}
-	}
-	return nil
-}
-
-// get map keys
-func keysFromMap[K comparable, V any](m map[K]V) []K {
-	keys := make([]K, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	return keys
-}
-
-// contains checks if a slice contains an element
-func contains[S ~[]E, E comparable](set S, element E) bool {
-	found := false
-	for _, setElement := range set {
-		if setElement == element {
-			found = true
-			break
-		}
-	}
-	return found
-}
-
-// containsAll checks if a slice contains all elements of another slice
-func containsAll[S ~[]E, E comparable](set S, subset S) bool {
-	for _, subsetElement := range subset {
-		if !contains(set, subsetElement) {
-			return false
-		}
-	}
-	return true
-}
-
-// equalSets checks if two slices are equal sets
-func equalSets[S ~[]E, E comparable](set1 S, set2 S) bool {
-	if len(set1) != len(set2) {
-		return false
-	}
-	return containsAll(set1, set2)
 }
 
 // expectSetEquality checks if two slices are equal sets and logs an error if they are not

--- a/go/tools/gopackagesdriver/gopackagesdriver_test.go
+++ b/go/tools/gopackagesdriver/gopackagesdriver_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"os"
 	"path"

--- a/go/tools/gopackagesdriver/gopackagesdriver_test.go
+++ b/go/tools/gopackagesdriver/gopackagesdriver_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"os"
 	"path"
@@ -91,7 +92,7 @@ const (
 )
 
 func TestBaseFileLookup(t *testing.T) {
-	resp := runForTest(t, ".", "file=hello.go")
+	resp := runForTest(t, "{}", ".", "file=hello.go")
 
 	t.Run("roots", func(t *testing.T) {
 		if len(resp.Roots) != 1 {
@@ -161,7 +162,7 @@ func TestBaseFileLookup(t *testing.T) {
 }
 
 func TestRelativeFileLookup(t *testing.T) {
-	resp := runForTest(t, "subhello", "file=./subhello.go")
+	resp := runForTest(t, "{}", "subhello", "file=./subhello.go")
 
 	t.Run("roots", func(t *testing.T) {
 		if len(resp.Roots) != 1 {
@@ -197,7 +198,7 @@ func TestRelativeFileLookup(t *testing.T) {
 }
 
 func TestRelativePatternWildcardLookup(t *testing.T) {
-	resp := runForTest(t, "subhello", "./...")
+	resp := runForTest(t, "{}", "subhello", "./...")
 
 	t.Run("roots", func(t *testing.T) {
 		if len(resp.Roots) != 1 {
@@ -233,7 +234,7 @@ func TestRelativePatternWildcardLookup(t *testing.T) {
 }
 
 func TestExternalTests(t *testing.T) {
-	resp := runForTest(t, ".", "file=hello_external_test.go")
+	resp := runForTest(t, "{}", ".", "file=hello_external_test.go")
 	if len(resp.Roots) != 2 {
 		t.Errorf("Expected exactly two roots for package: %+v", resp.Roots)
 	}
@@ -259,7 +260,117 @@ func TestExternalTests(t *testing.T) {
 	}
 }
 
-func runForTest(t *testing.T, relativeWorkingDir string, args ...string) driverResponse {
+
+func TestOverlay(t *testing.T) {
+	// format filepaths for overlay request using working directory
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// format filepaths for overlay request
+	helloPath := path.Join(wd, "hello.go")
+	subhelloPath := path.Join(wd, "subhello/subhello.go")
+
+	expectedImportsPerFile := map[string][]string{
+		helloPath: []string{"fmt"},
+		subhelloPath: []string{"os", "encoding/json"},
+	}
+
+	overlayDriverRequest := map[string]map[string]string{
+		"overlay": {
+			helloPath:    `
+				package hello
+				import "fmt"
+				import "unknown/unknown-package"
+				func main() {
+					invalid code
+
+				}`,
+			subhelloPath: `
+				package subhello
+				import "os"
+				import "encoding/json"
+				func main() {
+					fmt.Fprintln(os.Stderr, "Subdirectory Hello World!")
+				}
+			`,
+		},
+	}
+
+	// encode the overlay content
+	for key, value := range overlayDriverRequest["overlay"] {
+		encodedValue := base64.StdEncoding.EncodeToString([]byte(value))
+		overlayDriverRequest["overlay"][key] = encodedValue
+	}
+
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	if err := encoder.Encode(overlayDriverRequest); err != nil {
+		t.Errorf("hello package not found in response root")
+	}
+	overlayDriverRequestStr := buf.String()
+
+	// run the driver with the overlay
+	helloResp := runForTest(t, overlayDriverRequestStr, ".", "file=hello.go")
+	subhelloResp := runForTest(t, overlayDriverRequestStr, "subhello", "file=subhello.go")
+
+	// get root packages
+	var helloPkg, subhelloPkg *FlatPackage
+	for _, p := range helloResp.Packages {
+		if p.ID == helloResp.Roots[0] {
+			helloPkg = p
+		}
+	}
+	for _, p := range subhelloResp.Packages {
+		if p.ID == subhelloResp.Roots[0] {
+			subhelloPkg = p
+		}
+	}
+	if helloPkg == nil {
+		t.Errorf("hello package not found in response root")
+	}
+	if subhelloPkg == nil {
+		t.Errorf("subhello package not found in response")
+	}
+
+	for _, expectedImport := range expectedImportsPerFile[helloPath] {
+		found := false
+		for importPath, _ := range helloPkg.Imports {
+			if importPath == expectedImport {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Expected hello import %s not found in parsed imports: %v", expectedImport, helloPkg.Imports)
+		}
+	}
+
+	for _, expectedImport := range expectedImportsPerFile[subhelloPath] {
+		found := false
+		for importPath, _ := range subhelloPkg.Imports {
+			if importPath == expectedImport {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Expected subhello import %s not found in parsed imports: %v", expectedImport, helloPkg.Imports)
+		}
+	}
+
+	if len(helloPkg.Imports) != len(expectedImportsPerFile[helloPath]) {
+		t.Errorf("hello imports have unexpected length")
+	}
+
+	if len(subhelloPkg.Imports) != len(expectedImportsPerFile[subhelloPath]) {
+		t.Errorf("subhello imports have unexpected length")
+	}
+}
+
+
+func runForTest(t *testing.T, DriverRequestJson string, relativeWorkingDir string, args ...string) driverResponse {
 	t.Helper()
 
 	// Remove most environment variables, other than those on an allowlist.
@@ -268,7 +379,7 @@ func runForTest(t *testing.T, relativeWorkingDir string, args ...string) driverR
 	// If Bazel is invoked when these variables, it assumes (correctly)
 	// that it's being invoked by a test, and it does different things that
 	// we don't want. For example, it randomizes the output directory, which
-	// is extremely expensive here. Out test framework creates an output
+	// is extremely expensive here. Our test framework creates an output
 	// directory shared among go_bazel_tests and points to it using .bazelrc.
 	//
 	// This only works if TEST_TMPDIR is not set when invoking bazel.
@@ -318,7 +429,7 @@ func runForTest(t *testing.T, relativeWorkingDir string, args ...string) driverR
 		buildWorkingDirectory = oldBuildWorkingDirectory
 	}()
 
-	in := strings.NewReader("{}")
+	in := strings.NewReader(DriverRequestJson)
 	out := &bytes.Buffer{}
 	if err := run(context.Background(), in, out, args); err != nil {
 		t.Fatalf("running gopackagesdriver: %v", err)

--- a/go/tools/gopackagesdriver/json_packages_driver.go
+++ b/go/tools/gopackagesdriver/json_packages_driver.go
@@ -23,7 +23,7 @@ type JSONPackagesDriver struct {
 	registry *PackageRegistry
 }
 
-func NewJSONPackagesDriver(jsonFiles []string, prf PathResolverFunc, bazelVersion bazelVersion) (*JSONPackagesDriver, error) {
+func NewJSONPackagesDriver(jsonFiles []string, prf PathResolverFunc, bazelVersion bazelVersion, overlays map[string][]byte) (*JSONPackagesDriver, error) {
 	jpd := &JSONPackagesDriver{
 		registry: NewPackageRegistry(bazelVersion),
 	}
@@ -40,8 +40,8 @@ func NewJSONPackagesDriver(jsonFiles []string, prf PathResolverFunc, bazelVersio
 		return nil, fmt.Errorf("unable to resolve paths: %w", err)
 	}
 
-	if err := jpd.registry.ResolveImports(); err != nil {
-		return nil, fmt.Errorf("unable to resolve paths: %w", err)
+	if err := jpd.registry.ResolveImports(overlays); err != nil {
+		return nil, fmt.Errorf("unable to resolve imports: %w", err)
 	}
 
 	return jpd, nil

--- a/go/tools/gopackagesdriver/main.go
+++ b/go/tools/gopackagesdriver/main.go
@@ -102,7 +102,7 @@ func run(ctx context.Context, in io.Reader, out io.Writer, args []string) error 
 		return fmt.Errorf("unable to build JSON files: %w", err)
 	}
 
-	driver, err := NewJSONPackagesDriver(jsonFiles, bazelJsonBuilder.PathResolver(), bazel.version)
+	driver, err := NewJSONPackagesDriver(jsonFiles, bazelJsonBuilder.PathResolver(), bazel.version, request.Overlay)
 	if err != nil {
 		return fmt.Errorf("unable to load JSON files: %w", err)
 	}

--- a/go/tools/gopackagesdriver/packageregistry.go
+++ b/go/tools/gopackagesdriver/packageregistry.go
@@ -58,7 +58,7 @@ func (pr *PackageRegistry) ResolvePaths(prf PathResolverFunc) error {
 // ResolveImports adds stdlib imports to packages. This is required because
 // stdlib packages are not part of the JSON file exports as bazel is unaware of
 // them.
-func (pr *PackageRegistry) ResolveImports() error {
+func (pr *PackageRegistry) ResolveImports(overlays map[string][]byte) error {
 	resolve := func(importPath string) string {
 		if pkgID, ok := pr.stdlib[importPath]; ok {
 			return pkgID
@@ -68,7 +68,7 @@ func (pr *PackageRegistry) ResolveImports() error {
 	}
 
 	for _, pkg := range pr.packagesByID {
-		if err := pkg.ResolveImports(resolve); err != nil {
+		if err := pkg.ResolveImports(resolve, overlays); err != nil {
 			return err
 		}
 		testFp := pkg.MoveTestFiles()

--- a/go/tools/gopackagesdriver/utils.go
+++ b/go/tools/gopackagesdriver/utils.go
@@ -75,3 +75,51 @@ func packageID(pattern string) string {
 
 	return fmt.Sprintf("//%s", pattern)
 }
+
+func findPackageByID(packages []*FlatPackage, id string) *FlatPackage {
+	for _, pkg := range packages {
+		if pkg.ID == id {
+			return pkg
+		}
+	}
+	return nil
+}
+
+// get map keys
+func keysFromMap[K comparable, V any](m map[K]V) []K {
+	keys := make([]K, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// contains checks if a slice contains an element
+func contains[S ~[]E, E comparable](set S, element E) bool {
+	found := false
+	for _, setElement := range set {
+		if setElement == element {
+			found = true
+			break
+		}
+	}
+	return found
+}
+
+// containsAll checks if a slice contains all elements of another slice
+func containsAll[S ~[]E, E comparable](set S, subset S) bool {
+	for _, subsetElement := range subset {
+		if !contains(set, subsetElement) {
+			return false
+		}
+	}
+	return true
+}
+
+// equalSets checks if two slices are equal sets
+func equalSets[S ~[]E, E comparable](set1 S, set2 S) bool {
+	if len(set1) != len(set2) {
+		return false
+	}
+	return containsAll(set1, set2)
+}


### PR DESCRIPTION
- Introduced the ability to handle in-memory overlays via map[string][]byte in gopackagesdriver, allowing files to be dynamically provided as overlays during package resolution.
- Updated ResolveImports to accept overlays and apply them when parsing Go files.
- Modified tests to include new overlay functionality, ensuring correct import resolution for files supplied via overlay maps.
- Refactored runForTest function to support DriverRequestJson input, making it more flexible for testing overlays.
- Applied overlays in both the JSONPackagesDriver and PackageRegistry, providing seamless integration with existing workflows.

This feature enhances package resolution by supporting temporary or unsaved files, making it useful for IDEs, linters, and test scenarios where in-memory file content is needed.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
Implements the overlay function specified in the gopackagesdriver DriverRequest

**Which issues(s) does this PR fix?**
Fixes #4100 
