### PR TITLE
Exclude cgotest from stdlib build

### DIFF
--- a/go/private/BUILD.sdk.bazel
+++ b/go/private/BUILD.sdk.bazel
@@ -36,6 +36,7 @@ filegroup(
             "src/log/slog/internal/slogtest/**",
             "src/internal/obscuretestdata/**",
             "src/internal/testpty/**",
+            "src/net/internal/cgotest/**",
             "src/net/internal/socktest/**",
             "src/reflect/internal/example*/**",
             "src/runtime/internal/startlinetest/**",


### PR DESCRIPTION
It didn't build for me with a zig toolchain, but anyway we shouldn't need to build this for user code

```
# net/internal/cgotest
bazel-out/darwin_arm64-opt-exec-ST-6c94b0e707c0/bin/external/rules_go+/stdlib_/src/net/internal/cgotest/resstate.go:10:10: fatal error: 'resolv.h' file not found
   10 | #include <resolv.h>
```

**What type of PR is this?**
Perf tweak?
