### PR TITLE
go/tools/builders: Pass `CFLAGS` to assembly sources compilation

### DIFF
--- a/go/tools/builders/cgo2.go
+++ b/go/tools/builders/cgo2.go
@@ -213,13 +213,14 @@ func cgo2(goenv *env, goSrcs, cgoSrcs, cSrcs, cxxSrcs, objcSrcs, objcxxSrcs, sSr
 	// Compile C, C++, Objective-C/C++, and assembly code.
 	defaultCFlags := defaultCFlags(workDir)
 	combinedCFlags := combineFlags(cppFlags, hdrIncludes, cFlags, defaultCFlags)
+	asmCFlags := combineFlags(cppFlags, cFlags, defaultCFlags)
 	for _, lang := range []struct{ srcs, flags []string }{
 		{genCSrcs, combinedCFlags},
 		{cSrcs, combinedCFlags},
 		{cxxSrcs, combineFlags(cppFlags, hdrIncludes, cxxFlags, defaultCFlags)},
 		{objcSrcs, combineFlags(cppFlags, hdrIncludes, objcFlags, defaultCFlags)},
 		{objcxxSrcs, combineFlags(cppFlags, hdrIncludes, objcxxFlags, defaultCFlags)},
-		{sSrcs, nil},
+		{sSrcs, asmCFlags},
 	} {
 		for _, src := range lang.srcs {
 			obj := filepath.Join(workDir, fmt.Sprintf("_x%d.o", len(cObjs)))
@@ -331,7 +332,7 @@ func compileCSources(goenv *env, cSrcs, cxxSrcs, objcSrcs, objcxxSrcs, sSrcs, hS
 		{cxxSrcs, combineFlags(cppFlags, hdrIncludes, cxxFlags, defaultCFlags)},
 		{objcSrcs, combineFlags(cppFlags, hdrIncludes, objcFlags, defaultCFlags)},
 		{objcxxSrcs, combineFlags(cppFlags, hdrIncludes, objcxxFlags, defaultCFlags)},
-		{sSrcs, nil},
+		{sSrcs, combineFlags(cppFlags, cFlags, defaultCFlags)},
 	} {
 		for _, src := range lang.srcs {
 			obj := filepath.Join(workDir, fmt.Sprintf("_x%d.o", len(cObjs)))

--- a/tests/core/cgo/asm_copts/BUILD.bazel
+++ b/tests/core/cgo/asm_copts/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "asm_copts",
+    srcs = [
+        "asm_amd64.S",
+        "asm_arm64.S",
+        "cgoasm.go",
+    ],
+    cgo = True,
+    copts = ["-DASM_COPTS_VALUE=99"],
+    importpath = "github.com/bazelbuild/rules_go/tests/core/cgo/asm_copts",
+)
+
+go_test(
+    name = "asm_copts_test",
+    srcs = ["cgoasm_test.go"],
+    embed = [":asm_copts"],
+)

--- a/tests/core/cgo/asm_copts/asm_amd64.S
+++ b/tests/core/cgo/asm_copts/asm_amd64.S
@@ -1,0 +1,26 @@
+/*
+https://stackoverflow.com/questions/73435637/how-can-i-fix-usr-bin-ld-warning-trap-o-missing-note-gnu-stack-section-imp
+*/
+#if defined(__ELF__) && defined(__GNUC__)
+.section .note.GNU-stack,"",@progbits
+#endif
+
+#ifndef ASM_COPTS_VALUE
+#error "ASM_COPTS_VALUE not defined; copts not passed to assembly"
+#endif
+
+/*
+define this symbol both with and without underscore.
+It seems like Mac OS X wants the underscore, but Linux does not.
+*/
+.global example_asm_copts_func
+.global _example_asm_copts_func
+.text
+example_asm_copts_func:
+_example_asm_copts_func:
+    mov $ASM_COPTS_VALUE, %rax
+    ret
+
+#if NOT_DEFINED
+#error "should not fail"
+#endif

--- a/tests/core/cgo/asm_copts/asm_arm64.S
+++ b/tests/core/cgo/asm_copts/asm_arm64.S
@@ -1,0 +1,19 @@
+#ifndef ASM_COPTS_VALUE
+#error "ASM_COPTS_VALUE not defined; copts not passed to assembly"
+#endif
+
+/*
+define this symbol both with and without underscore.
+It seems like Mac OS X wants the underscore, but Linux does not.
+*/
+.global example_asm_copts_func
+.global _example_asm_copts_func
+.p2align 2 /* ld: warning: arm64 function not 4-byte aligned */
+example_asm_copts_func:
+_example_asm_copts_func:
+    mov x0, #ASM_COPTS_VALUE
+    ret
+
+#if NOT_DEFINED
+#error "should not fail"
+#endif

--- a/tests/core/cgo/asm_copts/cgoasm.go
+++ b/tests/core/cgo/asm_copts/cgoasm.go
@@ -1,0 +1,12 @@
+//go:build amd64 || arm64
+
+package asm_copts
+
+/*
+extern int example_asm_copts_func();
+*/
+import "C"
+
+func CallAssemblyCopts() int {
+	return int(C.example_asm_copts_func())
+}

--- a/tests/core/cgo/asm_copts/cgoasm_test.go
+++ b/tests/core/cgo/asm_copts/cgoasm_test.go
@@ -1,0 +1,13 @@
+//go:build amd64 || arm64
+
+package asm_copts
+
+import "testing"
+
+func TestAssemblyCopts(t *testing.T) {
+	expected := 99
+	actual := CallAssemblyCopts()
+	if actual != expected {
+		t.Errorf("CallAssemblyCopts()=%d; expected=%d", actual, expected)
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This PR passes C flags to the invocation of the assembly compiler when CGO is enabled.

**Which issues(s) does this PR fix?**

Fixes #4558

**Other notes for review**

* Please refer to the issue for a reproduction case.
* This PR includes a test case that directly exercises the fix, but does not attempt to reconstruct the convoluted setup that originally exposed the bug.