### PR TITLE
Escape backslashes and newlines in response files

### DIFF
--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -544,7 +544,10 @@ func passLongArgsInResponseFiles(cmd *exec.Cmd) (cleanup func()) {
 	var buf bytes.Buffer
 	for _, arg := range cmd.Args[1:] {
 		// Slashes need to be doubled for escaping
-		fmt.Fprintf(&buf, "%s\n", strings.ReplaceAll(arg, "\\", "\\\\"))
+		escaped_arg := strings.ReplaceAll(arg, "\\", "\\\\")
+		// Newlines too, so that they don't get split when read
+		escaped_arg = strings.ReplaceAll(escaped_arg, "\n", "\\n")
+		fmt.Fprintf(&buf, "%s\n", escaped_arg)
 	}
 	if _, err := tf.Write(buf.Bytes()); err != nil {
 		tf.Close()


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
Bug fix

**What does this PR do? Why is it needed?**

It escapes backlashes by doubling them when using response files. Without this, builds that trigger the usage of response files fail with:

```
<unknown line number>: internal compiler error: panic: badly formatted input
```

This comes from [this line of code](https://cs.opensource.google/go/go/+/master:src/cmd/internal/objabi/flag.go;l=193;drc=c7ea87132f4e6f3c81e525c396a64471c9af0091;bpv=0?q=badly%20formatted%20input&ss=go%2Fgo) in the Go compiler, which complains if a backlash is not followed either by another `\` or by `n`.

**Which issues(s) does this PR fix?**

Fixes #4112 (I'd expect).

**Other notes for review**

I'd be happy to add a test but that function is not written in a very testable way (and I'm not sure the response files feature as a whole has any tests). As it is and without more significant changes I don't think it would be possible to write a test for it.