### PR TITLE
Preserve common Go settings in go_stdlib_transition

### DIFF
--- a/go/private/rules/transition.bzl
+++ b/go/private/rules/transition.bzl
@@ -193,15 +193,6 @@ _reset_transition_dict = dict(_common_reset_transition_dict, **{
 
 _reset_transition_keys = sorted(_reset_transition_dict.keys())
 
-_stdlib_keep_keys = sorted([
-    "//go/config:msan",
-    "//go/config:race",
-    "//go/config:pure",
-    "//go/config:linkmode",
-    "//go/config:tags",
-    "//go/config:pgoprofile",
-])
-
 def _go_tool_transition_impl(settings, _attr):
     """Sets most Go settings to default values (use for external Go tools).
 
@@ -245,17 +236,16 @@ non_go_tool_transition = transition(
 )
 
 def _go_stdlib_transition_impl(settings, _attr):
-    """Sets all Go settings to their default values, except for those affecting the Go SDK.
+    """Preserves common Go settings in the standard library configuration.
 
-    This transition is similar to _non_go_tool_transition except that it keeps the
-    parts of the configuration that determine how to build the standard library.
-    It's used to consolidate the configurations used to build the standard library to limit
-    the number built.
+    go_stdlib_transition filters tags that do not affect the standard library
+    and disables bootstrap_nogo and coverage collection.
     """
+    # Preserve every setting in _reset_transition_keys. A Go rule and its
+    # //:stdlib dependency must resolve the C++ toolchain in the same
+    # configuration. Otherwise, GoLink can reference a C++ runtime archive
+    # from one configuration while Bazel declares the archive from another.
     settings = dict(settings)
-    for label, value in _reset_transition_dict.items():
-        if label not in _stdlib_keep_keys:
-            settings[label] = value
     settings["//go/config:tags"] = [t for t in settings["//go/config:tags"] if t in _TAG_AFFECTS_STDLIB]
     settings["//go/private:bootstrap_nogo"] = False
     settings["//command_line_option:collect_code_coverage"] = False

--- a/go/private/rules/transition.bzl
+++ b/go/private/rules/transition.bzl
@@ -236,15 +236,17 @@ non_go_tool_transition = transition(
 )
 
 def _go_stdlib_transition_impl(settings, _attr):
-    """Preserves common Go settings in the standard library configuration.
+    """Configures //:stdlib dependencies.
 
-    go_stdlib_transition filters tags that do not affect the standard library
-    and disables bootstrap_nogo and coverage collection.
+    go_stdlib_transition preserves each setting in
+    _common_reset_transition_dict except //go/config:tags. Changing another
+    setting could cause a Go rule and its //:stdlib dependency to resolve C++
+    runtime archives in different configurations, which could make GoLink
+    reference an archive that Bazel did not declare. go_stdlib_transition
+    filters //go/config:tags to _TAG_AFFECTS_STDLIB and sets
+    //go/private:bootstrap_nogo and
+    //command_line_option:collect_code_coverage to False.
     """
-    # Preserve every setting in _reset_transition_keys. A Go rule and its
-    # //:stdlib dependency must resolve the C++ toolchain in the same
-    # configuration. Otherwise, GoLink can reference a C++ runtime archive
-    # from one configuration while Bazel declares the archive from another.
     settings = dict(settings)
     settings["//go/config:tags"] = [t for t in settings["//go/config:tags"] if t in _TAG_AFFECTS_STDLIB]
     settings["//go/private:bootstrap_nogo"] = False

--- a/tests/core/transition/hermeticity_test.go
+++ b/tests/core/transition/hermeticity_test.go
@@ -31,6 +31,7 @@ func TestMain(m *testing.M) {
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 go_binary(
     name = "main",
@@ -123,6 +124,7 @@ message Foo {
 `,
 		ModuleFileSuffix: `
 bazel_dep(name = "protobuf", version = "29.0-rc2", repo_name = "com_google_protobuf")
+bazel_dep(name = "rules_cc", version = "0.1.5")
 bazel_dep(name = "toolchains_protoc", version = "0.3.4")
 `,
 		WorkspacePrefix: `
@@ -210,6 +212,22 @@ func TestGoProtoLibraryToolAttrsAreReset(t *testing.T) {
 	)
 }
 
+func TestStdlibPreservesRequestNogoConfigurations(t *testing.T) {
+	const target = "//:main"
+	const stdlib = "@io_bazel_rules_go//:stdlib"
+	if err := bazel_testing.RunBazel("build", target, stdlib, "--nobuild"); err != nil {
+		t.Fatalf("bazel build %s %s: %v", target, stdlib, err)
+	}
+
+	// //:main requests nogo, while coverdata sets request_nogo to false. //:stdlib must
+	// preserve both values so each //:stdlib target resolves the C++ toolchain in its
+	// parent configuration.
+	configHashes := getDependencyConfigHashes(t, target, stdlib)
+	if got, want := len(configHashes), 2; got != want {
+		t.Fatalf("%s depends on %s in %d configurations, want %d", target, stdlib, got, want)
+	}
+}
+
 func assertDependsCleanlyOnWithFlags(t *testing.T, targetA, targetB string, allowNoDep bool, flags ...string) {
 	// Analyze the targets to ensure that MODULE.bazel.lock has been created, otherwise bazel config
 	// will fail after the cquery command due to the Skyframe invalidation caused by a changed file.
@@ -217,22 +235,7 @@ func assertDependsCleanlyOnWithFlags(t *testing.T, targetA, targetB string, allo
 	if err != nil {
 		t.Fatalf("bazel build %s %s: %v", targetA, targetB, err)
 	}
-	query := fmt.Sprintf("deps(%s) intersect %s", targetA, targetB)
-	out, err := bazel_testing.BazelOutput(append(
-		[]string{
-			"cquery",
-			"--transitions=full",
-			"--output=jsonproto",
-			query,
-		},
-		flags...,
-	)...,
-	)
-	if err != nil {
-		t.Fatalf("bazel cquery '%s': %v", query, err)
-	}
-	cqueryOut := bytes.TrimSpace(out)
-	configHashes := extractConfigHashes(t, cqueryOut)
+	configHashes := getDependencyConfigHashes(t, targetA, targetB, flags...)
 	if len(configHashes) == 0 {
 		if allowNoDep {
 			return
@@ -259,6 +262,25 @@ func assertDependsCleanlyOnWithFlags(t *testing.T, targetA, targetB string, allo
 			strings.Join(goOptions, "\n"),
 		)
 	}
+}
+
+func getDependencyConfigHashes(t *testing.T, targetA, targetB string, flags ...string) []string {
+	t.Helper()
+	query := fmt.Sprintf("deps(%s) intersect %s", targetA, targetB)
+	out, err := bazel_testing.BazelOutput(append(
+		[]string{
+			"cquery",
+			"--transitions=full",
+			"--output=jsonproto",
+			query,
+		},
+		flags...,
+	)...,
+	)
+	if err != nil {
+		t.Fatalf("bazel cquery '%s': %v", query, err)
+	}
+	return extractConfigHashes(t, bytes.TrimSpace(out))
 }
 
 func extractConfigHashes(t *testing.T, rawJsonOut []byte) []string {


### PR DESCRIPTION
## Summary

Author: zbarsky-bot

Start `go_stdlib_transition` from all values in `_reset_transition_keys`; the transition then only filters `//go/config:tags` and disables `//go/private:bootstrap_nogo` and `//command_line_option:collect_code_coverage`. This keeps each Go rule and its `//:stdlib` dependency in the same configuration when resolving the C++ toolchain.

Since #4599 removed `cgo_context_data`, each Go rule resolves the C++ toolchain directly. Resetting `//go/private:request_nogo` made ordinary Go rules and `//:stdlib` resolve configuration-specific C++ runtime archives in different configurations, so `GoLink` could reference an archive that Bazel did not declare. Preserving every `_reset_transition_keys` value prevents `//go/config:static`, `//go/config:debug`, or future settings from recreating the same mismatch.

The regression test verifies the two required `//:stdlib` configurations for an ordinary Go target and `coverdata`. `//:stdlib` has no `_nogo` attribute, so preserving `//go/private:request_nogo` does not run nogo on `//:stdlib`.

## Testing

- `bazel test //tests/core/transition:hermeticity_test`
- `bazel test //tests:buildifier_test`
