### PR TITLE
expand make variables in x_defs

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -363,7 +363,7 @@ def new_go_info(
             v = go._ctx.expand_location(v, data)
         if "." not in k:
             k = "%s.%s" % (importmap, k)
-        x_defs[k] = v
+        x_defs[k] = go._ctx.expand_make_variables("x_defs." + k, v, {})
     go_info["x_defs"] = x_defs
 
     if not go_info["cgo"]:


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
This performs make variable substitution on the values of x_defs.

Context: trying to allow users of a ruleset to customize the tagged version of a binary generated inside the ruleset with a value from a ruleset-defined string flag- this is, to my understanding, the only way to get this string into the analysis context.

**Which issues(s) does this PR fix?**

Fixes #4308

