### PR TITLE
Set direct nogo attribute to prevent building nogo for the wrong platform when multiple exec platforms are set

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -65,7 +65,6 @@ go_context_data(
     name = "go_context_data",
     coverdata = "//go/tools/coverdata",
     go_config = ":go_config",
-    nogo = "@io_bazel_rules_nogo//:nogo",
     stdlib = ":stdlib",
     visibility = ["//visibility:public"],
 )

--- a/go/private/BUILD.bazel
+++ b/go/private/BUILD.bazel
@@ -168,25 +168,19 @@ bool_setting(
     visibility = ["//visibility:public"],
 )
 
-# Usually true. The entire toolchain gets nogo to use in builds via the
-# go_context_data rule, which has an incoming transition that flips this flag
-# to true. This will only be false in host mode (which disallows any
-# transitions) or accessing nogo without going through go_context_data (which
-# does not happen in rules_go and does not seem to be useful).
+# Defaults to True, meaning nogo runs everywhere except when transitioned to
+# False to prevent nogo from running on nogo's own dependencies (circular dep
+# guard).
 bool_setting(
     name = "request_nogo",
-    build_setting_default = False,
+    build_setting_default = True,
     visibility = ["//visibility:public"],
 )
 
 # Controls whether nogo alias will reference a noop or the configured nogo.
-# This *MUST* default to the noop to allow for tools to be built in the
-# deprecated "host" mode. Host mode cannot perform configuration transitions
-# so it cannot avoid circular dependencies. Therefore the default must work
-# without performing any transitions. The tradeoff is that nogo analysis is not
-# performed for any target built in host mode - this is not as bad as it seems
-# as most tools can (and should) use "exec" configuration instead of host which
-# does support transitions.
+# True (the default) means nogo runs. go_tool_transition and _reset_transition
+# both reset this to False, which prevents nogo from running on nogo's own
+# dependencies (circular dep guard) and on other tool targets.
 config_setting(
     name = "nogo_active",
     flag_values = {

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -47,7 +47,6 @@ load(
 load(
     "//go/private/rules:transition.bzl",
     "non_request_nogo_transition",
-    "request_nogo_transition",
 )
 load(
     ":common.bzl",
@@ -716,7 +715,7 @@ def go_context(
         importpath_aliases = importpath_aliases,
         pathtype = pathtype,
         cgo_tools = cgo_tools,
-        nogo = go_context_info.nogo if go_context_info else None,
+        nogo = ctx.attr._nogo[DefaultInfo].files_to_run if hasattr(ctx.attr, "_nogo") else None,
         coverdata = go_context_info.coverdata if go_context_info else None,
         coverage_enabled = ctx.configuration.coverage_enabled,
         coverage_instrumented = ctx.coverage_instrumented(),
@@ -759,7 +758,6 @@ def _go_context_data_impl(ctx):
     return [
         GoContextInfo(
             coverdata = ctx.attr.coverdata[0][GoArchive],
-            nogo = ctx.attr.nogo[DefaultInfo].files_to_run,
         ),
         ctx.attr.stdlib[GoStdLib],
         ctx.attr.go_config[GoConfigInfo],
@@ -777,10 +775,6 @@ go_context_data = rule(
             mandatory = True,
             providers = [GoConfigInfo],
         ),
-        "nogo": attr.label(
-            mandatory = True,
-            cfg = "exec",
-        ),
         "stdlib": attr.label(
             mandatory = True,
             providers = [GoStdLib],
@@ -792,7 +786,6 @@ go_context_data = rule(
     doc = """go_context_data gathers information about the build configuration.
     It is a common dependency of all Go targets.""",
     toolchains = [GO_TOOLCHAIN],
-    cfg = request_nogo_transition,
 )
 
 def cgo_context_data_impl(ctx):

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -481,6 +481,10 @@ def _go_binary_kwargs(go_cc_aspects = []):
                 default = "//go/config:empty",
             ),
             "_go_context_data": attr.label(default = "//:go_context_data"),
+            "_nogo": attr.label(
+                default = Label("@io_bazel_rules_nogo//:nogo"),
+                cfg = "exec",
+            ),
             "_allowlist_function_transition": attr.label(
                 default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
             ),

--- a/go/private/rules/library.bzl
+++ b/go/private/rules/library.bzl
@@ -192,6 +192,10 @@ go_library = rule(
             """,
         ),
         "_go_context_data": attr.label(default = "//:go_context_data"),
+        "_nogo": attr.label(
+            default = Label("@io_bazel_rules_nogo//:nogo"),
+            cfg = "exec",
+        ),
         "_allowlist_function_transition": attr.label(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),

--- a/go/private/rules/nogo.bzl
+++ b/go/private/rules/nogo.bzl
@@ -109,6 +109,7 @@ _nogo = rule(
         "_nogo_srcs": attr.label(
             default = "//go/tools/builders:nogo_srcs",
         ),
+        "_go_context_data": attr.label(default = "//:go_context_data"),
         "_go_config": attr.label(default = "//:go_config"),
         "_diff_deps": attr.label_list(default = [
             "@com_github_aymanbagabas_go_udiff//:go_default_library",

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -462,6 +462,10 @@ _go_test_kwargs = {
             """,
         ),
         "_go_context_data": attr.label(default = "//:go_context_data"),
+        "_nogo": attr.label(
+            default = Label("@io_bazel_rules_nogo//:nogo"),
+            cfg = "exec",
+        ),
         "_testmain_additional_deps": attr.label_list(
             providers = [GoInfo],
             default = ["//go/tools/bzltestutil"],

--- a/go/private/rules/transition.bzl
+++ b/go/private/rules/transition.bzl
@@ -161,26 +161,6 @@ go_transition = transition(
     ] + TRANSITIONED_GO_SETTING_KEYS + _SETTING_KEY_TO_ORIGINAL_SETTING_KEY.values(),
 )
 
-def _request_nogo_transition(settings, _attr):
-    """Indicates that we want the project configured nogo instead of a noop.
-
-    This does not guarantee that the project configured nogo will be used (if
-    bootstrap is true we are currently building nogo so that is a cyclic
-    dependency).
-
-    The config setting nogo_active requires bootstrap to be false and
-    request_nogo to be true to provide the project configured nogo.
-    """
-    settings = dict(settings)
-    settings["//go/private:request_nogo"] = True
-    return settings
-
-request_nogo_transition = transition(
-    implementation = _request_nogo_transition,
-    inputs = [],
-    outputs = ["//go/private:request_nogo"],
-)
-
 def _non_request_nogo_transition(_settings, _attr):
     # This transition is used to make sure we only end up with 1 copy of coverdata,
     # even if a test links against it and is run in coverage mode.

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -211,6 +211,10 @@ go_proto_library = rule(
         "_go_context_data": attr.label(
             default = "//:go_context_data",
         ),
+        "_nogo": attr.label(
+            default = Label("@io_bazel_rules_nogo//:nogo"),
+            cfg = "exec",
+        ),
         "_allowlist_function_transition": attr.label(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This PR fixes an issue whereby, when two or more exec platforms are set (via `--host_platform` and/or `--extra_execution_platforms`), it was possible for Nogo to be build for one exec platform A, but be executed on exec platform B, leading to an "exec format error" / "cannot execute binary file" error when the action is run.

This PR moves the nogo dep directly to the relevant rules instead of via `go_context_data`, removing the possibility for a discrepancy for the two exec configs.

**Which issues(s) does this PR fix?**

Fixes #4571

**Other notes for review**

I wasn't sure about the handling of "legacy host mode" mentioned in the comments so I added a test that covers the case... if that's what the comments meant by "host mode". Please someone check whether that's actually testing that (and/or if we still care about host mode).