### PR TITLE
Fix invalid comparison

### DIFF
--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -69,7 +69,7 @@ def cgo_configure(go, srcs, cdeps, cppopts, copts, cxxopts, clinkopts):
             if option not in ("-lstdc++", "-lc++")
         ]
 
-    if go.mode != LINKMODE_NORMAL:
+    if go.mode.linkmode != LINKMODE_NORMAL:
         for opt_list in (copts, cxxopts, objcopts, objcxxopts):
             if "-fPIC" not in opt_list:
                 opt_list.append("-fPIC")


### PR DESCRIPTION
`go.mode` is a struct, so it was never equal to `LINKMODE_NORMAL`. I'm
not sure what visible effect this had but I noticed it when debugging
another issue.
