### PR TITLE
Revert "Preserve common Go settings in go_stdlib_transition"

### DIFF
--- a/go/private/rules/transition.bzl
+++ b/go/private/rules/transition.bzl
@@ -193,6 +193,15 @@ _reset_transition_dict = dict(_common_reset_transition_dict, **{
 
 _reset_transition_keys = sorted(_reset_transition_dict.keys())
 
+_stdlib_keep_keys = sorted([
+    "//go/config:msan",
+    "//go/config:race",
+    "//go/config:pure",
+    "//go/config:linkmode",
+    "//go/config:tags",
+    "//go/config:pgoprofile",
+])
+
 def _go_tool_transition_impl(settings, _attr):
     """Sets most Go settings to default values (use for external Go tools).
 
@@ -236,18 +245,17 @@ non_go_tool_transition = transition(
 )
 
 def _go_stdlib_transition_impl(settings, _attr):
-    """Configures //:stdlib dependencies.
+    """Sets all Go settings to their default values, except for those affecting the Go SDK.
 
-    go_stdlib_transition preserves each setting in
-    _common_reset_transition_dict except //go/config:tags. Changing another
-    setting could cause a Go rule and its //:stdlib dependency to resolve C++
-    runtime archives in different configurations, which could make GoLink
-    reference an archive that Bazel did not declare. go_stdlib_transition
-    filters //go/config:tags to _TAG_AFFECTS_STDLIB and sets
-    //go/private:bootstrap_nogo and
-    //command_line_option:collect_code_coverage to False.
+    This transition is similar to _non_go_tool_transition except that it keeps the
+    parts of the configuration that determine how to build the standard library.
+    It's used to consolidate the configurations used to build the standard library to limit
+    the number built.
     """
     settings = dict(settings)
+    for label, value in _reset_transition_dict.items():
+        if label not in _stdlib_keep_keys:
+            settings[label] = value
     settings["//go/config:tags"] = [t for t in settings["//go/config:tags"] if t in _TAG_AFFECTS_STDLIB]
     settings["//go/private:bootstrap_nogo"] = False
     settings["//command_line_option:collect_code_coverage"] = False

--- a/tests/core/starlark/cgo/cgo_test.bzl
+++ b/tests/core/starlark/cgo/cgo_test.bzl
@@ -182,6 +182,7 @@ def cgo_test_suite():
 
     runtime_lib_inputs_test(
         name = "static_runtime_lib_inputs_test",
+        expected_input_count = 2,
         expected_inputs = ["configured_dummy.a"],
         expected_linkopts = ["configured_dummy.a"],
         target_under_test = ":runtime_libs_static_binary",
@@ -225,6 +226,7 @@ def cgo_test_suite():
 
     runtime_lib_inputs_test(
         name = "dynamic_runtime_lib_inputs_test",
+        expected_input_count = 2,
         expected_inputs = ["dummy.so"],
         expected_linkopts = ["dummy.so"],
         target_under_test = ":runtime_libs_dynamic_binary",

--- a/tests/core/transition/hermeticity_test.go
+++ b/tests/core/transition/hermeticity_test.go
@@ -31,7 +31,6 @@ func TestMain(m *testing.M) {
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
-load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 go_binary(
     name = "main",
@@ -124,7 +123,6 @@ message Foo {
 `,
 		ModuleFileSuffix: `
 bazel_dep(name = "protobuf", version = "29.0-rc2", repo_name = "com_google_protobuf")
-bazel_dep(name = "rules_cc", version = "0.1.5")
 bazel_dep(name = "toolchains_protoc", version = "0.3.4")
 `,
 		WorkspacePrefix: `
@@ -212,22 +210,6 @@ func TestGoProtoLibraryToolAttrsAreReset(t *testing.T) {
 	)
 }
 
-func TestStdlibPreservesRequestNogoConfigurations(t *testing.T) {
-	const target = "//:main"
-	const stdlib = "@io_bazel_rules_go//:stdlib"
-	if err := bazel_testing.RunBazel("build", target, stdlib, "--nobuild"); err != nil {
-		t.Fatalf("bazel build %s %s: %v", target, stdlib, err)
-	}
-
-	// //:main requests nogo, while coverdata sets request_nogo to false. //:stdlib must
-	// preserve both values so each //:stdlib target resolves the C++ toolchain in its
-	// parent configuration.
-	configHashes := getDependencyConfigHashes(t, target, stdlib)
-	if got, want := len(configHashes), 2; got != want {
-		t.Fatalf("%s depends on %s in %d configurations, want %d", target, stdlib, got, want)
-	}
-}
-
 func assertDependsCleanlyOnWithFlags(t *testing.T, targetA, targetB string, allowNoDep bool, flags ...string) {
 	// Analyze the targets to ensure that MODULE.bazel.lock has been created, otherwise bazel config
 	// will fail after the cquery command due to the Skyframe invalidation caused by a changed file.
@@ -235,7 +217,22 @@ func assertDependsCleanlyOnWithFlags(t *testing.T, targetA, targetB string, allo
 	if err != nil {
 		t.Fatalf("bazel build %s %s: %v", targetA, targetB, err)
 	}
-	configHashes := getDependencyConfigHashes(t, targetA, targetB, flags...)
+	query := fmt.Sprintf("deps(%s) intersect %s", targetA, targetB)
+	out, err := bazel_testing.BazelOutput(append(
+		[]string{
+			"cquery",
+			"--transitions=full",
+			"--output=jsonproto",
+			query,
+		},
+		flags...,
+	)...,
+	)
+	if err != nil {
+		t.Fatalf("bazel cquery '%s': %v", query, err)
+	}
+	cqueryOut := bytes.TrimSpace(out)
+	configHashes := extractConfigHashes(t, cqueryOut)
 	if len(configHashes) == 0 {
 		if allowNoDep {
 			return
@@ -262,25 +259,6 @@ func assertDependsCleanlyOnWithFlags(t *testing.T, targetA, targetB string, allo
 			strings.Join(goOptions, "\n"),
 		)
 	}
-}
-
-func getDependencyConfigHashes(t *testing.T, targetA, targetB string, flags ...string) []string {
-	t.Helper()
-	query := fmt.Sprintf("deps(%s) intersect %s", targetA, targetB)
-	out, err := bazel_testing.BazelOutput(append(
-		[]string{
-			"cquery",
-			"--transitions=full",
-			"--output=jsonproto",
-			query,
-		},
-		flags...,
-	)...,
-	)
-	if err != nil {
-		t.Fatalf("bazel cquery '%s': %v", query, err)
-	}
-	return extractConfigHashes(t, bytes.TrimSpace(out))
 }
 
 func extractConfigHashes(t *testing.T, rawJsonOut []byte) []string {


### PR DESCRIPTION
Reverts bazel-contrib/rules_go#4637