### PR TITLE
fix: restore internal_archive.direct after cycle-break recompile

### DIFF
--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -665,6 +665,10 @@ def _recompile_external_deps(go, external_go_info, internal_archive, library_lab
     # can't import anything that imports itself.
     internal_go_info = internal_archive.source
 
+    # Store the original labels so that we can map dependencies back onto
+    # internal_archive.direct after recompilation (see below).
+    original_internal_dep_labels = [dep.data.label for dep in internal_go_info.deps]
+
     internal_deps = []
 
     # Pass internal dependencies that need to be recompiled down to the builder to check if the internal archive
@@ -751,6 +755,20 @@ def _recompile_external_deps(go, external_go_info, internal_archive, library_lab
                 _headers = internal_archive._headers,
             )
         label_to_archive[label] = archive
+
+    # Fix up internal_archive.direct for gopackagesdriver, which queries the
+    # archive by label to build the go/packages response map for a test file,
+    # which could be part of an x_test package. Because the aspect uses the
+    # first archive it finds for that label, we need direct to hold the
+    # recompiled external deps (=intermediate test variants), even for the
+    # internal archive. See #3981.
+    attrs = structs.to_dict(internal_archive)
+    attrs["direct"] = [
+        label_to_archive[label]
+        for label in original_internal_dep_labels
+    ]
+    internal_archive = GoArchive(**attrs)
+    label_to_archive[internal_archive.data.label] = internal_archive
 
     # Finally, we need to replace external_go_info.deps with the recompiled
     # archives.

--- a/go/tools/gopackagesdriver/gopackagesdriver_test.go
+++ b/go/tools/gopackagesdriver/gopackagesdriver_test.go
@@ -40,6 +40,20 @@ go_test(
         "hello_external_test.go",
     ],
     embed = [":hello"],
+    deps = [":hellohelper"],
+)
+
+# hellohelper imports hello, so a go_test that embeds hello and depends on
+# hellohelper from an external (xtest) source forces _recompile_external_deps
+# to run. This is the trigger for #3981: the recompiled internal archive's
+# direct deps used to drop the cycle-forming dependency, so the
+# gopackagesdriver reported the xtest with a hole in its Imports.
+go_library(
+    name = "hellohelper",
+    srcs = ["hellohelper/hellohelper.go"],
+    importpath = "example.com/hello/hellohelper",
+    visibility = ["//visibility:public"],
+    deps = [":hello"],
 )
 
 go_library(
@@ -83,9 +97,22 @@ func TestHelloInternal(t *testing.T) {}
 -- hello_external_test.go --
 package hello_test
 
-import "testing"
+import (
+	"testing"
 
-func TestHelloExternal(t *testing.T) {}
+	"example.com/hello/hellohelper"
+)
+
+func TestHelloExternal(t *testing.T) {
+	hellohelper.Helper()
+}
+
+-- hellohelper/hellohelper.go --
+package hellohelper
+
+import _ "example.com/hello"
+
+func Helper() {}
 
 -- incompatible.go --
 //go:build ignore
@@ -290,6 +317,15 @@ func TestExternalTests(t *testing.T) {
 				t.Errorf("PkgPath missing _test suffix")
 			}
 			assertSuffixesInList(t, p.GoFiles, "/hello_external_test.go")
+			// hellohelper is imported only by the xtest source and itself
+			// imports the embedded library, which forces
+			// _recompile_external_deps to filter it out of the recompiled
+			// internal archive's deps. The Imports map must still report
+			// it; otherwise consumers see the import as unresolved (#3981).
+			if _, ok := p.Imports["example.com/hello/hellohelper"]; !ok {
+				t.Errorf("xtest %s missing import of example.com/hello/hellohelper; got Imports: %v",
+					p.ID, slices.Sorted(maps.Keys(p.Imports)))
+			}
 		} else if p.ID == testId {
 			assertSuffixesInList(t, p.GoFiles, "/hello.go", "/hello_test.go")
 		}


### PR DESCRIPTION
When a go_test embeds a library and an external test (x_test) source imports a package that transitively reaches the embedded library, _recompile_external_deps recompiles the internal archive with a filtered deps list to break the cycle. (We call these intermediate test variants in cmd/go).

However, when the go/packages driver queries package information for an x_test source, the go_pkg_info_aspect looks up imports in the first archive it encounters. Prior to this PR, that could be the internal archive, which only contained imports that were filtered in the middle of cycle-breaking.

This change restores the recompiled imports back onto the internal archive, so that the driver can reconstruct accurate import information for the x_test package.

Credit to @jgautier-dd for #4405, on which this was based.

Fixes #3981