### PR TITLE
fix the internal archive to include all of the original dependencies

### DIFF
--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -655,6 +655,7 @@ def _recompile_external_deps(go, external_go_info, internal_archive, library_lab
     # Pass internal dependencies that need to be recompiled down to the builder to check if the internal archive
     # tries to import any of the dependencies. If there is, that means that there is a dependency cycle.
     need_recompile_deps = []
+    original_internal_deps = internal_go_info.deps
     for archive in internal_go_info.deps:
         dep_data = archive.data
         if not need_recompile[dep_data.label]:
@@ -672,13 +673,14 @@ def _recompile_external_deps(go, external_go_info, internal_archive, library_lab
 
     # Build a map from labels to possibly recompiled GoArchives.
     label_to_archive = {}
-    i = 0
     for label in dep_list:
-        i += 1
-
         # If this library is the internal archive, use the recompiled version.
         if label == internal_archive.data.label:
-            label_to_archive[label] = internal_archive
+            # ensure the internal archive has all of the orignal dependencies including the recompiled ones.
+            internal_attrs = structs.to_dict(internal_archive)
+            internal_attrs["direct"] = [label_to_archive[archive.data.label] for archive in original_internal_deps]
+            internal_archive = GoArchive(**internal_attrs)
+            label_to_archive[internal_archive.data.label] = internal_archive
             continue
 
         # If this is a library embedded into the internal test archive,


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
I had an issue where the go packages driver was not loading all of the dependencies in a test resulting in unresolved imports. I tracked it down to the process of recompiling for internal/external in `go_test`. For the internal archive it is filtering out the dependencies that need to be recompiled, and recompiling them, but the final `internal_archive` does not include the recompiled dependencies. Later when the packages driver aspect lists the dependencies for the `go_test` target it is missing the dependencies which were recompiled.

