### PR TITLE
Remove //go/config:pure from go_tool_transition keys

### DIFF
--- a/go/private/rules/transition.bzl
+++ b/go/private/rules/transition.bzl
@@ -180,7 +180,6 @@ _common_reset_transition_dict = dict({
     "//go/config:static": False,
     "//go/config:msan": False,
     "//go/config:race": False,
-    "//go/config:pure": False,
     "//go/config:debug": False,
     "//go/config:linkmode": LINKMODE_NORMAL,
     "//go/config:tags": [],


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

This PR removes `//go/config:pure` from the transition keys of `go_tool_transition`. The motivation is to allow using nogo in a repository which sets `common --@rules_go//go/config:pure` and have `nogo` and other tool binaries respect this setting.

In our particular case, we're using the `llvm` toolchain in our repository and have opted to disable CGO rather than bootstrap and patch the compiler from source (until Go 1.27 is released). However, `nogo` unconditionally builds with CGO enabled without this patch.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

Original discussion in Bazel slack: https://bazelbuild.slack.com/archives/CDBP88Z0D/p1781013245715439