### PR TITLE
fix(gpd): add missing condition in MoveTestFiles()

### DIFF
--- a/go/tools/gopackagesdriver/flatpackage.go
+++ b/go/tools/gopackagesdriver/flatpackage.go
@@ -147,7 +147,7 @@ func (fp *FlatPackage) MoveTestFiles() *FlatPackage {
 
 	fp.CompiledGoFiles = append(cgf, ctgf...)
 
-	if len(xtgf) == 0 {
+	if len(xtgf) == 0 && len(cxtgf) == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
There is no reason for **CompiledGoFiles** to have external tests and not **GoFiles**, but it's more consistent in the code to support this edge case.
