### PR TITLE
chore: Mark go_download_sdk as reproducible

### DIFF
--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -121,7 +121,11 @@ def _go_download_sdk_impl(ctx):
             "version": version,
             "strip_prefix": ctx.attr.strip_prefix,
         }
-    return None
+
+    if hasattr(ctx, "repo_metadata"):
+        return ctx.repo_metadata(reproducible = True)
+    else:
+        return None
 
 go_download_sdk_rule = repository_rule(
     implementation = _go_download_sdk_impl,


### PR DESCRIPTION
If we pass the check `if not ctx.attr.sdks and not ctx.attr.version`, indicate that the repo rule is reproducible. This causes us to opt-in to using the local and remote repository content cache when enabled.