### PR TITLE
correct macOS Tahoe 26 build via apple_support

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -139,6 +139,14 @@ http_archive(
     urls = ["https://github.com/bazelbuild/buildtools/archive/refs/tags/v6.4.0.tar.gz"],
 )
 
+# Used for both testing objc interop and building on Apple platforms. Must be
+# above the llvm_toolchain declaration while it's still at 8.0.0.
+http_archive(
+    name = "build_bazel_apple_support",
+    sha256 = "85a7dc13e370f355bf00381238d1cba56450d3e598566b8c52d90ddf301c5dfb",
+    url = "https://github.com/bazelbuild/apple_support/releases/download/1.24.3/apple_support.1.24.3.tar.gz",
+)
+
 # For manual testing against an LLVM toolchain.
 # Use --extra_toolchains=@llvm_toolchain//:cc-toolchain-linux,@llvm_toolchain//:cc-toolchain-darwin
 http_archive(
@@ -292,13 +300,6 @@ http_archive(
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
 
 stardoc_repositories()
-
-# For testing objc_library interop, users should not need to install it
-http_archive(
-    name = "build_bazel_apple_support",
-    sha256 = "100d12617a84ebc7ee7a10ecf3b3e2fdadaebc167ad93a21f820a6cb60158ead",
-    url = "https://github.com/bazelbuild/apple_support/releases/download/1.12.0/apple_support.1.12.0.tar.gz",
-)
 
 load(
     "@build_bazel_apple_support//lib:repositories.bzl",


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

All of rules_go tests were failing on macOS Tahoe 26 due to `missing
LC_UUID load command` in the clang binary built and in other tools. Many
tools from Go to bazel itself have had to drop various workarounds for
these kinds of linker problems in the run-up to macOS Tahoe (see
https://github.com/bazelbuild/apple_support/commit/44c43c715a and
https://github.com/bazelbuild/bazel/pull/27014)

To fix this, we bump the version of build_bazel_apple_support (a.k.a.
apple_support in Bazel Central Registry) to 1.24.3 in WORKSPACE. We also
have to move the build_bazel_apple_support dependency above the
llvm_toolchain call in order to make sure that version is actually used.

It's possible we should also upgrade the llvm_toolchain to something
more modern to handle some of our deps problems. The current llvm used
by rules_go is 8.0.0 and is from 2019. The latest llvm version that
toolchains_llvm supports in its latest release 1.5.0 is llvm 21.1.0.


**Which issues(s) does this PR fix?**

Fixes #4499

