### PR TITLE
Allow go_binary to override go_library x_defs

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -206,9 +206,10 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
         _nogo_diagnostics = out_diagnostics,
         _cgo_deps = cgo_deps,
     )
-    x_defs = dict(source.x_defs)
+    x_defs = {}
     for a in direct:
         x_defs.update(a.x_defs)
+    x_defs.update(source.x_defs)
 
     # Ensure that the _cgo_export.h of the current target comes first when cgo_exports is iterated
     # by prepending it and specifying the order explicitly. This is required as the CcInfo attached

--- a/tests/core/go_binary/BUILD.bazel
+++ b/tests/core/go_binary/BUILD.bazel
@@ -293,3 +293,26 @@ build_test(
     name = "testing_testing_test",
     targets = [":testing_testing_bin_run"],
 )
+
+go_library(
+    name = "stamp_override_lib",
+    srcs = ["stamp_override_lib.go"],
+    importpath = "github.com/bazelbuild/rules_go/tests/core/go_binary/stamp_override_lib",
+    x_defs = {"Version": "lib_version"},
+)
+
+go_binary(
+    name = "stamp_override_bin",
+    srcs = ["stamp_override_bin.go"],
+    deps = [":stamp_override_lib"],
+    x_defs = {
+        "github.com/bazelbuild/rules_go/tests/core/go_binary/stamp_override_lib.Version": "bin_version",
+    },
+)
+
+go_test(
+    name = "stamp_override_test",
+    srcs = ["stamp_override_test.go"],
+    data = [":stamp_override_bin"],
+    deps = ["//go/tools/bazel"],
+)

--- a/tests/core/go_binary/stamp_override_bin.go
+++ b/tests/core/go_binary/stamp_override_bin.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/bazelbuild/rules_go/tests/core/go_binary/stamp_override_lib"
+)
+
+func main() {
+	fmt.Println(stamp_override_lib.GetVersion())
+}

--- a/tests/core/go_binary/stamp_override_lib.go
+++ b/tests/core/go_binary/stamp_override_lib.go
@@ -1,0 +1,7 @@
+package stamp_override_lib
+
+var Version = "redacted"
+
+func GetVersion() string {
+	return Version
+}

--- a/tests/core/go_binary/stamp_override_test.go
+++ b/tests/core/go_binary/stamp_override_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+)
+
+func TestStampOverride(t *testing.T) {
+	bin, ok := bazel.FindBinary("tests/core/go_binary", "stamp_override_bin")
+	if !ok {
+		t.Fatal("could not find stamp_override_bin")
+	}
+
+	out, err := exec.Command(bin).Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := strings.TrimSpace(string(out))
+	want := "bin_version"
+	if got != want {
+		t.Errorf("got:\n%s\nwant: %s", got, want)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Fixes #4561

**Other notes for review**

x_defs from dependencies were incorrectly applied after the source's x_defs, causing library values to overwrite binary values. Reverse the order so that source x_defs are applied last. This behavior matches the documentation which states:

  https://github.com/bazel-contrib/rules_go/blob/master/docs/go/core/defines_and_stamping.md

  > You can also override stamp values from libraries using x_defs on
  > the go_binary rule if needed.