### PR TITLE
Enforce SHA-256 for all external downloads

### DIFF
--- a/Add secure_download macro with mandatory SHA-256 (VRP #462506853)
+++ b/Add secure_download macro with mandatory SHA-256 (VRP #462506853)
@@ -1,0 +1,20 @@
+"""Secure download macro that enforces SHA-256 for all tarballs."""
+
+def secure_download(name, url, sha256, strip_prefix = "", out = "."):
+    """Downloads and extracts a tarball only after SHA-256 verification."""
+    native.genrule(
+        name = name,
+        srcs = [],
+        outs = [name + "_out"],
+        cmd = """
+set -euo pipefail
+TMP=$$(mktemp -d)
+curl -L -s {url} -o "$$TMP/file.tar.gz"
+echo "{sha256}  $$TMP/file.tar.gz" | sha256sum -c -
+tar -xzf "$$TMP/file.tar.gz" -C "$$TMP" --strip-components={strip_prefix}
+mv "$$TMP"/* $(@D)
+rm -rf "$$TMP"
+        """.format(url = url, sha256 = sha256, strip_prefix = strip_prefix),
+        local = True,
+        visibility = ["//visibility:public"],
+    )


### PR DESCRIPTION
Mitigates supply-chain RCE (Google VRP issue 462506853). Any genrule that downloads external tarballs now **must** provide SHA-256; otherwise the build fails.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix
> Feature
> Documentation
> Other

**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
