### PR TITLE
compilepkg: record importpath-relative source paths under -trimpath

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -101,6 +101,7 @@ go_config(
     gc_goopts = "//go/config:gc_goopts",
     gc_linkopts = "//go/config:gc_linkopts",
     gotags = "//go/config:tags",
+    importpath_trimpath = "//go/config:importpath_trimpath",
     linkmode = "//go/config:linkmode",
     msan = "//go/config:msan",
     pgoprofile = "//go/config:pgoprofile",

--- a/go/config/BUILD.bazel
+++ b/go/config/BUILD.bazel
@@ -69,6 +69,18 @@ string_flag(
     visibility = ["//visibility:public"],
 )
 
+# When enabled, source paths recorded under -trimpath are rewritten to be
+# importpath-relative (matching native `go build -trimpath`) instead of
+# execroot-relative, so debuggers can resolve them without configuration.
+# Note: runfiles.CurrentRepository()/CallerRepository() infer the caller's
+# repository from the execroot-relative path shape and report the main
+# repository for all callers when this is enabled.
+bool_flag(
+    name = "importpath_trimpath",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
 filegroup(
     name = "all_files",
     testonly = True,

--- a/go/modes.rst
+++ b/go/modes.rst
@@ -97,6 +97,18 @@ or using `Bazel configuration transitions`_.
 | but adds time to the initial build. Leave false unless you want to use       |
 | golangci-lint or another tool that relies on GOPACKAGESDRIVER.               |
 +------------------------+---------------------+-------------------------------+
+| :param:`importpath_trimpath` | :type:`bool`  | :value:`false`                |
++------------------------+---------------------+-------------------------------+
+| Records source paths as importpath-relative (e.g.                            |
+| ``example.com/mod/pkg/file.go``), matching native ``go build -trimpath``,    |
+| instead of execroot-relative. This lets debuggers such as Delve and GoLand   |
+| resolve sources without path substitution configuration, which is required   |
+| for remote debugging on hosts without a Bazel execroot.                      |
+|                                                                              |
+| Note: ``runfiles.CurrentRepository()`` and ``runfiles.CallerRepository()``   |
+| infer the calling repository from the execroot-relative path shape; with     |
+| this setting enabled they report the main repository for all callers.        |
++------------------------+---------------------+-------------------------------+
 
 Platforms
 ---------

--- a/go/private/actions/compilepkg.bzl
+++ b/go/private/actions/compilepkg.bzl
@@ -127,6 +127,9 @@ def emit_compilepkg(
         compile_args.add("-cover_format", go.mode.cover_format)
         compile_args.add_all(cover, before_each = "-cover")
 
+    if go.mode.importpath_trimpath:
+        compile_args.add("-importpath_trimpath")
+
     shared_args.add_all(archives, before_each = "-arc", map_each = _archive)
     if recompile_internal_deps:
         shared_args.add_all(recompile_internal_deps, before_each = "-recompile_internal_deps")

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -522,6 +522,7 @@ default_go_config_info = GoConfigInfo(
     stamp = False,
     cover_format = None,
     gc_goopts = [],
+    importpath_trimpath = False,
     amd64 = None,
     arm = None,
     pgoprofile = None,
@@ -1051,6 +1052,7 @@ def _go_config_impl(ctx):
         stamp = ctx.attr.stamp,
         cover_format = ctx.attr.cover_format[BuildSettingInfo].value,
         gc_goopts = ctx.attr.gc_goopts[BuildSettingInfo].value,
+        importpath_trimpath = ctx.attr.importpath_trimpath[BuildSettingInfo].value,
         amd64 = ctx.attr.amd64,
         arm = ctx.attr.arm,
         pgoprofile = pgoprofile,
@@ -1102,6 +1104,10 @@ go_config = rule(
             providers = [BuildSettingInfo],
         ),
         "gc_goopts": attr.label(
+            mandatory = True,
+            providers = [BuildSettingInfo],
+        ),
+        "importpath_trimpath": attr.label(
             mandatory = True,
             providers = [BuildSettingInfo],
         ),

--- a/go/tools/builders/cgo2.go
+++ b/go/tools/builders/cgo2.go
@@ -33,7 +33,7 @@ import (
 )
 
 // cgo2 processes a set of mixed source files with cgo.
-func cgo2(goenv *env, goSrcs, cgoSrcs, cSrcs, cxxSrcs, objcSrcs, objcxxSrcs, sSrcs, hSrcs []string, packagePath, packageName string, cc string, cppFlags, cFlags, cxxFlags, objcFlags, objcxxFlags, ldFlags []string, cgoExportHPath string, cgoGoSrcsPath string) (srcDir string, allGoSrcs, cObjs []string, err error) {
+func cgo2(goenv *env, goSrcs, cgoSrcs, cSrcs, cxxSrcs, objcSrcs, objcxxSrcs, sSrcs, hSrcs []string, importPath, packagePath, packageName string, cc string, cppFlags, cFlags, cxxFlags, objcFlags, objcxxFlags, ldFlags []string, cgoExportHPath string, cgoGoSrcsPath string) (srcDir string, allGoSrcs, cObjs []string, err error) {
 	// Report an error if the C/C++ toolchain wasn't configured.
 	if cc == "" {
 		err := cgoError(cgoSrcs[:])
@@ -173,6 +173,13 @@ func cgo2(goenv *env, goSrcs, cgoSrcs, cSrcs, cxxSrcs, objcSrcs, objcxxSrcs, sSr
 	trimPath, err := createTrimPath()
 	if err != nil {
 		return "", nil, nil, err
+	}
+	// Prepend a rewrite mapping srcDir to the package's importpath so //line
+	// paths become importpath-relative, matching native `go build -trimpath`.
+	// First-match-wins; the execroot rewrite stays as the fallback for
+	// anything outside srcDir.
+	if ipTrim := importpathTrimRewrite(srcDir, importPath); ipTrim != "" {
+		trimPath = ipTrim + ";" + trimPath
 	}
 	args := goenv.goTool("cgo", "-srcdir", srcDir, "-objdir", workDir, "-trimpath", trimPath)
 	if ldflagsFile != nil {

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -175,6 +175,16 @@ func compileArchive(
 	}
 	defer cleanup()
 
+	// Capture the package's original source directory before coverage
+	// instrumentation redirects sources to workDir copies and before an
+	// empty placeholder file is injected for empty archives. All real
+	// sources of a package share one directory, so the first file is
+	// representative. Used to build the importpath trimpath rewrite below.
+	packageSourceDir := ""
+	if len(srcs.goSrcs) > 0 {
+		packageSourceDir = filepath.Dir(srcs.goSrcs[0].filename)
+	}
+
 	if len(srcs.goSrcs) == 0 {
 		// We need to run the compiler to create a valid archive, even if there's nothing in it.
 		// Otherwise, GoPack will complain if we try to add assembly or cgo objects.
@@ -334,26 +344,36 @@ func compileArchive(
 		if coverMode != "" && cgoGoSrcsForNogoPath != "" {
 			// If the package uses Cgo, compile .s and .S files with cgo2, not the Go assembler.
 			// Otherwise: the .s/.S files will be compiled with the Go assembler later
-			srcDir, goSrcs, objFiles, err = cgo2(goenv, goSrcs, cgoSrcs, cSrcs, cxxSrcs, objcSrcs, objcxxSrcs, sSrcs, hSrcs, packagePath, packageName, cc, cppFlags, cFlags, cxxFlags, objcFlags, objcxxFlags, ldFlags, cgoExportHPath, "")
+			srcDir, goSrcs, objFiles, err = cgo2(goenv, goSrcs, cgoSrcs, cSrcs, cxxSrcs, objcSrcs, objcxxSrcs, sSrcs, hSrcs, importPath, packagePath, packageName, cc, cppFlags, cFlags, cxxFlags, objcFlags, objcxxFlags, ldFlags, cgoExportHPath, "")
 			if err != nil {
 				return err
 			}
 			// Also run cgo on original source files, not coverage instrumented, if using nogo.
 			// The compilation outputs are only used to run cgo, but the generated sources are
 			// passed to the separate nogo action via cgoGoSrcsForNogoPath.
-			_, _, _, err = cgo2(goenv, goSrcsNogo, cgoSrcsNogo, cSrcs, cxxSrcs, objcSrcs, objcxxSrcs, sSrcs, hSrcs, packagePath, packageName, cc, cppFlags, cFlags, cxxFlags, objcFlags, objcxxFlags, ldFlags, "", cgoGoSrcsForNogoPath)
+			_, _, _, err = cgo2(goenv, goSrcsNogo, cgoSrcsNogo, cSrcs, cxxSrcs, objcSrcs, objcxxSrcs, sSrcs, hSrcs, importPath, packagePath, packageName, cc, cppFlags, cFlags, cxxFlags, objcFlags, objcxxFlags, ldFlags, "", cgoGoSrcsForNogoPath)
 			if err != nil {
 				return err
 			}
 		} else {
 			// If the package uses Cgo, compile .s and .S files with cgo2, not the Go assembler.
 			// Otherwise: the .s/.S files will be compiled with the Go assembler later
-			srcDir, goSrcs, objFiles, err = cgo2(goenv, goSrcs, cgoSrcs, cSrcs, cxxSrcs, objcSrcs, objcxxSrcs, sSrcs, hSrcs, packagePath, packageName, cc, cppFlags, cFlags, cxxFlags, objcFlags, objcxxFlags, ldFlags, cgoExportHPath, cgoGoSrcsForNogoPath)
+			srcDir, goSrcs, objFiles, err = cgo2(goenv, goSrcs, cgoSrcs, cSrcs, cxxSrcs, objcSrcs, objcxxSrcs, sSrcs, hSrcs, importPath, packagePath, packageName, cc, cppFlags, cFlags, cxxFlags, objcFlags, objcxxFlags, ldFlags, cgoExportHPath, cgoGoSrcsForNogoPath)
 			if err != nil {
 				return err
 			}
 		}
-		gcFlags = append(gcFlags, "-trimpath="+srcDir)
+		// Prepend a rewrite mapping the package's original source directory to
+		// its importpath so recorded source paths become importpath-relative,
+		// matching native `go build -trimpath`. Go's -trimpath is
+		// first-match-wins, so srcDir stays as the fallback for everything
+		// else (cgo-processed copies, generated sources). The //line paths in
+		// cgo-generated sources are handled at the cgo level in cgo2.
+		trimPath := srcDir
+		if ipTrim := importpathTrimRewrite(packageSourceDir, importPath); ipTrim != "" {
+			trimPath = ipTrim + ";" + trimPath
+		}
+		gcFlags = append(gcFlags, "-trimpath="+trimPath)
 	} else {
 		if cgoExportHPath != "" {
 			if err := os.WriteFile(cgoExportHPath, nil, 0o666); err != nil {
@@ -363,6 +383,22 @@ func compileArchive(
 		trimPath, err := createTrimPath()
 		if err != nil {
 			return err
+		}
+		// Prepend a rewrite mapping the package's source directory to its
+		// importpath so the recorded (DWARF) source paths become
+		// importpath-relative, matching native `go build -trimpath`, instead
+		// of execroot-relative. This lets debuggers (GoLand/Delve) resolve
+		// sources without substitute-path config, which is required for
+		// remote debug where the debug host has no source checkout.
+		//
+		// Go's -trimpath is first-match-wins, so this rule goes before the
+		// execroot fallback, which still covers sources outside the package
+		// directory (coverage-instrumented copies, generated sources). The
+		// prefix is an absolute dir computed at builder runtime (not on the
+		// bazel command line) and the recorded path is machine-independent,
+		// so remote cache keys and output determinism are unaffected.
+		if ipTrim := importpathTrimRewrite(packageSourceDir, importPath); ipTrim != "" {
+			trimPath = ipTrim + ";" + trimPath
 		}
 		// Preserve an existing -trimpath argument, applying abs() to each prefix.
 		for i, flag := range gcFlags {
@@ -561,6 +597,18 @@ func appendToArchive(goenv *env, pack, outPath string, objFiles []string) error 
 	args := []string{pack, "r", abs(outPath)}
 	args = append(args, objFiles...)
 	return goenv.runCommand(args)
+}
+
+// importpathTrimRewrite builds a -trimpath rewrite that maps the absolute
+// source directory of the package being compiled to its importpath, e.g.
+// "/abs/execroot/utils=>example.com/repo/utils". Returns "" when the package
+// has no importpath or no original source directory (e.g. empty archives),
+// in which case callers keep their existing trimpath unchanged.
+func importpathTrimRewrite(sourceDir, importPath string) string {
+	if importPath == "" || sourceDir == "" {
+		return ""
+	}
+	return abs(sourceDir) + "=>" + importPath
 }
 
 func createTrimPath() (string, error) {

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -73,6 +73,8 @@ func compilePkg(args []string) error {
 	fs.StringVar(&coverFormat, "cover_format", "", "Emit source file paths in coverage instrumentation suitable for the specified coverage format")
 	fs.Var(&recompileInternalDeps, "recompile_internal_deps", "The import path of the direct dependencies that needs to be recompiled.")
 	fs.StringVar(&pgoprofile, "pgoprofile", "", "The pprof profile to consider for profile guided optimization.")
+	var importpathTrimpath bool
+	fs.BoolVar(&importpathTrimpath, "importpath_trimpath", false, "Record importpath-relative source paths, matching native 'go build -trimpath'")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -135,7 +137,8 @@ func compilePkg(args []string) error {
 		cgoGoSrcsPath,
 		coverFormat,
 		recompileInternalDeps,
-		pgoprofile)
+		pgoprofile,
+		importpathTrimpath)
 }
 
 func compileArchive(
@@ -168,6 +171,7 @@ func compileArchive(
 	coverFormat string,
 	recompileInternalDeps []string,
 	pgoprofile string,
+	importpathTrimpath bool,
 ) error {
 	workDir, cleanup, err := goenv.workDir()
 	if err != nil {
@@ -183,6 +187,14 @@ func compileArchive(
 	packageSourceDir := ""
 	if len(srcs.goSrcs) > 0 {
 		packageSourceDir = filepath.Dir(srcs.goSrcs[0].filename)
+	}
+
+	// The importpath rewrite is opt-in (//go/config:importpath_trimpath).
+	// An empty trimImportPath disables it everywhere below: the rewrite
+	// helper returns "" and cgo2 skips its //line rewrite.
+	trimImportPath := ""
+	if importpathTrimpath {
+		trimImportPath = importPath
 	}
 
 	if len(srcs.goSrcs) == 0 {
@@ -344,21 +356,21 @@ func compileArchive(
 		if coverMode != "" && cgoGoSrcsForNogoPath != "" {
 			// If the package uses Cgo, compile .s and .S files with cgo2, not the Go assembler.
 			// Otherwise: the .s/.S files will be compiled with the Go assembler later
-			srcDir, goSrcs, objFiles, err = cgo2(goenv, goSrcs, cgoSrcs, cSrcs, cxxSrcs, objcSrcs, objcxxSrcs, sSrcs, hSrcs, importPath, packagePath, packageName, cc, cppFlags, cFlags, cxxFlags, objcFlags, objcxxFlags, ldFlags, cgoExportHPath, "")
+			srcDir, goSrcs, objFiles, err = cgo2(goenv, goSrcs, cgoSrcs, cSrcs, cxxSrcs, objcSrcs, objcxxSrcs, sSrcs, hSrcs, trimImportPath, packagePath, packageName, cc, cppFlags, cFlags, cxxFlags, objcFlags, objcxxFlags, ldFlags, cgoExportHPath, "")
 			if err != nil {
 				return err
 			}
 			// Also run cgo on original source files, not coverage instrumented, if using nogo.
 			// The compilation outputs are only used to run cgo, but the generated sources are
 			// passed to the separate nogo action via cgoGoSrcsForNogoPath.
-			_, _, _, err = cgo2(goenv, goSrcsNogo, cgoSrcsNogo, cSrcs, cxxSrcs, objcSrcs, objcxxSrcs, sSrcs, hSrcs, importPath, packagePath, packageName, cc, cppFlags, cFlags, cxxFlags, objcFlags, objcxxFlags, ldFlags, "", cgoGoSrcsForNogoPath)
+			_, _, _, err = cgo2(goenv, goSrcsNogo, cgoSrcsNogo, cSrcs, cxxSrcs, objcSrcs, objcxxSrcs, sSrcs, hSrcs, trimImportPath, packagePath, packageName, cc, cppFlags, cFlags, cxxFlags, objcFlags, objcxxFlags, ldFlags, "", cgoGoSrcsForNogoPath)
 			if err != nil {
 				return err
 			}
 		} else {
 			// If the package uses Cgo, compile .s and .S files with cgo2, not the Go assembler.
 			// Otherwise: the .s/.S files will be compiled with the Go assembler later
-			srcDir, goSrcs, objFiles, err = cgo2(goenv, goSrcs, cgoSrcs, cSrcs, cxxSrcs, objcSrcs, objcxxSrcs, sSrcs, hSrcs, importPath, packagePath, packageName, cc, cppFlags, cFlags, cxxFlags, objcFlags, objcxxFlags, ldFlags, cgoExportHPath, cgoGoSrcsForNogoPath)
+			srcDir, goSrcs, objFiles, err = cgo2(goenv, goSrcs, cgoSrcs, cSrcs, cxxSrcs, objcSrcs, objcxxSrcs, sSrcs, hSrcs, trimImportPath, packagePath, packageName, cc, cppFlags, cFlags, cxxFlags, objcFlags, objcxxFlags, ldFlags, cgoExportHPath, cgoGoSrcsForNogoPath)
 			if err != nil {
 				return err
 			}
@@ -370,7 +382,7 @@ func compileArchive(
 		// else (cgo-processed copies, generated sources). The //line paths in
 		// cgo-generated sources are handled at the cgo level in cgo2.
 		trimPath := srcDir
-		if ipTrim := importpathTrimRewrite(packageSourceDir, importPath); ipTrim != "" {
+		if ipTrim := importpathTrimRewrite(packageSourceDir, trimImportPath); ipTrim != "" {
 			trimPath = ipTrim + ";" + trimPath
 		}
 		gcFlags = append(gcFlags, "-trimpath="+trimPath)
@@ -397,7 +409,7 @@ func compileArchive(
 		// prefix is an absolute dir computed at builder runtime (not on the
 		// bazel command line) and the recorded path is machine-independent,
 		// so remote cache keys and output determinism are unaffected.
-		if ipTrim := importpathTrimRewrite(packageSourceDir, importPath); ipTrim != "" {
+		if ipTrim := importpathTrimRewrite(packageSourceDir, trimImportPath); ipTrim != "" {
 			trimPath = ipTrim + ";" + trimPath
 		}
 		// Preserve an existing -trimpath argument, applying abs() to each prefix.

--- a/tests/core/go_library/trimpath_test.go
+++ b/tests/core/go_library/trimpath_test.go
@@ -115,7 +115,7 @@ func File() string {
 	return file
 }
 `,
-	WorkspaceSuffix: `
+		WorkspaceSuffix: `
 local_repository(
     name = "other_repo",
     path = "other_repo",
@@ -125,32 +125,54 @@ local_repository(
 }
 
 // These are the expected paths after applying trimpath.
-var expectedTrimpath = `
+var expectedDefault = `
+main.go
+maincgo.go
+external/other_repo/other.go
+external/other_repo/othercgo.go
+`
+
+var expectedSibling = `
+main.go
+maincgo.go
+../other_repo/other.go
+../other_repo/othercgo.go
+`
+
+// With --//go/config:importpath_trimpath, recorded paths are
+// importpath-relative in all layouts, matching native `go build -trimpath`.
+var expectedImportpath = `
 example.com/main_repo/main/main.go
 example.com/main_repo/maincgo/maincgo.go
 example.com/other_repo/other/other.go
 example.com/other_repo/othercgo/othercgo.go
 `
 
+const importpathTrimpathFlag = "--@io_bazel_rules_go//go/config:importpath_trimpath=true"
+
+func checkTrimpathOutput(t *testing.T, expected string, bazelArgs ...string) {
+	t.Helper()
+	out, err := bazel_testing.BazelOutput(append([]string{"run"}, append(bazelArgs, "//:main")...)...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outStr := "\n" + string(out)
+	if outStr != expected {
+		t.Fatal("actual", outStr, "vs expected", expected)
+	}
+}
+
 func TestTrimpath(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
-		out, err := bazel_testing.BazelOutput("run", "//:main")
-		if err != nil {
-			t.Fatal(err)
-		}
-		outStr := "\n" + string(out)
-		if outStr != expectedTrimpath {
-			t.Fatal("actual", outStr, "vs expected", expectedTrimpath)
-		}
+		checkTrimpathOutput(t, expectedDefault)
 	})
 	t.Run("experimental_sibling_repository_layout", func(t *testing.T) {
-		out, err := bazel_testing.BazelOutput("run", "--experimental_sibling_repository_layout", "//:main")
-		if err != nil {
-			t.Fatal(err)
-		}
-		outStr := "\n" + string(out)
-		if outStr != expectedTrimpath {
-			t.Fatal("actual", outStr, "vs expected", expectedTrimpath)
-		}
+		checkTrimpathOutput(t, expectedSibling, "--experimental_sibling_repository_layout")
+	})
+	t.Run("importpath_trimpath", func(t *testing.T) {
+		checkTrimpathOutput(t, expectedImportpath, importpathTrimpathFlag)
+	})
+	t.Run("importpath_trimpath_sibling_repository_layout", func(t *testing.T) {
+		checkTrimpathOutput(t, expectedImportpath, importpathTrimpathFlag, "--experimental_sibling_repository_layout")
 	})
 }

--- a/tests/core/go_library/trimpath_test.go
+++ b/tests/core/go_library/trimpath_test.go
@@ -125,18 +125,11 @@ local_repository(
 }
 
 // These are the expected paths after applying trimpath.
-var expectedDefault = `
-main.go
-maincgo.go
-external/other_repo/other.go
-external/other_repo/othercgo.go
-`
-
-var expectedSibling = `
-main.go
-maincgo.go
-../other_repo/other.go
-../other_repo/othercgo.go
+var expectedTrimpath = `
+example.com/main_repo/main/main.go
+example.com/main_repo/maincgo/maincgo.go
+example.com/other_repo/other/other.go
+example.com/other_repo/othercgo/othercgo.go
 `
 
 func TestTrimpath(t *testing.T) {
@@ -146,8 +139,8 @@ func TestTrimpath(t *testing.T) {
 			t.Fatal(err)
 		}
 		outStr := "\n" + string(out)
-		if outStr != expectedDefault {
-			t.Fatal("actual", outStr, "vs expected", expectedDefault)
+		if outStr != expectedTrimpath {
+			t.Fatal("actual", outStr, "vs expected", expectedTrimpath)
 		}
 	})
 	t.Run("experimental_sibling_repository_layout", func(t *testing.T) {
@@ -156,8 +149,8 @@ func TestTrimpath(t *testing.T) {
 			t.Fatal(err)
 		}
 		outStr := "\n" + string(out)
-		if outStr != expectedSibling {
-			t.Fatal("actual", outStr, "vs expected", expectedSibling)
+		if outStr != expectedTrimpath {
+			t.Fatal("actual", outStr, "vs expected", expectedTrimpath)
 		}
 	})
 }


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Adds an opt-in build setting `--@io_bazel_rules_go//go/config:importpath_trimpath` that records source paths as importpath-relative, the same shape native `go build -trimpath` produces, instead of execroot-relative.

Today the recorded paths are things like `pkg/file.go` for the main repo and `external/gazelle++go_deps+com_github_x_y/file.go` for external deps. Debuggers can't do anything with those: the former is a relative fragment with no anchor, the latter is Bazel-internal naming. In practice this makes remote debugging impossible — if you attach GoLand/Delve to a binary running on a machine that doesn't have a Bazel execroot, every breakpoint fails to resolve. #2258 and #1708 are both this problem, and cockroachdb/cockroach#64379 asked for essentially this feature.

With the setting enabled, compilepkg prepends a `-trimpath` rewrite mapping each package's source directory to its importpath, so the recorded path becomes e.g. `example.com/mod/pkg/file.go`. GoLand resolves those through its module index with no configuration, and dlv needs at most one `substitute-path` rule. The cgo tool gets the same rewrite for its `//line` directives, which as a side effect makes cgo and non-cgo packages record consistent shapes (today cgo paths are trimmed relative to the package dir instead of the execroot).

The reproducibility concern that keeps `-trimpath` always-on (see #2258) still holds: the rewrite prefix is computed inside the builder at runtime, not on the action command line, so cache keys don't change, and the recorded paths are machine-independent. The execroot rewrite from #4435 stays in place as the fallback (Go's `-trimpath` is first-match-wins), so coverage-instrumented copies and generated sources are unaffected. The package source dir is captured before coverage instrumentation redirects sources to workDir copies.

The setting defaults to off because `runfiles.CurrentRepository()` / `CallerRepository()` infer the calling repository by parsing `external/<repo>/` out of `runtime.Caller` paths; with importpath-relative paths they'd report the main repository for every caller. This is documented in `go/modes.rst` along with the new setting.

**Which issues(s) does this PR fix?**

Addresses #2258 and #1708 for users who opt in.

**Other notes for review**

- `tests/core/go_library:trimpath_test` now covers both modes in both repository layouts (default expectations are unchanged from today).
- External deps are recorded without the `@version` suffix that native `go build -trimpath` uses, since the compile action only knows the importpath. `go_repository` does know the version, so plumbing it through would make the output match the native toolchain exactly — seemed better as a follow-up.
- If there's interest in eventually making this the default, `CurrentRepository` would need a path-independent source of repository identity (e.g. an importpath→repository mapping emitted alongside the repo mapping manifest). Also follow-up material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
