### PR TITLE
impure_env

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -464,7 +464,8 @@ def go_context(
         importpath_aliases = None,
         go_context_data = None,
         goos = "auto",
-        goarch = "auto"):
+        goarch = "auto",
+        impure_env = None):
     """Returns an API used to build Go code.
 
     See /go/toolchains.rst#go-context
@@ -548,9 +549,14 @@ def go_context(
         # reparse points (junctions) as symbolic links. Bazel uses junctions
         # when constructing exec roots, and we use filepath.EvalSymlinks in
         # GoStdlib, so this broke us. Setting GODEBUG=winsymlink=0 restores
-        # the old behavior.
+        # the old behavior. (Ideally this would only be set on Windows)
         "GODEBUG": "winsymlink=0",
     }
+
+    if impure_env:
+        env.update(impure_env)
+    elif hasattr(attr, "impure_env"):
+        env.update(attr.impure_env)
 
     # The level of support is determined by the platform constraints in
     # //go/constraints/amd64.

--- a/go/private/rules/library.bzl
+++ b/go/private/rules/library.bzl
@@ -44,6 +44,7 @@ def _go_library_impl(ctx):
         importpath_aliases = ctx.attr.importpath_aliases,
         embed = ctx.attr.embed,
         go_context_data = ctx.attr._go_context_data,
+        impure_env = ctx.attr.impure_env,
     )
 
     go_info = new_go_info(go, ctx.attr)
@@ -185,6 +186,31 @@ go_library = rule(
             doc = """
             List of flags to add to the C link command.
             Subject to ["Make variable"] substitution and [Bourne shell tokenization]. Only valid if `cgo = True`.
+            """,
+        ),
+        "env_inherit": attr.string_list(
+            doc = """Environment variables to inherit from the external environment.
+            """,
+        ),
+        "env": attr.string_dict(
+            doc = """Environment variables to set for the binary execution.
+            The values (but not keys) are subject to
+            [location expansion](https://docs.bazel.build/versions/main/skylark/macros.html) but not full
+            [make variable expansion](https://docs.bazel.build/versions/main/be/make-variables.html).
+            """,
+        ),
+        "impure_env": attr.string_dict(
+            doc = """
+            A dictionary of environment variables to set during the build.
+            These variables will override any existing environment variables.
+            This is useful for setting variables like LD_LIBRARY_PATH that are needed
+            during the build process but should not be inherited from the host environment.
+
+            WARNING: This attribute should be used with caution. Setting environment variables
+            can make builds non-hermetic and potentially non-reproducible. Only use this if you
+            understand the implications and have a specific need that cannot be solved through
+            other means. This is particularly important for shared libraries and other external
+            dependencies that might affect build reproducibility.
             """,
         ),
         "_go_context_data": attr.label(default = "//:go_context_data"),

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -199,8 +199,12 @@ def _go_test_impl(ctx):
         # to run_dir configured above.
         "GO_TEST_RUN_FROM_BAZEL": "1",
     }
+
     for k, v in ctx.attr.env.items():
         env[k] = ctx.expand_location(v, ctx.attr.data)
+
+    if hasattr(ctx.attr, "impure_env"):
+        env.update(ctx.attr.impure_env)
 
     run_environment_info = RunEnvironmentInfo(env, ctx.attr.env_inherit)
 
@@ -289,6 +293,14 @@ _go_test_kwargs = {
         ),
         "env_inherit": attr.string_list(
             doc = """Environment variables to inherit from the external environment.
+            """,
+        ),
+        "impure_env": attr.string_dict(
+            doc = """
+            A dictionary of environment variables to set during the build and test execution.
+            These variables will override any existing environment variables.
+            WARNING: This attribute is impure and may cause non-hermetic builds.
+            Use with caution and only when absolutely necessary.
             """,
         ),
         "importpath": attr.string(

--- a/tests/core/impure_env/BUILD.bazel
+++ b/tests/core/impure_env/BUILD.bazel
@@ -1,0 +1,51 @@
+# To run the tests:
+# bazelisk test //tests/core/impure_env/...
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load(
+    "@bazel_skylib//lib:structs.bzl",
+    "structs",
+)
+load(
+    "//go/private:common.bzl",
+    "GO_TOOLCHAIN",
+    "GO_TOOLCHAIN_LABEL",
+    "SUPPORTS_PATH_MAPPING_REQUIREMENT",
+    "as_list",
+    "asm_exts",
+    "cgo_exts",
+    "go_exts",
+    "syso_exts",
+)
+
+go_library(
+    name = "impure_env_lib",
+    srcs = ["lib.go"],
+    importpath = "github.com/bazelbuild/rules_go/tests/core/impure_env",
+)
+
+go_test(
+    name = "impure_env_test",
+    srcs = ["test.go"],
+    deps = [":impure_env_lib"],
+    impure_env = {
+        "TEST_VAR": "test_value",
+    },
+)
+
+go_test(
+    name = "impure_env_test_no_env",
+    srcs = ["test_no_env.go"],
+    deps = [":impure_env_lib"],
+)
+
+go_test(
+    name = "impure_env_test_multiple",
+    srcs = ["test_multiple_env.go"],
+    deps = [":impure_env_lib"],
+    impure_env = {
+        "TEST_VAR1": "value1",
+        "TEST_VAR2": "value2",
+        "TEST_VAR3": "value3",
+    },
+)

--- a/tests/core/impure_env/lib.go
+++ b/tests/core/impure_env/lib.go
@@ -1,0 +1,17 @@
+package impure_env
+
+import "os"
+
+// GetTestVar returns the value of TEST_VAR environment variable
+func GetTestVar() string {
+	return os.Getenv("TEST_VAR")
+}
+
+// GetMultipleVars returns a map of multiple environment variables
+func GetMultipleVars() map[string]string {
+	return map[string]string{
+		"TEST_VAR1": os.Getenv("TEST_VAR1"),
+		"TEST_VAR2": os.Getenv("TEST_VAR2"),
+		"TEST_VAR3": os.Getenv("TEST_VAR3"),
+	}
+}

--- a/tests/core/impure_env/test.go
+++ b/tests/core/impure_env/test.go
@@ -1,0 +1,14 @@
+package impure_env_test
+
+import (
+	"testing"
+
+	"github.com/bazelbuild/rules_go/tests/core/impure_env"
+)
+
+func TestEnvironmentWithImpureEnv(t *testing.T) {
+	got := impure_env.GetTestVar()
+	if got != "test_value" {
+		t.Errorf("GetTestVar() = %q; want %q", got, "test_value")
+	}
+}

--- a/tests/core/impure_env/test_multiple_env.go
+++ b/tests/core/impure_env/test_multiple_env.go
@@ -1,0 +1,22 @@
+package impure_env_test
+
+import (
+	"testing"
+
+	"github.com/bazelbuild/rules_go/tests/core/impure_env"
+)
+
+func TestMultipleEnvironmentVars(t *testing.T) {
+	got := impure_env.GetMultipleVars()
+	want := map[string]string{
+		"TEST_VAR1": "value1",
+		"TEST_VAR2": "value2",
+		"TEST_VAR3": "value3",
+	}
+
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("GetMultipleVars()[%q] = %q; want %q", k, got[k], v)
+		}
+	}
+}

--- a/tests/core/impure_env/test_no_env.go
+++ b/tests/core/impure_env/test_no_env.go
@@ -1,0 +1,14 @@
+package impure_env_test
+
+import (
+	"testing"
+
+	"github.com/bazelbuild/rules_go/tests/core/impure_env"
+)
+
+func TestEnvironmentWithoutImpureEnv(t *testing.T) {
+	got := impure_env.GetTestVar()
+	if got != "" {
+		t.Errorf("GetTestVar() = %q; want %q", got, "")
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

This is small PR to provide a proof of concept idea to allow "impure environment variables" to be passed into the rules_go sandbox.  This is mostly for a discussion, as I imagine the "owners" of rules_go will have their own and probably better ideas for how to do this.

Really, I just wanted to be able to set LD_LIBRARY_PATH within the sandbox, but I implemented this in a very generic way, so that _any_ environment variable can be set.  Maybe people will want to limit this to a specific set of variable, or to exactly LD_LIBRARY_PATH.  The docs do include WARNINGS about why this is a bad idea.

This is arguably a bug fix, and is a new feature.

> Bug fix
> Feature

**What does this PR do? Why is it needed?**
This PR allows environment variables to be set within the sandbox for rules_go.

The reason is that for golang race tests, the go code needs to be linked against the libraries precompiled with LLVM, and so you need a linker.  The problem is that the ld.lld linker needs libxml2.so.2, and there's no way currently to set the LD_LIBRARY_PATH, so you can't supply libxml2.so.2 via a sysroot.

This PR introduces "impure_env" to allow you to set LD_LIBRARY_PATH, or any other environment variable.
```
go_test(
    name = "hello_test",
    srcs = ["hello_test.go"],
    embed = [":hello_lib"],
    cgo = True,
    cdeps = [":system_deps"],
    data = ["@bazel_sysroot_tarball//:all"],
    impure_env = {
        "LD_LIBRARY_PATH": "external/bazel_sysroot_tarball/lib",   <----- LD_LIBRARY_PATH
    },
    clinkopts = [
        "-L@bazel_sysroot_tarball//:lib",
        "-Wl,-rpath,$$ORIGIN/../../external/bazel_sysroot_tarball/lib",
        "-Wl,--no-as-needed",
        "-lxml2",
    ],
)
```

**Which issues(s) does this PR fix?**

With this PR, I'm able to use bazel on NixOS to run the go race tests!

Fixes #
https://github.com/bazel-contrib/rules_go/issues/4360

**Other notes for review**

To demonstrate this, there is a very simple repo: https://github.com/randomizedcoder/go_hello_world_race

The idea is to demonstrate how to execute go race tests.

The repo includes nix configuration to create a sysroot, which is hosted here: https://github.com/randomizedcoder/bazel_remote_runner_sysroot/

The sysroot contains the basic libraries clang needs to link the code required for the race test.  Please note the included libraries is currently more than is strictly required, but the repo is still only ~22MB, so it's not too bad.
https://github.com/randomizedcoder/go_hello_world_race/blob/main/sysroot/default.nix#L6

The patched rules_go is currently applied as an archive_override in this repo :https://github.com/randomizedcoder/go_hello_world_race/blob/main/MODULE.bazel#L21

With the new rules_go, I'm finally after weeks for trying able to run go race tests with bazel!!
```
bazelisk test //:hello_test --features=race --sandbox_debug --verbose_failures
...
1748208735.178445248: src/main/tools/linux-sandbox-pid1.cc:554: child exited normally with code 0
1748208735.179069961: src/main/tools/linux-sandbox.cc:253: child exited normally with code 0

Run this command to start an interactive shell in an identical sandboxed environment:
(exec env - \
    EXPERIMENTAL_SPLIT_XML_GENERATION=1 \
    GO_TEST_RUN_FROM_BAZEL=1 \
    JAVA_RUNFILES=bazel-out/k8-fastbuild/bin/hello_test_/hello_test.runfiles \
    LD_LIBRARY_PATH=external/bazel_sysroot_tarball/lib \
    PATH=/home/das/.cache/bazelisk/downloads/sha256/511d7879b4662382d6e1590a39d64241e4447515e586ad63df6ba15b8f72efaf/bin:/run/wrappers/bin:/usr/bin:/usr/sbin:/nix/store/33ivrhi748b8k8rdymrmjyqf9785dllb-cursor-0.49.6-extracted/usr/bin/:/nix/store/33ivrhi748b8k8rdymrmjyqf9785dllb-cursor-0.49.6-extracted/usr/sbin/:/nix/store/33ivrhi748b8k8rdymrmjyqf9785dllb-cursor-0.49.6-extracted/usr/games/:/nix/store/33ivrhi748b8k8rdymrmjyqf9785dllb-cursor-0.49.6-extracted/bin/:/nix/store/33ivrhi748b8k8rdymrmjyqf9785dllb-cursor-0.49.6-extracted/sbin/:/nix/store/m3hnxdlz6v6650ggqz29nsqbvzvdvnsy-bash-interactive-5.2p37/bin:/nix/store/hzw38c3f7s0w200cgk9645z53al7k8lw-binutils-2.44/bin:/nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin:/nix/store/qi25cvn9j1xyvl9p7lp8nw9wqk5k648r-gawk-5.3.1/bin:/nix/store/pmfmr1wrh8da7lk42hvyxgg4cnx629dr-libarchive-3.7.8/bin:/nix/store/fch0kdhkh26kd6r1wqsa9121xcy6xnvf-pv-1.9.31/bin:/nix/store/rgz9x6gjjfl34l1ikxlpz1cd3gf5m7ld-squashfs-4.6.1/bin:/run/wrappers/bin:/usr/bin:/usr/sbin:/run/wrappers/bin:/home/das/.nix-profile/bin:/nix/profile/bin:/home/das/.local/state/nix/profile/bin:/etc/profiles/per-user/das/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:/nix/store/xhg020fc8p329vrqb72m7bgc22wlvxs8-ghostty-1.1.3/bin \
    PYTHON_RUNFILES=bazel-out/k8-fastbuild/bin/hello_test_/hello_test.runfiles \
    RUNFILES_DIR=bazel-out/k8-fastbuild/bin/hello_test_/hello_test.runfiles \
    RUN_UNDER_RUNFILES=1 \
    TEST_BINARY=hello_test_/hello_test \
    TEST_INFRASTRUCTURE_FAILURE_FILE=bazel-out/k8-fastbuild/testlogs/hello_test/test.infrastructure_failure \
    TEST_LOGSPLITTER_OUTPUT_FILE=bazel-out/k8-fastbuild/testlogs/hello_test/test.raw_splitlogs/test.splitlogs \
    TEST_PREMATURE_EXIT_FILE=bazel-out/k8-fastbuild/testlogs/hello_test/test.exited_prematurely \
    TEST_SIZE=medium \
    TEST_SRCDIR=bazel-out/k8-fastbuild/bin/hello_test_/hello_test.runfiles \
    TEST_TARGET=//:hello_test \
    TEST_TIMEOUT=300 \
    TEST_TMPDIR=_tmp/df357f155bebd4a0bf649c1b474a0148 \
    TEST_UNDECLARED_OUTPUTS_ANNOTATIONS=bazel-out/k8-fastbuild/testlogs/hello_test/test.outputs_manifest/ANNOTATIONS \
    TEST_UNDECLARED_OUTPUTS_ANNOTATIONS_DIR=bazel-out/k8-fastbuild/testlogs/hello_test/test.outputs_manifest \
    TEST_UNDECLARED_OUTPUTS_DIR=bazel-out/k8-fastbuild/testlogs/hello_test/test.outputs \
    TEST_UNDECLARED_OUTPUTS_MANIFEST=bazel-out/k8-fastbuild/testlogs/hello_test/test.outputs_manifest/MANIFEST \
    TEST_UNUSED_RUNFILES_LOG_FILE=bazel-out/k8-fastbuild/testlogs/hello_test/test.unused_runfiles_log \
    TEST_WARNINGS_OUTPUT_FILE=bazel-out/k8-fastbuild/testlogs/hello_test/test.warnings \
    TEST_WORKSPACE=_main \
    TMPDIR=/tmp \
    TZ=UTC \
    XML_OUTPUT_FILE=bazel-out/k8-fastbuild/testlogs/hello_test/test.xml \
  /home/das/.cache/bazel/_bazel_das/install/254cc618fc52f01b2b1d5fd6ff343774/linux-sandbox -T 300 -t 15 -w /dev/shm -w /home/das/.cache/bazel/_bazel_das/2069c7e7bbea1cec17d73a6b1498e560/sandbox/linux-sandbox/10/execroot/_main -w /home/das/.cache/bazel/_bazel_das/2069c7e7bbea1cec17d73a6b1498e560/sandbox/linux-sandbox/10/execroot/_main/_tmp/df357f155bebd4a0bf649c1b474a0148 -w /tmp -M /home/das/.cache/bazel/_bazel_das/2069c7e7bbea1cec17d73a6b1498e560/sandbox/linux-sandbox/10/_hermetic_tmp -m /tmp -S /home/das/.cache/bazel/_bazel_das/2069c7e7bbea1cec17d73a6b1498e560/sandbox/linux-sandbox/10/stats.out -D /home/das/.cache/bazel/_bazel_das/2069c7e7bbea1cec17d73a6b1498e560/sandbox/linux-sandbox/10/debug.out -- /bin/sh -i)
INFO: Found 1 test target...
Target //:hello_test up-to-date:
  bazel-bin/hello_test_/hello_test
INFO: Elapsed time: 74.241s, Critical Path: 61.11s
INFO: 15 processes: 1 action cache hit, 5 internal, 10 linux-sandbox.
INFO: Build completed successfully, 15 total actions
//:hello_test                                                            PASSED in 0.0s

Executed 1 out of 1 test: 1 test passes.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.

[das@t:~/Downloads/go_hello_world_race]$ 
```

Looking forward to discussing the idea with you.

Thanks in advance,
Dave