### PR TITLE
tests: expect both stdlib C++ runtime inputs after reset

### DIFF
--- a/tests/core/starlark/cgo/cgo_test.bzl
+++ b/tests/core/starlark/cgo/cgo_test.bzl
@@ -182,6 +182,7 @@ def cgo_test_suite():
 
     runtime_lib_inputs_test(
         name = "static_runtime_lib_inputs_test",
+        expected_input_count = 2,
         expected_inputs = ["configured_dummy.a"],
         expected_linkopts = ["configured_dummy.a"],
         target_under_test = ":runtime_libs_static_binary",
@@ -225,6 +226,7 @@ def cgo_test_suite():
 
     runtime_lib_inputs_test(
         name = "dynamic_runtime_lib_inputs_test",
+        expected_input_count = 2,
         expected_inputs = ["dummy.so"],
         expected_linkopts = ["dummy.so"],
         target_under_test = ":runtime_libs_dynamic_binary",


### PR DESCRIPTION
## Summary

Author: zbarsky-bot

Stacked on #4658.

`go_stdlib_transition` in #4658 resets `//go/private:request_nogo`, so `runtime_libs_static_binary` and `runtime_libs_dynamic_binary` resolve C++ runtime files in both the Go target configuration and the `//:stdlib` configuration. #4657 correctly adds both configurations to `GoLink`. Set `expected_input_count = 2` in `static_runtime_lib_inputs_test` and `dynamic_runtime_lib_inputs_test` so the two analysis tests match the restored transition behavior and stop failing in Buildkite.

## Validation

```sh
bazel test \
  //tests/core/starlark/cgo:static_runtime_lib_inputs_test \
  //tests/core/starlark/cgo:dynamic_runtime_lib_inputs_test \
  //tests/core/starlark/cgo:stdlib_runtime_lib_inputs_test
```

All three tests pass with remote execution.
