### PR TITLE
Provide `DefaultInfo` on Go toolchain rules

### DIFF
--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -27,28 +27,31 @@ load("//go/private/actions:stdlib.bzl", "emit_stdlib")
 def _go_toolchain_impl(ctx):
     sdk = ctx.attr.sdk[GoSDK]
     cross_compile = ctx.attr.goos != sdk.goos or ctx.attr.goarch != sdk.goarch
-    return [platform_common.ToolchainInfo(
-        # Public fields
-        name = ctx.label.name,
-        cross_compile = cross_compile,
-        default_goos = ctx.attr.goos,
-        default_goarch = ctx.attr.goarch,
-        actions = struct(
-            archive = emit_archive,
-            binary = emit_binary,
-            link = emit_link,
-            stdlib = emit_stdlib,
-        ),
-        flags = struct(
-            compile = (),
-            link = ctx.attr.link_flags,
-            link_cgo = ctx.attr.cgo_link_flags,
-        ),
-        sdk = sdk,
+    return [
+        ctx.attr.sdk[DefaultInfo],
+        platform_common.ToolchainInfo(
+            # Public fields
+            name = ctx.label.name,
+            cross_compile = cross_compile,
+            default_goos = ctx.attr.goos,
+            default_goarch = ctx.attr.goarch,
+            actions = struct(
+                archive = emit_archive,
+                binary = emit_binary,
+                link = emit_link,
+                stdlib = emit_stdlib,
+            ),
+            flags = struct(
+                compile = (),
+                link = ctx.attr.link_flags,
+                link_cgo = ctx.attr.cgo_link_flags,
+            ),
+            sdk = sdk,
 
-        # Internal fields -- may be read by emit functions.
-        _builder = ctx.executable.builder,
-    )]
+            # Internal fields -- may be read by emit functions.
+            _builder = ctx.executable.builder,
+        ),
+    ]
 
 go_toolchain = rule(
     _go_toolchain_impl,

--- a/go/private/rules/sdk.bzl
+++ b/go/private/rules/sdk.bzl
@@ -22,19 +22,30 @@ def _go_sdk_impl(ctx):
     if package_list == None:
         package_list = ctx.actions.declare_file("packages.txt")
         _build_package_list(ctx, ctx.files.srcs, ctx.file.root_file, package_list)
-    return [GoSDK(
-        goos = ctx.attr.goos,
-        goarch = ctx.attr.goarch,
-        experiments = ",".join(ctx.attr.experiments),
-        root_file = ctx.file.root_file,
-        package_list = package_list,
-        libs = depset(ctx.files.libs),
-        headers = depset(ctx.files.headers),
-        srcs = depset(ctx.files.srcs),
-        tools = depset(ctx.files.tools),
-        go = ctx.executable.go,
-        version = ctx.attr.version,
-    )]
+    return [
+        DefaultInfo(
+            files = depset(
+                [ctx.file.go] +
+                ctx.files.libs +
+                ctx.files.headers +
+                ctx.files.srcs +
+                ctx.files.tools,
+            ),
+        ),
+        GoSDK(
+            goos = ctx.attr.goos,
+            goarch = ctx.attr.goarch,
+            experiments = ",".join(ctx.attr.experiments),
+            root_file = ctx.file.root_file,
+            package_list = package_list,
+            libs = depset(ctx.files.libs),
+            headers = depset(ctx.files.headers),
+            srcs = depset(ctx.files.srcs),
+            tools = depset(ctx.files.tools),
+            go = ctx.executable.go,
+            version = ctx.attr.version,
+        ),
+    ]
 
 go_sdk = rule(
     _go_sdk_impl,


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This makes it easier to deal with these toolchains in language-agnostic aspects and helpers (in particular, bazel_env.bzl), that propagate to toolchain targets.

Even though genrules now support `toolchain_type`s in their `toolchains`, this does *not* allow Go SDKs to be used in genrules as they don't expose the path to the Go binary via a Make variable. This is intentional as we don't want to allow running `go` in `genrule`s.

**Which issues(s) does this PR fix?**

**Other notes for review**
