### PR TITLE
runfiles: implement CurrentRepository via a package repository map

### DIFF
--- a/go/private/actions/binary.bzl
+++ b/go/private/actions/binary.bzl
@@ -54,7 +54,7 @@ def emit_binary(
         else:
             extension = goos_to_extension(go.mode.goos)
         executable = go.declare_file(go, path = name, ext = extension)
-    go.link(
+    package_repo_map = go.link(
         go,
         archive = archive,
         test_archives = test_archives,
@@ -69,6 +69,6 @@ def emit_binary(
         for d in archive.cgo_deps.to_list()
         if has_shared_lib_extension(d.basename)
     ]
-    runfiles = go._ctx.runfiles(files = cgo_dynamic_deps).merge(archive.runfiles)
+    runfiles = go._ctx.runfiles(files = cgo_dynamic_deps + [package_repo_map]).merge(archive.runfiles)
 
     return archive, executable, runfiles

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -35,7 +35,12 @@ load(
 )
 
 def _format_archive(d):
-    return "{}={}={}".format(d.label, d.importmap, d.file.path)
+    return "{}={}={}={}".format(d.label, d.importmap, d.file.path, d.label.workspace_name)
+
+def _rlocation_path(go, file):
+    if file.short_path.startswith("../"):
+        return file.short_path[len("../"):]
+    return go._ctx.workspace_name + "/" + file.short_path
 
 def emit_link(
         go,
@@ -128,6 +133,19 @@ def emit_link(
     builder_args.add_all(arcs, before_each = "-arc", map_each = _format_archive)
     builder_args.add("-package_list", go.sdk.package_list)
 
+    # Write a map from the package path of each linked package to the
+    # canonical name of the Bazel repository containing its sources. The
+    # runfiles library reads this file at runtime to implement
+    # CurrentRepository without relying on the format of the source file
+    # paths recorded in the binary.
+    package_repo_map = go.actions.declare_file(
+        executable.basename + ".package_repo_map",
+        sibling = executable,
+    )
+    builder_args.add("-package_repo_map", package_repo_map)
+    builder_args.add("-package_repo_map_rlocation", _rlocation_path(go, package_repo_map))
+    builder_args.add("-main_repo", archive.data.label.workspace_name)
+
     # Build a list of rpaths for dynamic libraries we need to find.
     # rpaths are relative paths from the binary to directories where libraries
     # are stored. Binaries that require these will only work when installed in
@@ -192,7 +210,7 @@ def emit_link(
 
     go.actions.run(
         inputs = inputs,
-        outputs = [executable],
+        outputs = [executable, package_repo_map],
         mnemonic = "GoLink",
         executable = go.toolchain._builder,
         arguments = [builder_args, "--", tool_args],
@@ -200,6 +218,8 @@ def emit_link(
         toolchain = GO_TOOLCHAIN_LABEL,
         exec_group = exec_group,
     )
+
+    return package_repo_map
 
 def _extract_extldflags(gc_linkopts, extldflags):
     """Extracts -extldflags from gc_linkopts and combines them into a single list.

--- a/go/runfiles/BUILD.bazel
+++ b/go/runfiles/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "fs.go",
         "global.go",
         "manifest.go",
+        "package_repo_map.go",
         "runfiles.go",
     ],
     importpath = "github.com/bazelbuild/rules_go/go/runfiles",
@@ -58,4 +59,10 @@ go_test(
         "rlocationpath_xdefs_example_test.go",
     ],
     deps = [":runfiles"],
+)
+
+go_test(
+    name = "package_repo_map_test",
+    srcs = ["package_repo_map_test.go"],
+    embed = [":runfiles"],
 )

--- a/go/runfiles/global.go
+++ b/go/runfiles/global.go
@@ -68,11 +68,30 @@ func CallerRepository() string {
 }
 
 func callerRepository(skip int) string {
-	_, file, _, _ := runtime.Caller(skip + 1)
-	if match := legacyExternalGeneratedFile.FindStringSubmatch(file); match != nil {
+	var pc [1]uintptr
+	if runtime.Callers(skip+2, pc[:]) < 1 {
+		return ""
+	}
+	frame, _ := runtime.CallersFrames(pc[:]).Next()
+
+	// The name of the caller's function is prefixed with the package path
+	// the caller's package was compiled with (the value of the compiler's
+	// -p flag). rules_go emits a file mapping these package paths to
+	// repository names into the runfiles of each binary. Unlike the file
+	// path check below, this works regardless of how the source paths
+	// recorded in the binary have been rewritten (e.g. via -trimpath).
+	if repo, ok := functionRepository(frame.Function); ok {
+		return repo
+	}
+
+	// Fall back to inspecting the source file path of the caller, which
+	// works for binaries built with rules_go versions that don't emit a
+	// package repository map, as long as source paths are recorded relative
+	// to the execroot.
+	if match := legacyExternalGeneratedFile.FindStringSubmatch(frame.File); match != nil {
 		return match[1]
 	}
-	if match := legacyExternalFile.FindStringSubmatch(file); match != nil {
+	if match := legacyExternalFile.FindStringSubmatch(frame.File); match != nil {
 		return match[1]
 	}
 	// If a file is not in an external repository, it is in the main repository,

--- a/go/runfiles/package_repo_map.go
+++ b/go/runfiles/package_repo_map.go
@@ -1,0 +1,112 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runfiles
+
+import (
+	"bufio"
+	"os"
+	"strings"
+	"sync"
+)
+
+// packageRepoMapRlocation is the runfiles-root-relative path of a file that
+// maps the link-time package path of each Go package linked into this binary
+// to the canonical name of the Bazel repository containing its sources. It
+// is set to a non-empty value via -X by the link action of rules_go versions
+// that emit this file; it is empty if the binary was built with an older
+// version of rules_go or outside of Bazel.
+var packageRepoMapRlocation string
+
+var packageRepoMap struct {
+	once sync.Once
+	m    map[string]string
+}
+
+// functionRepository returns the canonical name of the Bazel repository
+// containing the sources of the package of the function with the given
+// fully-qualified name as reported by [runtime.Frame], if known.
+func functionRepository(function string) (string, bool) {
+	packageRepoMap.once.Do(loadPackageRepoMap)
+	return lookupFunctionRepository(function, packageRepoMap.m)
+}
+
+func lookupFunctionRepository(function string, packageRepos map[string]string) (string, bool) {
+	if len(packageRepos) == 0 {
+		return "", false
+	}
+	// Cut off the type arguments of instantiations of generic functions or
+	// methods, which may themselves contain slashes and dots.
+	if i := strings.IndexByte(function, '['); i >= 0 {
+		function = function[:i]
+	}
+	// The package path is everything up to some '.' after the last '/':
+	// dots before the last slash are always part of the package path (e.g.
+	// in "example.com/foo/bar.F"), while dots after it separate the last
+	// package path element from the (possibly nested) function and receiver
+	// names. Since the last package path element may itself contain dots
+	// (e.g. "gopkg.in/yaml.v2"), try successively longer candidates until
+	// one matches a linked package.
+	start := strings.LastIndexByte(function, '/') + 1
+	for i := start; i < len(function); i++ {
+		if function[i] != '.' {
+			continue
+		}
+		if repo, ok := packageRepos[function[:i]]; ok {
+			return repo, true
+		}
+	}
+	return "", false
+}
+
+func loadPackageRepoMap() {
+	if packageRepoMapRlocation == "" {
+		return
+	}
+	// Create a fresh Runfiles instance instead of using the global one: the
+	// global instance may currently be initializing on this very goroutine
+	// (New calls CallerRepository, which may end up here) and its sync.Once
+	// would deadlock. Passing an explicit source repository keeps New from
+	// recursing into CallerRepository; the source repository is irrelevant
+	// here since the path below is already runfiles-root-relative.
+	r, err := New(SourceRepo(""))
+	if err != nil {
+		return
+	}
+	p, err := r.impl.path(packageRepoMapRlocation)
+	if err != nil {
+		return
+	}
+	f, err := os.Open(p)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	// Each line has the form:
+	// link-time package path,canonical name of the repository
+	m := make(map[string]string)
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		packagePath, repo, ok := strings.Cut(s.Text(), ",")
+		if !ok {
+			continue
+		}
+		m[packagePath] = repo
+	}
+	if s.Err() != nil {
+		return
+	}
+	packageRepoMap.m = m
+}

--- a/go/runfiles/package_repo_map_test.go
+++ b/go/runfiles/package_repo_map_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runfiles
+
+import "testing"
+
+func TestLookupFunctionRepository(t *testing.T) {
+	packageRepos := map[string]string{
+		"main":                   "my_repo",
+		"example.com/foo/bar":    "foo_repo",
+		"example.com/foo.v2":     "foo_v2_repo",
+		"example.com/foo.v2/pkg": "foo_v2_repo",
+		"pkg":                    "",
+	}
+	for _, tc := range []struct {
+		function string
+		want     string
+		wantOk   bool
+	}{
+		{"main.main", "my_repo", true},
+		{"main.main.func1", "my_repo", true},
+		{"example.com/foo/bar.F", "foo_repo", true},
+		{"example.com/foo/bar.F.func2", "foo_repo", true},
+		{"example.com/foo/bar.(*T).M", "foo_repo", true},
+		{"example.com/foo/bar.T.M", "foo_repo", true},
+		{"example.com/foo.v2.F", "foo_v2_repo", true},
+		{"example.com/foo.v2.(*T).M", "foo_v2_repo", true},
+		{"example.com/foo.v2/pkg.F", "foo_v2_repo", true},
+		{"example.com/foo/bar.F[go.shape.int]", "foo_repo", true},
+		{"example.com/foo/bar.F[example.com/other/pkg.T]", "foo_repo", true},
+		{"example.com/foo/bar.(*T[go.shape.string]).M", "foo_repo", true},
+		{"pkg.F", "", true},
+		{"runtime.gopanic", "", false},
+		{"example.com/unknown.F", "", false},
+		{"", "", false},
+		{"noPackage", "", false},
+	} {
+		got, ok := lookupFunctionRepository(tc.function, packageRepos)
+		if got != tc.want || ok != tc.wantOk {
+			t.Errorf("lookupFunctionRepository(%q) = %q, %t; want %q, %t", tc.function, got, ok, tc.want, tc.wantOk)
+		}
+	}
+}

--- a/go/toolchains.rst
+++ b/go/toolchains.rst
@@ -807,7 +807,10 @@ link
 
 The link function adds an action that runs ``go tool link`` on a library.
 
-It does not return anything.
+It returns a ``File`` that maps the package path of each linked package to
+the canonical name of the Bazel repository containing its sources. This file
+must be included in the runfiles of the binary for
+``runfiles.CurrentRepository`` to work.
 
 +--------------------------------+-----------------------------+-----------------------------------+
 | **Name**                       | **Type**                    | **Default value**                 |

--- a/go/tools/builders/importcfg.go
+++ b/go/tools/builders/importcfg.go
@@ -30,6 +30,11 @@ import (
 type archive struct {
 	label, importPath, packagePath, file string
 	importPathAliases                    []string
+
+	// repoName is the canonical name of the Bazel repository containing the
+	// package's sources. It is only set for archives passed to the link
+	// action.
+	repoName string
 }
 
 // checkImports verifies that each import in files refers to a
@@ -257,15 +262,34 @@ func (m *archiveMultiFlag) String() string {
 
 func (m *archiveMultiFlag) Set(v string) error {
 	parts := strings.Split(v, "=")
-	if len(parts) != 3 {
+	if len(parts) < 3 {
 		return fmt.Errorf("badly formed -arc flag: %s", v)
 	}
-	importPaths := strings.Split(parts[0], ":")
-	a := archive{
-		importPath:        importPaths[0],
-		importPathAliases: importPaths[1:],
-		packagePath:       parts[1],
-		file:              abs(parts[2]),
+	var a archive
+	if len(parts) == 3 {
+		// importpaths=packagePath=file, passed to compile actions.
+		importPaths := strings.Split(parts[0], ":")
+		a = archive{
+			importPath:        importPaths[0],
+			importPathAliases: importPaths[1:],
+			packagePath:       parts[1],
+			file:              abs(parts[2]),
+		}
+	} else {
+		// label=packagePath=file=repoName, passed to link actions. The label
+		// may itself contain '=' characters, so split off the other fields
+		// from the right.
+		label := strings.Join(parts[:len(parts)-3], "=")
+		a = archive{
+			label: label,
+			// TODO(zbarsky): The label is passed in place of the import path
+			// by the link action. Keep mirroring it into importPath, which
+			// is used in the duplicate package error message.
+			importPath:  label,
+			packagePath: parts[len(parts)-3],
+			file:        abs(parts[len(parts)-2]),
+			repoName:    parts[len(parts)-1],
+		}
 	}
 	*m = append(*m, a)
 	return nil

--- a/go/tools/builders/link.go
+++ b/go/tools/builders/link.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -45,6 +46,9 @@ func link(args []string) error {
 	main := flags.String("main", "", "Path to the main archive.")
 	packagePath := flags.String("p", "", "Package path of the main archive.")
 	outFile := flags.String("o", "", "Path to output file.")
+	packageRepoMap := flags.String("package_repo_map", "", "Path of a file to write that maps the package path of each linked package to the canonical name of the Bazel repository containing its sources.")
+	packageRepoMapRlocation := flags.String("package_repo_map_rlocation", "", "Runfiles-root-relative path of the file written to -package_repo_map.")
+	mainRepo := flags.String("main_repo", "", "Canonical name of the Bazel repository containing the main package.")
 	flags.Var(&archives, "arc", "Label, package path, and file name of a dependency, separated by '='")
 	packageList := flags.String("package_list", "", "The file containing the list of standard library packages")
 	buildmode := flags.String("buildmode", "", "Build mode used.")
@@ -95,6 +99,12 @@ func link(args []string) error {
 	if err != nil {
 		return err
 	}
+
+	if *packageRepoMap != "" {
+		if err := writePackageRepoMap(*packageRepoMap, archives, *packagePath, *mainRepo); err != nil {
+			return err
+		}
+	}
 	if !goenv.shouldPreserveWorkDir {
 		defer os.Remove(importcfgName)
 	}
@@ -133,6 +143,21 @@ func link(args []string) error {
 		})
 		if !missingKey {
 			goargs = append(goargs, "-X", fmt.Sprintf("%s.%s=%s", pkg, name, value))
+		}
+	}
+
+	// If the runfiles library is linked into the binary, tell it where to
+	// find the package repository map so that it can implement
+	// CurrentRepository without inspecting source file paths. The -X flag
+	// only takes effect if the given package is actually linked in, but
+	// skipping it entirely avoids referencing an unknown symbol.
+	const runfilesPackagePath = "github.com/bazelbuild/rules_go/go/runfiles"
+	if *packageRepoMapRlocation != "" {
+		for _, arc := range archives {
+			if arc.packagePath == runfilesPackagePath {
+				goargs = append(goargs, "-X", runfilesPackagePath+".packageRepoMapRlocation="+*packageRepoMapRlocation)
+				break
+			}
 		}
 	}
 
@@ -181,6 +206,24 @@ func link(args []string) error {
 	}
 
 	return nil
+}
+
+// writePackageRepoMap writes a file that maps the link-time package path of
+// each linked package to the canonical name of the Bazel repository
+// containing its sources, with one comma-separated pair per line. The main
+// package is included under the package path it is linked as (usually
+// "main"). The Go runfiles library reads this file at runtime to implement
+// CurrentRepository.
+func writePackageRepoMap(out string, archives []archive, mainPackagePath, mainRepo string) error {
+	lines := make([]string, 0, len(archives)+1)
+	lines = append(lines, mainPackagePath+","+mainRepo+"\n")
+	for _, arc := range archives {
+		lines = append(lines, arc.packagePath+","+arc.repoName+"\n")
+	}
+	// Sort the lines to make the output reproducible regardless of the order
+	// in which the archives are passed to the linker.
+	sort.Strings(lines)
+	return os.WriteFile(out, []byte(strings.Join(lines, "")), 0o666)
 }
 
 var versionExp = regexp.MustCompile(`.*go1\.(\d+).*$`)

--- a/tests/runfiles/runfiles_bazel_test.go
+++ b/tests/runfiles/runfiles_bazel_test.go
@@ -54,6 +54,34 @@ go_library(
     ],
     visibility = ["//visibility:public"],
 )
+
+# The recorded source paths of this library are relative to the repository
+# root rather than the execroot, so the repository name cannot be recovered
+# from them and CurrentRepository has to consult the package repository map.
+go_library(
+    name = "external_trimmed_lib",
+    srcs = ["external_trimmed_lib.go"],
+    gc_goopts = ["-trimpath=external"],
+    importpath = "example.com/runfiles/external_trimmed_lib",
+    deps = [
+        "@io_bazel_rules_go//go/runfiles",
+    ],
+    visibility = ["//visibility:public"],
+)
+-- other_repo/pkg/external_trimmed_lib.go --
+package external_trimmed_lib
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/bazelbuild/rules_go/go/runfiles"
+)
+
+func PrintRepo() {
+	_, file, _, _ := runtime.Caller(0)
+	fmt.Printf("%s: '%s'\n", file, runfiles.CurrentRepository())
+}
 -- other_repo/pkg/external_source_lib.go --
 package external_source_lib
 
@@ -123,6 +151,7 @@ go_binary(
         "//pkg:internal_generated_lib",
         "@other_repo//pkg:external_source_lib",
         "@other_repo//pkg:external_generated_lib",
+        "@other_repo//pkg:external_trimmed_lib",
     ],
 )
 -- main.go --
@@ -133,6 +162,7 @@ import (
 	"example.com/runfiles/internal_source_lib"
 	"example.com/runfiles/external_generated_lib"
 	"example.com/runfiles/external_source_lib"
+	"example.com/runfiles/external_trimmed_lib"
 )
 
 func main() {
@@ -140,6 +170,7 @@ func main() {
 	internal_generated_lib.PrintRepo()
 	external_source_lib.PrintRepo()
 	external_generated_lib.PrintRepo()
+	external_trimmed_lib.PrintRepo()
 }
 `,
 		WorkspaceSuffix: `
@@ -151,10 +182,11 @@ local_repository(
 	})
 }
 
-var expectedOutputLegacy = regexp.MustCompile(`^pkg/internal_source_lib.go: ''
+var expectedOutput = regexp.MustCompile(`^pkg/internal_source_lib.go: ''
 bazel-out/[^/]+/bin/pkg/internal_generated_lib.go: ''
 external/other_repo/pkg/external_source_lib.go: 'other_repo'
 bazel-out/[^/]+/bin/external/other_repo/pkg/external_generated_lib.go: 'other_repo'
+other_repo/pkg/external_trimmed_lib.go: 'other_repo'
 $`)
 
 func TestCurrentRepository(t *testing.T) {
@@ -162,7 +194,7 @@ func TestCurrentRepository(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !expectedOutputLegacy.Match(out) {
-		t.Fatalf("got: %q, want: %q", string(out), expectedOutputLegacy.String())
+	if !expectedOutput.Match(out) {
+		t.Fatalf("got: %q, want: %q", string(out), expectedOutput.String())
 	}
 }


### PR DESCRIPTION
CurrentRepository and CallerRepository currently recover the canonical repository name of the caller by matching the source file path recorded in the binary against the execroot-relative layout (external/<repo>/...). This breaks whenever recorded source paths are rewritten, e.g. with -trimpath or the proposed importpath-relative path scheme.

Instead, derive the caller's link-time package path from the symbol name reported by runtime.CallersFrames, which is unaffected by any source path rewriting, and look it up in a new per-binary file that maps the package path of every linked package to the canonical name of the repository containing its sources:

* The link action writes <binary>.package_repo_map next to the binary from the archives it already receives via -arc (extended with the owning repository name) and the main package, and the file is added to the binary's runfiles.
* The linker injects the runfiles-root-relative path of that file into the runfiles library via -X, but only if the library is actually linked into the binary.
* The runfiles library lazily loads the map and resolves the caller's package path to a repository name, trying successively longer package path candidates to disambiguate package paths that contain dots in their last element (e.g. gopkg.in/yaml.v2). The previous file path based logic is kept as a fallback for binaries built with older rules_go versions or outside of Bazel.

This also makes CurrentRepository work for callers in the main package of a binary in an external repository, which symbol names alone can't provide since main packages are always linked as "main".
