### PR TITLE
fix: put GoProtocGen in its own exec group

### DIFF
--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -29,7 +29,6 @@ load(
 load(
     "//go/private:common.bzl",
     "GO_TOOLCHAIN",
-    "GO_TOOLCHAIN_LABEL",
 )
 load(
     "//go/private:context.bzl",
@@ -177,7 +176,7 @@ def go_proto_compile(go, compiler, protos, imports, importpath):
         progress_message = "Generating into %s" % go_srcs[0].dirname,
         mnemonic = "GoProtocGen",
         executable = compiler.internal.go_protoc,
-        toolchain = GO_TOOLCHAIN_LABEL,
+        exec_group = "internal_use_only_go_proto_gen",
         tools = [compiler.internal.protoc, compiler.internal.plugin],
         arguments = [args],
         env = go.env,

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -215,6 +215,18 @@ go_proto_library = rule(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),
     } | CGO_ATTRS,
+    # go-protoc-bin is built via cfg = "exec" and lands on the first registered
+    # exec platform, while the Go toolchain may have constraints on the exec
+    # platform. Because of the possible differences in platform resolution,
+    # this may end up with a go-protoc-bin that is incompatible with the
+    # selected exec platform (when --incompatible_auto_exec_groups is unset).
+    # Assign it an explicit exec group with no toolchain constraints so it
+    # resolves to the same platform as the one resolved for the binary.
+    # Note that this exec platform matching is still fragile; the proper fix
+    # is to create proper toolchains for the protoc compiler.
+    exec_groups = {
+        "internal_use_only_go_proto_gen": exec_group(),
+    },
     fragments = CGO_FRAGMENTS,
     toolchains = [GO_TOOLCHAIN] + CGO_TOOLCHAINS,
 )


### PR DESCRIPTION
When building go_proto_library with two registered execution platforms (e.g. linux/x86_64 RBE registered first, darwin/arm64 local fallback), the GoProtocGen action would fail with "cannot execute binary file":

- go-protoc-bin is built via `cfg = "exec"` in _go_proto_compiler, which independently selects the first registered exec platform (e.g. linux ELF binary).
- Without --incompatible_auto_exec_groups, go_proto_library's Go toolchain declaration may have additional constraints (e.g. darwin arm64) and forces ALL rule actions onto darwin, including GoProtocGen.

This may lead to e.g. a linux binary executing on a darwin platform, leading to a "exec format error" error.

Fix: declare an unconstrained `go_proto_gen` exec group in go_proto_library and assign GoProtocGen to it via `exec_group = "go_proto_gen"`. The group has no toolchain constraints, making it equivalent to `cfg = "exec"`, so Bazel picks the first compatible exec platform — the same one that built go-protoc-bin via `cfg = "exec"`.

go.env already carries GOOS/GOARCH/GOROOT as concrete strings from go_context(), so the generated .pb.go files remain correctly targeted to the host platform. The generator itself does not need to run on the target platform.

Fixes #4604 

-- 

I pushed a way to reproduce the issue in https://github.com/sitaktif/rules_go/tree/rules-go-exec-format-error-repro, but I don't have an actual test in this PR to prevent future regressions because I'm not sure how to test that without an overly complicated and slow setup. Please share any suggestions on how to do that :-) 