### PR TITLE
Update bazel_dep versions in bzlmod.md

### DIFF
--- a/docs/go/core/bzlmod.md
+++ b/docs/go/core/bzlmod.md
@@ -8,8 +8,8 @@ Usages of rules_go and Gazelle in `BUILD` files are not affected by this; refer 
 Add the following lines to your `MODULE.bazel` file:
 
 ```starlark
-bazel_dep(name = "rules_go", version = "0.39.1")
-bazel_dep(name = "gazelle", version = "0.31.0")
+bazel_dep(name = "rules_go", version = "0.57.0")
+bazel_dep(name = "gazelle", version = "0.45.0")
 ```
 
 The latest versions are always listed on https://registry.bazel.build/.
@@ -17,8 +17,8 @@ The latest versions are always listed on https://registry.bazel.build/.
 If you have WORKSPACE dependencies that reference rules_go and/or Gazelle, you can still use the legacy repository names for the two repositories:
 
 ```starlark
-bazel_dep(name = "rules_go", version = "0.39.1", repo_name = "io_bazel_rules_go")
-bazel_dep(name = "gazelle", version = "0.31.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "rules_go", version = "0.57.0", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "gazelle", version = "0.45.0", repo_name = "bazel_gazelle")
 ```
 
 ## Go SDKs


### PR DESCRIPTION

**What type of PR is this?**
Documentation

**What does this PR do? Why is it needed?**

The older versions specified in the documentation don't work with `go_work`, which leads to confusing errors
