### PR TITLE
Handle absolutizing -internal-isystem

### DIFF
--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -35,7 +35,7 @@ var (
 	// cgoEnvVars is the list of all cgo environment variable
 	cgoEnvVars = []string{"CGO_CFLAGS", "CGO_CXXFLAGS", "CGO_CPPFLAGS", "CGO_LDFLAGS"}
 	// cgoAbsEnvFlags are all the flags that need absolute path in cgoEnvVars
-	cgoAbsEnvFlags = []string{"-I", "-L", "-isysroot", "-isystem", "-iquote", "-include", "-imacros", "-gcc-toolchain", "--sysroot", "-resource-dir", "-fsanitize-blacklist", "-fsanitize-ignorelist", "--warning-suppression-mappings"}
+	cgoAbsEnvFlags = []string{"-I", "-L", "-isysroot", "-isystem", "-internal-isystem", "-iquote", "-include", "-imacros", "-gcc-toolchain", "--sysroot", "-resource-dir", "-fsanitize-blacklist", "-fsanitize-ignorelist", "--warning-suppression-mappings"}
 	// cgoAbsPlaceholder is placed in front of flag values that must be absolutized
 	cgoAbsPlaceholder = "__GO_BAZEL_CC_PLACEHOLDER__"
 )
@@ -434,6 +434,12 @@ func absArgs(args []string, flags []string) {
 func transformArgs(args []string, flags []string, fn func(string) string) {
 	absNext := false
 	for i := range args {
+		// When expecting a path argument and we see -Xclang, skip over it
+		// and map the next argument instead.
+		// ex: -Xclang -isystem -Xclang path
+		if absNext && args[i] == "-Xclang" {
+			continue
+		}
 		if absNext {
 			args[i] = fn(args[i])
 			absNext = false

--- a/go/tools/builders/env_test.go
+++ b/go/tools/builders/env_test.go
@@ -2,7 +2,11 @@
 
 package main
 
-import "testing"
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
 
 func TestVerbFromName(t *testing.T) {
 	testCases := []struct {
@@ -22,5 +26,52 @@ func TestVerbFromName(t *testing.T) {
 		if result != tc.verb {
 			t.Fatalf("retrieved invalid verb %q from name %q", result, tc.name)
 		}
+	}
+}
+
+func TestTransformArgs(t *testing.T) {
+	upper := func(s string) string { return strings.ToUpper(s) }
+
+	testCases := []struct {
+		name     string
+		args     []string
+		flags    []string
+		expected []string
+	}{
+		{
+			name:     "space-separated",
+			args:     []string{"-isystem", "relative/path"},
+			flags:    []string{"-isystem"},
+			expected: []string{"-isystem", "RELATIVE/PATH"},
+		},
+		{
+			name:     "equals-separated",
+			args:     []string{"-isystem=relative/path"},
+			flags:    []string{"-isystem"},
+			expected: []string{"-isystem=RELATIVE/PATH"},
+		},
+		{
+			name:     "concatenated",
+			args:     []string{"-Irelative/path"},
+			flags:    []string{"-I"},
+			expected: []string{"-IRELATIVE/PATH"},
+		},
+		{
+			name:     "xclang forwarding",
+			args:     []string{"-Xclang", "-internal-isystem", "-Xclang", "relative/path"},
+			flags:    []string{"-internal-isystem"},
+			expected: []string{"-Xclang", "-internal-isystem", "-Xclang", "RELATIVE/PATH"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			args := make([]string, len(tc.args))
+			copy(args, tc.args)
+			transformArgs(args, tc.flags, upper)
+			if !reflect.DeepEqual(args, tc.expected) {
+				t.Errorf("got %v, want %v", args, tc.expected)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This is similar to the other flags except it is wrapped in -Xclang
forwarding flags. This can be set by a CC toolchain similar to the
others.
