### PR TITLE
Add tests for cgo ldflags response-file encoding for Go 1.27

### DIFF
--- a/go/private/platforms.bzl
+++ b/go/private/platforms.bzl
@@ -179,8 +179,13 @@ def _generate_platforms():
         ))
         if (goos, goarch) in CGO_GOOS_GOARCH:
             # On Windows, Bazel will pick an MSVC toolchain unless we
-            # specifically request mingw or msys.
-            mingw = ["@bazel_tools//tools/cpp:mingw"] if goos == "windows" else []
+            # specifically request mingw or msys. Bazel's built-in C++
+            # configuration and rules_cc use separate constraint settings, so
+            # include both constraints to support either toolchain source.
+            mingw = [
+                "@bazel_tools//tools/cpp:mingw",
+                "@rules_cc//cc/private/toolchain:mingw",
+            ] if goos == "windows" else []
             platforms.append(struct(
                 name = goos + "_" + goarch + "_cgo",
                 goos = goos,

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -3,6 +3,15 @@ load("//go/private:common.bzl", "RULES_GO_STDLIB_PREFIX")
 load("//go/private/rules:transition.bzl", "go_reset_target")
 
 go_test(
+    name = "cgo_response_test",
+    size = "small",
+    srcs = [
+        "cgo_response.go",
+        "cgo_response_test.go",
+    ],
+)
+
+go_test(
     name = "filter_test",
     size = "small",
     srcs = [
@@ -103,6 +112,7 @@ filegroup(
         "builder.go",
         "cc.go",
         "cgo2.go",
+        "cgo_response.go",
         "compilepkg.go",
         "constants.go",
         "cover.go",

--- a/go/tools/builders/cgo2.go
+++ b/go/tools/builders/cgo2.go
@@ -468,8 +468,7 @@ func copyOrLinkFile(inPath, outPath string) error {
 func formatLdFlagsFileContent(flags string) string {
 	shouldEscape, _ := onVersionOrHigher(27)
 	if shouldEscape {
-		escaped := strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(flags)
-		return `"` + escaped + `"` + "\n"
+		return encodeResponseFileArg(flags) + "\n"
 	}
 	return flags
 }

--- a/go/tools/builders/cgo_response.go
+++ b/go/tools/builders/cgo_response.go
@@ -1,0 +1,47 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "strings"
+
+// encodeResponseFileArg encodes one argv entry using Go 1.27's
+// GCC-compatible response-file format.
+func encodeResponseFileArg(arg string) string {
+	if arg == "" {
+		return `""`
+	}
+	if !strings.ContainsAny(arg, " \t\n\r'\"\\$`") {
+		return arg
+	}
+
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range arg {
+		switch r {
+		case '\\':
+			b.WriteString(`\\`)
+		case '"':
+			b.WriteString(`\"`)
+		case '$':
+			b.WriteString(`\$`)
+		case '`':
+			b.WriteString("\\`")
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}

--- a/go/tools/builders/cgo_response_test.go
+++ b/go/tools/builders/cgo_response_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "testing"
+
+func TestEncodeResponseFileArg(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{
+			name: "empty",
+			arg:  "",
+			want: `""`,
+		},
+		{
+			name: "unchanged without special characters",
+			arg:  "-pthread",
+			want: "-pthread",
+		},
+		{
+			name: "keeps whitespace in one argument",
+			arg:  "-target x86_64-linux-gnu --sysroot=/dev/null",
+			want: `"-target x86_64-linux-gnu --sysroot=/dev/null"`,
+		},
+		{
+			name: "escapes special characters",
+			arg:  `-Wl,-rpath,$ORIGIN -X "quoted" C:\tmp\lib`,
+			want: `"-Wl,-rpath,\$ORIGIN -X \"quoted\" C:\\tmp\\lib"`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := encodeResponseFileArg(tc.arg); got != tc.want {
+				t.Fatalf("encodeResponseFileArg(%q) = %q; want %q", tc.arg, got, tc.want)
+			}
+		})
+	}
+}

--- a/tests/integration/README.rst
+++ b/tests/integration/README.rst
@@ -15,6 +15,7 @@ Contents
 .. Child list start
 
 * `Gazelle functionality <gazelle/README.rst>`_
+* `Go 1.27 cgo linker flags <cgo_ldflags/README.rst>`_
 * `Popular repository tests <popular_repos/README.rst>`_
 * `Reproducibility <reproducibility/README.rst>`_
 * `Functionality related to @go_googleapis <googleapis/README.rst>`_

--- a/tests/integration/cgo_ldflags/BUILD.bazel
+++ b/tests/integration/cgo_ldflags/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
+
+go_bazel_test(
+    name = "cgo_ldflags_test",
+    size = "medium",
+    srcs = ["cgo_ldflags_test.go"],
+)

--- a/tests/integration/cgo_ldflags/README.rst
+++ b/tests/integration/cgo_ldflags/README.rst
@@ -1,0 +1,5 @@
+Go 1.27 cgo linker flags
+=========================
+
+Verifies that a cgo target built with Go 1.27rc1 and a C/C++ toolchain builds
+correctly when it receives multiple linker flags.

--- a/tests/integration/cgo_ldflags/cgo_ldflags_test.go
+++ b/tests/integration/cgo_ldflags/cgo_ldflags_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cgo_ldflags_test
+
+import (
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: `
+-- BUILD.bazel --
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "answer",
+    srcs = ["answer.c"],
+    hdrs = ["answer.h"],
+)
+
+go_binary(
+    name = "cgo_ldflags",
+    srcs = ["main.go"],
+    cdeps = [":answer"],
+    cgo = True,
+    # Go 1.27 expands response files before parsing cgo flags. Keep multiple
+    # linker flags here so an unquoted response file fails the build.
+    clinkopts = [
+        "-g",
+        "-v",
+    ],
+    pure = "off",
+)
+
+-- answer.h --
+int answer(void);
+
+-- answer.c --
+#include "answer.h"
+
+int answer(void) {
+    return 42;
+}
+
+-- main.go --
+package main
+
+/*
+#include "answer.h"
+*/
+import "C"
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func main() {
+	if got := runtime.Version(); got != "go1.27rc1" {
+		panic(fmt.Sprintf("built with %s, want go1.27rc1", got))
+	}
+	if got := int(C.answer()); got != 42 {
+		panic(fmt.Sprintf("C answer = %d, want 42", got))
+	}
+}
+`,
+		ModuleFileSuffix: `
+bazel_dep(name = "rules_cc", version = "0.1.5")
+
+cc_configure = use_extension("@rules_cc//cc:extensions.bzl", "cc_configure_extension")
+use_repo(cc_configure, "local_config_cc")
+
+go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(
+    name = "go_1_27_rc1",
+    sdks = {
+        "darwin_amd64": ["go1.27rc1.darwin-amd64.tar.gz", "ec2abfa675a1882a13fd72035bdc50635b5b4a2b424c1f692a5737b0a333a322"],
+        "darwin_arm64": ["go1.27rc1.darwin-arm64.tar.gz", "7b7b4d66fc0a7bc8e57b3602340dfef46d4f5f95fc5d30e5c5af6a671830de54"],
+        "linux_amd64": ["go1.27rc1.linux-amd64.tar.gz", "102a6055d682b1f233bc1741122cc6fddae7a7dded1305fbcc30079984187144"],
+        "linux_arm64": ["go1.27rc1.linux-arm64.tar.gz", "e9338b657430c7c32fffec696ce7d7b0286f99b65f8f90a2f5a6781a34f34928"],
+        "windows_amd64": ["go1.27rc1.windows-amd64.zip", "10d2c755c76ca94008558bb9ec93154529ea1c0a38abe938d9b6406a9d18ffe3"],
+    },
+    version = "1.27rc1",
+)
+`,
+	})
+}
+
+func TestGo127CgoWithMultipleLinkerFlags(t *testing.T) {
+	if err := bazel_testing.RunBazel(
+		"run",
+		"--@io_bazel_rules_go//go/toolchain:sdk_version=1.27rc1",
+		"//:cgo_ldflags",
+	); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This adds tests for the cgo argfile change for GCC compatible file parser in 1.27+

Bonus: fixes a toolchain constraint issue for windows