### PR TITLE
feat(sdk): allow per-platform strip_prefix via strip_prefixes

### DIFF
--- a/go/private/extensions.bzl
+++ b/go/private/extensions.bzl
@@ -53,6 +53,12 @@ _COMMON_TAG_ATTRS = {
         doc = "The number of leading path segments to be stripped from the file name in the patches.",
     ),
     "strip_prefix": attr.string(default = "go"),
+    "strip_prefixes": attr.string_dict(
+        doc = "Per-platform strip_prefix, keyed by '<goos>_<goarch>'. " +
+              "Takes precedence over strip_prefix when non-empty. Required for " +
+              "GOPROXY-style mirrors (e.g. the golang.org/toolchain module layout) " +
+              "where each platform archive has a different top-level directory.",
+    ),
     "experimental_build_compiler_from_source": attr.bool(
         default = False,
         doc = "Whether to bootstrap compiler tool binaries from source instead of using the prebuilt SDK compiler binaries.",
@@ -482,6 +488,7 @@ def _download_sdk(*, get_sdks_by_version, name, goos, goarch, download_tag):
         urls = download_tag.urls,
         version = download_tag.version,
         strip_prefix = download_tag.strip_prefix,
+        strip_prefixes = download_tag.strip_prefixes,
         experimental_build_compiler_from_source = download_tag.experimental_build_compiler_from_source,
     )
 

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -103,7 +103,14 @@ def _go_download_sdk_impl(ctx):
         fail("unsupported platform {}".format(platform))
 
     filename, sha256 = sdks[platform]
-    _remote_sdk(ctx, [url.format(filename) for url in ctx.attr.urls], ctx.attr.strip_prefix, sha256)
+
+    strip_prefix = ctx.attr.strip_prefix
+    if ctx.attr.strip_prefixes:
+        if platform not in ctx.attr.strip_prefixes:
+            fail("strip_prefixes does not contain platform '{}'".format(platform))
+        strip_prefix = ctx.attr.strip_prefixes[platform]
+
+    _remote_sdk(ctx, [url.format(filename) for url in ctx.attr.urls], strip_prefix, sha256)
     patch(ctx, patch_args = _get_patch_args(ctx.attr.patch_strip))
 
     sdk_build_file_override = ctx.attr._bootstrap_sdk_build_file if ctx.attr.experimental_build_compiler_from_source else None
@@ -122,6 +129,7 @@ def _go_download_sdk_impl(ctx):
             "urls": ctx.attr.urls,
             "version": version,
             "strip_prefix": ctx.attr.strip_prefix,
+            "strip_prefixes": ctx.attr.strip_prefixes,
             "experimental_build_compiler_from_source": ctx.attr.experimental_build_compiler_from_source,
         }
 
@@ -142,6 +150,12 @@ go_download_sdk_rule = repository_rule(
         "urls": attr.string_list(default = ["https://dl.google.com/go/{}"]),
         "version": attr.string(),
         "strip_prefix": attr.string(default = "go"),
+        "strip_prefixes": attr.string_dict(
+            doc = "Per-platform strip_prefix, keyed by '<goos>_<goarch>'. " +
+                  "Takes precedence over strip_prefix when non-empty. Required for " +
+                  "GOPROXY-style mirrors (e.g. the golang.org/toolchain module layout) " +
+                  "where each platform archive has a different top-level directory.",
+        ),
         "patches": attr.label_list(
             doc = "A list of patches to apply to the SDK after downloading it",
         ),

--- a/go/toolchains.rst
+++ b/go/toolchains.rst
@@ -397,7 +397,16 @@ This downloads a Go SDK for use in toolchains.
 | :param:`strip_prefix`          | :type:`string`              | :value:`"go"`                               |
 +--------------------------------+-----------------------------+---------------------------------------------+
 | A directory prefix to strip from the extracted files.                                                      |
-| Used with ``urls``.                                                                                        |
+| Used with ``urls``. Mutually exclusive with :param:`strip_prefixes`; when                                  |
+| :param:`strip_prefixes` is non-empty it takes precedence.                                                  |
++--------------------------------+-----------------------------+---------------------------------------------+
+| :param:`strip_prefixes`        | :type:`string_dict`         | :value:`{}`                                 |
++--------------------------------+-----------------------------+---------------------------------------------+
+| Per-platform directory prefix to strip from the extracted files, keyed by                                  |
+| ``"<goos>_<goarch>"``. Required when each platform archive has a distinct                                  |
+| top-level directory — most commonly when serving the SDK from a GOPROXY-style                              |
+| mirror using the ``golang.org/toolchain`` module layout. See the GOPROXY example                           |
+| below.                                                                                                     |
 +--------------------------------+-----------------------------+---------------------------------------------+
 | :param:`sdks`                  | :type:`string_list_dict`    | :value:`see description`                    |
 +--------------------------------+-----------------------------+---------------------------------------------+
@@ -466,6 +475,42 @@ This downloads a Go SDK for use in toolchains.
     go_rules_dependencies()
 
     go_register_toolchains()
+
+**GOPROXY-style mirror example**:
+
+The Go command (since Go 1.21) can fetch the toolchain as a standard Go module
+named ``golang.org/toolchain``. The same module is served by every GOPROXY-style
+mirror (``proxy.golang.org``, Artifactory, Athens, Nexus, etc.), which makes it
+convenient to serve the Go SDK from the same internal artifact store that
+already serves Go module dependencies. The archive layout differs from
+``go.dev/dl``: each per-platform ``.zip`` has a top-level directory of the form
+``golang.org/toolchain@v0.0.1-go{V}.{os}-{arch}``, so :param:`strip_prefixes`
+must be used instead of :param:`strip_prefix`.
+
+.. code:: bzl
+
+    load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk")
+
+    go_download_sdk(
+        name = "go_sdk",
+        urls = ["https://proxy.golang.org/golang.org/toolchain/@v/{}"],
+        sdks = {
+            "darwin_arm64":  ("v0.0.1-go1.22.5.darwin-arm64.zip",  "ebf537a1e8942b5939864e55e38d8885995682da4f04b392cf1017f649f46557"),
+            "linux_amd64":   ("v0.0.1-go1.22.5.linux-amd64.zip",   "0eb73889fac3ef46a759ca3f8079a7ff656158ee6aedfe127221101824001a77"),
+            "windows_amd64": ("v0.0.1-go1.22.5.windows-amd64.zip", "45a9ef35178c02c0f77d0fcb77960f7afde532332f12344f822166f21820d02d"),
+        },
+        strip_prefixes = {
+            "darwin_arm64":  "golang.org/toolchain@v0.0.1-go1.22.5.darwin-arm64",
+            "linux_amd64":   "golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64",
+            "windows_amd64": "golang.org/toolchain@v0.0.1-go1.22.5.windows-amd64",
+        },
+    )
+
+To point at an internal mirror, replace the ``proxy.golang.org`` host in
+``urls`` with the GOPROXY endpoint of the mirror (the path
+``/golang.org/toolchain/@v/{}`` is part of the Go module proxy protocol and is
+the same everywhere). Both ``go_download_sdk`` and the ``go_sdk.download``
+bzlmod tag accept :param:`strip_prefixes`.
 
 go_host_sdk
 ~~~~~~~~~~~

--- a/tests/core/go_download_sdk/go_download_sdk_test.go
+++ b/tests/core/go_download_sdk/go_download_sdk_test.go
@@ -111,6 +111,37 @@ go_download_sdk(
 			optToWantVersion: map[string]string{"": "go1.18"},
 		},
 		{
+			// Verifies that GOPROXY-style mirrors that serve the Go toolchain via the
+			// golang.org/toolchain module layout can be used as the SDK source. Unlike
+			// the go.dev/dl layout, each per-platform archive has a distinct top-level
+			// directory that includes the version and target triple, so a single
+			// strip_prefix string is not expressive enough.
+			desc: "strip_prefixes_goproxy_layout",
+			rule: `
+load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk")
+
+go_download_sdk(
+    name = "go_sdk",
+    urls = ["https://proxy.golang.org/golang.org/toolchain/@v/{}"],
+    sdks = {
+        "darwin_amd64":  ("v0.0.1-go1.22.5.darwin-amd64.zip",  "3c17b1ee6d6840157fb8fb2eb9bc48278b99b3f22c57929700ef5c6c757256ad"),
+        "darwin_arm64":  ("v0.0.1-go1.22.5.darwin-arm64.zip",  "ebf537a1e8942b5939864e55e38d8885995682da4f04b392cf1017f649f46557"),
+        "linux_amd64":   ("v0.0.1-go1.22.5.linux-amd64.zip",   "0eb73889fac3ef46a759ca3f8079a7ff656158ee6aedfe127221101824001a77"),
+        "linux_arm64":   ("v0.0.1-go1.22.5.linux-arm64.zip",   "2c4a947f05fdbdfc38bffe548309ab737bf32b4851aca6986625a5a1840381bb"),
+        "windows_amd64": ("v0.0.1-go1.22.5.windows-amd64.zip", "45a9ef35178c02c0f77d0fcb77960f7afde532332f12344f822166f21820d02d"),
+    },
+    strip_prefixes = {
+        "darwin_amd64":  "golang.org/toolchain@v0.0.1-go1.22.5.darwin-amd64",
+        "darwin_arm64":  "golang.org/toolchain@v0.0.1-go1.22.5.darwin-arm64",
+        "linux_amd64":   "golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64",
+        "linux_arm64":   "golang.org/toolchain@v0.0.1-go1.22.5.linux-arm64",
+        "windows_amd64": "golang.org/toolchain@v0.0.1-go1.22.5.windows-amd64",
+    },
+)
+`,
+			optToWantVersion: map[string]string{"": "go1.22.5"},
+		},
+		{
 			desc: "multiple_sdks",
 			rule: `
 load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_host_sdk")


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

`rules_go` currently can't fetch the Go SDK from a GOPROXY-style mirror because the `golang.org/toolchain` module layout has a different top-level directory per platform (`golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64`, `...darwin-arm64`, etc.), and a single `strip_prefix` can't express that.

So this adds a `strip_prefixes` attr (per-platform dict) on `go_download_sdk` and the `go_sdk.download` bzlmod tag. When set, it wins over `strip_prefix`. Otherwise nothing changes.

```bzl
go_sdk.download(
    urls = ["https://<mirror>/golang.org/toolchain/@v/{}"],
    sdks = {...},
    strip_prefixes = {...},
    version = "1.22.5",
)
```

**Which issues(s) does this PR fix?**

Closes #4516

**Other notes for review**

There's an end-to-end test in `tests/core/go_download_sdk/go_download_sdk_test.go` that pulls Go 1.22.5 from the public `proxy.golang.org`, so the new path actually runs on CI.

Kept the scope to just the attribute. Auto-deriving `urls` / `sdks` / `strip_prefixes` from a `goproxy = ` arg can be a separate PR if there's appetite for it.

The bzlmod tag was only smoke-tested locally with `bazel mod deps`. The automated test covers WORKSPACE-mode `go_download_sdk`, same rule underneath. Let me know if a BCR test for the tag would help.