### PR TITLE
Add dependency on cpp toolchain to rules that also depend on cgo_context_data

### DIFF
--- a/go/private/rules/library.bzl
+++ b/go/private/rules/library.bzl
@@ -21,6 +21,7 @@ load(
 )
 load(
     "//go/private:context.bzl",
+    "OPTIONAL_CPP_TOOLCHAIN",
     "go_context",
 )
 load(
@@ -236,7 +237,7 @@ go_tool_library = rule(
         "_cgo_context_data": attr.label(default = "//:cgo_context_data_proxy"),
         "_stdlib": attr.label(default = "//:stdlib"),
     },
-    toolchains = [GO_TOOLCHAIN],
+    toolchains = [GO_TOOLCHAIN, OPTIONAL_CPP_TOOLCHAIN],
 )
 # This is used instead of `go_library` for dependencies of the `nogo` rule and
 # packages that are depended on implicitly by code generated within the Go rules.

--- a/go/private/rules/nogo.bzl
+++ b/go/private/rules/nogo.bzl
@@ -18,6 +18,7 @@ load(
 )
 load(
     "//go/private:context.bzl",
+    "OPTIONAL_CPP_TOOLCHAIN",
     "go_context",
 )
 load(
@@ -110,7 +111,7 @@ _nogo = rule(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),
     },
-    toolchains = [GO_TOOLCHAIN],
+    toolchains = [GO_TOOLCHAIN, OPTIONAL_CPP_TOOLCHAIN],
     cfg = go_tool_transition,
 )
 

--- a/go/private/rules/source.bzl
+++ b/go/private/rules/source.bzl
@@ -18,6 +18,7 @@ load(
 )
 load(
     "//go/private:context.bzl",
+    "OPTIONAL_CPP_TOOLCHAIN",
     "go_context",
 )
 load(
@@ -82,7 +83,7 @@ go_source = rule(
         "_go_config": attr.label(default = "//:go_config"),
         "_cgo_context_data": attr.label(default = "//:cgo_context_data_proxy"),
     },
-    toolchains = [GO_TOOLCHAIN],
+    toolchains = [GO_TOOLCHAIN, OPTIONAL_CPP_TOOLCHAIN],
     doc = """This declares a set of source files and related dependencies that can be embedded into one of the
     other rules.
     This is used as a way of easily declaring a common set of sources re-used in multiple rules.<br><br>

--- a/go/private/rules/stdlib.bzl
+++ b/go/private/rules/stdlib.bzl
@@ -18,6 +18,7 @@ load(
 )
 load(
     "//go/private:context.bzl",
+    "OPTIONAL_CPP_TOOLCHAIN",
     "go_context",
 )
 load(
@@ -48,5 +49,5 @@ stdlib = rule(
     },
     doc = """stdlib builds the standard library for the target configuration
 or uses the precompiled standard library from the SDK if it is suitable.""",
-    toolchains = [GO_TOOLCHAIN],
+    toolchains = [GO_TOOLCHAIN, OPTIONAL_CPP_TOOLCHAIN],
 )


### PR DESCRIPTION

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This diff fixes the below issue by adding a cpp toolchain dependency to all the rules that depend on `cgo_context_data`, so they also have their execution platform constrained to the platforms compatible with the selected cpp toolchain.

**Which issues(s) does this PR fix?**

Fixes https://github.com/bazelbuild/rules_go/issues/4127

**Other notes for review**

A more ideal fix for this problem would be to turn `cgo_context_data` into a toolchain, however that would be a bigger diff.