### PR TITLE
fix(cgo): Handle headers in external repositories from cc_imports

### DIFF
--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -120,14 +120,44 @@ def cgo_configure(go, srcs, cdeps, cppopts, copts, cxxopts, clinkopts):
             cc_defines = d[CcInfo].compilation_context.defines.to_list()
             cppopts.extend(["-D" + define for define in cc_defines])
             cc_includes = d[CcInfo].compilation_context.includes.to_list()
+            cc_quote_includes = d[CcInfo].compilation_context.quote_includes.to_list()
             for inc in cc_includes:
                 _include_unique(cppopts, "-I", inc, seen_includes)
-            cc_quote_includes = d[CcInfo].compilation_context.quote_includes.to_list()
+
+                # cc_common.compile() (used by cc_import) may store package-relative
+                # include paths in compilation_context.includes,
+                # instead of exec-root-relative ones.
+                # For instance, it may store "include/lib" instead of "external/my_repo/include/lib".
+                # This will cause headers to be missing at build time.
+                # Resolve by combining with source roots from quote_includes,
+                # which always contain the correct prefixes for the source root and output root.
+                if not inc.startswith("external/") and not inc.startswith("bazel-out/"):
+                    for qi in cc_quote_includes:
+                        combined = qi + "/" + inc
+                        if combined != inc:
+                            _include_unique(cppopts, "-I", combined, seen_includes)
             for inc in cc_quote_includes:
                 _include_unique(cppopts, "-iquote", inc, seen_quote_includes)
             cc_system_includes = d[CcInfo].compilation_context.system_includes.to_list()
             for inc in cc_system_includes:
                 _include_unique(cppopts, "-isystem", inc, seen_system_includes)
+
+            # When the "external_include_paths" feature is enabled (common in
+            # newer Bazel versions), cc_common.compile() moves all include
+            # paths for external repos into compilation_context.external_includes
+            # instead of includes/system_includes. This is how rules_distroless
+            # Debian package cc_imports propagate their header search paths.
+            if hasattr(d[CcInfo].compilation_context, "external_includes"):
+                cc_external_includes = d[CcInfo].compilation_context.external_includes.to_list()
+                ext_roots = [p for p in cc_external_includes if p.startswith("external/") or p.startswith("bazel-out/")]
+                for inc in cc_external_includes:
+                    _include_unique(cppopts, "-isystem", inc, seen_system_includes)
+
+                    # Apply the same package-relative path resolution as for
+                    # compilation_context.includes above.
+                    if not inc.startswith("external/") and not inc.startswith("bazel-out/"):
+                        for root in ext_roots:
+                            _include_unique(cppopts, "-isystem", root + "/" + inc, seen_system_includes)
             for lib in cc_libs:
                 # If both static and dynamic variants are available, Bazel will only give
                 # us the static variant. We'll get one file for each transitive dependency,

--- a/tests/core/cgo/BUILD.bazel
+++ b/tests/core/cgo/BUILD.bazel
@@ -546,6 +546,12 @@ go_test(
 )
 
 go_bazel_test(
+    name = "cc_header_inputs_test",
+    srcs = ["cc_header_inputs_test.go"],
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+go_bazel_test(
     name = "wrapped_cgo_test",
     srcs = ["wrapped_cgo_test.go"],
     target_compatible_with = select({
@@ -556,3 +562,4 @@ go_bazel_test(
         "//conditions:default": ["@platforms//:incompatible"],
     }),
 )
+

--- a/tests/core/cgo/cc_header_inputs_test.go
+++ b/tests/core/cgo/cc_header_inputs_test.go
@@ -1,0 +1,107 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cc_header_inputs_test
+
+import (
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: `
+-- BUILD.bazel --
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+# Wrapper cc_library that transitively depends on the cc_import in the external repo.
+cc_library(
+    name = "greeting_wrapper",
+    deps = ["@greeting_repo//:greeting"],
+)
+
+go_binary(
+    name = "use_greeting",
+    srcs = ["use_greeting.go"],
+    cdeps = [":greeting_wrapper"],
+    cgo = True,
+    target_compatible_with = ["@platforms//os:linux"],
+)
+-- use_greeting.go --
+package main
+
+// #include <greeting.h>
+import "C"
+
+func main() {
+	if C.greeting() != 42 {
+		panic("unexpected value")
+	}
+}
+-- greeting_repo/WORKSPACE --
+-- greeting_repo/BUILD.bazel --
+load("@rules_cc//cc:cc_import.bzl", "cc_import")
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
+cc_binary(
+    name = "libgreeting.so",
+    srcs = ["greeting.c"],
+    linkshared = True,
+)
+
+cc_import(
+    name = "greeting",
+    hdrs = ["include/greeting.h"],
+    shared_library = ":libgreeting.so",
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)
+-- greeting_repo/greeting.c --
+int greeting(void) { return 42; }
+-- greeting_repo/include/greeting.h --
+#ifndef GREETING_H
+#define GREETING_H
+int greeting(void);
+#endif
+`,
+		WorkspaceSuffix: `
+local_repository(
+    name = "greeting_repo",
+    path = "greeting_repo",
+)
+`,
+	})
+}
+
+// TestTransitiveCcHeaders verifies that headers provided by a cc_import in an
+// external repository are available during CGo compilation when accessed transitively through a
+// wrapper cc_library.
+func TestTransitiveCcHeaders(t *testing.T) {
+	if out, err := bazel_testing.BazelOutput("build", "//:use_greeting"); err != nil {
+		t.Fatalf("bazel build //:use_greeting failed: %v\n%s", err, out)
+	}
+}
+
+// TestTransitiveCcHeadersExternalIncludePaths verifies the same as above, but
+// with the external_include_paths CC toolchain feature enabled.
+// When this feature is active, cc_common.compile() stores include paths for external
+// repos in compilation_context.external_includes instead of includes or
+// system_includes.
+func TestTransitiveCcHeadersExternalIncludePaths(t *testing.T) {
+	if out, err := bazel_testing.BazelOutput("build", "--features=external_include_paths", "//:use_greeting"); err != nil {
+		t.Fatalf("bazel build //:use_greeting failed: %v\n%s", err, out)
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

When depending on `cc_import` targets from external repositories, their `includes` attribute doesn't get resolved to execroot-relative paths. This means that we end up having `-Imy/includes/dir` instead of `-Iexternal/external_repo_name/my/includes/dir`, which leads to missing headers during compilation.

As a consequence, the `-dev` packages generated by `rules_distroless` were not being imported correctly, and we had to manually insert `-isystem` flags with canonical repository names.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
 This PR doesn't really depend on #4574, but both are needed for the project I'm working on and I'd rather that one merges first if possible, as it doesn't have a workaround.