### PR TITLE
fix/nogo: use resolved Label for GoGenNogo toolchain

### DIFF
--- a/go/private/rules/nogo.bzl
+++ b/go/private/rules/nogo.bzl
@@ -15,6 +15,7 @@
 load(
     "//go/private:common.bzl",
     "GO_TOOLCHAIN",
+    "GO_TOOLCHAIN_LABEL",
 )
 load(
     "//go/private:context.bzl",
@@ -64,7 +65,7 @@ def _nogo_impl(ctx):
         outputs = [nogo_main],
         mnemonic = "GoGenNogo",
         executable = go.toolchain._builder,
-        toolchain = GO_TOOLCHAIN,
+        toolchain = GO_TOOLCHAIN_LABEL,
         arguments = [nogo_args],
     )
 


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Automatic exec groups breaks nogo for us since we don't use `repo_name="io_bazel_rules_go"`. It looks like nogo was the only place that didn't use the preresolved label:

```
❯ git grep 'toolchain = GO_TOOLCHAIN'
extras/gomock.bzl:        toolchain = GO_TOOLCHAIN_LABEL,
extras/gomock.bzl:        toolchain = GO_TOOLCHAIN_LABEL,
go/private/actions/compilepkg.bzl:        toolchain = GO_TOOLCHAIN_LABEL,
go/private/actions/compilepkg.bzl:        toolchain = GO_TOOLCHAIN_LABEL,
go/private/actions/compilepkg.bzl:            toolchain = GO_TOOLCHAIN_LABEL,
go/private/actions/link.bzl:        toolchain = GO_TOOLCHAIN_LABEL,
go/private/actions/stdlib.bzl:        toolchain = GO_TOOLCHAIN_LABEL,
go/private/actions/stdlib.bzl:        toolchain = GO_TOOLCHAIN_LABEL,
go/private/rules/nogo.bzl:        toolchain = GO_TOOLCHAIN,
go/private/rules/test.bzl:        toolchain = GO_TOOLCHAIN_LABEL,
proto/compiler.bzl:        toolchain = GO_TOOLCHAIN_LABEL,
```

**Which issues(s) does this PR fix?**

This is a follow-up of #4139 which was about switching to the preresolved labels. PR #4141 was what introduced toolchain which didn't use the label.

**Other notes for review**

I tested this with `bazel test --incompatible_auto_exec_groups //tests/core/nogo/bzlmod:includes_exclude_test`