### PR TITLE
Support linux/loong64

### DIFF
--- a/go/private/platforms.bzl
+++ b/go/private/platforms.bzl
@@ -34,6 +34,7 @@ BAZEL_GOARCH_CONSTRAINTS = {
     "ppc64": "@platforms//cpu:ppc",
     "ppc64le": "@platforms//cpu:ppc64le",
     "s390x": "@platforms//cpu:s390x",
+    "loong64": "@platforms//cpu:loongarch64",
 }
 
 GOOS_GOARCH = (
@@ -59,6 +60,7 @@ GOOS_GOARCH = (
     ("linux", "amd64"),
     ("linux", "arm"),
     ("linux", "arm64"),
+    ("linux", "loong64"),
     ("linux", "mips"),
     ("linux", "mips64"),
     ("linux", "mips64le"),
@@ -128,6 +130,7 @@ CGO_GOOS_GOARCH = {
     ("linux", "amd64"): None,
     ("linux", "arm"): None,
     ("linux", "arm64"): None,
+    ("linux", "loong64"): None,
     ("linux", "mips"): None,
     ("linux", "mips64"): None,
     ("linux", "mips64le"): None,


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
enable bazel_rules_go on loongarch64(a risc architecture).

**Which issues(s) does this PR fix?**

**Other notes for review**
Golang officially supports [loongarch64](https://go.dev/doc/go1.19#loong64).
loong64 is an alias for loongarch64 and is used in golang.
