### PR TITLE
Fix trim path problems

### DIFF
--- a/tests/core/go_library/BUILD.bazel
+++ b/tests/core/go_library/BUILD.bazel
@@ -208,3 +208,8 @@ go_library(
         "//tests/core/go_test:__pkg__",
     ],
 )
+
+go_bazel_test(
+    name = "trimpath_test",
+    srcs = ["trimpath_test.go"],
+)

--- a/tests/core/go_library/README.rst
+++ b/tests/core/go_library/README.rst
@@ -7,6 +7,7 @@ Basic go_library functionality
 .. _#1772: https://github.com/bazelbuild/rules_go/issues/1772
 .. _#2058: https://github.com/bazelbuild/rules_go/issues/2058
 .. _#3558: https://github.com/bazelbuild/rules_go/issues/3558
+.. _#4434: https://github.com/bazel-contrib/rules_go/issues/4434
 
 empty
 -----
@@ -55,3 +56,8 @@ no_srcs_test
 
 Verifies that `go_library`_ targets without Go source files build concurrently,
 even unsandboxed, and reproducibly. Verifies `#3558`_.
+
+trimpath_test
+-------------
+
+Verifies that trimpath has the expected effect on paths. Verifies `#4434`_.

--- a/tests/core/go_library/trimpath_test.go
+++ b/tests/core/go_library/trimpath_test.go
@@ -1,0 +1,163 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trimpath_test
+
+import (
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: `
+-- BUILD.bazel --
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "maincgo",
+    srcs = ["maincgo.go"],
+    cgo = True,
+    importpath = "example.com/main_repo/maincgo",
+    visibility = ["//visibility:private"],
+)
+
+go_library(
+    name = "main_lib",
+    srcs = ["main.go"],
+    deps = [":maincgo", "@other_repo//:other", "@other_repo//:othercgo"],
+    importpath = "example.com/main_repo/main",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "main",
+    embed = [":main_lib"],
+    visibility = ["//visibility:public"],
+)
+-- main.go --
+package main
+
+import "runtime"
+import "fmt"
+import "example.com/main_repo/maincgo"
+import "example.com/other_repo/other"
+import "example.com/other_repo/othercgo"
+
+func File() string {
+	_, file, _, _ := runtime.Caller(0)
+	return file
+}
+
+func main() {
+	fmt.Println(File())
+	fmt.Println(maincgo.File())
+	fmt.Println(other.File())
+	fmt.Println(othercgo.File())
+}
+-- maincgo.go --
+package maincgo
+
+import "C"
+import "runtime"
+
+func File() string {
+	_, file, _, _ := runtime.Caller(0)
+	return file
+}
+-- other_repo/WORKSPACE --
+-- other_repo/BUILD.bazel --
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "other",
+    srcs = ["other.go"],
+    importpath = "example.com/other_repo/other",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "othercgo",
+    srcs = ["othercgo.go"],
+    cgo = True,
+    importpath = "example.com/other_repo/othercgo",
+    visibility = ["//visibility:public"],
+)
+-- other_repo/other.go --
+package other
+
+import "runtime"
+
+func File() string {
+	_, file, _, _ := runtime.Caller(0)
+	return file
+}
+-- other_repo/othercgo.go --
+package othercgo
+
+import "C"
+import "runtime"
+
+func File() string {
+	_, file, _, _ := runtime.Caller(0)
+	return file
+}
+`,
+	WorkspaceSuffix: `
+local_repository(
+    name = "other_repo",
+    path = "other_repo",
+)
+`,
+	})
+}
+
+// These are the expected paths after applying trimpath.
+var expectedDefault = `
+main.go
+maincgo.go
+external/other_repo/other.go
+external/other_repo/othercgo.go
+`
+
+var expectedSibling = `
+main.go
+maincgo.go
+../other_repo/other.go
+../other_repo/othercgo.go
+`
+
+func TestTrimpath(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		out, err := bazel_testing.BazelOutput("run", "//:main")
+		if err != nil {
+			t.Fatal(err)
+		}
+		outStr := "\n" + string(out)
+		if outStr != expectedDefault {
+			t.Fatal("actual", outStr, "vs expected", expectedDefault)
+		}
+	})
+	t.Run("experimental_sibling_repository_layout", func(t *testing.T) {
+		out, err := bazel_testing.BazelOutput("run", "--experimental_sibling_repository_layout", "//:main")
+		if err != nil {
+			t.Fatal(err)
+		}
+		outStr := "\n" + string(out)
+		if outStr != expectedSibling {
+			t.Fatal("actual", outStr, "vs expected", expectedSibling)
+		}
+	})
+}

--- a/tests/core/go_plugin_with_proto_library/BUILD.bazel
+++ b/tests/core/go_plugin_with_proto_library/BUILD.bazel
@@ -25,7 +25,7 @@ proto_library(
 
 go_proto_library(
     name = "validate",
-    gc_goopts = ["-trimpath=$(BINDIR)=>."],
+    gc_goopts = ["-trimpath=$(BINDIR)"],
     importpath = "go_plugin_with_proto_library/validate",
     proto = ":validate_proto",
 )


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

There were multiple problems with trim paths:

- The trim path was inconsistent between non-cgo and cgo. non-cgo trimmed the working directory, and cgo trimmed the parent of the working directory.
- For non-cgo, paths in external repos are not trimmed when --experimental_sibling_repository_layout is enabled.
- For cgo, the name of the working directory is included in the output, but this name is not consistent between local and remote builds, breaking reproducibility.

These are fixed here by creating the trim path in the same way for both non-cgo and cgo, and trimming the working directory as well as replacing the parent of the working directory with `..`. This means that the resulting paths are relative to the working directory.

Additionally, this fixes the existing feature to extend an existing trimpath. It used the wrong separator (`:` instead of `;`), and it applied `abs()` to the entire trimpath argument instead of the individual paths inside it. (See https://github.com/bazel-contrib/rules_go/pull/2994#issuecomment-1012730010 and https://github.com/bazel-contrib/rules_go/pull/2994#issuecomment-1012796895)

**Which issues(s) does this PR fix?**

Fixes: https://github.com/bazel-contrib/rules_go/issues/4434
Fixes: https://github.com/bazel-contrib/rules_go/issues/4161
