### PR TITLE
Add support for spaces and newlines in runfiles paths

### DIFF
--- a/tests/runfiles/runfiles_test.go
+++ b/tests/runfiles/runfiles_test.go
@@ -124,7 +124,9 @@ func TestRunfiles_empty(t *testing.T) {
 func TestRunfiles_manifestWithDir(t *testing.T) {
 	dir := t.TempDir()
 	manifest := filepath.Join(dir, "manifest")
-	if err := os.WriteFile(manifest, []byte("foo/dir path/to/foo/dir\n"), 0o600); err != nil {
+	if err := os.WriteFile(manifest, []byte(`foo/dir path/to/foo/dir
+ dir\swith\sspac\be\ns F:\bj k\bdir with spa\nces
+`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	r, err := runfiles.New(runfiles.ManifestFile(manifest))
@@ -136,6 +138,12 @@ func TestRunfiles_manifestWithDir(t *testing.T) {
 		"foo/dir":                    filepath.FromSlash("path/to/foo/dir"),
 		"foo/dir/file":               filepath.FromSlash("path/to/foo/dir/file"),
 		"foo/dir/deeply/nested/file": filepath.FromSlash("path/to/foo/dir/deeply/nested/file"),
+		`dir with spac\e
+s`:            filepath.FromSlash(`F:\j k\dir with spa
+ces`),
+		`dir with spac\e
+s/file`:            filepath.FromSlash(`F:\j k\dir with spa
+ces/file`),
 	} {
 		t.Run(rlocation, func(t *testing.T) {
 			got, err := r.Rlocation(rlocation)


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

In Bazel 8.0.0 since https://github.com/bazelbuild/bazel/commit/7407cef3837b4fe14e48e1a925f9b886c0cc945d.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
