### PR TITLE
Use param file to avoid argument list exceeding OS limit

### DIFF
--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -202,6 +202,7 @@ def cgo_configure(go, srcs, cdeps, cppopts, copts, cxxopts, clinkopts):
         ]
 
     ldflags = go.actions.args()
+    ldflags.use_param_file("-param=%s")
     _add_ldflags(ldflags, pre_runtime_clinkopts)
     if needs_cxx_runtime:
         ldflags.add_all(runtime_libs, before_each = "-ldflags")


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Regression in 0.61 where `use_param_file` is not used, resulting in rules_go sometimes producing arguments that exceeds OS limit.

**Which issues(s) does this PR fix?**

Fixes #4643 `Argument list too long` error when building with `-c fastbuild`.

**Other notes for review**
