### PR TITLE
chore(docs): add Quick Start section to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -164,6 +164,10 @@ Note: Since version v0.51.0, rules_go requires Bazel ≥ 6.5.0 to work.
 
 The ``master`` branch is only guaranteed to work with the latest version of Bazel.
 
+Quick Start
+-----------
+
+The fastest way to try this in an empty project is to click the green "Use this template" button on https://github.com/bazel-starters/go.
 
 Setup
 -----


### PR DESCRIPTION
Added a 'Quick Start' section to the README for easier project setup.

Note, this is the same link reachable from https://bazel.build/start
