### PR TITLE
Remove shadow analyzer from TOOLS_NOGO

### DIFF
--- a/go/def.bzl
+++ b/go/def.bzl
@@ -103,7 +103,8 @@ _TOOLS_NOGO = [
     "@org_golang_x_tools//go/analysis/passes/nilness:go_default_library",
     "@org_golang_x_tools//go/analysis/passes/pkgfact:go_default_library",
     "@org_golang_x_tools//go/analysis/passes/printf:go_default_library",
-    "@org_golang_x_tools//go/analysis/passes/shadow:go_default_library",
+    # shadow analyzer is too noisy, see #4340
+    # "@org_golang_x_tools//go/analysis/passes/shadow:go_default_library",
     "@org_golang_x_tools//go/analysis/passes/shift:go_default_library",
     "@org_golang_x_tools//go/analysis/passes/sortslice:go_default_library",
     "@org_golang_x_tools//go/analysis/passes/stdmethods:go_default_library",

--- a/tests/core/nogo/bzlmod/includes_excludes_test.go
+++ b/tests/core/nogo/bzlmod/includes_excludes_test.go
@@ -43,10 +43,10 @@ go_library(
 -- lib.go --
 package lib
 
-func shadowed() string {
+func useless() string {
 	foo := "original"
 	if foo == "original" {
-		foo := "shadow"
+		foo = foo
 		return foo
 	}
 	return foo
@@ -64,10 +64,10 @@ go_library(
 -- go/lib.go --
 package lib
 
-func shadowed() string {
+func useless() string {
 	foo := "original"
 	if foo == "original" {
-		foo := "shadow"
+		foo = foo
 		return foo
 	}
 	return foo
@@ -85,10 +85,10 @@ go_library(
 -- go/third_party/lib.go --
 package lib
 
-func shadowed() string {
+func useless() string {
 	foo := "original"
 	if foo == "original" {
-		foo := "shadow"
+		foo = foo
 		return foo
 	}
 	return foo
@@ -114,8 +114,8 @@ func TestNotIncluded(t *testing.T) {
 func TestIncluded(t *testing.T) {
 	if err := bazel_testing.RunBazel("build", "//go:lib"); err == nil {
 		t.Fatal("Expected build to fail")
-	} else if !strings.Contains(err.Error(), "lib.go:6:3: declaration of \"foo\" shadows declaration at line 4 (shadow)") {
-		t.Fatalf("Expected error to contain \"lib.go:6:3: declaration of \"foo\" shadows declaration at line 4 (shadow)\", got %s", err)
+	} else if !strings.Contains(err.Error(), "lib.go:6:3: self-assignment of foo to foo (assign)") {
+		t.Fatalf("Expected error to contain \"lib.go:6:3: self-assignment of foo to foo (assign)\", got %s", err)
 	}
 }
 

--- a/tests/core/nogo/includes_excludes/includes_excludes_test.go
+++ b/tests/core/nogo/includes_excludes/includes_excludes_test.go
@@ -45,10 +45,10 @@ go_library(
 -- lib.go --
 package lib
 
-func shadowed() string {
+func useless() string {
 	foo := "original"
 	if foo == "original" {
-		foo := "shadow"
+		foo = foo
 		return foo
 	}
 	return foo
@@ -66,10 +66,10 @@ go_library(
 -- go/lib.go --
 package lib
 
-func shadowed() string {
+func useless() string {
 	foo := "original"
 	if foo == "original" {
-		foo := "shadow"
+		foo = foo
 		return foo
 	}
 	return foo
@@ -87,10 +87,10 @@ go_library(
 -- go/third_party/lib.go --
 package lib
 
-func shadowed() string {
+func useless() string {
 	foo := "original"
 	if foo == "original" {
-		foo := "shadow"
+		foo = foo
 		return foo
 	}
 	return foo
@@ -108,8 +108,8 @@ func TestNotIncluded(t *testing.T) {
 func TestIncluded(t *testing.T) {
 	if err := bazel_testing.RunBazel("build", "//go:lib"); err == nil {
 		t.Fatal("Expected build to fail")
-	} else if !strings.Contains(err.Error(), "lib.go:6:3: declaration of \"foo\" shadows declaration at line 4 (shadow)") {
-		t.Fatalf("Expected error to contain \"lib.go:6:3: declaration of \"foo\" shadows declaration at line 4 (shadow)\", got %s", err)
+	} else if !strings.Contains(err.Error(), "lib.go:6:3: self-assignment of foo to foo (assign)") {
+		t.Fatalf("Expected error to contain \"lib.go:6:3: self-assignment of foo to foo (assign)\", got %s", err)
 	}
 }
 


### PR DESCRIPTION



<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

The shadow analyzer issues many false positives which are not in keeping with Go best practices. Even the upstream documentation for this analyzer admits this and claims that it is experimental. It should not be included in the default list of analyzers provided by nogo (users can still opt-in to it if they want it).


**Which issues(s) does this PR fix?**

Fixes #4340

**Other notes for review**
