### PR TITLE
Add `GoLink` actions to `go_link` exec group

### DIFF
--- a/go/private/actions/binary.bzl
+++ b/go/private/actions/binary.bzl
@@ -34,7 +34,8 @@ def emit_binary(
         gc_linkopts = [],
         version_file = None,
         info_file = None,
-        executable = None):
+        executable = None,
+        link_exec_group = None):
     """See go/toolchains.rst#binary for full documentation."""
 
     if name == "" and executable == None:
@@ -61,6 +62,7 @@ def emit_binary(
         gc_linkopts = gc_linkopts,
         version_file = version_file,
         info_file = info_file,
+        exec_group = link_exec_group,
     )
     cgo_dynamic_deps = [
         d

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -44,7 +44,8 @@ def emit_link(
         executable = None,
         gc_linkopts = [],
         version_file = None,
-        info_file = None):
+        info_file = None,
+        exec_group = None):
     """See go/toolchains.rst#link for full documentation."""
 
     if archive == None:
@@ -197,6 +198,7 @@ def emit_link(
         arguments = [builder_args, "--", tool_args],
         env = go.env,
         toolchain = GO_TOOLCHAIN_LABEL,
+        exec_group = exec_group,
     )
 
 def _extract_extldflags(gc_linkopts, extldflags):

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -172,6 +172,7 @@ def _go_binary_impl(ctx):
         gc_linkopts = gc_linkopts(ctx),
         version_file = ctx.version_file,
         info_file = ctx.info_file,
+        link_exec_group = "go_link",
         executable = executable,
     )
     validation_output = archive.data._validation_output
@@ -498,6 +499,11 @@ def _go_binary_kwargs(go_cc_aspects = []):
         } | CGO_ATTRS,
         "fragments": CGO_FRAGMENTS,
         "toolchains": [GO_TOOLCHAIN] + CGO_TOOLCHAINS,
+        "exec_groups": {
+            "go_link": exec_group(
+                toolchains = [GO_TOOLCHAIN] + CGO_TOOLCHAINS,
+            ),
+        },
         "doc": """This builds an executable from a set of source files,
         which must all be in the `main` package. You can run the binary with
         `bazel run`, or you can build it with `bazel build` and run it directly.


### PR DESCRIPTION
Allow specifying execution info such as `resources:memory` for the GoLink action

