### PR TITLE
go_download_sdk: propagate experimental source-bootstrap toolchain mode

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,8 +33,6 @@ build:ci --spawn_strategy=standalone
 build:ci --genrule_strategy=standalone
 test:ci --test_strategy=standalone
 
-common:bootstrap --//go/toolchain:source=bootstrapped
-
 # Incompatible flags to test in a dedicated CI pipeline.
 build:incompatible --incompatible_load_proto_rules_from_bzl
 build:incompatible --incompatible_enable_cc_toolchain_resolution

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -64,11 +64,6 @@ dev_go_sdk.download(
     name = "rules_go_internal_compatibility_sdk",
     version = "1.22.12",
 )
-dev_go_sdk.from_file(
-    name = "go_bootstrap_sdk",
-    go_mod = "//:go.mod",
-    experimental_build_compiler_from_source = True,
-)
 
 bazel_dep(name = "toolchains_protoc", version = "0.6.0", dev_dependency = True)
 

--- a/go/private/BUILD.bazel
+++ b/go/private/BUILD.bazel
@@ -81,6 +81,7 @@ bzl_library(
     deps = [
         "//go/private:platforms",
         "//go/private:providers",
+        "//go/private:sdk",
         "//go/private/actions:archive",
         "//go/private/actions:binary",
         "//go/private/actions:link",

--- a/go/private/BUILD.sdk.bazel
+++ b/go/private/BUILD.sdk.bazel
@@ -3,6 +3,11 @@ load("@io_bazel_rules_go//go/private:sdk_build_defs.bzl", "STDLIB_SRCS_EXCLUDE",
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
+    name = "host_compatible_root_file",
+    srcs = ["ROOT"],
+)
+
+filegroup(
     name = "libs",
     srcs = glob(
         ["pkg/{goos}_{goarch}/**/*.a"],
@@ -36,20 +41,6 @@ filegroup(
 )
 
 filegroup(
-    name = "compiler_binaries",
-    srcs = glob(
-        [
-            "pkg/tool/{goos}_{goarch}/asm*",
-            "pkg/tool/{goos}_{goarch}/cgo*",
-            "pkg/tool/{goos}_{goarch}/compile*",
-            "pkg/tool/{goos}_{goarch}/cover*",
-            "pkg/tool/{goos}_{goarch}/link*",
-        ],
-        allow_empty = True,
-    ),
-)
-
-filegroup(
     name = "config",
     srcs = glob(
         ["go.env*"],
@@ -58,8 +49,8 @@ filegroup(
 )
 
 define_sdk_repository_targets(
-    experiments = {experiments},
     exec_compatible_with = {exec_compatible_with},
+    experiments = {experiments},
     files_srcs = glob([
         "bin/go*",
         "src/**",
@@ -68,9 +59,9 @@ define_sdk_repository_targets(
         ":config",
     ],
     go = "bin/go{exe}",
+    go_sdk_root_file = "ROOT",
     goarch = "{goarch}",
     goos = "{goos}",
-    go_sdk_root_file = "ROOT",
     package_list_srcs = [":srcs"],
     version = "{version}",
 )

--- a/go/private/experimental/BUILD.bootstrap.sdk.bazel
+++ b/go/private/experimental/BUILD.bootstrap.sdk.bazel
@@ -11,6 +11,11 @@ experimental_bootstrap_go_sdk(
 )
 
 filegroup(
+    name = "host_compatible_root_file",
+    srcs = [":bootstrap_root_file"],
+)
+
+filegroup(
     name = "libs",
     # Go 1.20+ no longer ships precompiled stdlib .a files in pkg/{goos}_{goarch}.
     # Keep this empty so rules_go always compiles stdlib from source for the bootstrapped SDK.
@@ -24,6 +29,15 @@ filegroup(
 
 filegroup(
     name = "srcs",
+    srcs = glob(
+        ["src/**/*"],
+        allow_empty = True,
+        exclude = STDLIB_SRCS_EXCLUDE,
+    ),
+)
+
+filegroup(
+    name = "go_sdk_srcs",
     srcs = [":bootstrap_srcs"],
 )
 
@@ -37,13 +51,10 @@ define_sdk_repository_targets(
     experiments = {experiments},
     files_srcs = [":bootstrap_files"],
     go = ":bootstrap_go",
+    go_sdk_srcs = [":go_sdk_srcs"],
     go_sdk_root_file = ":bootstrap_root_file",
     goarch = "{goarch}",
     goos = "{goos}",
-    package_list_srcs = glob(
-        ["src/**/*"],
-        allow_empty = True,
-        exclude = STDLIB_SRCS_EXCLUDE,
-    ),
+    package_list_srcs = [":srcs"],
     version = "{version}",
 )

--- a/go/private/experimental/bootstrap_rules.bzl
+++ b/go/private/experimental/bootstrap_rules.bzl
@@ -79,6 +79,17 @@ ACTION_PATH="${PATH:-}"
 if [[ -z "$ACTION_PATH" ]]; then
   ACTION_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 fi
+WINDOWS_CMD=""
+if [[ "$IS_WINDOWS" == "1" ]]; then
+  WINDOWS_CMD="${COMSPEC:-${ComSpec:-}}"
+  if [[ -z "$WINDOWS_CMD" ]]; then
+    WINDOWS_ROOT="${SYSTEMROOT:-${SystemRoot:-C:\\Windows}}"
+    WINDOWS_CMD="${WINDOWS_ROOT}\\System32\\cmd.exe"
+  fi
+  if [[ "$WINDOWS_CMD" == [A-Za-z]:\\* || "$WINDOWS_CMD" == [A-Za-z]:/* ]]; then
+    WINDOWS_CMD="$(/usr/bin/cygpath -u "$WINDOWS_CMD")"
+  fi
+fi
 
 copy_dir() {
   local src="$1"
@@ -108,7 +119,7 @@ mkdir -p "$WORKDIR/home" "$WORKDIR/gocache"
     GOTOOLCHAIN=local \
     GOROOT_BOOTSTRAP="$BOOTSTRAP_ROOT" \
     GOEXPERIMENT="$EXPERIMENTS" \
-    cmd.exe /c "$(basename "$MAKE_BAT")"
+    "$WINDOWS_CMD" /c "$(basename "$MAKE_BAT")"
   else
     HOME="$WORKDIR/home" \
     GOCACHE="$WORKDIR/gocache" \

--- a/go/private/extensions.bzl
+++ b/go/private/extensions.bzl
@@ -15,7 +15,7 @@
 load("@io_bazel_rules_go_bazel_features//:features.bzl", "bazel_features")
 load("//go/private:go_mod.bzl", "version_from_go_mod")
 load("//go/private:nogo.bzl", "DEFAULT_NOGO", "NOGO_DEFAULT_EXCLUDES", "NOGO_DEFAULT_INCLUDES", "go_register_nogo")
-load("//go/private:sdk.bzl", "detect_host_platform", "fetch_sdks_by_version", "go_download_sdk_rule", "go_host_sdk_rule", "go_multiple_toolchains", "go_wrap_sdk_rule")
+load("//go/private:sdk.bzl", "SDK_SOURCE_BOOTSTRAPPED", "SDK_SOURCE_PREBUILT", "detect_host_platform", "fetch_sdks_by_version", "go_download_sdk_rule", "go_host_sdk_rule", "go_multiple_toolchains", "go_wrap_sdk_rule")
 
 def host_compatible_toolchain_impl(ctx):
     ctx.file("BUILD.bazel")
@@ -256,10 +256,10 @@ def _go_sdk_impl(ctx):
                 sdk_repo = name,
                 sdk_type = "remote",
                 sdk_version = wrap_tag.version,
-                sdk_source = "prebuilt",
+                sdk_source = SDK_SOURCE_PREBUILT,
             ))
             if (not wrap_tag.goos or wrap_tag.goos == host_detected_goos) and (not wrap_tag.goarch or wrap_tag.goarch == host_detected_goarch):
-                first_host_compatible_toolchain = first_host_compatible_toolchain or "@{}//:ROOT".format(name)
+                first_host_compatible_toolchain = first_host_compatible_toolchain or "@{}//:host_compatible_root_file".format(name)
 
         additional_download_tags = []
 
@@ -313,9 +313,9 @@ def _go_sdk_impl(ctx):
             )
 
             if (not download_tag.goos or download_tag.goos == host_detected_goos) and (not download_tag.goarch or download_tag.goarch == host_detected_goarch):
-                first_host_compatible_toolchain = first_host_compatible_toolchain or "@{}//:ROOT".format(name)
+                first_host_compatible_toolchain = first_host_compatible_toolchain or "@{}//:host_compatible_root_file".format(name)
 
-            sdk_source = "bootstrapped" if download_tag.experimental_build_compiler_from_source else "prebuilt"
+            sdk_source = SDK_SOURCE_BOOTSTRAPPED if download_tag.experimental_build_compiler_from_source else SDK_SOURCE_PREBUILT
             toolchains.append(struct(
                 goos = download_tag.goos,
                 goarch = download_tag.goarch,
@@ -387,9 +387,9 @@ def _go_sdk_impl(ctx):
                 sdk_repo = name,
                 sdk_type = "host",
                 sdk_version = host_tag.version,
-                sdk_source = "prebuilt",
+                sdk_source = SDK_SOURCE_PREBUILT,
             ))
-            first_host_compatible_toolchain = first_host_compatible_toolchain or "@{}//:ROOT".format(name)
+            first_host_compatible_toolchain = first_host_compatible_toolchain or "@{}//:host_compatible_root_file".format(name)
 
     host_compatible_toolchain(name = "go_host_compatible_sdk_label", toolchain = first_host_compatible_toolchain)
     if len(toolchains) > _MAX_NUM_TOOLCHAINS:
@@ -469,7 +469,7 @@ def _download_sdk(*, get_sdks_by_version, name, goos, goarch, download_tag):
         urls = download_tag.urls,
         version = download_tag.version,
         strip_prefix = download_tag.strip_prefix,
-        bootstrap = download_tag.experimental_build_compiler_from_source,
+        experimental_bootstrap = download_tag.experimental_build_compiler_from_source,
     )
 
 go_sdk_extra_kwargs = {

--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -19,6 +19,7 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 load("//go/private:common.bzl", "GO_TOOLCHAIN")
 load("//go/private:platforms.bzl", "PLATFORMS")
 load("//go/private:providers.bzl", "GoSDK")
+load("//go/private:sdk.bzl", "SDK_SOURCE_PREBUILT")
 load("//go/private/actions:archive.bzl", "emit_archive")
 load("//go/private/actions:binary.bzl", "emit_binary")
 load("//go/private/actions:link.bzl", "emit_link")
@@ -136,7 +137,7 @@ def declare_bazel_toolchains(
         prerelease,
         sdk_name,
         sdk_type,
-        sdk_source = "prebuilt",
+        sdk_source = SDK_SOURCE_PREBUILT,
         prefix = ""):
     """Declares toolchain targets for each platform."""
 
@@ -243,7 +244,7 @@ def declare_bazel_toolchains(
         visibility = ["//visibility:private"],
     )
 
-    sdk_source_label = Label("//go/toolchain:source")
+    sdk_source_label = Label("//go/toolchain:experimental_source")
 
     native.config_setting(
         name = prefix + "match_sdk_source",

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -319,9 +319,11 @@ def go_rules_dependencies(force = False):
         name = "io_bazel_rules_go_bazel_features",
     )
 
+    host_compatible_sdk_label = _get_host_compatible_sdk_label()
     _maybe(
         _go_host_compatible_s_d_k_label,
         name = "go_host_compatible_sdk_label",
+        host_compatible_sdk_label = host_compatible_sdk_label,
     )
 
     wrapper(
@@ -343,12 +345,26 @@ def go_rules_dependencies(force = False):
 
 def _go_host_compatible_sdk_label_impl(ctx):
     ctx.file("BUILD.bazel")
-    ctx.file("defs.bzl", """HOST_COMPATIBLE_SDK = Label("@go_sdk//:ROOT")""")
+    ctx.file("defs.bzl", """HOST_COMPATIBLE_SDK = Label("{}")""".format(ctx.attr.host_compatible_sdk_label))
+
+def _get_host_compatible_sdk_label():
+    # Keep compatibility with custom @go_sdk repositories that only expose :ROOT.
+    go_sdk_rule = native.existing_rules().get("go_sdk")
+    if go_sdk_rule and go_sdk_rule.get("kind") == "go_download_sdk_rule" and go_sdk_rule.get("experimental_bootstrap", False):
+        return "@go_sdk//:host_compatible_root_file"
+    return "@go_sdk//:ROOT"
 
 # This rule name has to avoid containing both "go_" and "_sdk" as substrings
 # due to this check in Gazelle:
 # https://github.com/bazelbuild/bazel-gazelle/blob/f08119735757370319d4f8c7653c0805fdae4817/deps.bzl#L92
-_go_host_compatible_s_d_k_label = repository_rule(_go_host_compatible_sdk_label_impl)
+_go_host_compatible_s_d_k_label = repository_rule(
+    implementation = _go_host_compatible_sdk_label_impl,
+    attrs = {
+        "host_compatible_sdk_label": attr.string(
+            default = "@go_sdk//:ROOT",
+        ),
+    },
+)
 
 def _maybe(repo_rule, name, **kwargs):
     if name not in native.existing_rules():

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -19,6 +19,12 @@ load("//go/private:platforms.bzl", "GOARCH_CONSTRAINTS", "GOOS_CONSTRAINTS")
 
 MIN_SUPPORTED_VERSION = (1, 14, 0)
 
+# SDK source selector values used by toolchain registration and by
+# `--@io_bazel_rules_go//go/toolchain:experimental_source`.
+# Keep these string values stable for compatibility with existing configs.
+SDK_SOURCE_BOOTSTRAPPED = "bootstrapped"
+SDK_SOURCE_PREBUILT = "prebuilt"
+
 def _go_host_sdk_impl(ctx):
     goroot = _detect_host_sdk(ctx)
     platform = _detect_sdk_platform(ctx, goroot)
@@ -106,7 +112,7 @@ def _go_download_sdk_impl(ctx):
     _remote_sdk(ctx, [url.format(filename) for url in ctx.attr.urls], ctx.attr.strip_prefix, sha256)
     patch(ctx, patch_args = _get_patch_args(ctx.attr.patch_strip))
 
-    sdk_build_file_override = ctx.attr._bootstrap_sdk_build_file if ctx.attr.bootstrap else None
+    sdk_build_file_override = ctx.attr._bootstrap_sdk_build_file if ctx.attr.experimental_bootstrap else None
 
     detected_version = _detect_sdk_version(ctx, ".")
     _sdk_build_file(ctx, platform, detected_version, experiments = ctx.attr.experiments, sdk_build_file_override = sdk_build_file_override)
@@ -148,7 +154,7 @@ go_download_sdk_rule = repository_rule(
             default = 0,
             doc = "The number of leading path segments to be stripped from the file name in the patches.",
         ),
-        "bootstrap": attr.bool(default = False),
+        "experimental_bootstrap": attr.bool(default = False),
         "_sdk_build_file": attr.label(
             default = Label("//go/private:BUILD.sdk.bazel"),
         ),
@@ -310,7 +316,7 @@ go_multiple_toolchains = repository_rule(
     },
 )
 
-def _go_toolchains(name, sdk_repo, sdk_type, sdk_version = None, goos = None, goarch = None, sdk_source = "prebuilt"):
+def _go_toolchains(name, sdk_repo, sdk_type, sdk_version = None, goos = None, goarch = None, sdk_source = SDK_SOURCE_PREBUILT):
     go_multiple_toolchains(
         name = name,
         prefixes = [""],
@@ -324,6 +330,7 @@ def _go_toolchains(name, sdk_repo, sdk_type, sdk_version = None, goos = None, go
 
 def go_download_sdk(name, register_toolchains = True, **kwargs):
     go_download_sdk_rule(name = name, **kwargs)
+    sdk_source = SDK_SOURCE_BOOTSTRAPPED if kwargs.get("experimental_bootstrap") else SDK_SOURCE_PREBUILT
     _go_toolchains(
         name = name + "_toolchains",
         sdk_repo = name,
@@ -331,6 +338,7 @@ def go_download_sdk(name, register_toolchains = True, **kwargs):
         sdk_version = kwargs.get("version"),
         goos = kwargs.get("goos"),
         goarch = kwargs.get("goarch"),
+        sdk_source = sdk_source,
     )
     if register_toolchains:
         _register_toolchains(name)

--- a/go/private/sdk_build_defs.bzl
+++ b/go/private/sdk_build_defs.bzl
@@ -43,12 +43,13 @@ def define_sdk_repository_targets(
         go,
         goarch,
         goos,
+        go_sdk_srcs = [":srcs"],
         go_sdk_root_file,
         package_list_srcs,
         version):
     go_sdk(
         name = "go_sdk",
-        srcs = [":srcs"],
+        srcs = go_sdk_srcs,
         experiments = experiments,
         go = go,
         goarch = goarch,

--- a/go/toolchain/BUILD.bazel
+++ b/go/toolchain/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("//go/private:sdk.bzl", "SDK_SOURCE_BOOTSTRAPPED", "SDK_SOURCE_PREBUILT")
 load(
     ":toolchains.bzl",
     "declare_constraints",
@@ -20,25 +21,25 @@ string_flag(
 )
 
 string_flag(
-    name = "source",
-    build_setting_default = "prebuilt",
+    name = "experimental_source",
+    build_setting_default = SDK_SOURCE_PREBUILT,
     values = [
-        "bootstrapped",
-        "prebuilt",
+        SDK_SOURCE_BOOTSTRAPPED,
+        SDK_SOURCE_PREBUILT,
     ],
 )
 
 config_setting(
-    name = "source_bootstrapped",
+    name = "bootstrapped",
     flag_values = {
-        ":source": "bootstrapped",
+        ":experimental_source": SDK_SOURCE_BOOTSTRAPPED,
     },
 )
 
 config_setting(
-    name = "source_prebuilt",
+    name = "prebuilt",
     flag_values = {
-        ":source": "prebuilt",
+        ":experimental_source": SDK_SOURCE_PREBUILT,
     },
 )
 

--- a/go/toolchains.rst
+++ b/go/toolchains.rst
@@ -113,6 +113,11 @@ with the same Go SDK version, but have different experiments enabled or patches 
       experiments = ["rangefunc"],
     )
 
+To experiment with source-bootstrapped compiler binaries instead of prebuilt
+ones, set ``--@io_bazel_rules_go//go/toolchain:experimental_source=bootstrapped``.
+The default is ``prebuilt``. This build setting is experimental and may change.
+See `Customizing go_sdk`_ for WORKSPACE / MODULE.bazel setup and prerequisites.
+
 The toolchain
 ~~~~~~~~~~~~~
 
@@ -209,6 +214,61 @@ temporary limitation that will be removed in the future.
     go_rules_dependencies()
 
     go_register_toolchains()
+
+.. _customizing_go_sdk:
+
+Customizing go_sdk
+~~~~~~~~~~~~~~~~~~
+
+``go_download_sdk`` applies ``patches`` / ``patch_strip`` to the downloaded SDK
+tree before it is exposed to rules_go. This includes the standard library source
+under ``src/``, so normal stdlib source patches are applied automatically.
+
+Use this default flow when you only need source-level changes (for example,
+patching ``src/net/http`` or other stdlib packages).
+
+If you need compiler/linker binaries themselves (for example, ``compile`` or
+``link`` under ``pkg/tool``) to reflect source changes, use
+``experimental_bootstrap = True`` and select the bootstrapped toolchain:
+
+.. code:: bzl
+
+    # WORKSPACE
+    load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_register_toolchains", "go_rules_dependencies")
+
+    go_download_sdk(
+        name = "go_sdk",
+        version = "1.23.5",
+        patches = ["//:my_go_patch.diff"],
+        patch_strip = 1,
+        experimental_bootstrap = True,
+    )
+
+    go_rules_dependencies()
+    load("@rules_shell//shell:repositories.bzl", "rules_shell_toolchains")
+    rules_shell_toolchains()
+    go_register_toolchains()
+
+Bzlmod equivalent:
+
+.. code:: bzl
+
+    # MODULE.bazel
+    go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+
+    go_sdk.download(
+        name = "go_sdk",
+        version = "1.23.5",
+        patches = ["//:my_go_patch.diff"],
+        patch_strip = 1,
+        experimental_build_compiler_from_source = True,
+    )
+
+    use_repo(go_sdk, "go_sdk")
+
+Build with
+``--@io_bazel_rules_go//go/toolchain:experimental_source=bootstrapped`` to use
+the bootstrapped compiler/linker binaries.
 
 
 Writing new Go rules
@@ -355,6 +415,13 @@ This downloads a Go SDK for use in toolchains.
 | :param:`patch_strip`           | :type:`int`                 | :value:`0`                                  |
 +--------------------------------+-----------------------------+---------------------------------------------+
 | The number of leading slashes to be stripped from the file name in thepatches.                             |
++--------------------------------+-----------------------------+---------------------------------------------+
+| :param:`experimental_bootstrap`| :type:`bool`                | :value:`False`                              |
++--------------------------------+-----------------------------+---------------------------------------------+
+| Experimental: if true, exposes source-bootstrapped Go compiler binaries via                                |
+| ``--@io_bazel_rules_go//go/toolchain:experimental_source=bootstrapped``.                                   |
+| In WORKSPACE mode, call ``rules_shell_toolchains()`` from                                                   |
+| ``@rules_shell//shell:repositories.bzl`` before ``go_register_toolchains()``.                              |
 +--------------------------------+-----------------------------+---------------------------------------------+
 
 **Example**:

--- a/tests/core/compatibility/BUILD.bazel
+++ b/tests/core/compatibility/BUILD.bazel
@@ -10,7 +10,7 @@ go_cross_binary(
     sdk_version = "1.22",
     target = ":hello",
     target_compatible_with = select({
-        "@io_bazel_rules_go//go/toolchain:source_bootstrapped": ["@platforms//:incompatible"],
+        "@io_bazel_rules_go//go/toolchain:bootstrapped": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
 )

--- a/tests/core/go_download_sdk/BUILD.bazel
+++ b/tests/core/go_download_sdk/BUILD.bazel
@@ -4,3 +4,9 @@ go_bazel_test(
     name = "go_download_sdk_test",
     srcs = ["go_download_sdk_test.go"],
 )
+
+go_bazel_test(
+    name = "bootstrap_determinism_test",
+    size = "large",
+    srcs = ["bootstrap_determinism_test.go"],
+)

--- a/tests/core/go_download_sdk/bootstrap_determinism_test.go
+++ b/tests/core/go_download_sdk/bootstrap_determinism_test.go
@@ -1,0 +1,241 @@
+package go_download_sdk_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: `
+-- BUILD.bazel --
+exports_files(["go.mod"])
+
+-- go.mod --
+module bootstrap_determinism_test
+
+go 1.26.0
+`,
+		ModuleFileSuffix: `
+go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.from_file(
+    name = "go_bootstrap_sdk",
+    go_mod = "//:go.mod",
+    experimental_build_compiler_from_source = True,
+)
+use_repo(go_sdk, "go_bootstrap_sdk")
+`,
+	})
+}
+
+func TestBootstrappedCompilerAndLinkerDeterministic(t *testing.T) {
+	baseDir := mustMkdirTemp(t, "bootstrap_determinism_test_")
+	t.Cleanup(func() {
+		makeWritable(baseDir)
+		_ = os.RemoveAll(baseDir)
+	})
+	first := buildBootstrapTools(t, filepath.Join(baseDir, "output-base-1"))
+	second := buildBootstrapTools(t, filepath.Join(baseDir, "output-base-2"))
+
+	assertSameBytes(t, "compile", first.compilePath, first.compileData, second.compilePath, second.compileData)
+	assertSameBytes(t, "link", first.linkPath, first.linkData, second.linkPath, second.linkData)
+
+	assertNoPathLeak(t, "compile", first.compileData, first.outputBase, second.outputBase)
+	assertNoPathLeak(t, "link", first.linkData, first.outputBase, second.outputBase)
+}
+
+type bootstrapTools struct {
+	outputBase  string
+	compilePath string
+	compileData []byte
+	linkPath    string
+	linkData    []byte
+}
+
+func buildBootstrapTools(t *testing.T, outputBase string) bootstrapTools {
+	t.Helper()
+
+	commonFlags := []string{
+		"--noshow_progress",
+		"--disk_cache=",
+		"--remote_accept_cached=false",
+		"--remote_upload_local_results=false",
+	}
+
+	target := "@go_bootstrap_sdk//:bootstrap_tools"
+	runBazelWithOutputBase(t, outputBase, append([]string{"build", target}, commonFlags...)...)
+
+	toolDir := findToolDir(t, outputBase, target, commonFlags)
+	toolExt := ""
+	if runtime.GOOS == "windows" {
+		toolExt = ".exe"
+	}
+
+	compilePath := filepath.Join(toolDir, "compile"+toolExt)
+	linkPath := filepath.Join(toolDir, "link"+toolExt)
+
+	compileData, err := os.ReadFile(compilePath)
+	if err != nil {
+		t.Fatalf("reading %s: %v", compilePath, err)
+	}
+	linkData, err := os.ReadFile(linkPath)
+	if err != nil {
+		t.Fatalf("reading %s: %v", linkPath, err)
+	}
+
+	return bootstrapTools{
+		outputBase:  outputBase,
+		compilePath: compilePath,
+		compileData: compileData,
+		linkPath:    linkPath,
+		linkData:    linkData,
+	}
+}
+
+func findToolDir(t *testing.T, outputBase, target string, flags []string) string {
+	t.Helper()
+
+	out := bazelOutputWithOutputBase(t, outputBase, append([]string{"cquery", target, "--output=files"}, flags...)...)
+
+	toolDirSuffix := path.Join("pkg", "tool", runtime.GOOS+"_"+runtime.GOARCH)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd: %v", err)
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strings.HasSuffix(line, toolDirSuffix) {
+			return filepath.Join(wd, filepath.FromSlash(line))
+		}
+	}
+
+	t.Fatalf("could not find %q in cquery output:\n%s", toolDirSuffix, out)
+	return ""
+}
+
+func assertSameBytes(t *testing.T, toolName, firstPath string, first []byte, secondPath string, second []byte) {
+	t.Helper()
+
+	if bytes.Equal(first, second) {
+		return
+	}
+	t.Fatalf(
+		"%s differs across bootstrapped builds: %s (%s) vs %s (%s)",
+		toolName,
+		firstPath,
+		sha256Hex(first),
+		secondPath,
+		sha256Hex(second),
+	)
+}
+
+func assertNoPathLeak(t *testing.T, toolName string, data []byte, outputBases ...string) {
+	t.Helper()
+
+	checks := map[string]struct{}{
+		"_bootstrap_sdk_workdir_": {},
+	}
+	for _, outputBase := range outputBases {
+		if outputBase == "" {
+			continue
+		}
+		checks[outputBase] = struct{}{}
+		checks[filepath.ToSlash(outputBase)] = struct{}{}
+	}
+	for needle := range checks {
+		if needle == "" {
+			continue
+		}
+		if bytes.Contains(data, []byte(needle)) {
+			t.Fatalf("%s contains non-hermetic path fragment %q", toolName, needle)
+		}
+	}
+}
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func runBazelWithOutputBase(t *testing.T, outputBase string, args ...string) {
+	t.Helper()
+
+	cmd := bazel_testing.BazelCmd(args...)
+	cmd.Args = append([]string{cmd.Args[0], "--output_base=" + filepath.ToSlash(outputBase)}, cmd.Args[1:]...)
+	cmd.Env = withUTF8Locale(cmd.Env)
+	stderr := &bytes.Buffer{}
+	cmd.Stderr = io.MultiWriter(os.Stderr, stderr)
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("bazel %s: %v\n%s", strings.Join(args, " "), err, stderr.String())
+	}
+}
+
+func bazelOutputWithOutputBase(t *testing.T, outputBase string, args ...string) []byte {
+	t.Helper()
+
+	cmd := bazel_testing.BazelCmd(args...)
+	cmd.Args = append([]string{cmd.Args[0], "--output_base=" + filepath.ToSlash(outputBase)}, cmd.Args[1:]...)
+	cmd.Env = withUTF8Locale(cmd.Env)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.Stdout = stdout
+	cmd.Stderr = io.MultiWriter(os.Stderr, stderr)
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("bazel %s: %v\n%s", strings.Join(args, " "), err, stderr.String())
+	}
+	return stdout.Bytes()
+}
+
+func withUTF8Locale(env []string) []string {
+	out := make([]string, 0, len(env)+2)
+	for _, v := range env {
+		if strings.HasPrefix(v, "LANG=") || strings.HasPrefix(v, "LC_ALL=") || strings.HasPrefix(v, "LC_CTYPE=") {
+			continue
+		}
+		out = append(out, v)
+	}
+	out = append(out, "LANG=C.UTF-8", "LC_ALL=C.UTF-8")
+	return out
+}
+
+func mustMkdirTemp(t *testing.T, pattern string) string {
+	t.Helper()
+
+	tempRoot := os.Getenv("TEST_TMPDIR")
+	dir, err := os.MkdirTemp(tempRoot, pattern)
+	if err != nil {
+		t.Fatalf("os.MkdirTemp: %v", err)
+	}
+	return dir
+}
+
+func makeWritable(root string) {
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		info, statErr := d.Info()
+		if statErr != nil {
+			return nil
+		}
+		mode := info.Mode()
+		if mode&0o200 == 0 {
+			_ = os.Chmod(path, mode|0o200)
+		}
+		return nil
+	})
+}

--- a/tests/core/go_download_sdk/go_download_sdk_test.go
+++ b/tests/core/go_download_sdk/go_download_sdk_test.go
@@ -17,6 +17,9 @@ package go_download_sdk_test
 import (
 	"bytes"
 	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
@@ -293,6 +296,334 @@ index 5306bcb..d110a19 100644
 	if err := bazel_testing.RunBazel(
 		"test",
 		"//:patch_test",
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBootstrapPropagatesToolchainSource(t *testing.T) {
+	for _, test := range []struct {
+		name, bootstrapAttr string
+	}{
+		{
+			name:          "experimental_bootstrap",
+			bootstrapAttr: "experimental_bootstrap = True,",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			origWorkspaceData, err := ioutil.ReadFile("WORKSPACE")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			i := bytes.Index(origWorkspaceData, []byte("go_rules_dependencies()"))
+			if i < 0 {
+				t.Fatal("could not find call to go_rules_dependencies()")
+			}
+
+			buf := &bytes.Buffer{}
+			buf.Write(origWorkspaceData[:i])
+			buf.WriteString(`
+load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk")
+
+go_download_sdk(
+    name = "go_sdk",
+    version = "1.26.0",
+    ` + test.bootstrapAttr + `
+)
+
+go_rules_dependencies()
+
+go_register_toolchains()
+`)
+			if err := ioutil.WriteFile("WORKSPACE", buf.Bytes(), 0666); err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				if err := ioutil.WriteFile("WORKSPACE", origWorkspaceData, 0666); err != nil {
+					t.Errorf("error restoring WORKSPACE: %v", err)
+				}
+			}()
+
+			if err := bazel_testing.RunBazel("query", "@go_sdk_toolchains//:all"); err != nil {
+				t.Fatal(err)
+			}
+
+			outputBase, err := bazel_testing.BazelOutput("info", "output_base")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			toolchainsBuildFile := filepath.Join(strings.TrimSpace(string(outputBase)), "external", "go_sdk_toolchains", "BUILD.bazel")
+			toolchainsBuildData, err := os.ReadFile(toolchainsBuildFile)
+			if err != nil {
+				t.Fatalf("reading %s: %v", toolchainsBuildFile, err)
+			}
+
+			if !bytes.Contains(toolchainsBuildData, []byte(`sdk_source = "bootstrapped"`)) {
+				t.Fatalf("go_sdk_toolchains should set sdk_source to bootstrapped when go_download_sdk(%s):\n%s", test.bootstrapAttr, toolchainsBuildData)
+			}
+		})
+	}
+}
+
+func TestExperimentalBootstrapWithRulesShellToolchains(t *testing.T) {
+	origWorkspaceData, err := ioutil.ReadFile("WORKSPACE")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	i := bytes.Index(origWorkspaceData, []byte("go_rules_dependencies()"))
+	if i < 0 {
+		t.Fatal("could not find call to go_rules_dependencies()")
+	}
+
+	buf := &bytes.Buffer{}
+	buf.Write(origWorkspaceData[:i])
+	buf.WriteString(`
+load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk")
+
+go_download_sdk(
+    name = "go_sdk",
+    version = "1.26.0",
+    experimental_bootstrap = True,
+)
+
+go_rules_dependencies()
+
+load("@rules_shell//shell:repositories.bzl", "rules_shell_toolchains")
+
+rules_shell_toolchains()
+
+go_register_toolchains()
+`)
+	if err := ioutil.WriteFile("WORKSPACE", buf.Bytes(), 0666); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := ioutil.WriteFile("WORKSPACE", origWorkspaceData, 0666); err != nil {
+			t.Errorf("error restoring WORKSPACE: %v", err)
+		}
+	}()
+
+	if err := bazel_testing.RunBazel(
+		"cquery",
+		"//:version_test",
+		"--@io_bazel_rules_go//go/toolchain:experimental_source=bootstrapped",
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExperimentalBootstrapHostCompatibleSDKRoot(t *testing.T) {
+	origWorkspaceData, err := ioutil.ReadFile("WORKSPACE")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	i := bytes.Index(origWorkspaceData, []byte("go_rules_dependencies()"))
+	if i < 0 {
+		t.Fatal("could not find call to go_rules_dependencies()")
+	}
+
+	buf := &bytes.Buffer{}
+	buf.Write(origWorkspaceData[:i])
+	buf.WriteString(`
+load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk")
+
+go_download_sdk(
+    name = "go_sdk",
+    version = "1.26.0",
+    experimental_bootstrap = True,
+)
+
+go_rules_dependencies()
+
+go_register_toolchains()
+`)
+	if err := ioutil.WriteFile("WORKSPACE", buf.Bytes(), 0666); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := ioutil.WriteFile("WORKSPACE", origWorkspaceData, 0666); err != nil {
+			t.Errorf("error restoring WORKSPACE: %v", err)
+		}
+	}()
+
+	if err := bazel_testing.RunBazel(
+		"query",
+		"set(@go_host_compatible_sdk_label//:all @go_sdk//:host_compatible_root_file)",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	outputBase, err := bazel_testing.BazelOutput("info", "output_base")
+	if err != nil {
+		t.Fatal(err)
+	}
+	outputBasePath := strings.TrimSpace(string(outputBase))
+
+	defsPath := filepath.Join(outputBasePath, "external", "go_host_compatible_sdk_label", "defs.bzl")
+	defsData, err := os.ReadFile(defsPath)
+	if err != nil {
+		t.Fatalf("reading %s: %v", defsPath, err)
+	}
+	if !bytes.Contains(defsData, []byte(`HOST_COMPATIBLE_SDK = Label("@go_sdk//:host_compatible_root_file")`)) {
+		t.Fatalf("go_host_compatible_sdk_label should point to :host_compatible_root_file:\n%s", defsData)
+	}
+
+	sdkBuildPath := filepath.Join(outputBasePath, "external", "go_sdk", "BUILD.bazel")
+	sdkBuildData, err := os.ReadFile(sdkBuildPath)
+	if err != nil {
+		t.Fatalf("reading %s: %v", sdkBuildPath, err)
+	}
+	if !bytes.Contains(sdkBuildData, []byte(`name = "host_compatible_root_file"`)) {
+		t.Fatalf("go_sdk BUILD.bazel should define :host_compatible_root_file:\n%s", sdkBuildData)
+	}
+	if !bytes.Contains(sdkBuildData, []byte(`srcs = [":bootstrap_root_file"]`)) {
+		t.Fatalf("go_sdk :host_compatible_root_file should point to :bootstrap_root_file in bootstrap mode:\n%s", sdkBuildData)
+	}
+	if !bytes.Contains(sdkBuildData, []byte(`name = "go_sdk_srcs"`)) {
+		t.Fatalf("go_sdk BUILD.bazel should define :go_sdk_srcs in bootstrap mode:\n%s", sdkBuildData)
+	}
+	if !bytes.Contains(sdkBuildData, []byte(`srcs = [":bootstrap_srcs"]`)) {
+		t.Fatalf("go_sdk :go_sdk_srcs should point to :bootstrap_srcs in bootstrap mode:\n%s", sdkBuildData)
+	}
+	if !bytes.Contains(sdkBuildData, []byte(`go_sdk_srcs = [":go_sdk_srcs"]`)) {
+		t.Fatalf("go_sdk should wire go_sdk_srcs to :go_sdk_srcs in bootstrap mode:\n%s", sdkBuildData)
+	}
+	if !bytes.Contains(sdkBuildData, []byte(`package_list_srcs = [":srcs"]`)) {
+		t.Fatalf("go_sdk :package_list should be derived from filtered :srcs in bootstrap mode:\n%s", sdkBuildData)
+	}
+}
+
+func TestCustomGoSDKHostCompatibleLabelBackwardCompatibility(t *testing.T) {
+	origWorkspaceData, err := ioutil.ReadFile("WORKSPACE")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	i := bytes.Index(origWorkspaceData, []byte("go_rules_dependencies()"))
+	if i < 0 {
+		t.Fatal("could not find call to go_rules_dependencies()")
+	}
+
+	customSDKPath, err := filepath.Abs("custom_go_sdk")
+	if err != nil {
+		t.Fatalf("resolving custom SDK path: %v", err)
+	}
+	if err := os.MkdirAll(customSDKPath, 0777); err != nil {
+		t.Fatalf("creating custom SDK path: %v", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(customSDKPath); err != nil {
+			t.Errorf("removing custom SDK path: %v", err)
+		}
+	}()
+	if err := os.WriteFile(filepath.Join(customSDKPath, "ROOT"), nil, 0666); err != nil {
+		t.Fatalf("creating custom SDK ROOT file: %v", err)
+	}
+
+	buf := &bytes.Buffer{}
+	buf.Write(origWorkspaceData[:i])
+	buf.WriteString(`
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
+
+new_local_repository(
+    name = "go_sdk",
+    path = "`)
+	buf.WriteString(filepath.ToSlash(customSDKPath))
+	buf.WriteString(`",
+    build_file_content = """package(default_visibility = ["//visibility:public"])
+exports_files(["ROOT"])
+""",
+)
+
+go_rules_dependencies()
+`)
+	if err := ioutil.WriteFile("WORKSPACE", buf.Bytes(), 0666); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := ioutil.WriteFile("WORKSPACE", origWorkspaceData, 0666); err != nil {
+			t.Errorf("error restoring WORKSPACE: %v", err)
+		}
+	}()
+
+	if err := bazel_testing.RunBazel(
+		"query",
+		"set(@go_host_compatible_sdk_label//:all @go_sdk//:ROOT)",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	outputBase, err := bazel_testing.BazelOutput("info", "output_base")
+	if err != nil {
+		t.Fatal(err)
+	}
+	outputBasePath := strings.TrimSpace(string(outputBase))
+
+	defsPath := filepath.Join(outputBasePath, "external", "go_host_compatible_sdk_label", "defs.bzl")
+	defsData, err := os.ReadFile(defsPath)
+	if err != nil {
+		t.Fatalf("reading %s: %v", defsPath, err)
+	}
+	if !bytes.Contains(defsData, []byte(`HOST_COMPATIBLE_SDK = Label("@go_sdk//:ROOT")`)) {
+		t.Fatalf("go_host_compatible_sdk_label should point to :ROOT for custom go_sdk repos:\n%s", defsData)
+	}
+}
+
+func TestExperimentalBootstrapWithBzlmod(t *testing.T) {
+	origModuleData, err := ioutil.ReadFile("MODULE.bazel")
+	hadModule := err == nil
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	defer func() {
+		if hadModule {
+			if err := ioutil.WriteFile("MODULE.bazel", origModuleData, 0666); err != nil {
+				t.Errorf("error restoring MODULE.bazel: %v", err)
+			}
+			return
+		}
+		if err := os.Remove("MODULE.bazel"); err != nil && !os.IsNotExist(err) {
+			t.Errorf("error removing MODULE.bazel: %v", err)
+		}
+	}()
+
+	const moduleData = `
+module(name = "go_download_sdk_bzlmod_test")
+
+bazel_dep(name = "rules_go", repo_name = "io_bazel_rules_go")
+# Keep @local_config_cc visible under bzlmod for Windows CI, where
+# GO_BAZEL_TEST_BAZELFLAGS includes --extra_toolchains=@local_config_cc//...
+bazel_dep(name = "rules_cc", version = "0.1.5")
+local_path_override(
+    module_name = "rules_go",
+    path = "../tested_repo",
+)
+
+cc_configure = use_extension("@rules_cc//cc:extensions.bzl", "cc_configure_extension")
+use_repo(cc_configure, "local_config_cc")
+
+go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(
+    name = "go_sdk",
+    version = "1.26.0",
+    experimental_build_compiler_from_source = True,
+)
+use_repo(go_sdk, "go_sdk")
+`
+	if err := ioutil.WriteFile("MODULE.bazel", []byte(moduleData), 0666); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := bazel_testing.RunBazel(
+		"cquery",
+		"//:version_test",
+		"--enable_bzlmod",
+		"--noenable_workspace",
+		"--@io_bazel_rules_go//go/toolchain:experimental_source=bootstrapped",
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/tests/core/stdlib/BUILD.bazel
+++ b/tests/core/stdlib/BUILD.bazel
@@ -5,8 +5,8 @@ go_test(
     name = "buildid_test",
     srcs = ["buildid_test.go"],
     data = [
-        "@go_sdk//:files",
         ":stdlib_files",
+        "@go_sdk//:files",
     ],
     deps = ["//go/runfiles"],
 )


### PR DESCRIPTION
## What type of PR is this?

Feature

## What does this PR do? Why is it needed?

This stacked change (on top of #4553) makes source-bootstrapped SDK usage explicit and testable.

It updates `go_download_sdk` / toolchain wiring so bootstrap intent is propagated through a stable sdk-source value:
- renames the internal repository-rule attr from `bootstrap` to `experimental_bootstrap`
- centralizes source values in `go/private/sdk_source.bzl` (`prebuilt` vs `bootstrapped`)
- wires `sdk_source` through `go_download_sdk(...)` toolchain registration
- renames the toolchain build setting to `--@io_bazel_rules_go//go/toolchain:experimental_source=`
- renames config settings to `:bootstrapped` and `:prebuilt`

It also documents how to use source bootstrapping in WORKSPACE / Bzlmod, including the `rules_shell_toolchains()` requirement in WORKSPACE mode.

Finally, it adds targeted coverage for:
- propagation of `experimental_bootstrap` into generated toolchain metadata
- end-to-end selection via `--@io_bazel_rules_go//go/toolchain:experimental_source=bootstrapped`
- deterministic bootstrap outputs for `compile` and `link` across distinct Bazel output bases

## Other notes for review

This PR removes temporary local bootstrap defaults from `.bazelrc` and `MODULE.bazel` so bootstrap selection is opt-in via the explicit experimental flag.
