### PR TITLE
Fix _xcode_config attribute for bazel 9.x

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -78,7 +78,7 @@ load(
 CPP_TOOLCHAIN_TYPE = Label("@bazel_tools//tools/cpp:toolchain_type")
 CGO_ATTRS = {
     "_cc_toolchain": attr.label(default = "@bazel_tools//tools/cpp:optional_current_cc_toolchain"),
-    "_xcode_config": attr.label(default = "@bazel_tools//tools/osx:current_xcode_config"),
+    "_xcode_config": attr.label(default = configuration_field(fragment = "apple", name = "xcode_config_label")),
     "_pure_flag": attr.label(default = "//go/config:pure"),
     "_pure_constraint": attr.label(default = "//go/toolchain:cgo_off"),
 }


### PR DESCRIPTION
This label was removed @ HEAD https://github.com/bazelbuild/bazel/commit/873b036afbf77ede4588aeaa95b119fb486accef#diff-063fdd9649746cd022e13edf6ac43956dfd4e55c5420847d00162557e7697d93L68

This is how it is accessed in rules_apple / apple_support
