### PR TITLE
Static mode internal linker

### DIFF
--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -79,6 +79,22 @@ def emit_link(
     else:
         extld = extld_from_cc_toolchain(go)
         tool_args.add_all(extld)
+        if extld and (go.mode.race or
+                      go.mode.linkmode != LINKMODE_NORMAL or
+                      go.mode.goos == "windows" and go.mode.msan):
+            # Force external linking for the following conditions:
+            # * Non-normal build mode: may not be strictly necessary, especially
+            #   for modes like "pie".
+            # * Race or msan build for Windows: Go linker has pairwise
+            #   incompatibilities with mingw, and we get link errors in race mode.
+            #   Using the C linker avoids that. Race and msan always require a
+            #   a C toolchain. See #2614.
+            # * Linux race builds: we get linker errors during build with Go's
+            #   internal linker. For example, when using zig cc v0.10
+            #   (clang-15.0.3):
+            #
+            #       runtime/cgo(.text): relocation target memset not defined
+            tool_args.add("-linkmode", "external")
         if go.mode.static:
             # When static linking is requested, the Go linker's auto mode may
             # not pick external linking for packages like net that implicitly

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -79,25 +79,13 @@ def emit_link(
     else:
         extld = extld_from_cc_toolchain(go)
         tool_args.add_all(extld)
-        if extld and (go.mode.static or
-                      go.mode.race or
-                      go.mode.linkmode != LINKMODE_NORMAL or
-                      go.mode.goos == "windows" and go.mode.msan):
-            # Force external linking for the following conditions:
-            # * Mode is static but not pure: -static must be passed to the C
-            #   linker if the binary contains cgo code. See #2168, #2216.
-            # * Non-normal build mode: may not be strictly necessary, especially
-            #   for modes like "pie".
-            # * Race or msan build for Windows: Go linker has pairwise
-            #   incompatibilities with mingw, and we get link errors in race mode.
-            #   Using the C linker avoids that. Race and msan always require a
-            #   a C toolchain. See #2614.
-            # * Linux race builds: we get linker errors during build with Go's
-            #   internal linker. For example, when using zig cc v0.10
-            #   (clang-15.0.3):
-            #
-            #       runtime/cgo(.text): relocation target memset not defined
-            tool_args.add("-linkmode", "external")
+        if go.mode.static:
+            # When static linking is requested, the Go linker's auto mode may
+            # not pick external linking for packages like net that implicitly
+            # import runtime/cgo (no .o files, so externalobj stays false).
+            # The wrapper detects runtime/cgo via an import graph walk and
+            # injects -linkmode external only when needed. See #2168, #2216.
+            builder_args.add("-force-external-if-cgo")
 
     if go.mode.static:
         extldflags.append("-static")

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -95,6 +95,29 @@ go_test(
     ],
 )
 
+go_test(
+    name = "goobj_test",
+    size = "small",
+    srcs = [
+        "ar.go",
+        "goobj.go",
+        "goobj_test.go",
+        "testutil_test.go",
+    ],
+)
+
+go_test(
+    name = "importgraph_test",
+    size = "small",
+    srcs = [
+        "ar.go",
+        "goobj.go",
+        "importgraph.go",
+        "importgraph_test.go",
+        "testutil_test.go",
+    ],
+)
+
 filegroup(
     name = "builder_srcs",
     srcs = [
@@ -114,7 +137,9 @@ filegroup(
         "flags.go",
         "generate_nogo_main.go",
         "generate_test_main.go",
+        "goobj.go",
         "importcfg.go",
+        "importgraph.go",
         "link.go",
         "nogo.go",
         "nogo_validation.go",

--- a/go/tools/builders/goobj.go
+++ b/go/tools/builders/goobj.go
@@ -1,0 +1,151 @@
+// Minimal reader for Go object files (.a archives containing goobj-format
+// _go_.o members). Extracts the Autolib block (list of directly imported
+// packages) from the goobj header without depending on cmd/internal/goobj.
+//
+// Binary layout reference: cmd/internal/goobj/objfile.go (Go 1.20+)
+//
+//	Header:
+//	  Magic       "\x00go120ld"  (8 bytes)
+//	  Fingerprint [8]byte
+//	  Flags       uint32
+//	  Offsets     [NBlk]uint32   (NBlk = 20)
+//
+//	Autolib block (Offsets[0]..Offsets[1]):
+//	  []ImportedPkg, each 16 bytes:
+//	    Pkg         StringRef (8 bytes: length uint32 LE + offset uint32 LE)
+//	    Fingerprint [8]byte
+//
+//	Strings block starts at Offsets[NBlk-1] (index 19) — but string data is
+//	stored starting at the very end of the header, so StringRef offsets are
+//	relative to the start of the goobj data (= start of _go_.o member).
+
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+)
+
+const (
+	goobjMagic         = "\x00go120ld"
+	goobjNBlk          = 20
+	goobjStringRefSize = 8
+	goobjImportPkgSize = goobjStringRefSize + 8 // StringRef + Fingerprint
+)
+
+// readAutolibImports opens an ar archive, finds the _go_.o member, parses its
+// goobj header, and returns the list of directly imported package paths.
+func readAutolibImports(archivePath string) ([]string, error) {
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	data, err := findGoObjMember(f)
+	if err != nil {
+		return nil, err
+	}
+	if data == nil {
+		return nil, nil
+	}
+
+	return parseAutolibFromGoobj(data)
+}
+
+// findGoObjMember scans an ar archive for the __.PKGDEF-terminated header area
+// then finds the _go_.o member (or the first member after __.PKGDEF).
+func findGoObjMember(f *os.File) ([]byte, error) {
+	magic := make([]byte, len(arHeader))
+	if _, err := io.ReadFull(f, magic); err != nil {
+		return nil, err
+	}
+	if string(magic) != arHeader {
+		return nil, fmt.Errorf("not an ar archive")
+	}
+
+	for {
+		hdr := &header{}
+		if err := binary.Read(f, binary.BigEndian, hdr); err != nil {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				return nil, nil
+			}
+			return nil, err
+		}
+
+		name := hdr.name()
+		size := hdr.size()
+
+		if name == "__.PKGDEF" || name == "__.PKGDEF/" {
+			// Skip the package definition; the _go_.o follows.
+			if _, err := f.Seek(hdr.next(), io.SeekCurrent); err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		if name == "_go_.o" || name == "_go_.o/" {
+			data := make([]byte, size)
+			if _, err := io.ReadFull(f, data); err != nil {
+				return nil, err
+			}
+			return data, nil
+		}
+
+		// Skip unknown members.
+		if _, err := f.Seek(hdr.next(), io.SeekCurrent); err != nil {
+			return nil, err
+		}
+	}
+}
+
+// parseAutolibFromGoobj extracts imported package names from raw goobj bytes.
+func parseAutolibFromGoobj(data []byte) ([]string, error) {
+	magicLen := len(goobjMagic)
+	if len(data) < magicLen {
+		return nil, fmt.Errorf("goobj too short")
+	}
+	if string(data[:magicLen]) != goobjMagic {
+		return nil, fmt.Errorf("bad goobj magic: %q", data[:magicLen])
+	}
+
+	// Header layout: Magic(8) + Fingerprint(8) + Flags(4) + Offsets(NBlk * 4)
+	headerSize := magicLen + 8 + 4 + goobjNBlk*4
+	if len(data) < headerSize {
+		return nil, fmt.Errorf("goobj header truncated")
+	}
+
+	offsetsStart := magicLen + 8 + 4
+	offsets := make([]uint32, goobjNBlk)
+	for i := range offsets {
+		offsets[i] = binary.LittleEndian.Uint32(data[offsetsStart+i*4:])
+	}
+
+	// BlkAutolib = 0: Offsets[0] is start, Offsets[1] is end.
+	autolibStart := offsets[0]
+	autolibEnd := offsets[1]
+	if autolibEnd < autolibStart {
+		return nil, nil
+	}
+	count := (autolibEnd - autolibStart) / goobjImportPkgSize
+	if count == 0 {
+		return nil, nil
+	}
+
+	imports := make([]string, 0, count)
+	for i := uint32(0); i < count; i++ {
+		entryOff := autolibStart + i*goobjImportPkgSize
+		if int(entryOff+goobjStringRefSize) > len(data) {
+			break
+		}
+		strLen := binary.LittleEndian.Uint32(data[entryOff:])
+		strOff := binary.LittleEndian.Uint32(data[entryOff+4:])
+		if int(strOff+strLen) > len(data) {
+			break
+		}
+		imports = append(imports, string(data[strOff:strOff+strLen]))
+	}
+	return imports, nil
+}

--- a/go/tools/builders/goobj_test.go
+++ b/go/tools/builders/goobj_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadAutolibImportsBasic(t *testing.T) {
+	dir := t.TempDir()
+	path := buildTestArchive(t, dir, "test.a", []string{"fmt", "runtime", "runtime/cgo"})
+
+	imports, err := readAutolibImports(path)
+	if err != nil {
+		t.Fatalf("readAutolibImports: %v", err)
+	}
+
+	want := map[string]bool{"fmt": true, "runtime": true, "runtime/cgo": true}
+	got := make(map[string]bool)
+	for _, imp := range imports {
+		got[imp] = true
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for k := range want {
+		if !got[k] {
+			t.Errorf("missing import %q", k)
+		}
+	}
+}
+
+func TestReadAutolibImportsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := buildTestArchive(t, dir, "empty.a", nil)
+
+	imports, err := readAutolibImports(path)
+	if err != nil {
+		t.Fatalf("readAutolibImports: %v", err)
+	}
+	if len(imports) != 0 {
+		t.Errorf("expected no imports, got %v", imports)
+	}
+}
+
+func TestReadAutolibImportsNotAnArchive(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.a")
+	os.WriteFile(path, []byte("not an archive"), 0644)
+
+	_, err := readAutolibImports(path)
+	if err == nil {
+		t.Fatal("expected error for non-archive file")
+	}
+}
+
+func TestReadAutolibImportsMissing(t *testing.T) {
+	_, err := readAutolibImports("/nonexistent/path.a")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}

--- a/go/tools/builders/importcfg.go
+++ b/go/tools/builders/importcfg.go
@@ -195,6 +195,9 @@ package with this path is linked.`,
 				arc.importPath,
 				prevLabel)
 		}
+		// TODO(zbarsky): The labels are empty, and `importPath` contains the label.
+		// The parsing is incorrect because arrchiveMultiFlag assuming the formatting from
+		// `compilepkg.bzl` but `_format_archive` in `link.bzl` formats differently.
 		depsSeen[arc.packagePath] = arc.importPath
 		fmt.Fprintf(buf, "packagefile %s=%s\n", arc.packagePath, arc.file)
 		pkgToFile[arc.packagePath] = arc.file

--- a/go/tools/builders/importcfg.go
+++ b/go/tools/builders/importcfg.go
@@ -154,33 +154,38 @@ func buildImportcfgFileForCompile(imports map[string]*archive, installSuffix, di
 	return filename, nil
 }
 
-func buildImportcfgFileForLink(archives []archive, stdPackageListPath, installSuffix, dir string) (string, error) {
+func buildImportcfgFileForLink(archives []archive, stdPackageListPath, installSuffix, dir string) (string, map[string]string, error) {
 	buf := &bytes.Buffer{}
 	goroot, ok := os.LookupEnv("GOROOT")
 	if !ok {
-		return "", errors.New("GOROOT not set")
+		return "", nil, errors.New("GOROOT not set")
 	}
 	prefix := abs(filepath.Join(goroot, "pkg", installSuffix))
 	stdPackageListFile, err := os.Open(stdPackageListPath)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 	defer stdPackageListFile.Close()
+
+	pkgToFile := make(map[string]string)
+
 	scanner := bufio.NewScanner(stdPackageListFile)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {
 			continue
 		}
-		fmt.Fprintf(buf, "packagefile %s=%s.a\n", line, filepath.Join(prefix, filepath.FromSlash(line)))
+		archivePath := filepath.Join(prefix, filepath.FromSlash(line)) + ".a"
+		fmt.Fprintf(buf, "packagefile %s=%s\n", line, archivePath)
+		pkgToFile[line] = archivePath
 	}
 	if err := scanner.Err(); err != nil {
-		return "", err
+		return "", nil, err
 	}
 	depsSeen := map[string]string{}
 	for _, arc := range archives {
 		if prevLabel, ok := depsSeen[arc.packagePath]; ok {
-			return "", fmt.Errorf(`
+			return "", nil, fmt.Errorf(`
 package conflict error: %s: multiple copies of package passed to linker:
     %s
     %s
@@ -190,27 +195,25 @@ package with this path is linked.`,
 				arc.importPath,
 				prevLabel)
 		}
-		// TODO(zbarsky): The labels are empty, and `importPath` contains the label.
-		// The parsing is incorrect because arrchiveMultiFlag assuming the formatting from
-		// `compilepkg.bzl` but `_format_archive` in `link.bzl` formats differently.
 		depsSeen[arc.packagePath] = arc.importPath
 		fmt.Fprintf(buf, "packagefile %s=%s\n", arc.packagePath, arc.file)
+		pkgToFile[arc.packagePath] = arc.file
 	}
 	f, err := ioutil.TempFile(dir, "importcfg")
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 	filename := f.Name()
 	if _, err := io.Copy(f, buf); err != nil {
 		f.Close()
 		os.Remove(filename)
-		return "", err
+		return "", nil, err
 	}
 	if err := f.Close(); err != nil {
 		os.Remove(filename)
-		return "", err
+		return "", nil, err
 	}
-	return filename, nil
+	return filename, pkgToFile, nil
 }
 
 type depsError struct {

--- a/go/tools/builders/importgraph.go
+++ b/go/tools/builders/importgraph.go
@@ -1,0 +1,34 @@
+package main
+
+// importGraphHasCgo performs a BFS walk of the import graph starting from
+// mainArchive. It reads Autolib entries from each .a file's goobj header to
+// discover transitive imports. Returns true if "runtime/cgo" is found anywhere
+// in the transitive closure.
+func importGraphHasCgo(mainArchive string, pkgToFile map[string]string) (bool, error) {
+	visited := make(map[string]bool)
+	queue := []string{mainArchive}
+
+	for len(queue) > 0 {
+		archivePath := queue[0]
+		queue = queue[1:]
+
+		if visited[archivePath] {
+			continue
+		}
+		visited[archivePath] = true
+
+		imports, err := readAutolibImports(archivePath)
+		if err != nil {
+			continue
+		}
+		for _, imp := range imports {
+			if imp == "runtime/cgo" {
+				return true, nil
+			}
+			if filePath, ok := pkgToFile[imp]; ok && !visited[filePath] {
+				queue = append(queue, filePath)
+			}
+		}
+	}
+	return false, nil
+}

--- a/go/tools/builders/importgraph_test.go
+++ b/go/tools/builders/importgraph_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestImportGraphHasCgoFound(t *testing.T) {
+	dir := t.TempDir()
+
+	// main → fmt, mylib
+	// mylib → net
+	// net → runtime/cgo
+	mainA := buildTestArchive(t, dir, "main.a", []string{"fmt", "mylib"})
+	mylibA := buildTestArchive(t, dir, "mylib.a", []string{"net"})
+	netA := buildTestArchive(t, dir, "net.a", []string{"runtime/cgo"})
+	buildTestArchive(t, dir, "fmt.a", []string{"io"})
+	buildTestArchive(t, dir, "io.a", nil)
+
+	pkgToFile := map[string]string{
+		"fmt":   filepath.Join(dir, "fmt.a"),
+		"mylib": mylibA,
+		"net":   netA,
+		"io":    filepath.Join(dir, "io.a"),
+	}
+
+	got, err := importGraphHasCgo(mainA, pkgToFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Error("importGraphHasCgo = false, want true (net imports runtime/cgo)")
+	}
+}
+
+func TestImportGraphHasCgoNotFound(t *testing.T) {
+	dir := t.TempDir()
+
+	// main → fmt → io (no runtime/cgo anywhere)
+	mainA := buildTestArchive(t, dir, "main.a", []string{"fmt"})
+	buildTestArchive(t, dir, "fmt.a", []string{"io"})
+	buildTestArchive(t, dir, "io.a", nil)
+
+	pkgToFile := map[string]string{
+		"fmt": filepath.Join(dir, "fmt.a"),
+		"io":  filepath.Join(dir, "io.a"),
+	}
+
+	got, err := importGraphHasCgo(mainA, pkgToFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got {
+		t.Error("importGraphHasCgo = true, want false (no runtime/cgo in graph)")
+	}
+}
+
+func TestImportGraphHasCgoDirectImport(t *testing.T) {
+	dir := t.TempDir()
+
+	// main directly imports runtime/cgo
+	mainA := buildTestArchive(t, dir, "main.a", []string{"runtime/cgo", "fmt"})
+	buildTestArchive(t, dir, "fmt.a", nil)
+
+	pkgToFile := map[string]string{
+		"fmt": filepath.Join(dir, "fmt.a"),
+	}
+
+	got, err := importGraphHasCgo(mainA, pkgToFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Error("importGraphHasCgo = false, want true (main directly imports runtime/cgo)")
+	}
+}
+
+func TestImportGraphHasCgoCycle(t *testing.T) {
+	dir := t.TempDir()
+
+	// main → a → b → a (cycle, no cgo)
+	mainA := buildTestArchive(t, dir, "main.a", []string{"a"})
+	buildTestArchive(t, dir, "a.a", []string{"b"})
+	buildTestArchive(t, dir, "b.a", []string{"a"})
+
+	pkgToFile := map[string]string{
+		"a": filepath.Join(dir, "a.a"),
+		"b": filepath.Join(dir, "b.a"),
+	}
+
+	got, err := importGraphHasCgo(mainA, pkgToFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got {
+		t.Error("importGraphHasCgo = true, want false (cycle but no runtime/cgo)")
+	}
+}
+
+func TestImportGraphHasCgoUnresolved(t *testing.T) {
+	dir := t.TempDir()
+
+	// main → unknown_pkg (not in pkgToFile)
+	mainA := buildTestArchive(t, dir, "main.a", []string{"unknown_pkg"})
+
+	pkgToFile := map[string]string{}
+
+	got, err := importGraphHasCgo(mainA, pkgToFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got {
+		t.Error("importGraphHasCgo = true, want false (unresolved deps should be skipped)")
+	}
+}

--- a/go/tools/builders/link.go
+++ b/go/tools/builders/link.go
@@ -48,6 +48,7 @@ func link(args []string) error {
 	flags.Var(&archives, "arc", "Label, package path, and file name of a dependency, separated by '='")
 	packageList := flags.String("package_list", "", "The file containing the list of standard library packages")
 	buildmode := flags.String("buildmode", "", "Build mode used.")
+	forceExternalIfCgo := flags.Bool("force-external-if-cgo", false, "Walk import graph; inject -linkmode external if runtime/cgo is transitively imported.")
 	flags.Var(&xdefs, "X", "A string variable to replace in the linked binary (repeated).")
 	flags.Var(&stamps, "stamp", "The name of a file with stamping values.")
 	if err := flags.Parse(builderArgs); err != nil {
@@ -90,13 +91,27 @@ func link(args []string) error {
 		}
 	}
 
-	// Build an importcfg file.
-	importcfgName, err := buildImportcfgFileForLink(archives, *packageList, goenv.installSuffix, filepath.Dir(*outFile))
+	// Build an importcfg file and get the package-to-archive-path mapping.
+	importcfgName, pkgToFile, err := buildImportcfgFileForLink(archives, *packageList, goenv.installSuffix, filepath.Dir(*outFile))
 	if err != nil {
 		return err
 	}
 	if !goenv.shouldPreserveWorkDir {
 		defer os.Remove(importcfgName)
+	}
+
+	// If -force-external-if-cgo is set, walk the import graph starting from
+	// the main archive to determine if runtime/cgo is transitively imported.
+	// If so, inject -linkmode external into toolArgs so the C linker is used,
+	// which is required for static builds containing cgo code. See #2168.
+	if *forceExternalIfCgo {
+		hasCgo, err := importGraphHasCgo(*main, pkgToFile)
+		if err != nil {
+			return fmt.Errorf("import graph walk: %v", err)
+		}
+		if hasCgo {
+			toolArgs = append([]string{"-linkmode", "external"}, toolArgs...)
+		}
 	}
 
 	// generate any additional link options we need

--- a/go/tools/builders/testutil_test.go
+++ b/go/tools/builders/testutil_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// buildTestArchive creates a minimal .a file containing a _go_.o member with
+// the given goobj Autolib imports.
+func buildTestArchive(t *testing.T, dir, name string, imports []string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	goobj := buildGoobj(imports)
+
+	// AR global header.
+	f.WriteString(arHeader)
+
+	// _go_.o member header (60 bytes, fixed format).
+	memberName := fmt.Sprintf("%-16s", "_go_.o")
+	memberHdr := fmt.Sprintf("%s%-12s%-6s%-6s%-8s%-10d`\n",
+		memberName, "0", "0", "0", "100644", len(goobj))
+	f.WriteString(memberHdr)
+
+	// goobj data.
+	f.Write(goobj)
+
+	// Pad to even boundary.
+	if len(goobj)%2 != 0 {
+		f.Write([]byte{'\n'})
+	}
+
+	return path
+}
+
+// buildGoobj constructs a minimal goobj binary blob with the given Autolib
+// imports. Only the header, Autolib block, and string data are populated.
+func buildGoobj(imports []string) []byte {
+	type strEntry struct {
+		s   string
+		off uint32
+	}
+
+	// Header: Magic(8) + Fingerprint(8) + Flags(4) + Offsets(NBlk*4)
+	headerSize := uint32(8 + 8 + 4 + goobjNBlk*4)
+	autolibBlockSize := uint32(len(imports)) * goobjImportPkgSize
+	strDataStart := headerSize + autolibBlockSize
+
+	entries := make([]strEntry, len(imports))
+	strOff := strDataStart
+	for i, imp := range imports {
+		entries[i] = strEntry{s: imp, off: strOff}
+		strOff += uint32(len(imp))
+	}
+	totalSize := strOff
+
+	buf := make([]byte, totalSize)
+
+	copy(buf, goobjMagic)
+
+	offsetsBase := 20
+	autolibStart := headerSize
+	autolibEnd := headerSize + autolibBlockSize
+	binary.LittleEndian.PutUint32(buf[offsetsBase+0*4:], autolibStart)
+	binary.LittleEndian.PutUint32(buf[offsetsBase+1*4:], autolibEnd)
+	for i := 2; i < goobjNBlk; i++ {
+		binary.LittleEndian.PutUint32(buf[offsetsBase+i*4:], autolibEnd)
+	}
+
+	for i, e := range entries {
+		entryOff := int(autolibStart) + i*int(goobjImportPkgSize)
+		binary.LittleEndian.PutUint32(buf[entryOff:], uint32(len(e.s)))
+		binary.LittleEndian.PutUint32(buf[entryOff+4:], e.off)
+	}
+
+	for _, e := range entries {
+		copy(buf[e.off:], e.s)
+	}
+
+	return buf
+}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix/Feature

**What does this PR do? Why is it needed?**
When static linking is enabled in a project that contains a mix of CGo and non-CGo binaries, rules_go currently forces `-linkmode external` for all of them. This means pure Go binaries are unnecessarily routed through the external C linker even though Go's internal linker can handle them just fine.

This matters because the internal linker is significantly faster than invoking an external C linker. In a large monorepo with hundreds of Go binaries where only a fraction use CGo, the wasted link time adds up.

The go tooling already handles this correctly, when you run go build with CGO_ENABLED=1, it only uses the external linker for binaries that actually import runtime/cgo (directly or transitively). Pure Go binaries get the fast internal linker regardless of the global CGO_ENABLED setting. This patch brings rules_go in line with that behavior.

How it works:

The linker wrapper (link.go) gains a -force-external-if-cgo flag, passed by link.bzl only when static=on. At link time, the wrapper performs a BFS walk of the import graph by reading Autolib entries from each Go archive's goobj header. If runtime/cgo appears anywhere in the transitive closure, -linkmode external is injected. Otherwise, the Go linker's default "auto" mode is left alone, and it picks the internal linker.

This preserves the fix for #2168 and #2216 (static builds that transitively import runtime/cgo via packages like net still get external linking and a proper static binary), while avoiding it for binaries that don't need it.

Other conditions that force external linking (race builds, non-normal link modes, Windows msan) are left unchanged.