### PR TITLE
Also allow to read the SDK version from `go.work`

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -34,6 +34,7 @@ tasks:
       # TODO: Bzlmod setup requires at least Bazel 7.
       - "-//tests/core/cross:proto_test"
       - "-//tests/core/from_go_mod_file:from_go_mod_file_test"
+      - "-//tests/core/from_go_work_file:from_go_work_file_test"
       - "-//tests/core/transition:hermeticity_test"
       - "-//tests/integration/gazelle:gazelle_test"
       # Requires https://github.com/bazelbuild/bazel/commit/ceddfb1ece1f8ed7ff81558fa1751e6526df031b.

--- a/docs/go/core/bzlmod.md
+++ b/docs/go/core/bzlmod.md
@@ -34,6 +34,9 @@ go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 # platforms, using the version given from the `go.mod` file.
 go_sdk.from_file(go_mod = "//:go.mod")
 
+# Alternatively, use the version from a `go.work` file.
+go_sdk.from_file(go_work = "//:go.work")
+
 # Download an SDK for the host OS & architecture as well as common remote execution
 # platforms, with a specific version.
 go_sdk.download(version = "1.23.1")
@@ -52,6 +55,11 @@ go_sdk.host()
 Nota bene: The use of `go_sdk.host()` [may break builds](https://github.com/enola-dev/enola/issues/713) whenever the host Go version is upgraded
 (because many OS package managers, such as Debian/Ubuntu's `apt`, distribute Go into a directory which contains the version, such as `/usr/lib/go-1.22/`).
 As package upgrades happen outside of Bazel's control, this will lead to non-reproducible builds. Due to this, use of `go_sdk.host()` is discouraged.
+
+When using `go_sdk.from_file()`, exactly one of `go_mod` or `go_work` must be specified.
+Version extraction follows the same precedence for both file types: the `toolchain` directive takes precedence
+over the `go` directive. If neither directive is present, `go.mod` has an implicit `go 1.16` line while
+`go.work` has an implicit `go 1.18` line as per [Go Toolchains](https://go.dev/doc/toolchain#config) documentation.
 
 You can register multiple Go SDKs and select which one to use on a per-target basis using [`go_cross_binary`](rules.md#go_cross_binary).
 As long as you specify the `version` of an SDK, it will be downloaded lazily, that is, only when it is actually needed during a particular build.

--- a/tests/core/from_go_work_file/BUILD.bazel
+++ b/tests/core/from_go_work_file/BUILD.bazel
@@ -1,0 +1,6 @@
+load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
+
+go_bazel_test(
+    name = "from_go_work_file_test",
+    srcs = ["from_go_work_file_test.go"],
+)

--- a/tests/core/from_go_work_file/README.rst
+++ b/tests/core/from_go_work_file/README.rst
@@ -1,0 +1,7 @@
+from_go_work_file
+=================
+
+from_go_work_file_test
+----------------------
+Verifies that ``go_sdk.from_file`` can be used to fetch the Go SDK version
+that is described by the toolchain in ``go.work``.

--- a/tests/core/from_go_work_file/from_go_work_file_test.go
+++ b/tests/core/from_go_work_file/from_go_work_file_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package from_go_work_file_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: `
+-- BUILD.bazel --
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "version_test",
+    srcs = ["version_test.go"],
+)
+
+-- version_test.go --
+package version_test
+
+import (
+    "fmt"
+    "flag"
+    "runtime"
+    "testing"
+)
+
+var want = flag.String("version", "", "")
+
+func Test(t *testing.T) {
+    fmt.Println(runtime.Version())
+    if v := runtime.Version(); v != *want {
+        t.Errorf("got version %q; want %q", v, *want)
+    }
+}
+`,
+		ModuleFileSuffix: `
+go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.from_file(name = "sdk_under_test", go_work = "//:go.work")
+`,
+	})
+}
+
+func Test(t *testing.T) {
+	for _, test := range []struct {
+		desc, go_work, want string
+	}{
+		{
+			desc: "toolchain",
+			go_work: `
+go 1.23.0
+
+toolchain go1.24.0
+
+use (
+    .  // unused, just here to test the go.work parser
+)
+`,
+			want: "go1.24.0",
+		},
+		{
+			desc: "toolchain minor version",
+			go_work: `
+go 1.23.0
+
+toolchain go1.24.1
+
+use (
+    .  // unused, just here to test the go.work parser
+)
+`,
+			want: "go1.24.1",
+		},
+		{
+			desc: "go only",
+			go_work: `
+go 1.16
+
+use (
+    .  // unused, just here to test the go.work parser
+)
+`,
+			want: "go1.16",
+		},
+		{
+			desc: "missing go",
+			go_work: `
+use (
+    .  // unused, just here to test the go.work parser
+)
+`,
+			want: "go1.18",
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			if err := ioutil.WriteFile("go.work", []byte(test.go_work), 0o666); err != nil {
+				t.Fatal(err)
+			}
+			args := []string{
+				"test",
+				"--test_arg=-version=" + test.want,
+				// This next flag forces the test environment to choose its own
+				// module's SDK, because `bazel_testing` uses `go_wrap_sdk` to
+				// create its own SDK in the WORKSPACE file.
+				"--@io_bazel_rules_go//go/toolchain:sdk_name=sdk_under_test",
+				"//:version_test",
+			}
+			if err := bazel_testing.RunBazel(args...); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Extends `go_sdk.from_file` (#4305) to accept a `go_work` attribute alongside the existing `go_mod` attribute. This allows modules to read their SDK version from a `go.work` file, providing better integration for workspace-based Go projects and maintaining consistency with the existing `go.mod` support.

Version extraction follows the same rules as `go.mod`: the `toolchain` directive takes precedence over the `go` directive.

**Which issues(s) does this PR fix?**

Fixes #4554.

**Other notes for review**

When the go line is omitted, `go.mod` has an implicit `go 1.16` line while `go.work` has an implicit `go 1.18` line, as per the Go toolchain documentation at https://go.dev/doc/toolchain#config.

The implementation reuses the existing parser by extracting common logic into a shared `_version_from_go_file` function that both `version_from_go_mod` and the new `version_from_go_work` call with different default versions.

Tests follow the same pattern as `from_go_mod_file_test`, covering toolchain precedence, minor version support, go-only directive, and missing directives.