### PR TITLE
bzltestutil: fix re-exec failure on Windows when runfiles path exceeds MAX_PATH

### DIFF
--- a/go/tools/bzltestutil/wrap.go
+++ b/go/tools/bzltestutil/wrap.go
@@ -136,20 +136,18 @@ func Wrap(pkg string) error {
 	// will be killed by Bazel after the grace period (15s) expires.
 	signal.Ignore(syscall.SIGTERM)
 
-	wd, wdErr := os.Getwd()
-
 	cmd := exec.Command(exePath, args...)
 	cmd.Env = append(os.Environ(), "GO_TEST_WRAP=0")
 	// On Windows, any current directory value longer than MAX_PATH(260 chars)
 	// will cause CreateProcess to fail, regardless of LongPathsEnabled=1 or a
-	// longPathAware PE manifest.
-	// Inheriting the value from the parent process (by passing NULL as
-	// lpCurrentDirectory) will also fail.
-	// Setting cmd.Dir to a short path bypasses this.
-	// The child's chdir package init() will call os.Chdir to restore the correct
-	// runfiles directory after launch: os.Chdir (SetCurrentDirectoryW) respects
-	// Go's runtime PEB long-path bit
-	if runtime.GOOS == "windows" && wdErr == nil && len(wd) >= 260 {
+	// longPathAware PE manifest. Inheriting the value from the parent process
+	// (by passing NULL as lpCurrentDirectory) will also fail.
+	// Always set cmd.Dir to a short path so CreateProcess succeeds.
+	// Re-add GO_TEST_RUN_FROM_BAZEL so the child's chdir package init() will
+	// call os.Chdir to restore the correct runfiles directory after launch.
+	// os.Chdir (SetCurrentDirectoryW) respects Go's runtime PEB long-path bit,
+	// so it handles paths longer than MAX_PATH.
+	if runtime.GOOS == "windows" {
 		cmd.Dir = os.TempDir()
 		cmd.Env = append(cmd.Env, "GO_TEST_RUN_FROM_BAZEL=1")
 	}

--- a/go/tools/bzltestutil/wrap.go
+++ b/go/tools/bzltestutil/wrap.go
@@ -151,6 +151,7 @@ func Wrap(pkg string) error {
 	// Go's runtime PEB long-path bit
 	if runtime.GOOS == "windows" && wdErr == nil && len(wd) >= 260 {
 		cmd.Dir = os.TempDir()
+		cmd.Env = append(cmd.Env, "GO_TEST_RUN_FROM_BAZEL=1")
 	}
 	cmd.Stderr = io.MultiWriter(os.Stderr, streamMerger.ErrW)
 	cmd.Stdout = io.MultiWriter(os.Stdout, streamMerger.OutW)

--- a/go/tools/bzltestutil/wrap.go
+++ b/go/tools/bzltestutil/wrap.go
@@ -25,6 +25,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -135,8 +136,22 @@ func Wrap(pkg string) error {
 	// will be killed by Bazel after the grace period (15s) expires.
 	signal.Ignore(syscall.SIGTERM)
 
+	wd, wdErr := os.Getwd()
+
 	cmd := exec.Command(exePath, args...)
 	cmd.Env = append(os.Environ(), "GO_TEST_WRAP=0")
+	// On Windows, any current directory value longer than MAX_PATH(260 chars)
+	// will cau/ CreateProcess to fail, regardless of LongPathsEnabled=1 or a
+	// longPathAware PE manifest.
+	// Inheriting the value from the parent process (by passing NULL as
+	// lpCurrentDirectory) will also fail.
+	// Setting cmd.Dir to a short path bypasses this.
+	// The child's chdir package init() will call os.Chdir to restore the correct
+	// runfiles directory after launch: os.Chdir (SetCurrentDirectoryW) respects
+	// Go's runtime PEB long-path bit
+	if runtime.GOOS == "windows" && wdErr == nil && len(wd) >= 260 {
+		cmd.Dir = os.TempDir()
+	}
 	cmd.Stderr = io.MultiWriter(os.Stderr, streamMerger.ErrW)
 	cmd.Stdout = io.MultiWriter(os.Stdout, streamMerger.OutW)
 	streamMerger.Start()

--- a/go/tools/bzltestutil/wrap.go
+++ b/go/tools/bzltestutil/wrap.go
@@ -141,7 +141,7 @@ func Wrap(pkg string) error {
 	cmd := exec.Command(exePath, args...)
 	cmd.Env = append(os.Environ(), "GO_TEST_WRAP=0")
 	// On Windows, any current directory value longer than MAX_PATH(260 chars)
-	// will cau/ CreateProcess to fail, regardless of LongPathsEnabled=1 or a
+	// will cause CreateProcess to fail, regardless of LongPathsEnabled=1 or a
 	// longPathAware PE manifest.
 	// Inheriting the value from the parent process (by passing NULL as
 	// lpCurrentDirectory) will also fail.


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Fix `go_test` failures when the path containing the test executable is longer than `MAX_PATH`.
The issue stems from `CreateProcess` which will systematically reject any working directory (whether passed explicitly or to be inherited) longer than `MAX_PATH`, regardless of longpath prefix (`\\?\`), long path setting being enabled in the registry, or `longPathAware` being present in the binary's manifest.

**Which issues(s) does this PR fix?**

AFAIK, there is no open issue.

I initially reported this to go's tracker as https://github.com/golang/go/issues/78601, but in the context of `rules_go` I don't think there is one.

**Other notes for review**

I wasn't sure what to do about testing. AFAICS testing `Wrap` might quickly become over complicated, and testing the new condition in isolation doesn't bring much. Please let me know if you have something in mind here!

