### PR TITLE
Only build cmd/internal/cov package on go1.20 where it exists

### DIFF
--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -143,9 +143,11 @@ def _build_stdlib(go):
     if not go.mode.pure:
         args.add("-package", "runtime/cgo")
 
-    # For bzltestutil's coverage support.
-    args.add("-package", "cmd/internal/cov")
-    args.add("-package", "cmd/internal/bio")
+    version = parse_version(go.sdk.version)
+    if version and version[0] >= 1 and version[1] >= 20:
+        # For bzltestutil's coverage support - `cmd/internal/cov` only introduced in go 1.20
+        args.add("-package", "cmd/internal/cov")
+        args.add("-package", "cmd/internal/bio")
 
     link_mode_flag = link_mode_arg(go.mode)
     if link_mode_flag:


### PR DESCRIPTION
**What type of PR is this?**
bug fix

**What does this PR do? Why is it needed?**
build_stdlib wouldn't work on <go1.20 

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
