### PR TITLE
feat(gpd): support of GOPACKAGESDRIVER_BAZEL_COMMON_FLAGS env variable

### DIFF
--- a/go/tools/gopackagesdriver/BUILD.bazel
+++ b/go/tools/gopackagesdriver/BUILD.bazel
@@ -39,6 +39,9 @@ go_bazel_test(
     size = "enormous",
     srcs = ["gopackagesdriver_test.go"],
     embed = [":gopackagesdriver_lib"],
+    env = {
+        "GOPACKAGESDRIVER_BAZEL_COMMON_FLAGS": "--noexperimental_enable_bzlmod",
+    },
     rule_files = ["//:all_files"],
     x_defs = {
         "rulesGoRepositoryName": RULES_GO_REPO_NAME_FOR_TEST,

--- a/go/tools/gopackagesdriver/bazel.go
+++ b/go/tools/gopackagesdriver/bazel.go
@@ -38,6 +38,7 @@ type Bazel struct {
 	bazelBin              string
 	workspaceRoot         string
 	buildWorkingDirectory string
+	bazelCommonFlags      []string
 	bazelStartupFlags     []string
 	info                  map[string]string
 	version               bazelVersion
@@ -53,11 +54,12 @@ type BEPNamedSet struct {
 	} `json:"namedSetOfFiles"`
 }
 
-func NewBazel(ctx context.Context, bazelBin, workspaceRoot string, buildWorkingDirectory string, bazelStartupFlags []string) (*Bazel, error) {
+func NewBazel(ctx context.Context, bazelBin, workspaceRoot string, buildWorkingDirectory string, bazelCommonFlags []string, bazelStartupFlags []string) (*Bazel, error) {
 	b := &Bazel{
 		bazelBin:              bazelBin,
 		workspaceRoot:         workspaceRoot,
 		buildWorkingDirectory: buildWorkingDirectory,
+		bazelCommonFlags:      bazelCommonFlags,
 		bazelStartupFlags:     bazelStartupFlags,
 	}
 	if err := b.fillInfo(ctx); err != nil {
@@ -87,11 +89,11 @@ func (b *Bazel) fillInfo(ctx context.Context) error {
 }
 
 func (b *Bazel) run(ctx context.Context, command string, args ...string) (string, error) {
-	defaultArgs := []string{
+	defaultArgs := append([]string{
 		command,
 		"--tool_tag=" + toolTag,
 		"--ui_actions_shown=0",
-	}
+	}, b.bazelCommonFlags...)
 	cmd := exec.CommandContext(ctx, b.bazelBin, concatStringsArrays(b.bazelStartupFlags, defaultArgs, args)...)
 	fmt.Fprintln(os.Stderr, "Running:", cmd.Args)
 	cmd.Dir = b.WorkspaceRoot()

--- a/go/tools/gopackagesdriver/main.go
+++ b/go/tools/gopackagesdriver/main.go
@@ -58,6 +58,7 @@ var (
 	goDefaultAspect       = rulesGoRepositoryName + "//go/tools/gopackagesdriver:aspect.bzl%go_pkg_info_aspect"
 	bazelBin              = getenvDefault("GOPACKAGESDRIVER_BAZEL", "bazel")
 	bazelStartupFlags     = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_FLAGS"))
+	bazelCommonFlags      = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_COMMON_FLAGS"))
 	bazelQueryFlags       = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_QUERY_FLAGS"))
 	bazelQueryScope       = getenvDefault("GOPACKAGESDRIVER_BAZEL_QUERY_SCOPE", "")
 	bazelBuildFlags       = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_BUILD_FLAGS"))
@@ -82,7 +83,7 @@ func run(ctx context.Context, in io.Reader, out io.Writer, args []string) error 
 		return fmt.Errorf("unable to read request: %w", err)
 	}
 
-	bazel, err := NewBazel(ctx, bazelBin, workspaceRoot, buildWorkingDirectory, bazelStartupFlags)
+	bazel, err := NewBazel(ctx, bazelBin, workspaceRoot, buildWorkingDirectory, bazelCommonFlags, bazelStartupFlags)
 	if err != nil {
 		return fmt.Errorf("unable to create bazel instance: %w", err)
 	}


### PR DESCRIPTION
This new environment variable can be used to explicitly give some flags for all bazel info, build and query commands, and complete the list of existing environment variables, i.e:

- GOPACKAGESDRIVER_BAZEL_FLAGS: Startup bazel flags.
- GOPACKAGESDRIVER_BAZEL_QUERY_FLAGS: Flags to give to all bazel query commands.
- GOPACKAGESDRIVER_BAZEL_BUILD_FLAGS: Flags to give to all bazel build commands.
