### PR TITLE
Cleanup path-mapping enablement

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,7 @@
 Benjamin Staffin <benley@gmail.com>
 Brian Silverman <bsilver16384@gmail.com>
 David Santiago <david.santiago@gmail.com>
+David Zbarsky <dzbarsky@gmail.com>
 Google Inc.
 Jake Voytko <jake@reviewninja.com>
 Yuki Yugui Sonoda <yugui@yugui.jp>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -14,6 +14,7 @@ Brian Silverman <bsilver16384@gmail.com>
 Damien Martin-Guillerez <dmarting@google.com>
 David Chen <dzc@google.com>
 David Santiago <david.santiago@gmail.com>
+David Zbarsky <dzbarsky@gmail.com>
 Fabian Meumertzheim <fabian@meumertzhe.im>
 Han-Wen Nienhuys <hanwen@google.com>
 Ian Cottrell <iancottrell@google.com>

--- a/go/private/actions/compilepkg.bzl
+++ b/go/private/actions/compilepkg.bzl
@@ -99,7 +99,7 @@ def emit_compilepkg(
     inputs_transitive = [sdk.headers, sdk.tools, go.stdlib.libs, headers]
     outputs = [out_lib, out_export]
 
-    shared_args = go.builder_args(go, use_path_mapping = True)
+    shared_args = go.builder_args(go)
     shared_args.add_all(sources, before_each = "-src")
 
     compile_args = go.tool_args(go)

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -66,7 +66,7 @@ def emit_link(
 
     # use ar tool from cc toolchain if cc toolchain provides it
     if go.cgo_tools and go.cgo_tools.ar_path and go.cgo_tools.ar_path.endswith("ar"):
-        tool_args.add_all(["-extar", go.cgo_tools.ar_path])
+        tool_args.add("-extar", go.cgo_tools.ar_path)
 
     # Add in any mode specific behaviours
     if go.mode.race:

--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -68,9 +68,8 @@ def _build_stdlib_list_json(go):
     out = go.declare_file(go, "stdlib.pkg.json")
     cache_dir = go.declare_directory(go, "gocache")
     args = go.builder_args(go, "stdliblist")
-    args.add("-sdk", sdk.root_file.dirname)
     args.add("-out", out)
-    args.add("-cache", cache_dir.path)
+    args.add_all("-cache", [cache_dir], expand_directories = False)
     if go.export_stdlib:
         args.add("-export", go.export_stdlib)
 
@@ -87,6 +86,7 @@ def _build_stdlib_list_json(go):
         arguments = [args],
         env = _build_env(go),
         toolchain = GO_TOOLCHAIN_LABEL,
+        execution_requirements = SUPPORTS_PATH_MAPPING_REQUIREMENT,
     )
     return out, cache_dir
 
@@ -130,7 +130,7 @@ def _dirname(file):
 
 def _build_stdlib(go):
     pkg = go.declare_directory(go, path = "pkg")
-    args = go.builder_args(go, "stdlib", use_path_mapping = True)
+    args = go.builder_args(go, "stdlib")
 
     # Use a file rather than pkg.dirname as the latter is just a string and thus
     # not subject to path mapping.

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -178,7 +178,7 @@ def _declare_directory(go, path = "", ext = "", name = ""):
 def _dirname(file):
     return file.dirname
 
-def _builder_args(go, command = None, use_path_mapping = False):
+def _builder_args(go, command = None):
     args = go.actions.args()
     args.use_param_file("-param=%s")
     if command:
@@ -188,15 +188,15 @@ def _builder_args(go, command = None, use_path_mapping = False):
 
     # Path mapping can't map the values of environment variables, so we need to pass GOROOT to the
     # action via an argument instead.
-    if use_path_mapping:
-        if go.stdlib:
-            goroot_file = go.stdlib.root_file
-        else:
-            goroot_file = sdk_root_file
+    if go.stdlib:
+        goroot_file = go.stdlib.root_file
+    else:
+        goroot_file = sdk_root_file
 
-        # Use a file rather than goroot as the latter is just a string and thus
-        # not subject to path mapping.
-        args.add_all("-goroot", [goroot_file], map_each = _dirname, expand_directories = False)
+    # Use a file rather than goroot as the latter is just a string and thus
+    # not subject to path mapping.
+    args.add_all("-goroot", [goroot_file], map_each = _dirname, expand_directories = False)
+
     mode = go.mode
     args.add("-installsuffix", installsuffix(mode))
     args.add_joined("-tags", mode.tags, join_with = ",")

--- a/go/private/rules/info.bzl
+++ b/go/private/rules/info.bzl
@@ -24,7 +24,8 @@ load(
 def _go_info_impl(ctx):
     go = go_context(ctx)
     report = go.declare_file(go, ext = ".txt")
-    args = go.builder_args(go)
+    args = go.actions.args()
+    args.add("-sdk", go.sdk.root_file.dirname)
     args.add("-out", report)
     go.actions.run(
         inputs = depset([go.sdk.go], transitive = [go.sdk.tools]),

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -120,7 +120,7 @@ def _go_test_impl(ctx):
         run_dir = repo_relative_rundir
 
     main_go = go.declare_file(go, path = "testmain.go")
-    arguments = go.builder_args(go, "gentestmain", use_path_mapping = True)
+    arguments = go.builder_args(go, "gentestmain")
     arguments.add("-output", main_go)
     if go.coverage_enabled:
         # Always use atomic mode as the "runtime/coverage" APIs require it


### PR DESCRIPTION
**What type of PR is this?**
code cleanup

**What does this PR do? Why is it needed?**
This enables path-mapping for the GoInfo action and simplifies the `builder_args`. As a side effect, we now set the `-goroot` flag for link actions but they do not yet opt into path mapping (and I don't think they will work yet, since they use .path on the archives)

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
