### PR TITLE
Exclude jsontest package from stdlib builder

### DIFF
--- a/go/private/BUILD.sdk.bazel
+++ b/go/private/BUILD.sdk.bazel
@@ -25,6 +25,7 @@ filegroup(
     name = "srcs",
     srcs = glob(
         ["src/**/*"],
+        allow_empty = True,
         exclude = [
             "src/**/*_test.go",
             "src/**/testdata/**",


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
`src/encoding/json/internal/jsontest` package in stdlib doesn't compile because we excluded testdata. It's only used in tests, so we can tweak our exclude patterns to skip this package as well.

Unfortunately I see another issue that prevents me from verifying this works
```
ERROR: /private/var/tmp/_bazel_dzbarsky/f02363070bdd15ed6c1c5741e4a6e4c0/external/rules_go+/BUILD.bazel:42:7: GoStdlib external/rules_go+/stdlib_/pkg failed: (Exit 1): builder failed: error executing GoStdlib command (from target @@rules_go+//:stdlib) bazel-out/darwin_arm64-opt-exec-ST-d57f47055a04/bin/external/rules_go++go_sdk+go_sdk/builder_reset/builder stdlib -sdk external/rules_go++go_sdk+go_sdk -goroot external/rules_go++go_sdk+go_sdk ... (remaining 10 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
go: unknown GOEXPERIMENT coverageredesign
stdlib: error running subcommand external/rules_go++go_sdk+go_sdk/bin/go: exit status 2
```

**Which issues(s) does this PR fix?**

Fixes #4428

**Other notes for review**
