### PR TITLE
Remove cgo_context_data

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,8 +4,6 @@ load(
 )
 load(
     "//go/private:context.bzl",
-    "cgo_context_data",
-    "cgo_context_data_proxy",
     "go_config",
     "go_context_data",
 )
@@ -41,11 +39,6 @@ load(
 
 stdlib(
     name = "stdlib",
-    cgo_context_data = select({
-        "//go/platform:internal_cgo_off": None,
-        "//go/private:is_pure": None,
-        "//conditions:default": ":cgo_context_data",
-    }),
     visibility = ["//visibility:public"],
 )
 
@@ -68,38 +61,12 @@ nogo(
 )
 
 # go_context_data collects build options and is depended on by all Go targets.
-# It may depend on cgo_context_data if CGo isn't disabled.
 go_context_data(
     name = "go_context_data",
-    cgo_context_data = select({
-        "//go/platform:internal_cgo_off": None,
-        "//go/private:is_pure": None,
-        "//conditions:default": ":cgo_context_data",
-    }),
     coverdata = "//go/tools/coverdata",
     go_config = ":go_config",
     nogo = "@io_bazel_rules_nogo//:nogo",
     stdlib = ":stdlib",
-    visibility = ["//visibility:public"],
-)
-
-# cgo_context_data collects information about the C/C++ toolchain.
-# go_context_data depends if cgo is enabled in the target configuration.
-cgo_context_data(
-    name = "cgo_context_data",
-    visibility = ["//visibility:private"],
-)
-
-# cgo_context_data_proxy depends on cgo_context_data if cgo is enabled and
-# forwards its provider. Rule attributes may depend on this, since they cannot
-# use select.
-cgo_context_data_proxy(
-    name = "cgo_context_data_proxy",
-    actual = select({
-        "//go/platform:internal_cgo_off": None,
-        "//go/private:is_pure": None,
-        "//conditions:default": ":cgo_context_data",
-    }),
     visibility = ["//visibility:public"],
 )
 

--- a/go/platform/list.bzl
+++ b/go/platform/list.bzl
@@ -14,18 +14,12 @@
 
 load(
     "//go/private:platforms.bzl",
-    _GOARCH = "GOARCH_CONSTRAINTS",
-    _GOOS = "GOOS_CONSTRAINTS",
-    _GOOS_GOARCH = "GOOS_GOARCH",
-    _MSAN_GOOS_GOARCH = "MSAN_GOOS_GOARCH",
-    _RACE_GOOS_GOARCH = "RACE_GOOS_GOARCH",
+    GOARCH = "GOARCH_CONSTRAINTS",
+    GOOS = "GOOS_CONSTRAINTS",
+    "GOOS_GOARCH",
+    "MSAN_GOOS_GOARCH",
+    "RACE_GOOS_GOARCH",
 )
-
-GOOS_GOARCH = _GOOS_GOARCH
-GOOS = _GOOS
-GOARCH = _GOARCH
-RACE_GOOS_GOARCH = _RACE_GOOS_GOARCH
-MSAN_GOOS_GOARCH = _MSAN_GOOS_GOARCH
 
 def declare_config_settings():
     """Generates config_setting targets.
@@ -56,12 +50,3 @@ def declare_config_settings():
             ],
             visibility = ["//visibility:public"],
         )
-
-    # Setting that determines whether cgo is enabled.
-    # This is experimental and may be changed or removed when we migrate
-    # to build settings.
-    native.config_setting(
-        name = "internal_cgo_off",
-        constraint_values = [Label("//go/toolchain:cgo_off")],
-        visibility = [Label("//:__pkg__")],
-    )

--- a/go/platform/list.bzl
+++ b/go/platform/list.bzl
@@ -14,12 +14,15 @@
 
 load(
     "//go/private:platforms.bzl",
+    "GOOS_GOARCH",
     GOARCH = "GOARCH_CONSTRAINTS",
     GOOS = "GOOS_CONSTRAINTS",
-    "GOOS_GOARCH",
-    "MSAN_GOOS_GOARCH",
-    "RACE_GOOS_GOARCH",
+    _MSAN_GOOS_GOARCH = "MSAN_GOOS_GOARCH",
+    _RACE_GOOS_GOARCH = "RACE_GOOS_GOARCH",
 )
+
+RACE_GOOS_GOARCH = _RACE_GOOS_GOARCH
+MSAN_GOOS_GOARCH = _MSAN_GOOS_GOARCH
 
 def declare_config_settings():
     """Generates config_setting targets.

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -573,18 +573,19 @@ def go_context(
         ctx.target_platform_has_constraint(attr._pure_constraint[platform_common.ConstraintValueInfo])
     )
 
-    if maybe_needs_cc_toolchain and not cgo_disabled:
-        if getattr(attr, "_cc_toolchain", None) and CPP_TOOLCHAIN_TYPE in ctx.toolchains:
-            cgo_context_info = cgo_context_data_impl(ctx)
+    has_cc_toolchain_attr = getattr(attr, "_cc_toolchain", None) != None
+    needs_cgo_context = maybe_needs_cc_toolchain or go_config_info != None
+    if not cgo_disabled and needs_cgo_context and has_cc_toolchain_attr and CPP_TOOLCHAIN_TYPE in ctx.toolchains:
+        cgo_context_info = cgo_context_data_impl(ctx)
 
-    if maybe_needs_cc_toolchain:
+    if has_cc_toolchain_attr:
         cgo_available = cgo_context_info != None
     else:
         # Preserve cgo build-mode/tag behavior for rules that won't use the
         # C/C++ toolchain in their own actions.
         cgo_available = not cgo_disabled
 
-    if goos == "auto" and goarch == "auto" and cgo_available and (go_config_info == None or not go_config_info.pure):
+    if goos == "auto" and goarch == "auto" and cgo_available and go_config_info != None and not go_config_info.pure:
         # Fast-path to reuse the GoConfigInfo as-is
         mode = go_config_info or default_go_config_info
     else:

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -496,15 +496,6 @@ def maybe_needs_cc_toolchain(attr, go_infos = []):
     """Returns whether this rule's own sources may use the C/C++ toolchain."""
     return _sources_use_cgo(attr, go_infos)
 
-def _precomputed_cgo_context_info(attr, go_context_data):
-    if go_context_data and CgoContextInfo in go_context_data:
-        return go_context_data[CgoContextInfo]
-    if getattr(attr, "_cgo_context_data", None) and CgoContextInfo in attr._cgo_context_data:
-        return attr._cgo_context_data[CgoContextInfo]
-    if getattr(attr, "cgo_context_data", None) and CgoContextInfo in attr.cgo_context_data:
-        return attr.cgo_context_data[CgoContextInfo]
-    return None
-
 def validate_nogo(go):
     """Whether nogo should be run as a validation action rather than just to generate fact files for the current
     target."""
@@ -583,18 +574,15 @@ def go_context(
     )
 
     if maybe_needs_cc_toolchain and not cgo_disabled:
-        has_cc_toolchain = getattr(attr, "_cc_toolchain", None) and CPP_TOOLCHAIN_TYPE in ctx.toolchains
-        if has_cc_toolchain:
+        if getattr(attr, "_cc_toolchain", None) and CPP_TOOLCHAIN_TYPE in ctx.toolchains:
             cgo_context_info = cgo_context_data_impl(ctx)
-        else:
-            cgo_context_info = _precomputed_cgo_context_info(attr, go_context_data)
 
     if maybe_needs_cc_toolchain:
         cgo_available = cgo_context_info != None
     else:
         # Preserve cgo build-mode/tag behavior for rules that won't use the
         # C/C++ toolchain in their own actions.
-        cgo_available = not cgo_disabled and _precomputed_cgo_context_info(attr, go_context_data) != None
+        cgo_available = not cgo_disabled
 
     if goos == "auto" and goarch == "auto" and cgo_available and (go_config_info == None or not go_config_info.pure):
         # Fast-path to reuse the GoConfigInfo as-is
@@ -755,7 +743,8 @@ def _go_context_data_impl(ctx):
         print("WARNING: --features=race is no longer supported. Use --@io_bazel_rules_go//go/config:race instead.")
     if "msan" in ctx.features:
         print("WARNING: --features=msan is no longer supported. Use --@io_bazel_rules_go//go/config:msan instead.")
-    providers = [
+
+    return [
         GoContextInfo(
             coverdata = ctx.attr.coverdata[0][GoArchive],
             nogo = ctx.attr.nogo[DefaultInfo].files_to_run,
@@ -763,14 +752,10 @@ def _go_context_data_impl(ctx):
         ctx.attr.stdlib[GoStdLib],
         ctx.attr.go_config[GoConfigInfo],
     ]
-    if ctx.attr.cgo_context_data and CgoContextInfo in ctx.attr.cgo_context_data:
-        providers.append(ctx.attr.cgo_context_data[CgoContextInfo])
-    return providers
 
 go_context_data = rule(
     _go_context_data_impl,
     attrs = {
-        "cgo_context_data": attr.label(),
         "coverdata": attr.label(
             mandatory = True,
             cfg = non_request_nogo_transition,
@@ -1018,38 +1003,6 @@ def cgo_context_data_impl(ctx):
             ar_path = cc_toolchain.ar_executable,
         ),
     )
-
-cgo_context_data = rule(
-    implementation = cgo_context_data_impl,
-    attrs = {
-        "_allowlist_function_transition": attr.label(
-            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
-        ),
-    } | CGO_ATTRS,
-    toolchains = CGO_TOOLCHAINS,
-    fragments = CGO_FRAGMENTS,
-    doc = """Collects information about the C/C++ toolchain. The C/C++ toolchain
-    is needed to build cgo code, but is generally optional. Rules can't have
-    optional toolchains, so instead, we have an optional dependency on this
-    rule.""",
-    cfg = non_request_nogo_transition,
-)
-
-def _cgo_context_data_proxy_impl(ctx):
-    if ctx.attr.actual and CgoContextInfo in ctx.attr.actual:
-        return [ctx.attr.actual[CgoContextInfo]]
-    return []
-
-cgo_context_data_proxy = rule(
-    implementation = _cgo_context_data_proxy_impl,
-    attrs = {
-        "actual": attr.label(),
-    },
-    doc = """Conditionally depends on cgo_context_data and forwards it provider.
-
-    Useful in situations where select cannot be used, like attribute defaults.
-    """,
-)
 
 def _go_config_impl(ctx):
     pgo_profiles = ctx.attr.pgoprofile.files.to_list()

--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -101,8 +101,6 @@ def declare_go_toolchains(exec_goos, sdk, builder, pack):
     for p in PLATFORMS:
         if p.cgo:
             # Don't declare separate toolchains for cgo_on / cgo_off.
-            # This is controlled by the cgo_context_data dependency of
-            # go_context_data, which is configured using constraint_values.
             continue
 
         link_flags = []
@@ -245,8 +243,6 @@ def declare_bazel_toolchains(
     for p in PLATFORMS:
         if p.cgo:
             # Don't declare separate toolchains for cgo_on / cgo_off.
-            # This is controlled by the cgo_context_data dependency of
-            # go_context_data, which is configured using constraint_values.
             continue
 
         cgo_constraints = (

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -30,6 +30,7 @@ load(
     "CGO_FRAGMENTS",
     "CGO_TOOLCHAINS",
     "go_context",
+    "maybe_needs_cc_toolchain",
     "new_go_info",
 )
 load(
@@ -130,6 +131,7 @@ def _go_binary_impl(ctx):
         importpath = ctx.attr.importpath,
         embed = ctx.attr.embed,
         go_context_data = ctx.attr._go_context_data,
+        maybe_needs_cc_toolchain = maybe_needs_cc_toolchain(ctx.attr, go_infos = ctx.attr.deps),
         goos = ctx.attr.goos,
         goarch = ctx.attr.goarch,
     )

--- a/go/private/rules/library.bzl
+++ b/go/private/rules/library.bzl
@@ -242,7 +242,6 @@ go_tool_library = rule(
         "gc_goopts": attr.string_list(),
         "x_defs": attr.string_dict(),
         "_go_config": attr.label(default = "//:go_config"),
-        "_cgo_context_data": attr.label(default = "//:cgo_context_data_proxy"),
         "_stdlib": attr.label(default = "//:stdlib"),
     } | CGO_ATTRS,
     fragments = CGO_FRAGMENTS,

--- a/go/private/rules/nogo.bzl
+++ b/go/private/rules/nogo.bzl
@@ -22,6 +22,7 @@ load(
     "CGO_FRAGMENTS",
     "CGO_TOOLCHAINS",
     "go_context",
+    "maybe_needs_cc_toolchain",
     "new_go_info",
 )
 load(
@@ -45,6 +46,7 @@ def _nogo_impl(ctx):
     go = go_context(
         ctx,
         include_deprecated_properties = False,
+        maybe_needs_cc_toolchain = maybe_needs_cc_toolchain(ctx.attr, go_infos = ctx.attr.deps),
     )
     nogo_main = go.declare_file(go, path = "nogo_main.go")
     nogo_args = ctx.actions.args()

--- a/go/private/rules/nogo.bzl
+++ b/go/private/rules/nogo.bzl
@@ -107,7 +107,6 @@ _nogo = rule(
         "_nogo_srcs": attr.label(
             default = "//go/tools/builders:nogo_srcs",
         ),
-        "_cgo_context_data": attr.label(default = "//:cgo_context_data_proxy"),
         "_go_config": attr.label(default = "//:go_config"),
         "_go_difflib": attr.label(default = "@com_github_pmezard_go_difflib//difflib:go_default_library"),
         "_stdlib": attr.label(default = "//:stdlib"),

--- a/go/private/rules/source.bzl
+++ b/go/private/rules/source.bzl
@@ -83,7 +83,6 @@ go_source = rule(
             """,
         ),
         "_go_config": attr.label(default = "//:go_config"),
-        "_cgo_context_data": attr.label(default = "//:cgo_context_data_proxy"),
     },
     toolchains = [GO_TOOLCHAIN],
     provides = [GoInfo],

--- a/go/private/rules/stdlib.bzl
+++ b/go/private/rules/stdlib.bzl
@@ -40,7 +40,6 @@ stdlib = rule(
     implementation = _stdlib_impl,
     cfg = go_stdlib_transition,
     attrs = {
-        "cgo_context_data": attr.label(),
         "_go_config": attr.label(
             default = "//:go_config",
             providers = [GoConfigInfo],

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -32,6 +32,7 @@ load(
     "CGO_FRAGMENTS",
     "CGO_TOOLCHAINS",
     "go_context",
+    "maybe_needs_cc_toolchain",
     "new_go_info",
 )
 load(
@@ -66,6 +67,7 @@ def _go_test_impl(ctx):
         importpath = ctx.attr.importpath,
         embed = ctx.attr.embed,
         go_context_data = ctx.attr._go_context_data,
+        maybe_needs_cc_toolchain = maybe_needs_cc_toolchain(ctx.attr, go_infos = ctx.attr.deps),
         goos = ctx.attr.goos,
         goarch = ctx.attr.goarch,
     )


### PR DESCRIPTION
It's tempting to use a single target to centralize cc toolchain lookup, but ultimately it is incorrect. Toolchain resolution must be performed by the rules using that toolchain, in order to properly match on the exec platforms. The other reason for cgo_context_data was that previously optional toolchains were not possible, but now they are. Cleanup this incorrect rule to thwart the temptations.