### PR TITLE
Declare GoArchive in rule provider declarations

### DIFF
--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -257,6 +257,7 @@ def _go_binary_kwargs(go_cc_aspects = []):
     return {
         "cfg": go_transition,
         "implementation": _go_binary_impl,
+        "provides": [GoArchive],
         "attrs": {
             "srcs": attr.label_list(
                 allow_files = go_exts + asm_exts + cgo_exts + syso_exts,

--- a/go/private/rules/library.bzl
+++ b/go/private/rules/library.bzl
@@ -31,6 +31,7 @@ load(
 )
 load(
     "//go/private:providers.bzl",
+    "GoArchive",
     "GoInfo",
 )
 load(
@@ -202,7 +203,7 @@ go_library = rule(
     } | CGO_ATTRS,
     fragments = CGO_FRAGMENTS,
     toolchains = [GO_TOOLCHAIN] + CGO_TOOLCHAINS,
-    provides = [GoInfo],
+    provides = [GoArchive, GoInfo],
     doc = """This builds a Go library from a set of source files that are all part of
     the same package.
 

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -239,6 +239,7 @@ def _go_test_impl(ctx):
 _go_test_kwargs = {
     "cfg": go_transition,
     "implementation": _go_test_impl,
+    "provides": [GoArchive],
     "attrs": {
         "data": attr.label_list(
             allow_files = True,

--- a/tests/core/starlark/provider_tests.bzl
+++ b/tests/core/starlark/provider_tests.bzl
@@ -1,5 +1,32 @@
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
-load("//go:def.bzl", "go_binary", "go_library", "go_test")
+load("//go:def.bzl", "GoArchive", "go_binary", "go_library", "go_test")
+
+GoArchiveAspectInfo = provider()
+
+def _go_archive_aspect_impl(_target, _ctx):
+    return [GoArchiveAspectInfo()]
+
+_go_archive_aspect = aspect(
+    implementation = _go_archive_aspect_impl,
+    required_providers = [GoArchive],
+)
+
+def _go_archive_aspect_consumer_impl(ctx):
+    if GoArchiveAspectInfo not in ctx.attr.dep:
+        fail("GoArchive aspect was not applied to {}".format(ctx.attr.dep.label))
+
+go_archive_aspect_consumer = rule(
+    implementation = _go_archive_aspect_consumer_impl,
+    attrs = {
+        "dep": attr.label(aspects = [_go_archive_aspect]),
+    },
+)
+
+def _required_provider_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    return analysistest.end(env)
+
+required_provider_test = analysistest.make(_required_provider_test_impl)
 
 # go_binary and go_test targets must not be used as deps/embed attributes;
 # their dependencies may be built in different modes, resulting in conflicts and opaque errors.
@@ -45,6 +72,24 @@ def provider_test_suite():
         name = "go_test",
         tags = ["manual"],
     )
+
+    go_library(
+        name = "go_library",
+        tags = ["manual"],
+    )
+
+    for rule_name in ["go_binary", "go_library", "go_test"]:
+        go_archive_aspect_consumer(
+            name = rule_name + "_go_archive_aspect_consumer",
+            dep = ":" + rule_name,
+            tags = ["manual"],
+            testonly = True,
+        )
+
+        required_provider_test(
+            name = rule_name + "_go_archive_required_provider_test",
+            target_under_test = ":" + rule_name + "_go_archive_aspect_consumer",
+        )
 
     go_library(
         name = "lib_test_deps",


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

`go_binary`, `go_library`, and `go_test` return `GoArchive`, but their rule declarations did not consistently list `GoArchive` in `provides`. Bazel therefore skipped aspects that use `required_providers = [GoArchive]` before running the aspect implementation. Declare `GoArchive` for all three rules and add analysis tests that verify the aspect runs for each rule.

**Which issues(s) does this PR fix?**

Fixes #4612

**Other notes for review**

Validated with `bazel test --jobs=4 //tests/core/starlark:all` and `bazel test --jobs=4 //tests:buildifier_test`.
