### PR TITLE
Support --force_pic for cgo interop

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -94,6 +94,10 @@ go_config(
         "//conditions:default": "//go/config:debug",
     }),
     export_stdlib = "//go/config:export_stdlib",
+    force_pic = select({
+        "//go/private:force_pic": True,
+        "//conditions:default": False,
+    }),
     gc_goopts = "//go/config:gc_goopts",
     gc_linkopts = "//go/config:gc_linkopts",
     gotags = "//go/config:tags",

--- a/go/private/BUILD.bazel
+++ b/go/private/BUILD.bazel
@@ -214,3 +214,11 @@ config_setting(
     },
     visibility = ["//:__pkg__"],
 )
+
+config_setting(
+    name = "force_pic",
+    values = {
+        "force_pic": "true",
+    },
+    visibility = ["//:__pkg__"],
+)

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -1031,8 +1031,10 @@ def _go_config_impl(ctx):
 
     linkmode = ctx.attr.linkmode[BuildSettingInfo].value
     if linkmode == "auto":
-        # Mirror Go's logic by defaulting to PIE on supported platforms
-        linkmode = LINKMODE_PIE if _defaults_to_pie(toolchain.default_goos, race) else LINKMODE_NORMAL
+        if ctx.attr.force_pic or _defaults_to_pie(toolchain.default_goos, race):
+            linkmode = LINKMODE_PIE
+        else:
+            linkmode = LINKMODE_NORMAL
 
     go_config_info = GoConfigInfo(
         goos = toolchain.default_goos,
@@ -1113,6 +1115,7 @@ go_config = rule(
             mandatory = False,
             providers = [BuildSettingInfo],
         ),
+        "force_pic": attr.bool(mandatory = True),
     },
     provides = [GoConfigInfo],
     doc = """Collects information about build settings in the current


### PR DESCRIPTION
If you set --force_pic on linux and then link go into a cc_binary, the
C++ code is likely built with pic but the go code was not, leading to
linker failures. Now this default bazel flag is respected.
