### PR TITLE
[builder/cgo] escape ldflags for invoking cgo starting Go 1.27

### DIFF
--- a/go/tools/builders/cgo2.go
+++ b/go/tools/builders/cgo2.go
@@ -118,7 +118,7 @@ func cgo2(goenv *env, goSrcs, cgoSrcs, cSrcs, cxxSrcs, objcSrcs, objcxxSrcs, sSr
 			return "", nil, nil, fmt.Errorf("failed to create temporary file for ldflags: %w", err)
 		}
 		defer os.Remove(ldflagsFile.Name())
-		if _, err := ldflagsFile.WriteString(combinedLdFlagsStr); err != nil {
+		if _, err := ldflagsFile.WriteString(formatLdFlagsFileContent(combinedLdFlagsStr)); err != nil {
 			ldflagsFile.Close()
 			return "", nil, nil, fmt.Errorf("failed to write ldflags to temporary file: %w", err)
 		}
@@ -463,6 +463,15 @@ func copyOrLinkFile(inPath, outPath string) error {
 	} else {
 		return linkFile(inPath, outPath)
 	}
+}
+
+func formatLdFlagsFileContent(flags string) string {
+	shouldEscape, _ := onVersionOrHigher(27)
+	if shouldEscape {
+		escaped := strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(flags)
+		return `"` + escaped + `"` + "\n"
+	}
+	return flags
 }
 
 func onVersionOrHigher(version int) (bool, error) {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix


**What does this PR do? Why is it needed?**
Go 1.27 changes how the cgo tool expands `@file` response file arguments. Starting in Go 1.27, any argument beginning with @ is expanded before flag parsing using GCC-compatible tokenization — the file content is split on whitespace into multiple tokens.

Rules_go passes cgo its linker flags via -ldflags @<tmpfile>, writing the file as a plain space-joined string (e.g., -fsanitize-undefined-strip-path-components=0 -lm -lpthread). Before Go 1.27, cgo handled @<file> inside its own -ldflags flag handler, treating the file content as a single string. With the new global expansion, the file is tokenized before flag parsing, injecting each whitespace-separated flag as an independent argument into cgo's own flag space. The first token is consumed as the value of -ldflags, and the rest are parsed as unknown cgo flags, producing an error similar to the following:
```
flag provided but not defined: -fsanitize-undefined-strip-path-components
```

This PR fixes the issue by wrapping the ldflags file content in double quotes (with proper escaping of \ and ") when building with Go 1.27+. GCC tokenization then yields exactly one quoted token — the complete ldflags string — which is correctly consumed as the value of -ldflags. A separate build-tag-gated file preserves the original behavior for older Go versions.

**Which issues(s) does this PR fix?**

Fixes #4640

**Other notes for review**
