### PR TITLE
Update doc to clarify analysis and reporting scope for nogo

### DIFF
--- a/go/tools/builders/generate_nogo_main.go
+++ b/go/tools/builders/generate_nogo_main.go
@@ -198,5 +198,4 @@ type Config struct {
 	OnlyFiles     map[string]string `json:"only_files"`
 	ExcludeFiles  map[string]string `json:"exclude_files"`
 	AnalyzerFlags map[string]string `json:"analyzer_flags"`
-	NeedsDeps bool `json:"needs_deps"`
 }


### PR DESCRIPTION
**What type of PR is this?**
Documentation

**What does this PR do? Why is it needed?**
#4268 caused a big performance regression, especially when analyzers from [staticcheck](https://staticcheck.dev/) are enabled. In fact, the feature requested in #4241 is already partially supported without #4268, but it was reported as a "bug": https://github.com/bazel-contrib/rules_go/issues/4241#issuecomment-2612505898

This PR documents the "bug" before #4268 as the design: `includes` is the scope for nogo analysis, while `only_files` is the scope for reporting violations. #4268 makes both `includes` and `only_files` reporting scope and make everything in the analysis scope without a way to customize.

With this clarified, we can revert #4268 and potentially replace it with #4277 to allow people to include all dependencies into the analysis scope.

**Which issues(s) does this PR fix?**

Work towards #4241

**Other notes for review**
An alternative to fix the performance issue is to add a new field to nogo's JSON configuration to allow every analyzer decide whether it needs facts from dependencies.
