### PR TITLE
Add missing `bazel_dep` to BCR test module

### DIFF
--- a/tests/bcr/MODULE.bazel
+++ b/tests/bcr/MODULE.bazel
@@ -19,6 +19,7 @@ local_path_override(
 )
 
 bazel_dep(name = "gazelle", version = "0.36.0")
+bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "protobuf", version = "29.0-rc2.bcr.1")
 bazel_dep(name = "rules_shell", version = "0.4.1")
 


### PR DESCRIPTION
This is required with Bazel 8, which doesn't expose the `platforms` WORKSPACE suffix repo by default. 98940c33e64548d13314a372bdc0103732407dc3 forgot to add it.