### PR TITLE
Use -ffile-prefix-map for reproducibility

### DIFF
--- a/go/tools/builders/cgo2.go
+++ b/go/tools/builders/cgo2.go
@@ -428,8 +428,8 @@ func cCompile(goenv *env, src, cc string, flags []string, out string) error {
 
 func defaultCFlags(workDir string) []string {
 	flags := []string{
-		"-fdebug-prefix-map=" + abs(".") + "=.",
-		"-fdebug-prefix-map=" + workDir + "=.",
+		"-ffile-prefix-map=" + abs(".") + "=.",
+		"-ffile-prefix-map=" + workDir + "=.",
 	}
 	goos, goarch := os.Getenv("GOOS"), os.Getenv("GOARCH")
 	switch {


### PR DESCRIPTION
Fixes `__FILE__` macros being non-hermetic

Supported since clang 10 (April 2020) and gcc 8 (May 2018)

Fixes https://github.com/bazel-contrib/rules_go/issues/4577
