### PR TITLE
Add missing load statements

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -39,6 +39,7 @@ load(
     NOGO_EXCLUDES = "EXCLUDES",
     NOGO_INCLUDES = "INCLUDES",
 )
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load(
     "//go/platform:apple.bzl",
     "apple_ensure_options",

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load(
     "//go/private:common.bzl",
     "GO_TOOLCHAIN",

--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load(
     "//go/private:common.bzl",
     "get_versioned_shared_lib_extension",

--- a/go/private/rules/cross.bzl
+++ b/go/private/rules/cross.bzl
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load(
     "//go/private:providers.bzl",
     "GoArchive",

--- a/tests/core/c_linkmodes/BUILD.bazel
+++ b/tests/core/c_linkmodes/BUILD.bazel
@@ -1,4 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 go_binary(
     name = "adder_archive",

--- a/tests/core/cgo/BUILD.bazel
+++ b/tests/core/cgo/BUILD.bazel
@@ -1,5 +1,8 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_import.bzl", "cc_import")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(
     # go_* rules do not emit module maps.

--- a/tests/core/cgo/cgo_alwayslink_init/BUILD.bazel
+++ b/tests/core/cgo/cgo_alwayslink_init/BUILD.bazel
@@ -1,4 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 cc_library(
     name = "lib",

--- a/tests/core/cgo/objc/BUILD.bazel
+++ b/tests/core/cgo/objc/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_cc//cc:objc_library.bzl", "objc_library")
 
 go_test(
     name = "objc_test",

--- a/tests/core/go_library/BUILD.bazel
+++ b/tests/core/go_library/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//go:def.bzl", "go_binary", "go_library", "go_source", "go_test")
 load("//go/tools/bazel_testing:def.bzl", "go_bazel_test")
 load(":def.bzl", "embedsrcs_files")

--- a/tests/core/go_plugin_with_proto_library/BUILD.bazel
+++ b/tests/core/go_plugin_with_proto_library/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 

--- a/tests/core/go_proto_aspect/codegen.bzl
+++ b/tests/core/go_proto_aspect/codegen.bzl
@@ -1,5 +1,5 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("@io_bazel_rules_go//go:def.bzl", "GoArchive", "GoInfo", "go_context", "new_go_info")
+load("@io_bazel_rules_go//go:def.bzl", "go_context", "new_go_info")
 
 def _go_generated_library_impl(ctx):
     src = ctx.actions.declare_file("generated.go")

--- a/tests/examples/executable_name/BUILD.bazel
+++ b/tests/examples/executable_name/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 go_binary(
     name = "some_binary",

--- a/tests/legacy/cgo_select/BUILD.bazel
+++ b/tests/legacy/cgo_select/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 go_library(
     name = "go_default_library",

--- a/tests/legacy/examples/cgo/cc_dependency/BUILD.bazel
+++ b/tests/legacy/examples/cgo/cc_dependency/BUILD.bazel
@@ -1,3 +1,7 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_import.bzl", "cc_import")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 cc_library(
     name = "version",
     srcs = ["cxx_version.cc"],

--- a/tests/legacy/examples/cgo/example_command/BUILD.bazel
+++ b/tests/legacy/examples/cgo/example_command/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load(":generate_test.bzl", "generate_script")
 
 package(

--- a/tests/legacy/extldflags_rpath/BUILD.bazel
+++ b/tests/legacy/extldflags_rpath/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 go_binary(
     name = "extldflags_rpath",

--- a/tests/legacy/info/BUILD.bazel
+++ b/tests/legacy/info/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
 sh_test(
     name = "info",
     srcs = ["info_test.sh"],

--- a/tests/legacy/providers/BUILD.bazel
+++ b/tests/legacy/providers/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//go:def.bzl", "go_source")
 load("//tests/legacy/providers:test.bzl", "test_source")
 

--- a/tests/legacy/transitive_data/BUILD.bazel
+++ b/tests/legacy/transitive_data/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 go_test(
     name = "go_default_test",


### PR DESCRIPTION
This is required for compatibility with bazel @ HEAD. Done with:
`buildifier --lint=fix -r .`
