### PR TITLE
Make go/tools/builders absolute paths robust to PWD=/proc/self/cwd.

### DIFF
--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -415,12 +415,23 @@ func abs(path string) string {
 	if strings.HasPrefix(path, "__BAZEL_") {
 		return path
 	}
-
-	if abs, err := filepath.Abs(path); err != nil {
-		return path
-	} else {
-		return abs
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
 	}
+	// Instead of filepath.Abs(), we EvalSymlinks on os.Getwd.  On
+	// Linux, PWD=/proc/self/cwd will cause
+	// filepath.Abs("sometool") to return
+	// "/proc/self/cwd/sometool". But that path does not behave
+	// like an absolute path. When a `go` invocation chdirs, that
+	// suddenly points somewhere else.
+	wd, err := os.Getwd()
+	if err != nil {
+		return path
+	}
+	if real, err := filepath.EvalSymlinks(wd); err == nil {
+		wd = real
+	}
+	return filepath.Join(wd, path)
 }
 
 // absArgs applies abs to strings that appear in args. Only paths that are

--- a/go/tools/builders/env_test.go
+++ b/go/tools/builders/env_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -73,5 +74,17 @@ func TestTransformArgs(t *testing.T) {
 				t.Errorf("got %v, want %v", args, tc.expected)
 			}
 		})
+	}
+}
+
+func TestAbs(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.SkipNow()
+	}
+	before := abs("sometool")
+	t.Setenv("PWD", "/proc/self/cwd")
+	after := abs("sometool")
+	if after != before {
+		t.Errorf("got %v, want %v", after, before)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The command invocations and environment variable handling in ./go/tools/builders are careful to construct absolute paths, so that those paths continue to work from new working directories. However, if PWD=/proc/self/cwd, then the computed absolute paths actually change meaning as the working directory changes.

This became acutely relevant with rules_cc 0.2.19, when rule-based cc toolchains that took
`experimental_replace_legacy_action_config_features` picked up a new feature, `sanitize_pwd`. That feature sets PWD=/proc/self/cwd in the environment of archive and link actions. The end result is that those toolchains on that rules_cc version broke with rules_go. Certain builder invocations merge the cc command context, and certain `go` invocations chdir before using the supplied paths.

**Other notes for review**

I wasn't familiar with and didn't investigate the e2e tests, so this PR is lacking one. The requirements on rules_cc 0.2.19 and platform=linux and a rule-based cc toolchain seemed pretty heavy, but maybe this is not so complicated.

I have made a minimal repro repository here: https://github.com/reltuk/sanitize_pwd_repro. I have verified that this branch fixes it. Caveat emptor: the repro repository was created by an LLM–sorry for the verbosity of the README and some of the comments throughout.

The sanitize_pwd feature can be seen in rules_cc here (current tip-of-main): https://github.com/bazelbuild/rules_cc/blob/8edac4e1d8f164e1e5b559598213e57fd74dd8e8/cc/toolchains/args/sanitize_pwd/BUILD