### PR TITLE
wrap_sdk: make root_files a string_keyed_label_dict

### DIFF
--- a/go/private/extensions.bzl
+++ b/go/private/extensions.bzl
@@ -98,13 +98,20 @@ Uses the same format as 'visibility', i.e., every entry must be a label that end
     },
 )
 
+# string_keyed_label_dict was added in 8.0.0
+_maybe_string_keyed_label_dict = getattr(
+    attr,
+    "string_keyed_label_dict",
+    attr.string_dict,
+)
+
 _wrap_tag = tag_class(
     attrs = {
         "root_file": attr.label(
             mandatory = False,
             doc = "A file in the SDK root directory. Use to determine GOROOT.",
         ),
-        "root_files": attr.string_dict(
+        "root_files": _maybe_string_keyed_label_dict(
             mandatory = False,
             doc = "A set of mappings from the host platform to a file in the SDK's root directory.",
         ),
@@ -234,7 +241,7 @@ def _go_sdk_impl(ctx):
                 if key not in ["go_mod"]
             }
             download_tag["version"] = version
-            additional_download_tags += [struct(**download_tag)]
+            additional_download_tags.append(struct(**download_tag))
 
         for index, download_tag in enumerate(module.tags.download + additional_download_tags):
             # SDKs without an explicit version are fetched even when not selected by toolchain

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -371,6 +371,12 @@ def _go_wrap_sdk_impl(ctx):
     _sdk_build_file(ctx, platform, version, ctx.attr.experiments)
     _local_sdk(ctx, goroot)
 
+# string_keyed_label_dict was added in 8.0.0
+_maybe_string_keyed_label_dict = getattr(
+    attr,
+    "string_keyed_label_dict",
+    attr.string_dict,
+)
 go_wrap_sdk_rule = repository_rule(
     implementation = _go_wrap_sdk_impl,
     attrs = {
@@ -378,7 +384,7 @@ go_wrap_sdk_rule = repository_rule(
             mandatory = False,
             doc = "A file in the SDK root direcotry. Used to determine GOROOT.",
         ),
-        "root_files": attr.string_dict(
+        "root_files": _maybe_string_keyed_label_dict(
             mandatory = False,
             doc = "A set of mappings from the host platform to a file in the SDK's root directory",
         ),


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
I'm trying to use an extension-generated repo as a wrapped sdk using `root_files`. I get a package load error similar to https://github.com/bazelbuild/bazel/issues/19301.

**Which issues(s) does this PR fix?**
I saw in the comments (specifically https://github.com/bazelbuild/bazel/issues/19301#issuecomment-1694588371) that this would probably work if `root_files` used a `string_keyed_label_dict` and, when I tried it locally it did.

Fixes #4418

**Other notes for review**
https://github.com/bazelbuild/bazel/issues/19301