### PR TITLE
fix: fix slice init length

### DIFF
--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -403,7 +403,7 @@ func compileArchive(
 		for _, hdr := range srcs.hSrcs {
 			includeSet[filepath.Dir(hdr.filename)] = struct{}{}
 		}
-		includes := make([]string, len(includeSet))
+		includes := make([]string, 0, len(includeSet))
 		for inc := range includeSet {
 			includes = append(includes, inc)
 		}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**


> Bug fix


**What does this PR do? Why is it needed?**

The intention here should be to initialize a slice with a capacity of  `len(includeSet)`  rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW


**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
