### PR TITLE
builders: filter test sources in place

### DIFF
--- a/go/tools/builders/filter.go
+++ b/go/tools/builders/filter.go
@@ -121,25 +121,26 @@ func applyTestFilter(testFilter string, srcs *archiveSrcs) error {
 	switch testFilter {
 	case "off":
 	case "only":
-		testSrcs := make([]fileInfo, 0, len(srcs.goSrcs))
-		for _, f := range srcs.goSrcs {
-			if strings.HasSuffix(f.pkg, "_test") {
-				testSrcs = append(testSrcs, f)
-			}
-		}
-		srcs.goSrcs = testSrcs
+		srcs.goSrcs = filterTestFiles(srcs.goSrcs, true)
 	case "exclude":
-		libSrcs := make([]fileInfo, 0, len(srcs.goSrcs))
-		for _, f := range srcs.goSrcs {
-			if !strings.HasSuffix(f.pkg, "_test") {
-				libSrcs = append(libSrcs, f)
-			}
-		}
-		srcs.goSrcs = libSrcs
+		srcs.goSrcs = filterTestFiles(srcs.goSrcs, false)
 	default:
 		return fmt.Errorf("invalid test filter %q", testFilter)
 	}
 	return nil
+}
+
+func filterTestFiles(srcs []fileInfo, keepTest bool) []fileInfo {
+	filtered := srcs[:0]
+	for _, f := range srcs {
+		if strings.HasSuffix(f.pkg, "_test") == keepTest {
+			filtered = append(filtered, f)
+		}
+	}
+	for i := len(filtered); i < len(srcs); i++ {
+		srcs[i] = fileInfo{}
+	}
+	return filtered
 }
 
 // readFileInfo applies build constraints to an input file and returns whether

--- a/go/tools/builders/filter_test.go
+++ b/go/tools/builders/filter_test.go
@@ -130,6 +130,49 @@ func runTest(t *testing.T, bctx build.Context, inputs []string, expect []string)
 	}
 }
 
+func TestApplyTestFilter(t *testing.T) {
+	inputs := []fileInfo{
+		{filename: "lib.go", pkg: "example"},
+		{filename: "internal_test.go", pkg: "example"},
+		{filename: "external_test.go", pkg: "example_test"},
+	}
+	for _, tc := range []struct {
+		name       string
+		testFilter string
+		want       []string
+	}{
+		{
+			name:       "off",
+			testFilter: "off",
+			want:       []string{"lib.go", "internal_test.go", "external_test.go"},
+		},
+		{
+			name:       "only",
+			testFilter: "only",
+			want:       []string{"external_test.go"},
+		},
+		{
+			name:       "exclude",
+			testFilter: "exclude",
+			want:       []string{"lib.go", "internal_test.go"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srcs := archiveSrcs{goSrcs: append([]fileInfo(nil), inputs...)}
+			if err := applyTestFilter(tc.testFilter, &srcs); err != nil {
+				t.Fatalf("applyTestFilter(%q): %v", tc.testFilter, err)
+			}
+			got := make([]string, len(srcs.goSrcs))
+			for i, src := range srcs.goSrcs {
+				got[i] = src.filename
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("applyTestFilter(%q): got %v, want %v", tc.testFilter, got, tc.want)
+			}
+		})
+	}
+}
+
 // abs is a dummy env.go abs to avoid depending on env.go and flags.go.
 func abs(p string) string {
 	return p


### PR DESCRIPTION
Large compilepkg and nogo actions can run test filtering after
readFileInfo has attached AST, import, and embed metadata to every Go
source. This matters because each discarded fileInfo may retain parser
state for a source file.

The old only and exclude modes allocated a second fileInfo slice. That
increased short-lived memory use and kept discarded metadata reachable
longer than needed.

Compact the Go source slice in place for test filtering and zero the
discarded tail. This preserves order and the existing off, only, and
exclude behavior while reducing allocation pressure in the builders
path.
