### PR TITLE
Add dedicated load files for go_binary(), go_library(), go_test()

### DIFF
--- a/go/BUILD.bazel
+++ b/go/BUILD.bazel
@@ -69,3 +69,30 @@ bzl_library(
         "//go/private:sdk",
     ],
 )
+
+bzl_library(
+    name = "go_binary",
+    srcs = ["go_binary.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//go/private/rules:wrappers",
+    ],
+)
+
+bzl_library(
+    name = "go_library",
+    srcs = ["go_library.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//go/private/rules:library",
+    ],
+)
+
+bzl_library(
+    name = "go_test",
+    srcs = ["go_test.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//go/private/rules:test",
+    ],
+)

--- a/go/def.bzl
+++ b/go/def.bzl
@@ -14,12 +14,13 @@
 
 """Public definitions for Go rules.
 
-All public Go rules, providers, and other definitions are imported and
-re-exported in this file. This allows the real location of definitions
-to change for easier maintenance.
+This file serves as the primary entry point for loading public Go rules,
+providers, and definitions. Re-exporting them here allows the underlying
+implementations to be maintained and relocated without breaking public APIs.
 
-Definitions outside this file are private unless otherwise noted, and
-may change without notice.
+Definitions outside this file are private and subject to change with the
+exception of (go/go_binary.bzl, go/go_library.bzl, go/go_test.bzl) which are provided as
+a convenience.
 """
 
 load(

--- a/go/go_binary.bzl
+++ b/go/go_binary.bzl
@@ -1,0 +1,19 @@
+# Copyright 2014 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Public entry point for go_binary."""
+
+load("//go/private/rules:wrappers.bzl", _go_binary = "go_binary_macro")
+
+go_binary = _go_binary

--- a/go/go_library.bzl
+++ b/go/go_library.bzl
@@ -1,0 +1,19 @@
+# Copyright 2014 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Public entry point for go_library."""
+
+load("//go/private/rules:library.bzl", _go_library = "go_library")
+
+go_library = _go_library

--- a/go/go_test.bzl
+++ b/go/go_test.bzl
@@ -1,0 +1,19 @@
+# Copyright 2014 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Public entry point for go_test."""
+
+load("//go/private/rules:test.bzl", _go_test = "go_test")
+
+go_test = _go_test

--- a/tests/core/entry_points/BUILD.bazel
+++ b/tests/core/entry_points/BUILD.bazel
@@ -1,0 +1,21 @@
+load("//go:go_binary.bzl", "go_binary")
+load("//go:go_library.bzl", "go_library")
+load("//go:go_test.bzl", "go_test")
+
+go_library(
+    name = "entry_lib",
+    srcs = ["entry_lib.go"],
+    importpath = "entry_lib",
+)
+
+go_binary(
+    name = "entry_bin",
+    srcs = ["entry_bin.go"],
+    deps = [":entry_lib"],
+)
+
+go_test(
+    name = "entry_test",
+    srcs = ["entry_test.go"],
+    embed = [":entry_lib"],
+)

--- a/tests/core/entry_points/entry_bin.go
+++ b/tests/core/entry_points/entry_bin.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"fmt"
+	"entry_lib"
+)
+
+func main() {
+	fmt.Println(entry_lib.Message())
+}

--- a/tests/core/entry_points/entry_lib.go
+++ b/tests/core/entry_points/entry_lib.go
@@ -1,0 +1,5 @@
+package entry_lib
+
+func Message() string {
+	return "Hello from entry_lib"
+}

--- a/tests/core/entry_points/entry_test.go
+++ b/tests/core/entry_points/entry_test.go
@@ -1,0 +1,9 @@
+package entry_lib
+
+import "testing"
+
+func TestMessage(t *testing.T) {
+	if Message() != "Hello from entry_lib" {
+		t.Errorf("Unexpected message")
+	}
+}


### PR DESCRIPTION
as alternates to def.bzl. This tremendously simplifies migration to and from other environments which expect the same separation and brings Go in line with common practice for other languages (for example, rules_python does this).

**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

It's a nice quality-of-life for amphibian developers.
go_binary() and go_library() and go_test() now each have their own separate .bzl files (in addition to def.bzl).

**Which issues(s) does this PR fix?**

Fixes #4654

**Other notes for review**

These are all just one-liners which happen to wrap the same functions in go/private/ that are already wrapped by def.bzl, so they are a parallel (if trivial) code path. We could also be slightly more intrusive by defining them to be the new SoT and redirecting def.bzl to point to them instead.