### PR TITLE
go: preserve race mode for go_source rules

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -631,7 +631,7 @@ def go_context(
         mode_kwargs = structs.to_dict(go_config_info)
         mode_kwargs["goos"] = toolchain.default_goos if goos == "auto" else goos
         mode_kwargs["goarch"] = toolchain.default_goarch if goarch == "auto" else goarch
-        if not cgo_available:
+        if not cgo_available and (maybe_needs_cc_toolchain or CPP_TOOLCHAIN_TYPE in ctx.toolchains):
             if getattr(ctx.attr, "pure", None) == "off":
                 fail("{} has pure explicitly set to off, but no C++ toolchain could be found for its platform".format(ctx.label))
             mode_kwargs["pure"] = True

--- a/tests/core/race/race_test.go
+++ b/tests/core/race/race_test.go
@@ -30,7 +30,7 @@ func TestMain(m *testing.M) {
 	bazel_testing.TestMain(m, bazel_testing.Args{
 		Main: `
 -- BUILD.bazel --
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_source", "go_test")
 
 go_library(
     name = "racy",
@@ -86,6 +86,17 @@ go_library(
 		name = "coverrace",
 		srcs = ["coverrace.go"],
 		importpath = "example.com/coverrace",
+)
+
+go_source(
+    name = "race_source",
+    srcs = ["coverrace.go"],
+)
+
+go_library(
+    name = "race_source_library",
+    embed = [":race_source"],
+    importpath = "example.com/race_source",
 )
 
 go_test(
@@ -269,6 +280,16 @@ func Test(t *testing.T) {
 			target:      "//:racy_test",
 			featureFlag: true,
 			wantRace:    true,
+		}, {
+			desc:        "source_feature",
+			cmd:         "build",
+			target:      "//:race_source",
+			featureFlag: true,
+		}, {
+			desc:        "source_library_feature",
+			cmd:         "build",
+			target:      "//:race_source_library",
+			featureFlag: true,
 		}, {
 			desc:        "pure_bin",
 			cmd:         "build",


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

`go_source` calls `go_context(..., maybe_needs_cc_toolchain = False)` and intentionally does not declare a C/C++ toolchain. `go_context` still treated the undeclared toolchain as unavailable, forced pure mode, and rejected race instrumentation. Preserve the configured mode for rules that opt out and do not declare the C/C++ toolchain while retaining missing-toolchain validation for normal Go rules. Add race-mode regression coverage for both standalone `go_source` and an embedding `go_library`.

**Which issue(s) does this PR fix?**

Fixes #4673

**Other notes for review**

Validated with:

```
bazel test --jobs=2 --local_test_jobs=1 //tests/core/race:race_test //tests/core/starlark/cgo:missing_cc_toolchain_explicit_pure_off_test
```
