### PR TITLE
Don't set module version outside BCR

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,5 @@
 module(
     name = "rules_go",
-    # Updated by the Publish to BCR app.
-    version = "0.0.0",
     compatibility_level = 0,
     repo_name = "io_bazel_rules_go",
 )


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This results in an empty version when rules_go is used as an override, which should avoid the warning reported in https://github.com/bazel-contrib/rules_go/issues/4380.

**Which issues(s) does this PR fix?**

Fixes #4380

**Other notes for review**
