### PR TITLE
Consistent auto-registered toolchain path naming

### DIFF
--- a/go/private/extensions.bzl
+++ b/go/private/extensions.bzl
@@ -307,6 +307,10 @@ def _go_sdk_impl(ctx):
                 multi_version = multi_version_module[module.name],
                 tag_type = "download",
                 index = index,
+                suffix = "_{}_{}".format(
+                    download_tag.goos or host_detected_goos,
+                    download_tag.goarch or host_detected_goarch,
+                ),
             )
 
             _download_sdk(

--- a/go/private/extensions.bzl
+++ b/go/private/extensions.bzl
@@ -432,9 +432,12 @@ def _go_sdk_impl(ctx):
 def _default_go_sdk_name(*, module, multi_version, tag_type, index, goos = None, goarch = None):
     # Keep the version and name of the root module out of the repository name if possible to
     # prevent unnecessary rebuilds when it changes.
-    suffix = ""
     if goos and goarch:
         suffix = "_{}_{}".format(goos, goarch)
+    elif not goos and not goarch:
+        suffix = ""
+    else:
+        fail("goos and goarch must be specified together")
     return "{name}_{version}_{tag_type}_{index}{suffix}".format(
         # "main_" is not a valid module name and thus can't collide.
         name = "main_" if module.is_root else module.name,

--- a/go/private/extensions.bzl
+++ b/go/private/extensions.bzl
@@ -307,10 +307,8 @@ def _go_sdk_impl(ctx):
                 multi_version = multi_version_module[module.name],
                 tag_type = "download",
                 index = index,
-                suffix = "_{}_{}".format(
-                    download_tag.goos or host_detected_goos,
-                    download_tag.goarch or host_detected_goarch,
-                ),
+                goos = download_tag.goos or host_detected_goos,
+                goarch = download_tag.goarch or host_detected_goarch,
             )
 
             _download_sdk(
@@ -349,7 +347,8 @@ def _go_sdk_impl(ctx):
                         multi_version = multi_version_module[module.name],
                         tag_type = "download",
                         index = index,
-                        suffix = "_{}_{}".format(goos, goarch),
+                        goos = goos,
+                        goarch = goarch,
                     )
 
                     _download_sdk(
@@ -430,9 +429,12 @@ def _go_sdk_impl(ctx):
     else:
         return None
 
-def _default_go_sdk_name(*, module, multi_version, tag_type, index, suffix = ""):
+def _default_go_sdk_name(*, module, multi_version, tag_type, index, goos = None, goarch = None):
     # Keep the version and name of the root module out of the repository name if possible to
     # prevent unnecessary rebuilds when it changes.
+    suffix = ""
+    if goos and goarch:
+        suffix = "_{}_{}".format(goos, goarch)
     return "{name}_{version}_{tag_type}_{index}{suffix}".format(
         # "main_" is not a valid module name and thus can't collide.
         name = "main_" if module.is_root else module.name,


### PR DESCRIPTION
**What type of PR is this?**

 Bug fix

**What does this PR do? Why is it needed?**

As discussed in https://bazelbuild.slack.com/archives/CA31HN1T3/p1776898907041159?thread_ts=1776576264.819169&cid=CA31HN1T3.
Name autoregistered go toolchain paths consistently independent of host platform.

**Which issues(s) does this PR fix?**

We have a remote execution cluster running linux/amd64. The toolchain paths look different if we target it from a linux/amd64 or a darwin/arm64 host, changing the ActionKey:s and thereby preventing us from sharing cache hits. Here is an example diff between aquery:s from the two host platforms:
```diff
Environment: [CGO_ENABLED=0, GOARCH=amd64, GODEBUG=winsymlink=0, GOEXPERIMENT=, GOOS=linux, GOPATH=, GOROOT=bazel-out/linux-amd64-opt-ST-c808acfdf156/bin/external/rules_go+/stdlib_, GOROOT_FINAL=GOROOT, GOTOOLCHAIN=local]
-  Command Line: (exec bazel-out/linux-amd64-opt-exec-ST-4601870f3351/bin/external/rules_go++go_sdk+main___download_0/builder_reset/builder \
+  Command Line: (exec bazel-out/linux-amd64-opt-exec-ST-4601870f3351/bin/external/rules_go++go_sdk+main___download_0_linux_amd64/builder_reset/builder \
     link \
     -sdk \
-    external/rules_go++go_sdk+main___download_0 \
+    external/rules_go++go_sdk+main___download_0_linux_amd64 \
     -goroot \
     bazel-out/linux-amd64-opt-ST-c808acfdf156/bin/external/rules_go+/stdlib_ \
     -installsuffix \
@@ -2593,7 +2593,7 @@
     -arc \
     '@@rules_go+//go/tools/bzltestutil:bzltestutil=github.com/bazelbuild/rules_go/go/tools/bzltestutil=bazel-out/linux-amd64-opt-ST-4601870f3351/bin/external/rules_go+/go/tools/bzltestutil/bzltestutil.a' \
     -package_list \
-    bazel-out/linux-amd64-opt-exec-ST-4601870f3351/bin/external/rules_go++go_sdk+main___download_0/packages.txt \
+    bazel-out/linux-amd64-opt-exec-ST-4601870f3351/bin/external/rules_go++go_sdk+main___download_0_linux_amd64/packages.txt \
     -X \
     'github.com/formulatehq/ingest/defaults.GitBranch={STABLE_GIT_BRANCH}' \
     -X \
```

With this change the toolchain path is `bazel-out/linux-amd64-opt-exec-ST-4601870f3351/bin/external/rules_go++go_sdk+main___download_0_linux_amd64/packages.txt` regardless of host platform.

**Other notes for review**
